### PR TITLE
Material You dynamic colours

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -188,6 +188,16 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   Also fixed: starred places on the search page drew their name in BLACK in dark mode - the
   page is a plain background Box, not a Surface, so a colourless Text falls back to black; the
   row now uses the same on-surface colour as every neighbouring row in both themes.
+- ✅ **Material You dynamic colour (issue #15, 2026-07-09, device-verified light + dark).** A
+  Settings -> Appearance toggle (Android 12+ only) tints every themed surface - buttons, chips,
+  FABs, dialogs, the focus ring, the nav notification's arrow tile and accent row - from the
+  system wallpaper palette. Off by default (Vela teal stays the stock look). Accents stay legible
+  because everything uses the scheme's paired slots (primary/onPrimary etc.), which Android
+  generates at accessible contrast in both themes; the dynamic scheme is also sanity-checked
+  (background luminance must match the requested theme) and falls back to Vela's own colours on
+  ROMs that hand back a broken palette (seen on GrapheneOS once). The map tiles, route line and
+  location dot stay neutral on purpose - road/label contrast beats wallpaper vibes, same call
+  Google makes.
 - ✅ **List notes stick to chain stores + show in the list (2026-07-09, device-verified).** Notes on a
   chain place (a Safeway with several co-located Google listings) silently vanished: list membership
   was keyed on a volatile internal id that could point at a different listing next visit, so the note

--- a/app/src/main/java/app/vela/VelaApp.kt
+++ b/app/src/main/java/app/vela/VelaApp.kt
@@ -10,6 +10,7 @@ import app.vela.ui.Traffic
 import app.vela.ui.TransitLayer
 import app.vela.ui.Units
 import app.vela.ui.theme.AppTheme
+import app.vela.ui.theme.DynamicColor
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
@@ -28,6 +29,7 @@ class VelaApp : Application() {
         super.onCreate()
         Units.init(this)
         AppTheme.init(this)
+        DynamicColor.init(this)
         AppLocale.init(this) // resolve the app language (system default) → drives the nav-text locale
         Traffic.init(this)
         TransitLayer.init(this)

--- a/app/src/main/java/app/vela/service/NavGlyphs.kt
+++ b/app/src/main/java/app/vela/service/NavGlyphs.kt
@@ -18,10 +18,10 @@ object NavGlyphs {
 
     const val TEAL = 0xFF14857A.toInt() // ui.theme.VelaTeal; also the notification accent
 
-    fun bitmap(type: ManeuverType, sizePx: Int): Bitmap {
+    fun bitmap(type: ManeuverType, sizePx: Int, background: Int = TEAL): Bitmap {
         val bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
         val c = Canvas(bmp)
-        val bg = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = TEAL }
+        val bg = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = background }
         val r = sizePx * 0.22f
         c.drawRoundRect(RectF(0f, 0f, sizePx.toFloat(), sizePx.toFloat()), r, r, bg)
         val s = sizePx / 96f // glyph coordinate space

--- a/app/src/main/java/app/vela/service/NavigationService.kt
+++ b/app/src/main/java/app/vela/service/NavigationService.kt
@@ -19,6 +19,7 @@ import app.vela.R
 import android.graphics.Bitmap
 import app.vela.core.model.ManeuverType
 import app.vela.core.nav.NavSession
+import app.vela.ui.theme.DynamicColor
 import app.vela.ui.formatDistance
 import app.vela.ui.formatDuration
 import dagger.hilt.android.AndroidEntryPoint
@@ -57,8 +58,10 @@ class NavigationService : Service() {
     private var observing = false
 
     // One-entry glyph cache (state ticks ~1 Hz; the type changes only at each turn).
+    // Keyed on the accent too, so flipping Material You mid-drive recolours the arrow.
     private var cachedGlyph: Bitmap? = null
     private var cachedGlyphType: ManeuverType? = null
+    private var cachedGlyphAccent: Int = 0
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -169,18 +172,26 @@ class NavigationService : Service() {
         } else {
             s.route?.maneuvers?.getOrNull(s.nav.stepIndex)?.type
         }
+        // Material You (issue #15): the arrow tile + accent row follow the system accent when
+        // the user opted into dynamic colour; Vela teal otherwise (matches the in-app theme).
+        val accent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && DynamicColor.isOn(this)) {
+            getColor(android.R.color.system_accent1_600)
+        } else {
+            NavGlyphs.TEAL
+        }
         val largeIcon = maneuverType?.let { t ->
-            cachedGlyph?.takeIf { cachedGlyphType == t } ?: NavGlyphs.bitmap(
+            cachedGlyph?.takeIf { cachedGlyphType == t && cachedGlyphAccent == accent } ?: NavGlyphs.bitmap(
                 t,
                 resources.getDimensionPixelSize(android.R.dimen.notification_large_icon_width).coerceAtLeast(96),
-            ).also { cachedGlyph = it; cachedGlyphType = t }
+                background = accent,
+            ).also { cachedGlyph = it; cachedGlyphType = t; cachedGlyphAccent = accent }
         }
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_nav)
             .setContentTitle(title)
             .setContentText(text)
             .setLargeIcon(largeIcon)
-            .setColor(NavGlyphs.TEAL) // VelaTeal accent on the action/app name row
+            .setColor(accent) // dynamic accent when Material You is on, VelaTeal otherwise
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setShowWhen(false) // the post time is noise on a continuously-updating nav card

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -83,6 +83,7 @@ import app.vela.core.voice.VoiceEngine
 import app.vela.ui.map.MapUiState
 import app.vela.ui.map.MapViewModel
 import app.vela.ui.theme.AppTheme
+import app.vela.ui.theme.DynamicColor
 import app.vela.ui.theme.ThemeMode
 import app.vela.ui.dpadHighlight // D-pad-only operation (docs/dpad.md)
 import app.vela.ui.dpadFieldEscape
@@ -181,6 +182,16 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 onClick = { AppTheme.set(context, ThemeMode.DARK) },
             )
             Hint(stringResource(R.string.settings_appearance_hint))
+            // Material You (issue #15): tint the app's buttons, chips and accents from the
+            // wallpaper palette. Android 12+ only - below S there is no dynamic palette, so
+            // the row is not shown at all rather than shown dead.
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                Spacer(Modifier.height(8.dp))
+                ToggleRow(stringResource(R.string.settings_dynamic_color), DynamicColor.on.value) {
+                    DynamicColor.set(context, it)
+                }
+                Hint(stringResource(R.string.settings_dynamic_color_hint))
+            }
 
             Spacer(Modifier.height(20.dp))
             SectionTitle(stringResource(R.string.settings_map_style))

--- a/app/src/main/java/app/vela/ui/theme/AppTheme.kt
+++ b/app/src/main/java/app/vela/ui/theme/AppTheme.kt
@@ -41,3 +41,29 @@ fun isAppInDarkTheme(): Boolean = when (AppTheme.mode.value) {
     ThemeMode.DARK -> true
     ThemeMode.SYSTEM -> isSystemInDarkTheme()
 }
+
+/**
+ * Material You dynamic colour preference (issue #15). Same reactive-holder shape as
+ * [AppTheme]: flip it in Settings and every MaterialTheme surface recomposes with the
+ * wallpaper palette. Off by default - Vela teal is the out-of-the-box look, dynamic
+ * colour is the opt-in customization. Android 12+ only; the toggle is hidden below that.
+ */
+object DynamicColor {
+    val on = mutableStateOf(false)
+
+    fun init(context: Context) {
+        on.value = prefs(context).getBoolean(KEY, false)
+    }
+
+    fun set(context: Context, value: Boolean) {
+        on.value = value
+        prefs(context).edit().putBoolean(KEY, value).apply()
+    }
+
+    /** For non-compose readers (the nav notification): the persisted value, straight
+     *  from prefs, so a Service path needs no compose state. */
+    fun isOn(context: Context): Boolean = prefs(context).getBoolean(KEY, false)
+
+    private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
+    private const val KEY = "dynamic_color"
+}

--- a/app/src/main/java/app/vela/ui/theme/Theme.kt
+++ b/app/src/main/java/app/vela/ui/theme/Theme.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
 
 // Containers are set to teal tints too — otherwise Material's defaults leave
@@ -35,22 +36,30 @@ private val DarkColors = darkColorScheme(
 )
 
 /**
- * App theme. Uses Vela's explicit teal light/dark schemes rather than Material You
- * dynamic colour: the in-app Light/Dark switch is the contract, and on some ROMs
- * (observed on GrapheneOS) `dynamicDarkColorScheme` hands back a *light* background,
- * which broke "Dark" for every MaterialTheme surface (Settings etc.). `dynamicColor`
- * stays as an opt-in param but defaults off so the switch is always honoured.
+ * App theme. Vela's explicit teal light/dark schemes by default; Material You dynamic
+ * colour (issue #15) when the user opts in via Settings -> Appearance ([DynamicColor]).
+ *
+ * The dynamic scheme is sanity-checked before use: on some ROMs (observed on GrapheneOS)
+ * `dynamicDarkColorScheme` handed back a *light* background, which broke "Dark" for every
+ * MaterialTheme surface (Settings etc.). If the scheme's background luminance contradicts
+ * the requested theme, Vela falls back to its own colours - the Light/Dark switch is the
+ * contract and always wins. Accent legibility comes from using the scheme's PAIRED slots
+ * everywhere (primary with onPrimary, container with onContainer), which the system
+ * generates at accessible contrast in both themes.
  */
 @Composable
 fun VelaTheme(
     darkTheme: Boolean = isAppInDarkTheme(),
-    dynamicColor: Boolean = false,
+    dynamicColor: Boolean = DynamicColor.on.value,
     content: @Composable () -> Unit,
 ) {
     val context = LocalContext.current
     val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val dyn = if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            val saneBackground = if (darkTheme) dyn.background.luminance() < 0.4f else dyn.background.luminance() > 0.6f
+            if (saneBackground) dyn else if (darkTheme) DarkColors else LightColors
+        }
         darkTheme -> DarkColors
         else -> LightColors
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -6,6 +6,8 @@
     <string name="settings_theme_light">Hell</string>
     <string name="settings_theme_dark">Dunkel</string>
     <string name="settings_appearance_hint">Hell/Dunkel gilt nur für Vela – das System-Design Ihres Telefons wird nicht verändert.</string>
+    <string name="settings_dynamic_color">Material-You-Farben</string>
+    <string name="settings_dynamic_color_hint">Färbt Schaltflächen, Chips und Akzente nach Ihrem Hintergrundbild (Android 12+). Aus = Velas eigenes Türkis. Die Karte selbst bleibt neutral, damit Straßen und Beschriftungen ihren Kontrast behalten.</string>
     <string name="settings_map_style">Kartenstil</string>
     <string name="settings_map_style_hint">OpenFreeMap (Standard) ist detailliert und braucht keinen Schlüssel. Protomaps benötigt einen API-Schlüssel; der Demo-Stil zeigt nur Ländergrenzen.</string>
     <string name="settings_units">Einheiten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -6,6 +6,8 @@
     <string name="settings_theme_light">Claro</string>
     <string name="settings_theme_dark">Oscuro</string>
     <string name="settings_appearance_hint">Claro/Oscuro se aplica solo a Vela; no cambia el tema del sistema de tu teléfono.</string>
+    <string name="settings_dynamic_color">Colores Material You</string>
+    <string name="settings_dynamic_color_hint">Tiñe botones, chips y acentos según tu fondo de pantalla (Android 12+). Desactivado = el verde azulado propio de Vela. El mapa se mantiene neutro para que las carreteras y etiquetas conserven su contraste.</string>
     <string name="settings_map_style">Estilo del mapa</string>
     <string name="settings_map_style_hint">OpenFreeMap (el predeterminado) no necesita clave y es detallado. Protomaps requiere una clave de API; el estilo de demostración solo muestra los contornos de los países.</string>
     <string name="settings_units">Unidades</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -6,6 +6,8 @@
     <string name="settings_theme_light">Clair</string>
     <string name="settings_theme_dark">Sombre</string>
     <string name="settings_appearance_hint">Le mode clair/sombre s\'applique uniquement à Vela — il ne modifie pas le thème système de votre téléphone.</string>
+    <string name="settings_dynamic_color">Couleurs Material You</string>
+    <string name="settings_dynamic_color_hint">Teinte les boutons, puces et accents selon votre fond d\'écran (Android 12+). Désactivé = le bleu-vert propre à Vela. La carte reste neutre pour que routes et libellés gardent leur contraste.</string>
     <string name="settings_map_style">Style de carte</string>
     <string name="settings_map_style_hint">OpenFreeMap (par défaut) est détaillé et ne nécessite aucune clé. Protomaps exige une clé API ; le style de démonstration n\'affiche que les contours des pays.</string>
     <string name="settings_units">Unités</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -6,6 +6,8 @@
     <string name="settings_theme_light">Chiaro</string>
     <string name="settings_theme_dark">Scuro</string>
     <string name="settings_appearance_hint">Chiaro/Scuro si applica solo a Vela, non modifica il tema di sistema del telefono.</string>
+    <string name="settings_dynamic_color">Colori Material You</string>
+    <string name="settings_dynamic_color_hint">Colora pulsanti, chip e accenti in base allo sfondo (Android 12+). Disattivato = il verde acqua di Vela. La mappa resta neutra così strade ed etichette mantengono il contrasto.</string>
     <string name="settings_map_style">Stile mappa</string>
     <string name="settings_map_style_hint">OpenFreeMap (predefinito) è dettagliato e non richiede chiave. Protomaps richiede una chiave API; lo stile demo mostra solo i contorni dei Paesi.</string>
     <string name="settings_units">Unità</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -6,6 +6,8 @@
     <string name="settings_theme_light">Licht</string>
     <string name="settings_theme_dark">Donker</string>
     <string name="settings_appearance_hint">Licht/donker geldt alleen voor Vela — het thema van uw telefoon wordt niet gewijzigd.</string>
+    <string name="settings_dynamic_color">Material You-kleuren</string>
+    <string name="settings_dynamic_color_hint">Kleurt knoppen, chips en accenten naar je achtergrond (Android 12+). Uit = Vela\'s eigen groenblauw. De kaart zelf blijft neutraal zodat wegen en labels hun contrast houden.</string>
     <string name="settings_map_style">Kaartstijl</string>
     <string name="settings_map_style_hint">OpenFreeMap (de standaard) werkt zonder sleutel en is gedetailleerd. Protomaps vereist een API-sleutel; de demostijl toont alleen de contouren van landen.</string>
     <string name="settings_units">Eenheden</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -6,6 +6,8 @@
     <string name="settings_theme_light">Jasny</string>
     <string name="settings_theme_dark">Ciemny</string>
     <string name="settings_appearance_hint">Tryb jasny/ciemny dotyczy tylko Vela — nie zmienia motywu systemowego telefonu.</string>
+    <string name="settings_dynamic_color">Kolory Material You</string>
+    <string name="settings_dynamic_color_hint">Barwi przyciski, chipy i akcenty według tapety (Android 12+). Wyłączone = własny morski kolor Veli. Sama mapa pozostaje neutralna, by drogi i etykiety zachowały kontrast.</string>
     <string name="settings_map_style">Styl mapy</string>
     <string name="settings_map_style_hint">OpenFreeMap (domyślny) nie wymaga klucza i jest szczegółowy. Protomaps wymaga klucza API; styl demonstracyjny pokazuje wyłącznie zarysy granic państw.</string>
     <string name="settings_units">Jednostki</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -6,6 +6,8 @@
     <string name="settings_theme_light">Claro</string>
     <string name="settings_theme_dark">Escuro</string>
     <string name="settings_appearance_hint">Claro/Escuro aplica-se apenas ao Vela — não altera o tema do sistema do seu telemóvel.</string>
+    <string name="settings_dynamic_color">Cores Material You</string>
+    <string name="settings_dynamic_color_hint">Pinta botões, chips e destaques a partir do seu fundo de ecrã (Android 12+). Desligado = o verde-azulado da Vela. O mapa mantém-se neutro para que estradas e etiquetas conservem o contraste.</string>
     <string name="settings_map_style">Estilo do mapa</string>
     <string name="settings_map_style_hint">O OpenFreeMap (predefinição) é detalhado e não requer chave. O Protomaps precisa de uma chave de API; o estilo de demonstração mostra apenas contornos de países.</string>
     <string name="settings_units">Unidades</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -6,6 +6,8 @@
     <string name="settings_theme_light">Светлая</string>
     <string name="settings_theme_dark">Тёмная</string>
     <string name="settings_appearance_hint">Светлая или тёмная тема применяется только к Vela — системная тема телефона не меняется.</string>
+    <string name="settings_dynamic_color">Цвета Material You</string>
+    <string name="settings_dynamic_color_hint">Окрашивает кнопки, чипы и акценты по обоям (Android 12+). Выключено = фирменный бирюзовый Vela. Сама карта остаётся нейтральной, чтобы дороги и подписи сохраняли контраст.</string>
     <string name="settings_map_style">Стиль карты</string>
     <string name="settings_map_style_hint">OpenFreeMap (по умолчанию) не требует ключа и содержит много деталей. Для Protomaps нужен ключ API; демо-стиль показывает только контуры стран.</string>
     <string name="settings_units">Единицы измерения</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -6,6 +6,8 @@
     <string name="settings_theme_light">Ljust</string>
     <string name="settings_theme_dark">Mörkt</string>
     <string name="settings_appearance_hint">Ljust/Mörkt gäller endast Vela – det påverkar inte telefonens systemtema.</string>
+    <string name="settings_dynamic_color">Material You-färger</string>
+    <string name="settings_dynamic_color_hint">Färgar knappar, chips och accenter efter din bakgrund (Android 12+). Av = Velas egen turkos. Själva kartan förblir neutral så att vägar och etiketter behåller kontrasten.</string>
     <string name="settings_map_style">Kartstil</string>
     <string name="settings_map_style_hint">OpenFreeMap (standard) är nyckellös och detaljerad. Protomaps kräver en API-nyckel; demostilen visar bara landsgränser.</string>
     <string name="settings_units">Enheter</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -6,6 +6,8 @@
     <string name="settings_theme_light">Світла</string>
     <string name="settings_theme_dark">Темна</string>
     <string name="settings_appearance_hint">Світла/темна тема застосовується лише до Vela — системна тема телефона не змінюється.</string>
+    <string name="settings_dynamic_color">Кольори Material You</string>
+    <string name="settings_dynamic_color_hint">Забарвлює кнопки, чипи й акценти за шпалерами (Android 12+). Вимкнено = фірмовий бірюзовий Vela. Сама карта лишається нейтральною, щоб дороги й підписи зберігали контраст.</string>
     <string name="settings_map_style">Стиль карти</string>
     <string name="settings_map_style_hint">OpenFreeMap (за замовчуванням) не потребує ключа й має детальні дані. Protomaps потребує ключ API; демонстраційний стиль показує лише контури країн.</string>
     <string name="settings_units">Одиниці</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="settings_theme_light">Light</string>
     <string name="settings_theme_dark">Dark</string>
     <string name="settings_appearance_hint">Light/Dark applies to Vela only. It won\'t touch your phone\'s system theme.</string>
+    <string name="settings_dynamic_color">Material You colours</string>
+    <string name="settings_dynamic_color_hint">Tints buttons, chips and accents from your wallpaper (Android 12+). Off = Vela\'s own teal. The map itself stays neutral so roads and labels keep their contrast.</string>
     <string name="settings_map_style">Map style</string>
     <string name="settings_map_style_hint">OpenFreeMap (the default) is keyless and detailed. Protomaps needs an API key; the demo style is country outlines only.</string>
     <string name="settings_units">Units</string>


### PR DESCRIPTION
Closes #15

Adds a Material You toggle under Settings > Appearance. Android 12+ only, the row is hidden on older versions. Off by default so the stock look stays Vela teal, flip it on and the buttons, chips, dialogs, focus ring and the nav notification all pick up the wallpaper palette instantly.

On legibility: every accent uses the scheme's paired slots (primary with onPrimary and so on), which the system generates at accessible contrast for both light and dark. The dynamic scheme is also sanity checked before use, if its background luminance contradicts the requested theme (some ROMs return a light background for the dark scheme) the app falls back to its own colours, so the Light/Dark switch always wins.

I left the map tiles, route line and location dot alone. Tinting the basemap from a wallpaper eats into road and label contrast, which matters more in a nav app than matching the phone theme, and Google Maps makes the same call. The buttons floating over the map (parking, recenter, zoom, chips) do follow the palette since they are ordinary themed surfaces.

Tested on a Pixel in both themes, everything recolours and stays readable, and turning it off goes straight back to teal.
