### PR TITLE
Fix AbstractMethodError crash on API 26–29 (LocationListener SAM lambda)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,6 +562,12 @@ Defaults that make the safe path the easy one:
   frozen-speedo/creeping-puck bug). Measured speeds pass a SYMMETRIC accel-bounded gate against the
   last ACCEPTED value (`gateMeasuredSpeed`, 2-fix persistence escape, shared with replay) - one-sided
   spike filters self-latch (a down-glitch to 0 then rejects every real speed as an up-spike forever).
+  **The `LocationListener` in `LocationProvider.updates` MUST be a full `object :`, never a SAM lambda
+  (2026-07-09 crash fix):** compiled against compileSdk 35 a `LocationListener { }` implements only
+  `onLocationChanged` and leans on the default methods the interface gained in API 30 - but on our
+  minSdk-26 targets (Android 10 / API 29 phones) `onProviderDisabled`/`onProviderEnabled`/
+  `onStatusChanged` are still ABSTRACT, so the first provider toggle threw `AbstractMethodError` and
+  hard-crashed the app on launch. Keep all four overrides.
 - Nav guidance discipline (2026-07-04 audit): prompt/turn-now distances SCALE WITH SPEED in
   `NavEngine` (max(fixed, v×T); `spoken` stores band SLOTS not metres), one prompt per update speaking
   the TRUE distance, silent catch-up past maneuvers >75 m behind, proximity arrival (crow ≤40 m) +

--- a/core/src/main/java/app/vela/core/location/LocationProvider.kt
+++ b/core/src/main/java/app/vela/core/location/LocationProvider.kt
@@ -78,9 +78,22 @@ class LocationProvider @Inject constructor(
     fun updates(minIntervalMs: Long = 1_000L, minDistanceM: Float = 0f): Flow<Location> =
         callbackFlow {
             val mgr = lm ?: run { close(); return@callbackFlow }
-            val listener = LocationListener { loc ->
-                cache(loc)
-                trySend(loc)
+            // NOT a SAM lambda: compiled against compileSdk 35 a `LocationListener { }`
+            // implements only onLocationChanged, relying on the default methods LocationListener
+            // gained in API 30. On our API 26–29 targets (Android 10 kosher phones) those methods
+            // are still ABSTRACT, so the first onProviderDisabled/onStatusChanged the OS delivers
+            // throws AbstractMethodError and crashes the app. Implement the full interface.
+            val listener = object : LocationListener {
+                override fun onLocationChanged(loc: Location) {
+                    cache(loc)
+                    trySend(loc)
+                }
+
+                override fun onProviderDisabled(provider: String) {}
+                override fun onProviderEnabled(provider: String) {}
+
+                @Deprecated("Required abstract on API < 30", ReplaceWith(""))
+                override fun onStatusChanged(provider: String?, status: Int, extras: android.os.Bundle?) {}
             }
             val active = PROVIDERS.filter { mgr.allProviders.contains(it) }
             active.forEach { p ->


### PR DESCRIPTION
## Problem

The app hard-crashes on launch on Android 10 / API 29 devices (and any API 26–29 target) with:

```
java.lang.AbstractMethodError: abstract method "void android.location.LocationListener.onProviderDisabled(java.lang.String)"
    at android.location.LocationManager$ListenerTransport._handleMessage(LocationManager.java:365)
    ...
    at android.app.ActivityThread.main(ActivityThread.java:7397)
```

## Cause

`LocationProvider.updates()` registered its listener as a **SAM lambda**:

```kotlin
val listener = LocationListener { loc -> cache(loc); trySend(loc) }
```

Compiled against `compileSdk 35`, `LocationListener` is a functional interface (only `onLocationChanged` is abstract) because API 30 added **default** methods for `onProviderDisabled`/`onProviderEnabled`/`onStatusChanged`. But on `minSdk 26`–29 those methods are still **abstract** on the platform, so the generated class is missing them — the first time the OS delivers a provider toggle, the runtime throws `AbstractMethodError`.

## Fix

Replace the lambda with a full `object : LocationListener` that implements all four callbacks (the three extras as no-ops). No behavior change on API 30+; fixes the crash on 26–29.

Verified: `:core` compiles clean. This was the only affected listener in the codebase (the two `SensorEventListener`s are already full `object :` overrides and unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)