### PR TITLE
Voice search mic in the search bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,6 +402,18 @@ Defaults that make the safe path the easy one:
   symbol layers `textHaloWidth 1.9` vs the 1.1 every other label gets - route lines and the
   dotted walking line run right under street names and made them unreadable; the fatter halo
   is the "underlay tint" (Google does the same). Keep the exception if the blanket pass changes.
+- **Voice search mic is tier-2 intent handoff, not in-process recording (2026-07-10).**
+  `VoiceSearch` (reactive holder, pref `voice_search_button`) + a mic in `SearchBar` (param `onMic`,
+  shown only when query is empty and `onMic != null`). MapScreen computes `onMic` = toggle on AND
+  `VoiceSearch.hasProvider()` (a `queryIntentActivities(ACTION_RECOGNIZE_SPEECH)` check; needs the
+  `<queries>` entry in the manifest for Android 11+ visibility). The tap fires
+  `startActivityForResult(ACTION_RECOGNIZE_SPEECH)` and reads `EXTRA_RESULTS` into the query -
+  **the provider records, so Vela needs NO RECORD_AUDIO for this tier.** KEY DISTINCTION verified
+  2026-07-10: only apps that register the RECOGNIZE_SPEECH **activity** count (FUTO Voice Input
+  does - confirmed in its manifest). Keyboard/IME voice (Sayboard, FUTO Keyboard) provides a
+  RecognitionService or in-IME mic, NOT the activity, so `queryIntentActivities` returns empty and
+  the mic correctly hides - Vela can't `startActivityForResult` to them. That's intended: those
+  users use the keyboard mic, and tier-1 (PR3, on-device Whisper) will serve everyone regardless.
 - **Location is requested in onboarding, NOT on map load (2026-07-10).** `MapScreen`'s
   `LaunchedEffect` only STARTS location when it's already granted; it no longer fires the raw
   system dialog. The first ask lives in `VelaRoot` as an onboarding step gated on

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -179,6 +179,14 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   previews as results with a **Save list** pill - nothing is added to Your lists until you tap it
   (opt-in, 2026-07-09), then it's a durable local list. Remaining: reorder, share-out, a dedicated
   full-screen list view.
+- ✅ **Voice search mic (2026-07-10).** A mic in the search bar: tap it, a voice-input app you have
+  (FUTO Voice Input, Google's recognizer on GMS phones, …) captures speech and the text runs as a
+  search. Vela records nothing itself, the provider does, so no microphone permission. The mic only
+  appears when it can actually work: a Settings toggle (Search section, on by default) AND an app
+  that handles the recognize-speech intent. With no such app the mic is hidden, never shown dead,
+  and Settings says why. Keyboard-only dictation (Sayboard, FUTO Keyboard) doesn't trigger it since
+  apps can't invoke a keyboard's mic; those users keep using the keyboard mic, and a later build
+  adds an on-device model so voice search works with no third-party app at all.
 - ✅ **Location asked with a reason, in onboarding (2026-07-10).** The location permission used to
   pop the instant the map first loaded, a bare system dialog with no context. It now comes as the
   first onboarding step: a plain-words screen ("Vela uses your location to center the map and route

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,11 @@
         <intent>
             <action android:name="android.intent.action.TTS_SERVICE" />
         </intent>
+        <!-- See whether any app can handle voice input (FUTO Voice Input, Sayboard, …) so the
+             search-bar mic can hand off to it. Package visibility on Android 11+ requires this. -->
+        <intent>
+            <action android:name="android.speech.action.RECOGNIZE_SPEECH" />
+        </intent>
     </queries>
 
     <application

--- a/app/src/main/java/app/vela/VelaApp.kt
+++ b/app/src/main/java/app/vela/VelaApp.kt
@@ -40,6 +40,7 @@ class VelaApp : Application() {
         app.vela.ui.HideAdult.init(this)
         app.vela.ui.HideExternalLinks.init(this)
         app.vela.ui.Buildings3d.init(this)
+        app.vela.ui.VoiceSearch.init(this)
         Onboarding.init(this)
         // Persist any fatal crash (stack trace + breadcrumbs) so it survives the
         // restart and can be exported from Settings → Diagnostics next launch.

--- a/app/src/main/java/app/vela/ui/VoiceSearch.kt
+++ b/app/src/main/java/app/vela/ui/VoiceSearch.kt
@@ -1,0 +1,44 @@
+package app.vela.ui
+
+import android.content.Context
+import android.content.Intent
+import android.speech.RecognizerIntent
+import androidx.compose.runtime.mutableStateOf
+
+/**
+ * Voice search for the search bar: tap a mic, an installed voice-input app (FUTO Voice Input,
+ * Sayboard, Google's recognizer on GMS phones, …) captures speech and hands back text, which
+ * fills the query and runs the search. Vela never records audio itself for this - the provider
+ * does, so no microphone permission is needed here.
+ *
+ * The mic only appears when it can actually do something: the toggle is on AND some provider
+ * resolves the recognize-speech intent. When nothing can service it the button is hidden, never
+ * shown dead. (A later branch adds an on-device Whisper model as a second path; this same holder
+ * will report that too, so the mic shows when EITHER is available.)
+ *
+ * Process-wide reactive holder, same shape as [Units]/[DynamicColor]; `init()`-ed in [VelaApp].
+ */
+object VoiceSearch {
+    /** User toggle (Settings). On by default - it only renders when a provider exists anyway, so
+     *  "on" costs nothing to someone with no voice app. */
+    val enabled = mutableStateOf(true)
+
+    fun init(context: Context) {
+        enabled.value = prefs(context).getBoolean(KEY, true)
+    }
+
+    fun set(context: Context, value: Boolean) {
+        enabled.value = value
+        prefs(context).edit().putBoolean(KEY, value).apply()
+    }
+
+    /** Is there an app that can handle voice input right now? Cheap PackageManager query;
+     *  providers don't install mid-session, so callers can treat it as stable per launch. */
+    fun hasProvider(context: Context): Boolean = runCatching {
+        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
+        context.packageManager.queryIntentActivities(intent, 0).isNotEmpty()
+    }.getOrDefault(false)
+
+    private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
+    private const val KEY = "voice_search_button"
+}

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -406,6 +406,45 @@ fun MapScreen(
     LaunchedEffect(Unit) {
         if (hasLocation()) vm.startLocation()
     }
+    // Voice search: launch a system speech recognizer (FUTO Voice Input etc.), drop the recognised
+    // text into the query and search. Vela records nothing itself - the provider does, so no mic
+    // permission here. The mic only shows when a provider exists (VoiceSearch.hasProvider + toggle);
+    // a later branch adds an on-device model as a second path.
+    val voiceLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val heard = result.data
+                ?.getStringArrayListExtra(android.speech.RecognizerIntent.EXTRA_RESULTS)
+                ?.firstOrNull()
+                ?.trim()
+            if (!heard.isNullOrEmpty()) {
+                focusManager.clearFocus()
+                vm.onQueryChange(heard)
+                vm.search()
+            }
+        }
+    }
+    val voiceAvailable = remember { app.vela.ui.VoiceSearch.hasProvider(context) }
+    val voicePrompt = stringResource(R.string.search_voice_prompt)
+    val onMic: (() -> Unit)? = if (app.vela.ui.VoiceSearch.enabled.value && voiceAvailable) {
+        {
+            val intent = Intent(android.speech.RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                putExtra(
+                    android.speech.RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                    android.speech.RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
+                )
+                putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE, app.vela.ui.AppLocale.effective().toLanguageTag())
+                putExtra(android.speech.RecognizerIntent.EXTRA_PROMPT, voicePrompt)
+            }
+            // The resolver check can go stale (provider uninstalled since launch); catch it so a
+            // tap can never crash - it just does nothing.
+            runCatching { voiceLauncher.launch(intent) }
+        }
+    } else {
+        null
+    }
+
     // Tapping the locate button with no permission is an unambiguous "I want my location" - request
     // it (no rationale screen needed, the tap IS the intent). Granted → normal recenter.
     val onRecenter: () -> Unit = {
@@ -709,6 +748,7 @@ fun MapScreen(
                         onBack = if (searchOpen) ({ searchExpanded = false; focusManager.clearFocus(); vm.cancelPickOrigin(); vm.cancelPickStop() }) else null,
                         offline = state.offline,
                         dpadMode = dpadMode,
+                        onMic = onMic,
                     )
                     when {
                         // Show the entry page (Your location, Choose on map, Home/Work, saved, recents)

--- a/app/src/main/java/app/vela/ui/search/SearchBar.kt
+++ b/app/src/main/java/app/vela/ui/search/SearchBar.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.PublicOff
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
@@ -69,6 +70,9 @@ fun SearchBar(
     onBack: (() -> Unit)? = null,
     offline: Boolean = false,
     dpadMode: Boolean = false,
+    // Voice search: shown only when there's a way to service it (a voice-input app, and later an
+    // on-device model). Null = no mic. Sits at the right when the field is empty, Google-style.
+    onMic: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     // D-pad (docs/dpad.md): mere focus traversal must NOT fall into the text field (its
@@ -237,6 +241,18 @@ fun SearchBar(
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                     modifier = Modifier.padding(end = 4.dp),
                 )
+            }
+            // Voice search mic: only with the field empty (the clear "X" owns the typing state,
+            // Google-style) and only when something can service it (onMic != null). Sits just
+            // before the settings gear.
+            if (onMic != null && query.isEmpty()) {
+                IconButton(onClick = onMic, modifier = Modifier.size(40.dp)) {
+                    Icon(
+                        Icons.Default.Mic,
+                        contentDescription = stringResource(R.string.search_voice_cd),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
             if (searching) {
                 // padding BEFORE size: sizing the indicator itself to 22dp keeps it a true circle.

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -234,6 +234,19 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
             Hint(stringResource(R.string.settings_language_hint))
 
             Spacer(Modifier.height(20.dp))
+            SectionTitle(stringResource(R.string.settings_search))
+            ToggleRow(stringResource(R.string.settings_voice_search_toggle), app.vela.ui.VoiceSearch.enabled.value) {
+                app.vela.ui.VoiceSearch.set(context, it)
+            }
+            // The hint tells the truth about whether the mic can actually appear: it needs a
+            // voice-input app installed (a later build adds an on-device model as a second path).
+            val hasVoiceProvider = remember { app.vela.ui.VoiceSearch.hasProvider(context) }
+            Hint(
+                if (hasVoiceProvider) stringResource(R.string.settings_voice_search_hint)
+                else stringResource(R.string.settings_voice_search_none),
+            )
+
+            Spacer(Modifier.height(20.dp))
             SectionTitle(stringResource(R.string.settings_map))
             ToggleRow(stringResource(R.string.settings_live_traffic), app.vela.ui.Traffic.on.value) { app.vela.ui.Traffic.set(context, it) }
             Hint(stringResource(R.string.settings_live_traffic_hint))

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -15,6 +15,12 @@
     <string name="settings_units_metric">Metrisch (Kilometer, Meter)</string>
     <string name="settings_language">Sprache</string>
     <string name="settings_language_hint">Legt die Sprache der gesprochenen Navigationsansagen fest (Englisch, Französisch, Deutsch, Spanisch, Italienisch, Portugiesisch, Niederländisch, Russisch, Polnisch, Schwedisch, Ukrainisch) – unabhängig von der Systemsprache Ihres Telefons. Wählen Sie unten in der Stimmenbibliothek eine passende Stimme. Der übrige Bildschirmtext der App wird als Nächstes übersetzt.</string>
+    <string name="settings_search">Suche</string>
+    <string name="settings_voice_search_toggle">Mikrofon für Sprachsuche</string>
+    <string name="settings_voice_search_hint">Zeigt ein Mikrofon in der Suchleiste. Tippe darauf, um deine Suche zu sprechen, über eine Spracheingabe-App auf dem Gerät.</string>
+    <string name="settings_voice_search_none">Zeigt ein Mikrofon in der Suchleiste zum Sprechen deiner Suche. Benötigt eine Spracheingabe-App wie FUTO Voice Input; noch keine installiert.</string>
+    <string name="search_voice_cd">Sprachsuche</string>
+    <string name="search_voice_prompt">Zum Suchen sprechen</string>
     <string name="settings_voice">Stimme</string>
     <string name="settings_voice_fallback_name">Stimme</string>
     <string name="settings_voice_downloading">%1$s wird heruntergeladen … %2$d%%</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -15,6 +15,12 @@
     <string name="settings_units_metric">Métricas (kilómetros, metros)</string>
     <string name="settings_language">Idioma</string>
     <string name="settings_language_hint">Establece el idioma de las indicaciones de voz giro a giro (inglés, francés, alemán, español, italiano, portugués, neerlandés, ruso, polaco, sueco, ucraniano), independiente del idioma del sistema de tu teléfono. Elige una voz acorde en la Biblioteca de voces de más abajo. El resto del texto en pantalla de la app se traducirá próximamente.</string>
+    <string name="settings_search">Búsqueda</string>
+    <string name="settings_voice_search_toggle">Micrófono de búsqueda por voz</string>
+    <string name="settings_voice_search_hint">Muestra un micrófono en la barra de búsqueda. Tócalo para dictar tu búsqueda con una app de entrada de voz del teléfono.</string>
+    <string name="settings_voice_search_none">Muestra un micrófono en la barra de búsqueda para dictar tu búsqueda. Necesita una app de voz como FUTO Voice Input; aún no hay ninguna instalada.</string>
+    <string name="search_voice_cd">Búsqueda por voz</string>
+    <string name="search_voice_prompt">Habla para buscar</string>
     <string name="settings_voice">Voz</string>
     <string name="settings_voice_fallback_name">voz</string>
     <string name="settings_voice_downloading">Descargando %1$s… %2$d%%</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -15,6 +15,12 @@
     <string name="settings_units_metric">Métriques (kilomètres, mètres)</string>
     <string name="settings_language">Langue</string>
     <string name="settings_language_hint">Définit la langue des instructions vocales de navigation (anglais, français, allemand, espagnol, italien, portugais, néerlandais, russe, polonais, suédois, ukrainien) — indépendamment de la langue système de votre téléphone. Choisissez une voix correspondante dans la Bibliothèque de voix ci-dessous. Le reste des textes de l\'application est en cours de traduction.</string>
+    <string name="settings_search">Recherche</string>
+    <string name="settings_voice_search_toggle">Micro de recherche vocale</string>
+    <string name="settings_voice_search_hint">Affiche un micro dans la barre de recherche. Touchez-le pour dicter votre recherche via une appli de saisie vocale du téléphone.</string>
+    <string name="settings_voice_search_none">Affiche un micro dans la barre de recherche pour dicter votre recherche. Nécessite une appli vocale comme FUTO Voice Input ; aucune installée pour l\'instant.</string>
+    <string name="search_voice_cd">Recherche vocale</string>
+    <string name="search_voice_prompt">Parlez pour rechercher</string>
     <string name="settings_voice">Voix</string>
     <string name="settings_voice_fallback_name">voix</string>
     <string name="settings_voice_downloading">Téléchargement de %1$s… %2$d %%</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -15,6 +15,12 @@
     <string name="settings_units_metric">Metriche (chilometri, metri)</string>
     <string name="settings_language">Lingua</string>
     <string name="settings_language_hint">Imposta la lingua delle indicazioni vocali passo-passo (inglese, francese, tedesco, spagnolo, italiano, portoghese, olandese, russo, polacco, svedese, ucraino), indipendente dalla lingua di sistema del telefono. Scegli una voce corrispondente nella Libreria voci qui sotto. Il resto del testo dell\'app sarà tradotto a breve.</string>
+    <string name="settings_search">Ricerca</string>
+    <string name="settings_voice_search_toggle">Microfono ricerca vocale</string>
+    <string name="settings_voice_search_hint">Mostra un microfono nella barra di ricerca. Toccalo per dettare la ricerca con un\'app di input vocale sul telefono.</string>
+    <string name="settings_voice_search_none">Mostra un microfono nella barra di ricerca per dettare la ricerca. Serve un\'app vocale come FUTO Voice Input; nessuna ancora installata.</string>
+    <string name="search_voice_cd">Ricerca vocale</string>
+    <string name="search_voice_prompt">Parla per cercare</string>
     <string name="settings_voice">Voce</string>
     <string name="settings_voice_fallback_name">voce</string>
     <string name="settings_voice_downloading">Download di %1$s… %2$d%%</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -15,6 +15,12 @@
     <string name="settings_units_metric">Metrisch (kilometers, meters)</string>
     <string name="settings_language">Taal</string>
     <string name="settings_language_hint">Stelt de taal in voor gesproken route-instructies (Engels, Frans, Duits, Spaans, Italiaans, Portugees, Nederlands, Russisch, Pools, Zweeds, Oekraïens) — los van de systeemtaal van uw telefoon. Kies hieronder een passende stem in de Stembibliotheek. De rest van de tekst in de app wordt hierna vertaald.</string>
+    <string name="settings_search">Zoeken</string>
+    <string name="settings_voice_search_toggle">Microfoon voor spraakzoeken</string>
+    <string name="settings_voice_search_hint">Toont een microfoon in de zoekbalk. Tik erop om je zoekopdracht in te spreken via een spraakinvoer-app op je telefoon.</string>
+    <string name="settings_voice_search_none">Toont een microfoon in de zoekbalk om je zoekopdracht in te spreken. Vereist een spraak-app zoals FUTO Voice Input; nog geen geïnstalleerd.</string>
+    <string name="search_voice_cd">Zoeken met stem</string>
+    <string name="search_voice_prompt">Spreek om te zoeken</string>
     <string name="settings_voice">Stem</string>
     <string name="settings_voice_fallback_name">stem</string>
     <string name="settings_voice_downloading">%1$s downloaden… %2$d%%</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -15,6 +15,12 @@
     <string name="settings_units_metric">Metryczne (kilometry, metry)</string>
     <string name="settings_language">Język</string>
     <string name="settings_language_hint">Ustawia język mówionej nawigacji zakręt po zakręcie (angielski, francuski, niemiecki, hiszpański, włoski, portugalski, niderlandzki, rosyjski, polski, szwedzki, ukraiński) — niezależnie od języka systemowego telefonu. Wybierz pasujący głos w Bibliotece głosów poniżej. Reszta tekstu w aplikacji zostanie przetłumaczona wkrótce.</string>
+    <string name="settings_search">Wyszukiwanie</string>
+    <string name="settings_voice_search_toggle">Mikrofon wyszukiwania głosowego</string>
+    <string name="settings_voice_search_hint">Pokazuje mikrofon na pasku wyszukiwania. Dotknij go, aby wypowiedzieć zapytanie za pomocą aplikacji do wprowadzania głosem.</string>
+    <string name="settings_voice_search_none">Pokazuje mikrofon na pasku wyszukiwania do wypowiedzenia zapytania. Wymaga aplikacji głosowej, np. FUTO Voice Input; żadna nie jest zainstalowana.</string>
+    <string name="search_voice_cd">Wyszukiwanie głosowe</string>
+    <string name="search_voice_prompt">Mów, aby wyszukać</string>
     <string name="settings_voice">Głos</string>
     <string name="settings_voice_fallback_name">głos</string>
     <string name="settings_voice_downloading">Pobieranie %1$s… %2$d%%</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -15,6 +15,12 @@
     <string name="settings_units_metric">Métrico (quilómetros, metros)</string>
     <string name="settings_language">Idioma</string>
     <string name="settings_language_hint">Define o idioma das indicações de voz curva a curva (inglês, francês, alemão, espanhol, italiano, português, neerlandês, russo, polaco, sueco, ucraniano) — independente do idioma do sistema do seu telemóvel. Escolha uma voz correspondente na Biblioteca de vozes abaixo. O restante texto no ecrã da aplicação será traduzido a seguir.</string>
+    <string name="settings_search">Pesquisa</string>
+    <string name="settings_voice_search_toggle">Microfone de pesquisa por voz</string>
+    <string name="settings_voice_search_hint">Mostra um microfone na barra de pesquisa. Toque para ditar a pesquisa com uma app de entrada de voz do telemóvel.</string>
+    <string name="settings_voice_search_none">Mostra um microfone na barra de pesquisa para ditar a pesquisa. Precisa de uma app de voz como o FUTO Voice Input; nenhuma instalada ainda.</string>
+    <string name="search_voice_cd">Pesquisa por voz</string>
+    <string name="search_voice_prompt">Fale para pesquisar</string>
     <string name="settings_voice">Voz</string>
     <string name="settings_voice_fallback_name">voz</string>
     <string name="settings_voice_downloading">A transferir %1$s… %2$d%%</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -15,6 +15,12 @@
     <string name="settings_units_metric">Метрические (километры, метры)</string>
     <string name="settings_language">Язык</string>
     <string name="settings_language_hint">Задаёт язык голосовых подсказок при навигации (английский, французский, немецкий, испанский, итальянский, португальский, нидерландский, русский, польский, шведский, украинский) — независимо от системного языка телефона. Выберите подходящий голос в разделе «Библиотека голосов» ниже. Остальной текст интерфейса будет переведён в ближайшее время.</string>
+    <string name="settings_search">Поиск</string>
+    <string name="settings_voice_search_toggle">Микрофон голосового поиска</string>
+    <string name="settings_voice_search_hint">Показывает микрофон в строке поиска. Нажмите, чтобы продиктовать запрос через приложение голосового ввода на телефоне.</string>
+    <string name="settings_voice_search_none">Показывает микрофон в строке поиска для диктовки запроса. Нужно приложение голосового ввода, например FUTO Voice Input; пока не установлено.</string>
+    <string name="search_voice_cd">Голосовой поиск</string>
+    <string name="search_voice_prompt">Говорите для поиска</string>
     <string name="settings_voice">Голос</string>
     <string name="settings_voice_fallback_name">голос</string>
     <string name="settings_voice_downloading">Загрузка %1$s… %2$d%%</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -15,6 +15,12 @@
     <string name="settings_units_metric">Metriskt (kilometer, meter)</string>
     <string name="settings_language">Språk</string>
     <string name="settings_language_hint">Anger språket för talade vägbeskrivningar sväng för sväng (engelska, franska, tyska, spanska, italienska, portugisiska, nederländska, ryska, polska, svenska, ukrainska) – oberoende av telefonens systemspråk. Välj en röst som matchar i Röstbiblioteket nedan. Resten av appens skärmtext översätts härnäst.</string>
+    <string name="settings_search">Sök</string>
+    <string name="settings_voice_search_toggle">Mikrofon för röstsökning</string>
+    <string name="settings_voice_search_hint">Visar en mikrofon i sökfältet. Tryck för att tala din sökning via en röstinmatnings-app på telefonen.</string>
+    <string name="settings_voice_search_none">Visar en mikrofon i sökfältet för att tala din sökning. Kräver en röst-app som FUTO Voice Input; ingen är installerad ännu.</string>
+    <string name="search_voice_cd">Röstsökning</string>
+    <string name="search_voice_prompt">Tala för att söka</string>
     <string name="settings_voice">Röst</string>
     <string name="settings_voice_fallback_name">röst</string>
     <string name="settings_voice_downloading">Hämtar %1$s… %2$d %%</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -15,6 +15,12 @@
     <string name="settings_units_metric">Метричні (кілометри, метри)</string>
     <string name="settings_language">Мова</string>
     <string name="settings_language_hint">Задає мову голосових покрокових вказівок (англійська, французька, німецька, іспанська, італійська, португальська, нідерландська, російська, польська, шведська, українська) — незалежно від системної мови телефона. Виберіть відповідний голос у розділі «Бібліотека голосів» нижче. Решту тексту в застосунку буде перекладено далі.</string>
+    <string name="settings_search">Пошук</string>
+    <string name="settings_voice_search_toggle">Мікрофон голосового пошуку</string>
+    <string name="settings_voice_search_hint">Показує мікрофон у рядку пошуку. Торкніться, щоб продиктувати запит через застосунок голосового введення.</string>
+    <string name="settings_voice_search_none">Показує мікрофон у рядку пошуку для диктування запиту. Потрібен застосунок голосового введення, як-от FUTO Voice Input; ще не встановлено.</string>
+    <string name="search_voice_cd">Голосовий пошук</string>
+    <string name="search_voice_prompt">Говоріть, щоб шукати</string>
     <string name="settings_voice">Голос</string>
     <string name="settings_voice_fallback_name">голос</string>
     <string name="settings_voice_downloading">Завантаження %1$s… %2$d%%</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,12 @@
     <string name="settings_units_metric">Metric (kilometers, meters)</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_hint">Sets the language for spoken turn-by-turn directions (English, French, German, Spanish, Italian, Portuguese, Dutch, Russian, Polish, Swedish, Ukrainian), independent of your phone\'s system language. Pick a matching voice in Voice library below. The rest of the app\'s on-screen text is being translated next.</string>
+    <string name="settings_search">Search</string>
+    <string name="settings_voice_search_toggle">Voice search mic</string>
+    <string name="settings_voice_search_hint">Shows a mic in the search bar. Tap it to speak your search, using a voice-input app on your phone.</string>
+    <string name="settings_voice_search_none">Shows a mic in the search bar to speak your search. Needs a voice-input app such as FUTO Voice Input; none is installed yet.</string>
+    <string name="search_voice_cd">Voice search</string>
+    <string name="search_voice_prompt">Speak to search</string>
     <string name="settings_voice">Voice</string>
     <string name="settings_voice_fallback_name">voice</string>
     <string name="settings_voice_downloading">Downloading %1$s… %2$d%%</string> <!-- format -->


### PR DESCRIPTION
Adds a voice-search mic to the search bar. Tap it, a voice-input app on the phone captures speech, and the text runs as a search. Vela records nothing itself for this, the provider does, so it needs no microphone permission.

**Stacked on #21** (base branch is `onboarding-perms`, not `main`) so it doesn't conflict in the files both touch. Retarget to `main` after #21 merges.

**When the mic shows:** only when it can actually work, a Settings toggle (new Search section, on by default) AND an app that handles the recognize-speech intent. Otherwise it's hidden, never a dead button, and Settings says why.

**A real distinction found while testing:** only apps that register the RECOGNIZE_SPEECH activity count. FUTO Voice Input does (confirmed in its manifest). Keyboard/IME voice like Sayboard provides a RecognitionService or an in-keyboard mic, not that activity, so the resolver check returns empty and the mic correctly hides, since Vela can't hand off to them this way. Those users keep using the keyboard mic. A follow-up adds an on-device Whisper model so voice search works for everyone regardless.

**Testing:** compiles, verified on a device with no provider: the mic is correctly hidden in the search bar, and Settings shows the toggle plus the honest "needs a voice-input app such as FUTO Voice Input; none is installed yet" hint. The mic-appears-and-hands-off path is verified by construction, detection uses the exact activity FUTO registers, and is easy to eyeball on any phone with FUTO Voice Input installed. New strings translated across all 11 languages.
