### PR TITLE
D-pad: pressing up at the top of Settings lands on Back, not lost focus

### DIFF
--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -90,6 +90,7 @@ import app.vela.ui.dpadSwallowHorizontal
 import app.vela.ui.rememberDpadAutoFocus
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -126,6 +127,7 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
     // button (top of screen) so the first arrow press enters the content, never a wasted
     // "wake up focus" press. No-op under touch.
     val settingsAutoFocus = rememberDpadAutoFocus()
+    var atTopItem by remember { mutableStateOf(false) }   // top content row focused? (routes its UP to Back)
     Scaffold(
         topBar = {
             TopAppBar(
@@ -145,6 +147,17 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 // no-target horizontal move can't clear focus. The vibrate FilterChips row (a real
                 // horizontal row) handles its own LEFT/RIGHT first, so this never runs for it.
                 .dpadSwallowHorizontal()
+                // The back button lives in the TopAppBar, a SEPARATE container Compose's directional
+                // UP can't reach, so an UP from the TOP row cleared focus (leaving nothing focused,
+                // no way back via arrows). When the top row holds focus (atTopItem) route its UP
+                // straight to Back via requestFocus (proven to land — it's how opening auto-focuses
+                // Back); NEVER moveFocus, which itself clears at the top edge. Other UP falls through.
+                .onKeyEvent { ev ->
+                    if (ev.key == Key.DirectionUp && atTopItem) {
+                        if (ev.type == KeyEventType.KeyDown) runCatching { settingsAutoFocus.requestFocus() }
+                        true
+                    } else false
+                }
                 .onGloballyPositioned { viewportTopY = it.positionInRoot().y }
                 .verticalScroll(scrollState)
                 .padding(horizontal = 16.dp),
@@ -154,6 +167,8 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 label = stringResource(R.string.settings_follow_system),
                 selected = AppTheme.mode.value == ThemeMode.SYSTEM,
                 onClick = { AppTheme.set(context, ThemeMode.SYSTEM) },
+                // The top focusable row: track when it holds focus so the Column routes its UP to Back.
+                modifier = Modifier.onFocusEvent { atTopItem = it.isFocused },
             )
             SelectableRow(
                 label = stringResource(R.string.settings_theme_light),
@@ -994,9 +1009,9 @@ private fun CollapsibleSectionTitle(text: String, expanded: Boolean, onToggle: (
 }
 
 @Composable
-private fun SelectableRow(label: String, selected: Boolean, onClick: () -> Unit) {
+private fun SelectableRow(label: String, selected: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
     Row(
-        Modifier.fillMaxWidth().dpadHighlight(DpadShape(6.dp)).clickable(onClick = onClick).padding(vertical = 4.dp),
+        modifier.fillMaxWidth().dpadHighlight(DpadShape(6.dp)).clickable(onClick = onClick).padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // onClick = null: the RadioButton is display-only so the ROW is the single focus stop. A

--- a/docs/dpad.md
+++ b/docs/dpad.md
@@ -85,6 +85,12 @@ but practically unusable.
   a vertical list of focusable controls. (The search bar's field solves the same trap inline —
   see Trap C below — because it also needs the BACK/close handling in the same key handler.)
 
+- **UP at the top of a `TopAppBar` screen** (Settings): the back button lives in the `TopAppBar`, a
+  separate container from the scroll `Column`, so Compose's directional UP can't bridge them and an
+  UP from the top row *clears* focus (nothing focused, no way back via arrows). Settings tracks when
+  its top row holds focus and routes that UP to the back button with `requestFocus` — `moveFocus(Up)`
+  can't be used here because it itself clears focus at the top edge before it returns.
+
 ### The MapLibre `MapView` steals D-pad keys — the load-bearing fix
 
 **Finding 0 (the reason "nothing happened"):** MapLibre's `MapView` calls `requestFocus()`


### PR DESCRIPTION
**What this changes and why**

On a D-pad, pressing UP from the top row of Settings cleared focus instead of landing on the Back button, leaving nothing focused with no way back via the arrows (you had to press hardware BACK to recover). The back button lives in the `TopAppBar`, a separate container from the settings scroll `Column`, so Compose's directional UP can't bridge the two and clears focus at the top edge.

Fix: track when the top content row holds focus and route its UP straight to the back button with `requestFocus` (the same call that focuses Back when the screen opens, so it reliably lands). `moveFocus(Up)` can't be used here because it *itself* clears focus at the top edge before it returns. Every other UP falls through to normal list navigation, and mid-list behaviour is unchanged.

Touch is byte-identical (the new path is a D-pad `onKeyEvent`; the added `SelectableRow` `modifier` param defaults to `Modifier`).

Verified on a device driven by D-pad: from inside Settings, walking UP past the top row now lands on Back across repeated runs instead of dropping focus.

**Checklist**
- [x] Docs updated in this same PR where behaviour changed (docs/dpad.md note added; no user-facing behaviour/string change beyond the focus fix)
- [x] No new user-facing strings
- [x] No GMS, no static Google keys, no backend calls introduced
- [x] `:core` untouched (UI-only change)
- [x] Tested on a release build driven by D-pad
- [x] `./gradlew :core:test` passes
- [x] Commit subject reads as a changelog line
