### PR TITLE
Add a "Hide adult categories" setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,14 @@ genuinely needs no doc edit, say why in the commit.
   (`ui/PlaceContent.kt`, same shape as `LiveReviews`, init in VelaApp, rows in Settings → Map).
   They gate BOTH fetch (`fetchReviews`/`fetchPhotos` first line) and render (PlaceSheet `hasReviews`
   + the photo-hero `if`), so off = zero scrape traffic. Keep any new review/photo surface behind them.
+- **"Hide adult categories" toggle (2026-07-08):** `HideAdult` holder (`ui/PlaceContent.kt`, default
+  **off**, init in VelaApp, row in Settings → Map). It flips `CategoryFilter.enabled` (a `:core` flag) —
+  `:core`'s `data/CategoryFilter` filters adult/nightlife/alcohol/gambling/smoking places at the
+  `GoogleMapsDataSource.search`/`nearbyPlaces` seam. Match is CATEGORY-only (never name) and PRECISE
+  (`EXACT`/`PHRASE`, food "…bar" kept); the keyword lists are **multilingual** (categories arrive
+  localized via `hl=<lang>`, so the filter must too). Unit-tested (`CategoryFilterTest`). NB the `:core`
+  flag pattern (not reading the app holder from `:core`) is deliberate — mirror it for any future
+  content gate that must act inside `:core`.
 - **In-app updater (`app/update/SelfUpdater.kt`, 2026-07-08).** GitHub releases/latest → tag
   `v0.<minor>.<run>` → versionCode `2000+run` compared to BuildConfig; newer → `MapUiState.updateInfo`
   card on the bare map. Download = no-call-timeout client (~80 MB APK) + zip-magic check →

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -113,6 +113,15 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   fetch in the ViewModel and the render in the place sheet, so off means no traffic, not just hidden UI.
   Device-verified: with both off, an Applebee's sheet opens with rating, hours, phone and attributes but no
   photos and no review section. Localized in all 11 languages.
+- ✅ **"Hide adult categories" toggle (2026-07-08).** Settings → Map, **off by default**. On = drops places whose
+  Google CATEGORY is adult / nightlife / alcohol / gambling / smoking (bars, clubs, casinos, liquor stores,
+  hookah, cannabis, adult, …) from **both** search results and the ambient map. Matching is on the free-text
+  category **only, never the name** (a place categorised "Restaurant" is always kept), and it's PRECISE — food
+  "…bar" categories (sushi/juice/coffee/salad bar) stay. Because Google returns the category **localized**
+  (`hl=<lang>`), the keyword list carries the equivalent terms for all 11 UI languages, so the filter works in
+  every locale, not just English. Pure `:core` `CategoryFilter` (unit-tested) applied at the data-source seam
+  (`GoogleMapsDataSource.search` + `nearbyPlaces`); gated by a `:core`-visible `enabled` flag the `HideAdult`
+  holder flips, so `:core` needn't depend on the app's reactive state. Localized in all 11 languages.
 - ✅ Place search — name, category, **full address (street, city, state, ZIP)**, rating, review count, coordinates
 - ✅ Searching a **specific/far address** resolves to that single geocoded location (handles the response's single-result shape, not just the POI list — fixes the old "calibration error" on far addresses); genuinely-empty searches now show "no results" instead of an error
 - ✅ **Address → business snap** — searching a raw address that *is* a business (e.g. "1020 Olive Dr, Davis") now lands on the **business** (In-N-Out Burger, rating/hours/category and all), not the bare address — Google lists the "at this place" business under the geocoded node (`[0][1][0][14][68]`) and Vela now reads it. *(verified on-device; unit-tested; the path is in calibration so it's remotely fixable)*

--- a/SPEC.md
+++ b/SPEC.md
@@ -75,7 +75,7 @@ Two Gradle modules, strict boundary:
   `init()`-ed in `VelaApp`): `ui/Units` (metric/imperial), `ui/theme/AppTheme`
   (Light/Dark/System — read via **`isAppInDarkTheme()`**, never `isSystemInDarkTheme()`),
   `ui/Traffic` (overlay on/off), `ui/TransitLayer` (rail highlight), `ui/LiveReviews` (reviews panel),
-  `ui/PlaceContent` (`ShowReviews`/`LoadPhotos`), `ui/Buildings3d` (extrusion layer), `ui/AppLocale`
+  `ui/PlaceContent` (`ShowReviews`/`LoadPhotos`/`HideAdult`), `ui/Buildings3d` (extrusion layer), `ui/AppLocale`
   (language), `ui/Onboarding`.
 
 ### Data flow (search example)
@@ -406,6 +406,12 @@ itself shows the traffic, not the whole map.
   (default on). Off gates BOTH the fetch (`fetchReviews`/`fetchPhotos` in the VM) and the
   render (review tab / photo strip in `PlaceSheet`), so off means no scrape traffic at
   all, not just hidden UI.
+- **"Hide adult categories" toggle**: Settings → Map, `HideAdult` holder (default **off**).
+  On drops adult/nightlife/alcohol/gambling/smoking categories from search + ambient map via the
+  pure `:core` `CategoryFilter` (category-only, never name; multilingual keyword lists so it works
+  in every UI language; unit-tested). Applied at the `GoogleMapsDataSource.search`/`nearbyPlaces`
+  seam, gated by `CategoryFilter.enabled` (a `:core` flag `HideAdult` flips — keeps `:core` free of
+  the app's reactive holder).
 - **Nav puck motion model** (`VelaMapView`, `NavPuck`): the displayed position during
   nav is decoupled from the raw GPS fix. A `withFrameNanos` ticker glides the puck
   **monotonically forward along the route** by metres-along (`cumLengths`/`pointAtMeters`),

--- a/app/src/main/java/app/vela/VelaApp.kt
+++ b/app/src/main/java/app/vela/VelaApp.kt
@@ -34,6 +34,7 @@ class VelaApp : Application() {
         app.vela.ui.LiveReviews.init(this)
         app.vela.ui.ShowReviews.init(this)
         app.vela.ui.LoadPhotos.init(this)
+        app.vela.ui.HideAdult.init(this)
         app.vela.ui.Buildings3d.init(this)
         Onboarding.init(this)
         // Persist any fatal crash (stack trace + breadcrumbs) so it survives the

--- a/app/src/main/java/app/vela/ui/PlaceContent.kt
+++ b/app/src/main/java/app/vela/ui/PlaceContent.kt
@@ -45,3 +45,28 @@ object LoadPhotos {
     private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
     private const val KEY = "load_photos"
 }
+
+/**
+ * Whether to hide adult / nightlife categories (bars, clubs, casinos, liquor stores, adult, smoking,
+ * gambling, …) from search results and the ambient map. OFF by default (everything shown); ON drops
+ * those places at the data-source seam via [app.vela.core.data.CategoryFilter]. Matches on Google's
+ * free-text CATEGORY only, never the name, so a place categorised "Restaurant" is always kept. Same
+ * process-wide reactive holder shape as [ShowReviews] / [LoadPhotos], persisted in vela_settings.
+ */
+object HideAdult {
+    val on = mutableStateOf(false)
+
+    fun init(context: Context) {
+        on.value = prefs(context).getBoolean(KEY, false)
+        app.vela.core.data.CategoryFilter.enabled = on.value
+    }
+
+    fun set(context: Context, value: Boolean) {
+        on.value = value
+        app.vela.core.data.CategoryFilter.enabled = value // gate the :core data-source seam
+        prefs(context).edit().putBoolean(KEY, value).apply()
+    }
+
+    private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
+    private const val KEY = "hide_adult"
+}

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -260,6 +260,18 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
             }
             Hint(stringResource(R.string.settings_load_photos_hint))
 
+            Row(
+                Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(stringResource(R.string.settings_hide_adult), style = MaterialTheme.typography.bodyLarge, modifier = Modifier.weight(1f))
+                Switch(
+                    checked = app.vela.ui.HideAdult.on.value,
+                    onCheckedChange = { app.vela.ui.HideAdult.set(context, it) },
+                )
+            }
+            Hint(stringResource(R.string.settings_hide_adult_hint))
+
             Spacer(Modifier.height(20.dp))
             SectionTitle(stringResource(R.string.settings_navigation))
             val prefs = remember { context.getSharedPreferences("vela_settings", android.content.Context.MODE_PRIVATE) }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -55,6 +55,8 @@
     <string name="settings_show_reviews_hint">Aus = Orte zeigen keine Bewertungen, und Vela ruft sie auch nie ab.</string>
     <string name="settings_load_photos">Fotos laden</string>
     <string name="settings_load_photos_hint">Aus = Orte zeigen keine Fotos, und es wird nichts dafür heruntergeladen. Spart Datenvolumen.</string>
+    <string name="settings_hide_adult">Erwachsenen-Kategorien ausblenden</string>
+    <string name="settings_hide_adult_hint">An = Bars, Clubs, Casinos, Spirituosengeschäfte und andere Erwachsenen- / Nachtleben-Orte werden aus Suche und Karte ausgeblendet.</string>
     <string name="settings_offline">Offline</string>
     <string name="settings_offline_hint">Für die Kartennutzung ohne Signal braucht es zwei Dinge – die KARTEN-Kacheln, die Sie sehen, und das STRASSENNETZ, das Sie leitet. Das Speichern eines Kartenbereichs holt beides für diesen Ort; die Regionsliste unten fügt das Straßennetz für Ihr Reiseziel hinzu.</string>
     <string name="settings_offline_map_area">Kartenbereich</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -55,6 +55,8 @@
     <string name="settings_show_reviews_hint">Desactivado = las páginas de sitios no muestran reseñas y Vela nunca las descarga.</string>
     <string name="settings_load_photos">Cargar fotos</string>
     <string name="settings_load_photos_hint">Desactivado = las páginas de sitios no muestran fotos y no se descarga nada. Ahorra datos.</string>
+    <string name="settings_hide_adult">Ocultar categorías para adultos</string>
+    <string name="settings_hide_adult_hint">Activado = oculta bares, discotecas, casinos, licorerías y otros lugares para adultos / de ocio nocturno de la búsqueda y el mapa.</string>
     <string name="settings_offline">Sin conexión</string>
     <string name="settings_offline_hint">Usar el mapa sin señal requiere dos cosas: los MOSAICOS del mapa que ves y la RED DE CARRETERAS que traza tus rutas. Guardar una zona del mapa obtiene ambas para ese punto; la lista de regiones de abajo añade la red de carreteras de cualquier lugar por el que viajes.</string>
     <string name="settings_offline_map_area">Zona del mapa</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -55,6 +55,8 @@
     <string name="settings_show_reviews_hint">Désactivé = les fiches de lieux n\'affichent aucun avis et Vela ne les récupère jamais.</string>
     <string name="settings_load_photos">Charger les photos</string>
     <string name="settings_load_photos_hint">Désactivé = les fiches de lieux n\'affichent aucune photo et rien n\'est téléchargé. Économise les données.</string>
+    <string name="settings_hide_adult">Masquer les catégories pour adultes</string>
+    <string name="settings_hide_adult_hint">Activé = masque les bars, clubs, casinos, cavistes et autres lieux pour adultes / de vie nocturne des résultats et de la carte.</string>
     <string name="settings_offline">Hors ligne</string>
     <string name="settings_offline_hint">Utiliser la carte sans réseau nécessite deux éléments — les TUILES de carte que vous voyez et le RÉSEAU ROUTIER qui vous guide. Enregistrer une zone de carte récupère les deux pour cet endroit ; la liste des régions ci-dessous ajoute le réseau routier partout où vous voyagez.</string>
     <string name="settings_offline_map_area">Zone de carte</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -55,6 +55,8 @@
     <string name="settings_show_reviews_hint">Disattivato = le pagine dei luoghi non mostrano recensioni e Vela non le scarica mai.</string>
     <string name="settings_load_photos">Carica foto</string>
     <string name="settings_load_photos_hint">Disattivato = le pagine dei luoghi non mostrano foto e non viene scaricato nulla. Risparmia dati.</string>
+    <string name="settings_hide_adult">Nascondi categorie per adulti</string>
+    <string name="settings_hide_adult_hint">Attivo = nasconde bar, discoteche, casinò, enoteche e altri luoghi per adulti / della vita notturna da ricerca e mappa.</string>
     <string name="settings_offline">Offline</string>
     <string name="settings_offline_hint">Usare la mappa senza segnale richiede due cose: i RIQUADRI della mappa che vedi e la RETE STRADALE che ti guida. Salvare un\'area della mappa scarica entrambi per quel punto; l\'elenco delle regioni qui sotto aggiunge la rete stradale ovunque tu stia viaggiando.</string>
     <string name="settings_offline_map_area">Area mappa</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -55,6 +55,8 @@
     <string name="settings_show_reviews_hint">Uit = plaatspagina\'s tonen geen reviews en Vela haalt ze ook nooit op.</string>
     <string name="settings_load_photos">Foto\'s laden</string>
     <string name="settings_load_photos_hint">Uit = plaatspagina\'s tonen geen foto\'s en er wordt niets voor gedownload. Bespaart data.</string>
+    <string name="settings_hide_adult">Volwassen categorieën verbergen</string>
+    <string name="settings_hide_adult_hint">Aan = verbergt bars, clubs, casino’s, slijterijen en andere volwassen- / uitgaanslocaties uit zoekresultaten en de kaart.</string>
     <string name="settings_offline">Offline</string>
     <string name="settings_offline_hint">De kaart zonder signaal gebruiken vereist twee dingen — de kaartTEGELS die u ziet, en het WEGENNETWERK dat uw route berekent. Een kaartgebied opslaan haalt beide op voor die plek; de regiolijst hieronder voegt het wegennetwerk toe voor waar u ook reist.</string>
     <string name="settings_offline_map_area">Kaartgebied</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -55,6 +55,8 @@
     <string name="settings_show_reviews_hint">Wył. = strony miejsc nie pokazują recenzji i Vela nigdy ich nie pobiera.</string>
     <string name="settings_load_photos">Wczytuj zdjęcia</string>
     <string name="settings_load_photos_hint">Wył. = strony miejsc nie pokazują zdjęć i nic nie jest pobierane. Oszczędza dane.</string>
+    <string name="settings_hide_adult">Ukryj kategorie dla dorosłych</string>
+    <string name="settings_hide_adult_hint">Wł. = ukrywa bary, kluby, kasyna, sklepy monopolowe i inne miejsca dla dorosłych / nocnego życia z wyników i mapy.</string>
     <string name="settings_offline">Offline</string>
     <string name="settings_offline_hint">Korzystanie z mapy bez zasięgu wymaga dwóch rzeczy — KAFELKÓW mapy, które widzisz, oraz SIECI DRÓG, która wyznacza trasę. Zapisanie obszaru mapy pobiera oba dla tego miejsca; lista regionów poniżej dodaje sieć dróg wszędzie tam, gdzie podróżujesz.</string>
     <string name="settings_offline_map_area">Obszar mapy</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -55,6 +55,8 @@
     <string name="settings_show_reviews_hint">Desligado = as páginas de locais não mostram avaliações e o Vela nunca as transfere.</string>
     <string name="settings_load_photos">Carregar fotos</string>
     <string name="settings_load_photos_hint">Desligado = as páginas de locais não mostram fotos e nada é transferido. Poupa dados.</string>
+    <string name="settings_hide_adult">Ocultar categorias adultas</string>
+    <string name="settings_hide_adult_hint">Ativado = oculta bares, casas noturnas, casinos, lojas de bebidas e outros locais adultos / noturnos da pesquisa e do mapa.</string>
     <string name="settings_offline">Offline</string>
     <string name="settings_offline_hint">Usar o mapa sem sinal requer duas coisas — os MOSAICOS do mapa que vê e a REDE VIÁRIA que traça os percursos. Guardar uma área do mapa obtém ambos para esse local; a lista de regiões abaixo adiciona a rede viária para onde estiver a viajar.</string>
     <string name="settings_offline_map_area">Área do mapa</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -55,6 +55,8 @@
     <string name="settings_show_reviews_hint">Выкл. = страницы мест не показывают отзывы, и Vela их никогда не загружает.</string>
     <string name="settings_load_photos">Загружать фото</string>
     <string name="settings_load_photos_hint">Выкл. = страницы мест не показывают фото, и ничего не скачивается. Экономит трафик.</string>
+    <string name="settings_hide_adult">Скрывать категории для взрослых</string>
+    <string name="settings_hide_adult_hint">Вкл. = скрывает бары, клубы, казино, алкогольные магазины и другие места для взрослых / ночной жизни из поиска и карты.</string>
     <string name="settings_offline">Офлайн</string>
     <string name="settings_offline_hint">Для работы карты без сигнала нужны две вещи — ТАЙЛЫ карты, которые вы видите, и ДОРОЖНАЯ СЕТЬ, которая строит маршруты. Сохранение области карты загружает и то, и другое для этого места; список регионов ниже добавляет дорожную сеть для любого места, куда вы едете.</string>
     <string name="settings_offline_map_area">Область карты</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -55,6 +55,8 @@
     <string name="settings_show_reviews_hint">Av = platssidor visar inga recensioner och Vela hämtar dem aldrig.</string>
     <string name="settings_load_photos">Ladda foton</string>
     <string name="settings_load_photos_hint">Av = platssidor visar inga foton och inget laddas ner. Sparar data.</string>
+    <string name="settings_hide_adult">Dölj vuxenkategorier</string>
+    <string name="settings_hide_adult_hint">På = döljer barer, klubbar, kasinon, spritbutiker och andra vuxen- / nöjeslivsplatser från sökning och karta.</string>
     <string name="settings_offline">Offline</string>
     <string name="settings_offline_hint">Att använda kartan utan täckning kräver två saker – KARTRUTORNA du ser och VÄGNÄTET som beräknar rutter åt dig. Att spara ett kartområde hämtar båda för den platsen; regionlistan nedan lägger till vägnätet för dit du reser.</string>
     <string name="settings_offline_map_area">Kartområde</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -55,6 +55,8 @@
     <string name="settings_show_reviews_hint">Вимк. = сторінки місць не показують відгуки, і Vela ніколи їх не завантажує.</string>
     <string name="settings_load_photos">Завантажувати фото</string>
     <string name="settings_load_photos_hint">Вимк. = сторінки місць не показують фото, і нічого не завантажується. Економить трафік.</string>
+    <string name="settings_hide_adult">Приховати дорослі категорії</string>
+    <string name="settings_hide_adult_hint">Увімк. = приховує бари, клуби, казино, магазини алкоголю та інші дорослі / нічні місця з пошуку та карти.</string>
     <string name="settings_offline">Офлайн</string>
     <string name="settings_offline_hint">Щоб користуватися картою без зв’язку, потрібні дві речі — ПЛИТКИ карти, які ви бачите, і ДОРОЖНЯ МЕРЕЖА, яка прокладає маршрут. Збереження ділянки карти завантажує обидві для цього місця; список регіонів нижче додає дорожню мережу для будь-де, куди ви прямуєте.</string>
     <string name="settings_offline_map_area">Ділянка карти</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,8 @@
     <string name="settings_show_reviews_hint">Off = place pages show no reviews, and Vela never fetches them.</string>
     <string name="settings_load_photos">Load photos</string>
     <string name="settings_load_photos_hint">Off = place pages show no photos, and nothing gets downloaded for them. Saves data.</string>
+    <string name="settings_hide_adult">Hide adult categories</string>
+    <string name="settings_hide_adult_hint">On = hide bars, clubs, casinos, liquor stores and other adult / nightlife places from search and the map.</string>
     <string name="settings_offline">Offline</string>
     <string name="settings_offline_hint">Using the map without signal takes two things: the map TILES you see, and the ROAD NETWORK that routes you. Saving a map area grabs both for that spot; the region list below adds the road network for anywhere you\'re travelling.</string>
     <string name="settings_offline_map_area">Map area</string>

--- a/core/src/main/java/app/vela/core/data/CategoryFilter.kt
+++ b/core/src/main/java/app/vela/core/data/CategoryFilter.kt
@@ -1,0 +1,111 @@
+package app.vela.core.data
+
+import app.vela.core.model.Place
+
+/**
+ * Optional content filter: drop places whose Google CATEGORY marks them as adult / nightlife /
+ * alcohol / gambling / smoking. Off by default; enabled by the "Hide adult categories" setting.
+ * Category is free text from Google (e.g. "Bar", "Night club", "Liquor store"). Matching is on the
+ * CATEGORY only — never the name — so a place whose category is "Restaurant" is always kept.
+ *
+ * Matching is PRECISE, not naive substring (a bare `" bar" in category` both misses a standalone
+ * "Bar" and false-matches "Sushi bar"/"Public library"/"Discount store"/"Alcoholism treatment"):
+ *  - [EXACT]  — the whole category equals one of these (handles standalone "Bar"/"Pub").
+ *  - [PHRASE] — the category CONTAINS one of these specific, unambiguous strings.
+ * Food "…bar" categories (sushi/juice/coffee/salad/oyster/snack bar) are deliberately KEPT — only
+ * the alcohol-bar phrases below are blocked. "Bar & grill" is left as-is (food-primary).
+ *
+ * **Localised categories:** Google returns the category in the app's language (`hl=<lang>`), so the
+ * PHRASE list also carries the equivalent terms for Vela's other UI languages (fr de es it pt nl ru
+ * pl sv uk). Only high-confidence, unambiguous terms are included per language — deliberately
+ * conservative to avoid dropping a benign place for a general user (a stricter, name-aware variant
+ * is a downstream concern, not this shared filter).
+ *
+ * Applied at the data-source boundary ([app.vela.core.data.google.GoogleMapsDataSource.search] and
+ * [nearbyPlaces]) so search results AND ambient map POIs are filtered from one seam.
+ */
+object CategoryFilter {
+
+    /** Whether the filter is active. Off by default; the app flips it from the "Hide adult categories"
+     *  setting ([app.vela.ui.HideAdult]) so the data-source seam can gate on a :core-visible flag
+     *  without :core depending on the app's reactive holder. */
+    @Volatile
+    var enabled: Boolean = false
+
+    /** The entire category equals one of these (after lowercase+trim). */
+    private val EXACT = setOf(
+        // English
+        "bar", "pub", "gastropub", "night club", "nightclub", "lounge bar", "wine bar", "cocktail bar",
+        "brewery", "brewpub", "distillery", "winery", "casino", "liquor store", "adult entertainment",
+        // Other languages — standalone bar/pub words
+        "bár", "барь", "бар", // ru/uk transliterations of "bar"
+        "kneipe", "diskothek", "kasino", // de
+        "discoteca", // es/it/pt
+        "kasyno", "dyskoteka", // pl
+        "nattklubb", // sv
+        "казино", "нічний клуб", "ночной клуб", // ru/uk
+    )
+
+    /** The category CONTAINS one of these — each specific enough not to collide with a benign
+     *  category (no bare "bar"/"pub"/"disco"/"alcohol"/"lounge" here — those over-match). */
+    private val PHRASE = listOf(
+        // ---- English ----
+        "wine bar", "cocktail bar", "sports bar", "beer bar", "dive bar", "gay bar", "hookah bar",
+        "piano bar", "karaoke bar", "tiki bar", "whisky bar", "whiskey bar", "cigar bar",
+        "night club", "nightclub", "cabaret", "gentlemen's club", "gentlemens club", "strip club",
+        "go-go bar", "topless bar", "peep show", "adult entertainment", "adult video", "adult dvd",
+        "sex shop", "adult store", "adult book", "escort service", "escort agency", "massage parlor",
+        "brewpub", "brewery", "brewing company", "distillery", "winery", "vineyard", "wine cellar",
+        "liquor store", "wine shop", "wine store", "bottle shop", "off-licence", "off licence",
+        "beer store", "beer garden", "beer hall",
+        "casino", "gambling", "betting", "bookmaker", "sportsbook", "off-track betting", "lottery retailer",
+        "hookah lounge", "shisha", "cigar lounge", "smoke shop", "head shop", "tobacco shop", "tobacco store",
+        "vape shop", "e-cigarette", "vaporizer store", "cannabis", "marijuana dispensary", "cannabis store",
+        "dispensary",
+        // ---- French ----
+        "boîte de nuit", "discothèque", "bar à vin", "bar à cocktails", "débit de boissons", "cave à vin",
+        "caviste", "brasserie artisanale", "club de striptease", "sex-shop", "boutique érotique",
+        "maison close", "salle de jeux", "casa de apostas",
+        // ---- Spanish ----
+        "club nocturno", "bar de copas", "coctelería", "licorería", "vinatería", "cervecería artesanal",
+        "club de estriptis", "sala de fiestas", "casa de apuestas", "tienda erótica", "sex-shop",
+        // ---- German ----
+        "nachtclub", "nachtbar", "weinbar", "cocktailbar", "spirituosen", "weinhandlung", "brauerei",
+        "spielhalle", "spielbank", "wettbüro", "erotik", "bordell", "shisha-bar",
+        // ---- Italian ----
+        "discoteca", "enoteca", "vineria", "birreria", "birrificio", "distilleria", "sala giochi",
+        "sala scommesse", "sexy shop", "night club",
+        // ---- Portuguese ----
+        "casa noturna", "boate", "adega", "loja de bebidas", "cervejaria artesanal", "casa de apostas",
+        "sex shop", "casa de shows adulto",
+        // ---- Dutch ----
+        "nachtclub", "wijnbar", "slijterij", "brouwerij", "gokhal", "speelhal", "wedkantoor", "seksshop",
+        "coffeeshop",
+        // ---- Polish ----
+        "klub nocny", "winiarnia", "sklep monopolowy", "browar", "gorzelnia", "kasyno", "salon gier",
+        "zakłady bukmacherskie", "sklep erotyczny", "nocny klub",
+        // ---- Russian ----
+        "ночной клуб", "винный бар", "кальян-бар", "магазин алкоголя", "пивоварня", "казино",
+        "букмекер", "тотализатор", "секс-шоп", "стриптиз",
+        // ---- Ukrainian ----
+        "нічний клуб", "винний бар", "кальян-бар", "магазин алкоголю", "пивоварня", "казино",
+        "букмекер", "секс-шоп", "стриптиз",
+        // ---- Swedish ----
+        "nattklubb", "vinbar", "systembolaget", "spritbutik", "bryggeri", "spelhall", "vadslagning",
+        "sexbutik",
+    )
+
+    /** True if [category] is an adult/nightlife/alcohol/gambling/smoking category that should be hidden. */
+    fun isAdult(category: String?): Boolean {
+        val c = category?.lowercase()?.trim() ?: return false
+        if (c.isEmpty()) return false
+        if (c in EXACT) return true
+        return PHRASE.any { it in c }
+    }
+
+    /** Keep only places whose category isn't adult/nightlife. */
+    fun filter(places: List<Place>): List<Place> = places.filterNot { isAdult(it.category) }
+
+    /** Filter only when [enabled] (the setting is on); otherwise pass through unchanged. */
+    fun applyIfEnabled(places: List<Place>): List<Place> = if (enabled) filter(places) else places
+}

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -5,6 +5,7 @@ import app.vela.core.config.CalibrationStore
 import app.vela.core.config.JsTransforms
 import app.vela.core.diag.DiagLog
 import app.vela.core.data.CalibrationNeededException
+import app.vela.core.data.CategoryFilter
 import app.vela.core.data.MapDataSource
 import app.vela.core.data.RouteEngine
 import app.vela.core.data.RouteGeometry
@@ -115,7 +116,7 @@ class GoogleMapsDataSource @Inject constructor(
                 "",
             )
         }
-        SearchResult(query, jsTransforms.refineSearch(places))
+        SearchResult(query, CategoryFilter.applyIfEnabled(jsTransforms.refineSearch(places)))
     }
 
     override suspend fun nearbyPlaces(center: LatLng, spanMeters: Double): List<Place> = io {
@@ -160,7 +161,7 @@ class GoogleMapsDataSource @Inject constructor(
         val deduped = all.distinctBy {
             it.featureId ?: "${it.name}@${(it.location.lat * 1e4).toInt()},${(it.location.lng * 1e4).toInt()}"
         }
-        rankAmbientPlaces(deduped)
+        rankAmbientPlaces(CategoryFilter.applyIfEnabled(deduped))
     }
 
     override suspend fun placeDetails(id: String): Place = io {

--- a/core/src/test/java/app/vela/core/data/CategoryFilterTest.kt
+++ b/core/src/test/java/app/vela/core/data/CategoryFilterTest.kt
@@ -1,0 +1,52 @@
+package app.vela.core.data
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CategoryFilterTest {
+
+    @Test fun blocksEnglishAdultCategories() {
+        listOf(
+            "Bar", "Pub", "Night club", "Nightclub", "Cocktail bar", "Sports bar", "Strip club",
+            "Liquor store", "Wine bar", "Brewery", "Winery", "Casino", "Sportsbook", "Hookah lounge",
+            "Cannabis store", "Dispensary", "Adult entertainment", "Sex shop", "Tobacco shop", "Escort service",
+        ).forEach { assertTrue("should block '$it'", CategoryFilter.isAdult(it)) }
+    }
+
+    @Test fun blocksLocalisedAdultCategories() {
+        // Categories come localised (hl=<lang>) — the filter must catch them too.
+        listOf(
+            "Boîte de nuit", "Bar à vin", "Cave à vin",          // fr
+            "Discoteca", "Licorería", "Casa de apuestas",         // es
+            "Nachtclub", "Spielhalle", "Weinhandlung",            // de
+            "Enoteca", "Sala scommesse",                          // it
+            "Casa noturna", "Loja de bebidas",                    // pt
+            "Slijterij", "Wedkantoor",                            // nl
+            "Klub nocny", "Sklep monopolowy",                     // pl
+            "Ночной клуб", "Магазин алкоголя", "Казино",          // ru
+            "Магазин алкоголю",                                   // uk
+            "Nattklubb", "Systembolaget",                         // sv
+        ).forEach { assertTrue("should block '$it'", CategoryFilter.isAdult(it)) }
+    }
+
+    @Test fun keepsBenignCategories() {
+        // Food "…bar" and benign categories must NOT be dropped.
+        listOf(
+            "Restaurant", "Sushi bar", "Juice bar", "Coffee shop", "Salad bar", "Snack bar", "Oyster bar",
+            "Public library", "Discount store", "Grocery store", "Bakery", "Pharmacy", "Barber shop",
+            "Alcoholism treatment center", null, "",
+        ).forEach { assertFalse("should keep '$it'", CategoryFilter.isAdult(it)) }
+    }
+
+    @Test fun applyIfEnabledRespectsFlag() {
+        val prev = CategoryFilter.enabled
+        try {
+            CategoryFilter.enabled = false
+            // With the flag off, nothing is filtered (isAdult still classifies, but applyIfEnabled passes through).
+            assertTrue(CategoryFilter.isAdult("Bar"))
+        } finally {
+            CategoryFilter.enabled = prev
+        }
+    }
+}


### PR DESCRIPTION
Adds an opt-in **Hide adult categories** toggle under Settings → Map (**off by default**), like the existing *Show reviews* / *Load photos* switches. When on, it drops places whose Google **category** is adult / nightlife / alcohol / gambling / smoking (bars, clubs, casinos, liquor stores, hookah, cannabis, adult, …) from **both search results and the ambient map**.

### Design
- **Category-only, never the name** — a place categorised "Restaurant" is always kept; matching is precise (`EXACT` + `PHRASE`), so food "…bar" categories (sushi/juice/coffee/salad bar) stay.
- **Works in every language** — Google returns the category localized (`hl=<lang>`), so the keyword lists carry the equivalent terms for all 11 UI languages (an English-only list would pass "Bar à vin"/"Discoteca"/"Nachtclub"/"Магазин алкоголя").
- **Clean module boundary** — pure `:core` `CategoryFilter` (unit-tested) at the `GoogleMapsDataSource.search`/`nearbyPlaces` seam; `HideAdult` flips a `:core`-visible `CategoryFilter.enabled` flag so `:core` need not read app state.

Off by default → no behaviour change unless opted in. Strings in all 11 languages; `CategoryFilterTest` included. Release build + `:core` tests pass.