### PR TITLE
Declutter Settings: Advanced/Developer groups, shorter language and voice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ Defaults that make the safe path the easy one:
   out of their old sections: **Advanced** = 3D buildings + traffic-light guidance; **Developer** =
   demo drive, simulate location, trip recording (each "turn off for real use"). The two **content
   filters (hide-adult, hide-external-links) stay in Place pages** with the other place-content
-  toggles (user 2026-07-10), NOT Advanced. **Offline maps** (renamed from "Offline") sits right below Language, ABOVE Search (people reach it often, user 2026-07-10). Its routing-region filter field just says "Search" (the old "Filter N regions…" wrapped to multiple lines). **Language is a "Follow
+  toggles (user 2026-07-10), NOT Advanced. **Offline maps** (renamed from "Offline") sits right below Language, ABOVE Search (people reach it often, user 2026-07-10). Its two subheads were reframed 2026-07-10 (user: region vs routing region read confusing): **"Local area"** (the viewport download: map + roads + addresses for where you are) and **"States & countries"** (renamed from "Routing regions": the whole-region graph + place pack, framed as "everything to get around a state/province/country offline"). The region filter field just says "Search" (the old "Filter N regions…" wrapped to multiple lines). **Language is a "Follow
   system language" ToggleRow** that reveals the 11-language picker only when OFF (seeded with
   `AppLocale.deviceDefaultSupported()`); most people never see the list. **The Voice library is a
   DEDICATED screen** (`VoiceBrowseScreen`, reached by the "Browse voices" `OutlinedButton` in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ Defaults that make the safe path the easy one:
   Manifest also declares `FEATURE_CLUSTER` (instrument-cluster nav) and `CAR_INFO` (AAOS car speed).
   The PHONE also feeds NavSession when not projecting; the car and phone share the one nav loop.
 - **Settings ORDER is deliberate (declutter reorg 2026-07-10, supersedes 2026-07-08):** Appearance →
-  Map style → Units → Language → Search → Map (traffic/transit) → **Offline** → **Place pages**
+  Map style → Units → Language → **Offline maps** → Search → Map (traffic/transit) → **Place pages**
   (ShowReviews / read-all-reviews / LoadPhotos / hide-adult / hide-external-links) → Navigation (keep-screen-on, vibrate-on-turns as
   FilterChips one per mode, parking history) → Voice → Saved places → Lists → Data & privacy →
   Diagnostics (share-diagnostics + the crash card) → **Advanced** → **Developer** → About/Support/
@@ -249,7 +249,7 @@ Defaults that make the safe path the easy one:
   out of their old sections: **Advanced** = 3D buildings + traffic-light guidance; **Developer** =
   demo drive, simulate location, trip recording (each "turn off for real use"). The two **content
   filters (hide-adult, hide-external-links) stay in Place pages** with the other place-content
-  toggles (user 2026-07-10), NOT Advanced. **Offline moved UP** to right after Map (people reach it often). **Language is a "Follow
+  toggles (user 2026-07-10), NOT Advanced. **Offline maps** (renamed from "Offline") sits right below Language, ABOVE Search (people reach it often, user 2026-07-10). Its routing-region filter field just says "Search" (the old "Filter N regions…" wrapped to multiple lines). **Language is a "Follow
   system language" ToggleRow** that reveals the 11-language picker only when OFF (seeded with
   `AppLocale.deviceDefaultSupported()`); most people never see the list. **The Voice library is a
   DEDICATED screen** (`VoiceBrowseScreen`, reached by the "Browse voices" `OutlinedButton` in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,13 +242,14 @@ Defaults that make the safe path the easy one:
   The PHONE also feeds NavSession when not projecting; the car and phone share the one nav loop.
 - **Settings ORDER is deliberate (declutter reorg 2026-07-10, supersedes 2026-07-08):** Appearance →
   Map style → Units → Language → Search → Map (traffic/transit) → **Offline** → **Place pages**
-  (ShowReviews / read-all-reviews / LoadPhotos) → Navigation (keep-screen-on, vibrate-on-turns as
+  (ShowReviews / read-all-reviews / LoadPhotos / hide-adult / hide-external-links) → Navigation (keep-screen-on, vibrate-on-turns as
   FilterChips one per mode, parking history) → Voice → Saved places → Lists → Data & privacy →
   Diagnostics (share-diagnostics + the crash card) → **Advanced** → **Developer** → About/Support/
   Version(+updater). Two **collapsible buckets at the bottom** hold the rarely-touched toggles, moved
-  out of their old sections: **Advanced** = 3D buildings, hide adult, hide external links, traffic-
-  light guidance; **Developer** = demo drive, simulate location, trip recording (each "turn off for
-  real use"). **Offline moved UP** to right after Map (people reach it often). **Language is a "Follow
+  out of their old sections: **Advanced** = 3D buildings + traffic-light guidance; **Developer** =
+  demo drive, simulate location, trip recording (each "turn off for real use"). The two **content
+  filters (hide-adult, hide-external-links) stay in Place pages** with the other place-content
+  toggles (user 2026-07-10), NOT Advanced. **Offline moved UP** to right after Map (people reach it often). **Language is a "Follow
   system language" ToggleRow** that reveals the 11-language picker only when OFF (seeded with
   `AppLocale.deviceDefaultSupported()`); most people never see the list. **The Voice library is a
   DEDICATED screen** (`VoiceBrowseScreen`, reached by the "Browse voices" `OutlinedButton` in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,11 +240,21 @@ Defaults that make the safe path the easy one:
   card + the cluster/HUD nav data; `ManeuverMapper` maps Vela maneuvers → car `Maneuver`/`Step`/`Trip`.
   Manifest also declares `FEATURE_CLUSTER` (instrument-cluster nav) and `CAR_INFO` (AAOS car speed).
   The PHONE also feeds NavSession when not projecting; the car and phone share the one nav loop.
-- **Settings ORDER is deliberate (reorg 2026-07-08):** Appearance → Map (traffic/transit/3D) →
-  **Place pages** (ShowReviews / read-all-reviews / LoadPhotos) → Navigation (keep-screen-on,
-  traffic lights, vibrate-on-turns as FilterChips one per mode, demo LAST) → Voice → Offline →
-  Saved places → Data & privacy → Diagnostics → About/Support/Version(+updater). Put a new setting
-  in the section it serves, not at the end; place-content settings go under Place pages, not Map.
+- **Settings ORDER is deliberate (declutter reorg 2026-07-10, supersedes 2026-07-08):** Appearance →
+  Map style → Units → Language → Search → Map (traffic/transit) → **Offline** → **Place pages**
+  (ShowReviews / read-all-reviews / LoadPhotos) → Navigation (keep-screen-on, vibrate-on-turns as
+  FilterChips one per mode, parking history) → Voice → Saved places → Lists → Data & privacy →
+  Diagnostics (share-diagnostics + the crash card) → **Advanced** → **Developer** → About/Support/
+  Version(+updater). Two **collapsible buckets at the bottom** hold the rarely-touched toggles, moved
+  out of their old sections: **Advanced** = 3D buildings, hide adult, hide external links, traffic-
+  light guidance; **Developer** = demo drive, simulate location, trip recording (each "turn off for
+  real use"). **Offline moved UP** to right after Map (people reach it often). **Language is a "Follow
+  system language" ToggleRow** that reveals the 11-language picker only when OFF (seeded with
+  `AppLocale.deviceDefaultSupported()`); most people never see the list. **The Voice library is a
+  DEDICATED screen** (`VoiceBrowseScreen`, reached by the "Browse voices" `OutlinedButton` in the
+  Voice section) not an inline accordion - `SettingsScreen` early-returns to it when
+  `showVoiceLibrary`; its own Back returns to Settings. Put a new setting in the section it serves;
+  niche/experimental → Advanced, demo/test tools → Developer, place-content → Place pages not Map.
 - **Nav UI style (2026-07-08):** ManeuverBanner + NavControls are RoundedCornerShape(24/28dp)
   Cards with elevation 6dp, 54dp turn glyph, headlineMedium-bold distance, titleMedium-medium road
   name, FilledTonalIconButton for mute/steps. Keep new nav chrome on this treatment (no flat

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -209,9 +209,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   stays a plain text button, so the recommended action reads at a glance. Long labels wrap the pill
   to its own line instead of breaking mid-word, and it all still works by D-pad on a feature phone.
 - ✅ **Settings decluttered (2026-07-10).** The Settings page was one very long scroll. The rarely-
-  touched toggles now live in two collapsed groups at the bottom: **Advanced** (3D buildings, hide
-  adult categories, hide website/links, traffic-light guidance) and **Developer** (simulate driving,
-  simulate location, save trips — the demo/testing tools, each labelled "turn off for real use").
+  touched toggles now live in two collapsed groups at the bottom: **Advanced** (3D buildings, traffic-
+  light guidance) and **Developer** (simulate driving, simulate location, save trips — the demo/testing
+  tools, each labelled "turn off for real use"). The content filters (hide adult categories, hide
+  website & external links) sit with the other place-content toggles under Place pages.
   Everything else stays one tap away. **Offline moved up** near the top since you reach it often.
   **Language** is now a simple "Follow system language" switch that only shows the full language list
   when you turn it off. And the **voice library is its own screen** now (a "Browse voices" button in

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -208,6 +208,14 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   dialogs (voice, location, diagnostics, trip recording, …) is now a filled pill and the decline
   stays a plain text button, so the recommended action reads at a glance. Long labels wrap the pill
   to its own line instead of breaking mid-word, and it all still works by D-pad on a feature phone.
+- ✅ **Settings decluttered (2026-07-10).** The Settings page was one very long scroll. The rarely-
+  touched toggles now live in two collapsed groups at the bottom: **Advanced** (3D buildings, hide
+  adult categories, hide website/links, traffic-light guidance) and **Developer** (simulate driving,
+  simulate location, save trips — the demo/testing tools, each labelled "turn off for real use").
+  Everything else stays one tap away. **Offline moved up** near the top since you reach it often.
+  **Language** is now a simple "Follow system language" switch that only shows the full language list
+  when you turn it off. And the **voice library is its own screen** now (a "Browse voices" button in
+  the Voice section) instead of a giant list unrolling inline. All of it still works by D-pad.
 - ✅ **Update from Settings directly (2026-07-09).** The Version section's "Check for updates"
   used to answer "update available, go back to the map to install it" - now the full offer
   renders inline: version line, Update button, live download progress, Not now. Same state and

--- a/app/src/main/java/app/vela/ui/AppLocale.kt
+++ b/app/src/main/java/app/vela/ui/AppLocale.kt
@@ -34,6 +34,12 @@ object AppLocale {
     /** The language's own name (endonym) — what a speaker of it expects to see in a language list. */
     fun endonym(code: String): String = ENDONYMS[code] ?: code.replaceFirstChar { it.uppercase() }
 
+    /** The supported language closest to the device/system locale. Used when the user turns OFF
+     *  "follow system language" so the revealed picker starts on a sensible current choice instead
+     *  of nothing; falls back to English when the system language isn't one Vela ships. */
+    fun deviceDefaultSupported(): String =
+        Locale.getDefault().language.takeIf { it in SUPPORTED } ?: "en"
+
     fun init(context: Context) {
         language.value = prefs(context).getString(KEY, "") ?: ""
         apply()

--- a/app/src/main/java/app/vela/ui/Format.kt
+++ b/app/src/main/java/app/vela/ui/Format.kt
@@ -8,13 +8,13 @@ import kotlin.math.roundToInt
 /**
  * Distance-unit preference. Backed by Compose state so reads inside composables
  * (via [formatDistance]) recompose when it flips, and persisted so it sticks.
- * Defaults to imperial in the US/Liberia/Myanmar, metric elsewhere.
+ * Defaults to imperial where roads are signed in miles (US, UK, Liberia, Myanmar), metric elsewhere.
  */
 object Units {
     val imperial = mutableStateOf(false)
 
     fun init(context: Context) {
-        val default = Locale.getDefault().country in setOf("US", "LR", "MM")
+        val default = Locale.getDefault().country in setOf("US", "GB", "LR", "MM")
         imperial.value = prefs(context).getBoolean(KEY, default)
     }
 

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -1299,7 +1299,7 @@ private fun VoiceRow(
                 downloading -> stringResource(R.string.settings_voice_row_downloading, (downloadPct * 100).toInt())
                 active -> stringResource(R.string.settings_voice_row_in_use, v.region, gender, v.sizeMb)
                 installed -> stringResource(R.string.settings_voice_row_downloaded, v.region, gender, v.sizeMb)
-                else -> "${v.region} · $gender · ${v.quality.name.lowercase()} · ${v.sizeMb} MB" + (v.note?.let { " · $it" } ?: "")
+                else -> "${v.region} · $gender · ${v.quality.name.lowercase()} · ${v.sizeMb} MB"
             }
             Text(sub, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -456,7 +456,13 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
 
             ToggleRow(stringResource(R.string.settings_load_photos), app.vela.ui.LoadPhotos.on.value) { app.vela.ui.LoadPhotos.set(context, it) }
             Hint(stringResource(R.string.settings_load_photos_hint))
-            // "Hide adult categories" + "Hide website & external links" moved to Advanced.
+
+            // Content filters belong with the other place-content toggles, not in Advanced.
+            ToggleRow(stringResource(R.string.settings_hide_adult), app.vela.ui.HideAdult.on.value) { app.vela.ui.HideAdult.set(context, it) }
+            Hint(stringResource(R.string.settings_hide_adult_hint))
+
+            ToggleRow(stringResource(R.string.settings_hide_external_links), app.vela.ui.HideExternalLinks.on.value) { app.vela.ui.HideExternalLinks.set(context, it) }
+            Hint(stringResource(R.string.settings_hide_external_links_hint))
 
             Spacer(Modifier.height(20.dp))
             SectionTitle(stringResource(R.string.settings_navigation))
@@ -840,10 +846,6 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 Hint(stringResource(R.string.settings_advanced_hint))
                 ToggleRow(stringResource(R.string.settings_buildings_3d), app.vela.ui.Buildings3d.on.value) { app.vela.ui.Buildings3d.set(context, it) }
                 Hint(stringResource(R.string.settings_buildings_3d_hint))
-                ToggleRow(stringResource(R.string.settings_hide_adult), app.vela.ui.HideAdult.on.value) { app.vela.ui.HideAdult.set(context, it) }
-                Hint(stringResource(R.string.settings_hide_adult_hint))
-                ToggleRow(stringResource(R.string.settings_hide_external_links), app.vela.ui.HideExternalLinks.on.value) { app.vela.ui.HideExternalLinks.set(context, it) }
-                Hint(stringResource(R.string.settings_hide_external_links_hint))
                 var trafficLights by remember { mutableStateOf(prefs.getBoolean("nav_traffic_lights", false)) }
                 ToggleRow(stringResource(R.string.settings_traffic_lights), trafficLights) {
                     trafficLights = it

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -104,6 +104,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape as DpadShape
 fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = false) {
     val state by vm.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    // The voice library (browse / download / switch / delete voices) is a DEDICATED screen now, not an
+    // inline accordion on this long list. When open it fully replaces Settings; its own Back returns here.
+    var showVoiceLibrary by remember { mutableStateOf(false) }
+    if (showVoiceLibrary) {
+        VoiceBrowseScreen(vm = vm, onClose = { showVoiceLibrary = false })
+        return
+    }
     // System back should return to the map, not fall through and exit the app.
     BackHandler(onBack = onBack)
     // When arriving from the onboarding "set up offline" prompt, open the Offline section expanded and
@@ -219,17 +226,22 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
 
             Spacer(Modifier.height(20.dp))
             SectionTitle(stringResource(R.string.settings_language))
-            SelectableRow(
-                label = stringResource(R.string.settings_follow_system),
-                selected = app.vela.ui.AppLocale.language.value.isBlank(),
-                onClick = { app.vela.ui.AppLocale.set(context, "") },
-            )
-            app.vela.ui.AppLocale.SUPPORTED.forEach { code ->
-                SelectableRow(
-                    label = app.vela.ui.AppLocale.endonym(code),
-                    selected = app.vela.ui.AppLocale.language.value == code,
-                    onClick = { app.vela.ui.AppLocale.set(context, code) },
-                )
+            // Most people want the system language, so lead with a single toggle and only reveal the
+            // full 11-language picker when they turn it off (keeps the list out of the common case).
+            val followSystemLang = app.vela.ui.AppLocale.language.value.isBlank()
+            ToggleRow(stringResource(R.string.settings_follow_system_language), followSystemLang) { on ->
+                // Off → seed with the language closest to the device locale so the picker opens on a
+                // real current choice, not blank; on → clear the override back to the system locale.
+                app.vela.ui.AppLocale.set(context, if (on) "" else app.vela.ui.AppLocale.deviceDefaultSupported())
+            }
+            if (!followSystemLang) {
+                app.vela.ui.AppLocale.SUPPORTED.forEach { code ->
+                    SelectableRow(
+                        label = app.vela.ui.AppLocale.endonym(code),
+                        selected = app.vela.ui.AppLocale.language.value == code,
+                        onClick = { app.vela.ui.AppLocale.set(context, code) },
+                    )
+                }
             }
             Hint(stringResource(R.string.settings_language_hint))
 
@@ -253,292 +265,7 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
 
             ToggleRow(stringResource(R.string.settings_transit_layer), app.vela.ui.TransitLayer.on.value) { app.vela.ui.TransitLayer.set(context, it) }
             Hint(stringResource(R.string.settings_transit_layer_hint))
-
-            ToggleRow(stringResource(R.string.settings_buildings_3d), app.vela.ui.Buildings3d.on.value) { app.vela.ui.Buildings3d.set(context, it) }
-            Hint(stringResource(R.string.settings_buildings_3d_hint))
-
-            Spacer(Modifier.height(20.dp))
-            SectionTitle(stringResource(R.string.settings_place_pages))
-
-            ToggleRow(stringResource(R.string.settings_show_reviews), app.vela.ui.ShowReviews.on.value) { app.vela.ui.ShowReviews.set(context, it) }
-            Hint(stringResource(R.string.settings_show_reviews_hint))
-
-            ToggleRow(stringResource(R.string.settings_read_all_reviews), app.vela.ui.LiveReviews.on.value) { app.vela.ui.LiveReviews.set(context, it) }
-            Hint(stringResource(R.string.settings_read_all_reviews_hint))
-
-            ToggleRow(stringResource(R.string.settings_load_photos), app.vela.ui.LoadPhotos.on.value) { app.vela.ui.LoadPhotos.set(context, it) }
-            Hint(stringResource(R.string.settings_load_photos_hint))
-
-            ToggleRow(stringResource(R.string.settings_hide_adult), app.vela.ui.HideAdult.on.value) { app.vela.ui.HideAdult.set(context, it) }
-            Hint(stringResource(R.string.settings_hide_adult_hint))
-
-            ToggleRow(stringResource(R.string.settings_hide_external_links), app.vela.ui.HideExternalLinks.on.value) { app.vela.ui.HideExternalLinks.set(context, it) }
-            Hint(stringResource(R.string.settings_hide_external_links_hint))
-
-            Spacer(Modifier.height(20.dp))
-            SectionTitle(stringResource(R.string.settings_navigation))
-            val prefs = remember { context.getSharedPreferences("vela_settings", android.content.Context.MODE_PRIVATE) }
-
-            var keepAwake by remember { mutableStateOf(prefs.getBoolean("keep_screen_on_nav", true)) }
-            ToggleRow(stringResource(R.string.settings_keep_screen_on), keepAwake) {
-                keepAwake = it
-                prefs.edit().putBoolean("keep_screen_on_nav", it).apply()
-            }
-            Hint(stringResource(R.string.settings_keep_screen_on_hint))
-
-            var trafficLights by remember { mutableStateOf(prefs.getBoolean("nav_traffic_lights", false)) }
-            ToggleRow(stringResource(R.string.settings_traffic_lights), trafficLights) {
-                trafficLights = it
-                prefs.edit().putBoolean("nav_traffic_lights", it).apply()
-            }
-            Hint(stringResource(R.string.settings_traffic_lights_hint))
-            Text(stringResource(R.string.settings_vibrate_on_turns), style = MaterialTheme.typography.bodyLarge, modifier = Modifier.padding(top = 4.dp))
-            // One chip per travel mode (was four stacked switch rows — a lot of vertical space
-            // for a setting most people touch once). Selected = that mode vibrates at turns.
-            Row(
-                // Scrollable so four localized labels can never squeeze each other off-screen.
-                Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(top = 4.dp, bottom = 2.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                listOf(
-                    TravelMode.DRIVE to stringResource(R.string.settings_mode_driving),
-                    TravelMode.WALK to stringResource(R.string.settings_mode_walking),
-                    TravelMode.BICYCLE to stringResource(R.string.settings_mode_cycling),
-                    TravelMode.TRANSIT to stringResource(R.string.settings_mode_transit),
-                ).let { modes ->
-                    // The ROOT swallows bare LEFT/RIGHT (see above), so this horizontal row drives its
-                    // OWN LEFT/RIGHT via FocusRequesters — requestFocus (not moveFocus) never clears at
-                    // the ends, and consuming the key stops it reaching the root swallow.
-                    val chipFocus = remember { List(modes.size) { FocusRequester() } }
-                    modes.forEachIndexed { i, (mode, label) ->
-                        var on by remember(mode) {
-                            val default = if (!prefs.getBoolean(Haptics.KEY, true)) false else Haptics.defaultFor(mode)
-                            mutableStateOf(prefs.getBoolean(Haptics.keyFor(mode), default))
-                        }
-                        FilterChip(
-                            selected = on,
-                            onClick = {
-                                on = !on
-                                prefs.edit().putBoolean(Haptics.keyFor(mode), on).apply()
-                            },
-                            label = { Text(label) },
-                            shape = androidx.compose.foundation.shape.CircleShape,
-                            modifier = Modifier
-                                .focusRequester(chipFocus[i])
-                                .onKeyEvent { ev ->
-                                    if (ev.key == Key.DirectionRight || ev.key == Key.DirectionLeft) {
-                                        if (ev.type == KeyEventType.KeyDown) {
-                                            if (ev.key == Key.DirectionRight && i < chipFocus.lastIndex) chipFocus[i + 1].requestFocus()
-                                            if (ev.key == Key.DirectionLeft && i > 0) chipFocus[i - 1].requestFocus()
-                                        }
-                                        true
-                                    } else {
-                                        false
-                                    }
-                                },
-                        )
-                    }
-                }
-            }
-            Hint(stringResource(R.string.settings_vibrate_hint))
-
-            var demoDrive by remember { mutableStateOf(prefs.getBoolean("demo_drive", false)) }
-            ToggleRow(stringResource(R.string.settings_demo_drive), demoDrive) {
-                demoDrive = it
-                prefs.edit().putBoolean("demo_drive", it).apply()
-            }
-            Hint(stringResource(R.string.settings_demo_drive_hint))
-
-            // Simulated location — pretend to be at the current map centre (for demos / screenshots
-            // without leaking where you actually are). Reactive holder so the switch reflects state.
-            ToggleRow(stringResource(R.string.settings_sim_location), app.vela.ui.SimLocation.on) { on -> if (on) vm.simulateLocationHere() else vm.stopSimulateLocation() }
-            Hint(stringResource(R.string.settings_sim_location_hint))
-
-            // Parking history — recent "parked here" saves, so an accidental overwrite is
-            // recoverable (also reachable by long-pressing the P button on the map).
-            if (state.parkingHistory.isNotEmpty()) {
-                Spacer(Modifier.height(20.dp))
-                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                    SectionTitle(stringResource(R.string.settings_parking_history))
-                    Spacer(Modifier.weight(1f))
-                    TextButton(onClick = { vm.clearParkingHistory() }) { Text(stringResource(R.string.parking_history_clear_all)) }
-                }
-                Hint(stringResource(R.string.settings_parking_history_hint))
-                state.parkingHistory.forEach { entry ->
-                    val isCurrent = entry.savedAtMillis == state.parkedAtMillis
-                    Row(
-                        Modifier.fillMaxWidth().padding(vertical = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            Icons.Default.LocalParking,
-                            contentDescription = null,
-                            tint = if (isCurrent) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(18.dp),
-                        )
-                        Spacer(Modifier.width(10.dp))
-                        Text(
-                            java.text.SimpleDateFormat("MMM d, h:mm a", java.util.Locale.getDefault())
-                                .format(java.util.Date(entry.savedAtMillis)),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            fontWeight = if (isCurrent) FontWeight.Bold else FontWeight.Normal,
-                            modifier = Modifier.weight(1f),
-                        )
-                        if (isCurrent) {
-                            Text(stringResource(R.string.parking_history_current), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
-                        } else {
-                            TextButton(onClick = { vm.restoreParkingFromHistory(entry) }) { Text(stringResource(R.string.parking_history_restore)) }
-                            IconButton(onClick = { vm.deleteParkingHistoryEntry(entry) }) {
-                                Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.parking_history_delete), tint = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                        }
-                    }
-                }
-            }
-
-            Spacer(Modifier.height(20.dp))
-            SectionTitle(stringResource(R.string.settings_voice))
-            // Vela's own on-device neural voices (the Piper catalog) — download in the Voice
-            // library below; once downloaded each shows in the engine list (selectable). No
-            // standalone TTS app needed.
-            // A download in flight shows a compact progress line here too, so it's visible even when the
-            // Voice library (below) is collapsed. The per-voice controls live in the library.
-            state.voiceDownloadingId?.let { id ->
-                val nm = vm.voiceCatalog().firstOrNull { it.id == id }?.displayName ?: stringResource(R.string.settings_voice_fallback_name)
-                val pct = state.voiceDownloadPct ?: 0f
-                Text(stringResource(R.string.settings_voice_downloading, nm, (pct * 100).toInt()), style = MaterialTheme.typography.bodyMedium)
-                Spacer(Modifier.height(6.dp))
-                LinearProgressIndicator(progress = { pct }, modifier = Modifier.fillMaxWidth())
-                Spacer(Modifier.height(12.dp))
-            } ?: Spacer(Modifier.height(4.dp))
-            // Enumerate TTS engines OFF the main thread. PackageManager.queryIntentServices + the
-            // per-engine loadLabel is a binder IPC that took >5 s on the flip phone and ANR'd the UI
-            // when run in composition (input-dispatch timeout). Load async (cached in VoiceGuide);
-            // render nothing until ready so there's no flash of the "no engines" hint.
-            val engines by produceState<List<VoiceEngine>?>(null, state.voiceDownloadingId) {
-                value = withContext(Dispatchers.IO) { vm.voiceEngines() }
-            }
-            val engineList = engines
-            if (engineList == null) {
-                // still loading — render nothing
-            } else if (engineList.isEmpty()) {
-                Hint(stringResource(R.string.settings_voice_none_hint))
-            } else {
-                engineList.forEach { e ->
-                    SelectableRow(
-                        label = e.label,
-                        selected = state.selectedEngine?.packageName == e.packageName,
-                        onClick = { vm.setVoiceEngine(e) },
-                    )
-                }
-                Spacer(Modifier.height(8.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    OutlinedButton(onClick = { vm.testVoice() }) { Text(stringResource(R.string.settings_voice_test)) }
-                    Spacer(Modifier.width(8.dp))
-                    OutlinedButton(onClick = {
-                        runCatching {
-                            context.startActivity(
-                                android.content.Intent("com.android.settings.TTS_SETTINGS")
-                                    .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK),
-                            )
-                        }
-                    }) { Text(stringResource(R.string.settings_voice_system_settings)) }
-                }
-                Hint(stringResource(R.string.settings_voice_test_hint))
-            }
-
-            // Voice library — browse, download, switch between and remove Vela's neural voices (Piper).
-            // Auto-expanded when nothing is installed so the download path is obvious.
-            // Auto-expand when nothing is installed so the download path is obvious — EXCEPT when we
-            // arrived to set up offline, where a big open voice list between the top and the Offline
-            // section would push it around and fight the scroll-into-view.
-            var voiceLibExpanded by remember { mutableStateOf(state.installedVoiceIds.isEmpty() && !openOffline) }
-            CollapsibleSectionTitle(stringResource(R.string.settings_voice_library), voiceLibExpanded) { voiceLibExpanded = !voiceLibExpanded }
-            if (voiceLibExpanded) VoiceLibrary(vm, state)
-
-            if (engineList?.isNotEmpty() == true) {
-                // Speed + the niche bits (playground, the multi-speaker variant picker) — most people never
-                // touch these, so tuck them behind a collapsible header (collapsed by default).
-                var voiceAdvExpanded by remember { mutableStateOf(false) }
-                CollapsibleSectionTitle(stringResource(R.string.settings_voice_advanced), voiceAdvExpanded) { voiceAdvExpanded = !voiceAdvExpanded }
-                if (voiceAdvExpanded) {
-                // Playground: hear the selected voice on any text (or a nav-style sample).
-                Spacer(Modifier.height(12.dp))
-                var tryText by remember { mutableStateOf("") }
-                OutlinedTextField(
-                    value = tryText,
-                    onValueChange = { tryText = it },
-                    modifier = Modifier.fillMaxWidth().dpadFieldEscape(),
-                    label = { Text(stringResource(R.string.settings_voice_try_label)) },
-                    maxLines = 3,
-                )
-                Spacer(Modifier.height(6.dp))
-                val navSampleText = stringResource(R.string.settings_voice_nav_sample_text)
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    OutlinedButton(onClick = { vm.speakText(tryText) }, enabled = tryText.isNotBlank()) { Text(stringResource(R.string.settings_voice_speak)) }
-                    Spacer(Modifier.width(8.dp))
-                    OutlinedButton(onClick = {
-                        vm.speakText(navSampleText)
-                    }) { Text(stringResource(R.string.settings_voice_nav_sample)) }
-                }
-                // Speed applies to whichever voice is selected (neural + system TTS).
-                Spacer(Modifier.height(10.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        stringResource(R.string.settings_voice_speed, "%.2fx".format(state.voiceSpeed)),
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.weight(1f),
-                    )
-                    OutlinedButton(onClick = { vm.setVoiceSpeed(-0.1f) }) { Text("−") }
-                    Spacer(Modifier.width(6.dp))
-                    OutlinedButton(onClick = { vm.setVoiceSpeed(0.1f) }) { Text("+") }
-                }
-                Hint(stringResource(R.string.settings_voice_speed_hint))
-                // Multi-speaker Vela voices (libritts_r=904, VCTK=109, Arctic=18) — let the user audition +
-                // pick a variant. Hidden for single-speaker voices (lessac/hfc/…), where it's meaningless.
-                if (state.selectedEngine?.packageName?.startsWith("vela.") == true && vm.voiceSpeakerCount() > 1) {
-                    Spacer(Modifier.height(10.dp))
-                    val cnt = vm.voiceSpeakerCount()
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            if (cnt > 0) stringResource(R.string.settings_voice_variant_of, state.voiceSpeaker, cnt)
-                            else stringResource(R.string.settings_voice_variant, state.voiceSpeaker),
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier.weight(1f),
-                        )
-                        OutlinedButton(onClick = { vm.stepSpeaker(-1) }) { Text("◀") }
-                        Spacer(Modifier.width(6.dp))
-                        OutlinedButton(onClick = { vm.stepSpeaker(1) }) { Text("▶") }
-                    }
-                    Spacer(Modifier.height(8.dp))
-                    // Jump straight to a variant number (904 is a lot to step through).
-                    var jump by remember { mutableStateOf("") }
-                    val goToVariant = {
-                        jump.trim().toIntOrNull()?.let { vm.setSpeaker(it) }
-                        jump = ""
-                    }
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        OutlinedTextField(
-                            value = jump,
-                            onValueChange = { s -> jump = s.filter { it.isDigit() }.take(4) },
-                            singleLine = true,
-                            label = { Text(stringResource(R.string.settings_voice_variant_field)) },
-                            keyboardOptions = KeyboardOptions(
-                                keyboardType = KeyboardType.Number,
-                                imeAction = ImeAction.Go,
-                            ),
-                            keyboardActions = KeyboardActions(onGo = { goToVariant() }),
-                            modifier = Modifier.width(150.dp).dpadFieldEscape(),
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        OutlinedButton(onClick = goToVariant, enabled = jump.isNotBlank()) { Text(stringResource(R.string.settings_voice_variant_go)) }
-                    }
-                    Hint(stringResource(R.string.settings_voice_variant_hint))
-                }
-                } // end "Advanced voice options"
-            }
-
+            // 3D buildings moved to Advanced (niche + a documented z16+ perf cost).
             Spacer(Modifier.height(20.dp).onGloballyPositioned { offlineSectionY = it.positionInRoot().y })
             // Collapsed by default — the routing-region list can be long, so don't make the user
             // scroll past all of it to reach the sections below. Opens expanded when the onboarding
@@ -719,6 +446,267 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
             } // end if (offlineExpanded)
 
             Spacer(Modifier.height(20.dp))
+            SectionTitle(stringResource(R.string.settings_place_pages))
+
+            ToggleRow(stringResource(R.string.settings_show_reviews), app.vela.ui.ShowReviews.on.value) { app.vela.ui.ShowReviews.set(context, it) }
+            Hint(stringResource(R.string.settings_show_reviews_hint))
+
+            ToggleRow(stringResource(R.string.settings_read_all_reviews), app.vela.ui.LiveReviews.on.value) { app.vela.ui.LiveReviews.set(context, it) }
+            Hint(stringResource(R.string.settings_read_all_reviews_hint))
+
+            ToggleRow(stringResource(R.string.settings_load_photos), app.vela.ui.LoadPhotos.on.value) { app.vela.ui.LoadPhotos.set(context, it) }
+            Hint(stringResource(R.string.settings_load_photos_hint))
+            // "Hide adult categories" + "Hide website & external links" moved to Advanced.
+
+            Spacer(Modifier.height(20.dp))
+            SectionTitle(stringResource(R.string.settings_navigation))
+            val prefs = remember { context.getSharedPreferences("vela_settings", android.content.Context.MODE_PRIVATE) }
+
+            var keepAwake by remember { mutableStateOf(prefs.getBoolean("keep_screen_on_nav", true)) }
+            ToggleRow(stringResource(R.string.settings_keep_screen_on), keepAwake) {
+                keepAwake = it
+                prefs.edit().putBoolean("keep_screen_on_nav", it).apply()
+            }
+            Hint(stringResource(R.string.settings_keep_screen_on_hint))
+
+            // Traffic-light guidance moved to Advanced (experimental, English-only).
+            Text(stringResource(R.string.settings_vibrate_on_turns), style = MaterialTheme.typography.bodyLarge, modifier = Modifier.padding(top = 4.dp))
+            // One chip per travel mode (was four stacked switch rows — a lot of vertical space
+            // for a setting most people touch once). Selected = that mode vibrates at turns.
+            Row(
+                // Scrollable so four localized labels can never squeeze each other off-screen.
+                Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(top = 4.dp, bottom = 2.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                listOf(
+                    TravelMode.DRIVE to stringResource(R.string.settings_mode_driving),
+                    TravelMode.WALK to stringResource(R.string.settings_mode_walking),
+                    TravelMode.BICYCLE to stringResource(R.string.settings_mode_cycling),
+                    TravelMode.TRANSIT to stringResource(R.string.settings_mode_transit),
+                ).let { modes ->
+                    // The ROOT swallows bare LEFT/RIGHT (see above), so this horizontal row drives its
+                    // OWN LEFT/RIGHT via FocusRequesters — requestFocus (not moveFocus) never clears at
+                    // the ends, and consuming the key stops it reaching the root swallow.
+                    val chipFocus = remember { List(modes.size) { FocusRequester() } }
+                    modes.forEachIndexed { i, (mode, label) ->
+                        var on by remember(mode) {
+                            val default = if (!prefs.getBoolean(Haptics.KEY, true)) false else Haptics.defaultFor(mode)
+                            mutableStateOf(prefs.getBoolean(Haptics.keyFor(mode), default))
+                        }
+                        FilterChip(
+                            selected = on,
+                            onClick = {
+                                on = !on
+                                prefs.edit().putBoolean(Haptics.keyFor(mode), on).apply()
+                            },
+                            label = { Text(label) },
+                            shape = androidx.compose.foundation.shape.CircleShape,
+                            modifier = Modifier
+                                .focusRequester(chipFocus[i])
+                                .onKeyEvent { ev ->
+                                    if (ev.key == Key.DirectionRight || ev.key == Key.DirectionLeft) {
+                                        if (ev.type == KeyEventType.KeyDown) {
+                                            if (ev.key == Key.DirectionRight && i < chipFocus.lastIndex) chipFocus[i + 1].requestFocus()
+                                            if (ev.key == Key.DirectionLeft && i > 0) chipFocus[i - 1].requestFocus()
+                                        }
+                                        true
+                                    } else {
+                                        false
+                                    }
+                                },
+                        )
+                    }
+                }
+            }
+            Hint(stringResource(R.string.settings_vibrate_hint))
+
+            // Demo drive + simulated location moved to Developer (screenshot/testing tools).
+
+            // Parking history — recent "parked here" saves, so an accidental overwrite is
+            // recoverable (also reachable by long-pressing the P button on the map).
+            if (state.parkingHistory.isNotEmpty()) {
+                Spacer(Modifier.height(20.dp))
+                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    SectionTitle(stringResource(R.string.settings_parking_history))
+                    Spacer(Modifier.weight(1f))
+                    TextButton(onClick = { vm.clearParkingHistory() }) { Text(stringResource(R.string.parking_history_clear_all)) }
+                }
+                Hint(stringResource(R.string.settings_parking_history_hint))
+                state.parkingHistory.forEach { entry ->
+                    val isCurrent = entry.savedAtMillis == state.parkedAtMillis
+                    Row(
+                        Modifier.fillMaxWidth().padding(vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            Icons.Default.LocalParking,
+                            contentDescription = null,
+                            tint = if (isCurrent) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(Modifier.width(10.dp))
+                        Text(
+                            java.text.SimpleDateFormat("MMM d, h:mm a", java.util.Locale.getDefault())
+                                .format(java.util.Date(entry.savedAtMillis)),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontWeight = if (isCurrent) FontWeight.Bold else FontWeight.Normal,
+                            modifier = Modifier.weight(1f),
+                        )
+                        if (isCurrent) {
+                            Text(stringResource(R.string.parking_history_current), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                        } else {
+                            TextButton(onClick = { vm.restoreParkingFromHistory(entry) }) { Text(stringResource(R.string.parking_history_restore)) }
+                            IconButton(onClick = { vm.deleteParkingHistoryEntry(entry) }) {
+                                Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.parking_history_delete), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+            SectionTitle(stringResource(R.string.settings_voice))
+            // Vela's own on-device neural voices (the Piper catalog) — download in the Voice
+            // library below; once downloaded each shows in the engine list (selectable). No
+            // standalone TTS app needed.
+            // A download in flight shows a compact progress line here too, so it's visible even when the
+            // Voice library (below) is collapsed. The per-voice controls live in the library.
+            state.voiceDownloadingId?.let { id ->
+                val nm = vm.voiceCatalog().firstOrNull { it.id == id }?.displayName ?: stringResource(R.string.settings_voice_fallback_name)
+                val pct = state.voiceDownloadPct ?: 0f
+                Text(stringResource(R.string.settings_voice_downloading, nm, (pct * 100).toInt()), style = MaterialTheme.typography.bodyMedium)
+                Spacer(Modifier.height(6.dp))
+                LinearProgressIndicator(progress = { pct }, modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(12.dp))
+            } ?: Spacer(Modifier.height(4.dp))
+            // Enumerate TTS engines OFF the main thread. PackageManager.queryIntentServices + the
+            // per-engine loadLabel is a binder IPC that took >5 s on the flip phone and ANR'd the UI
+            // when run in composition (input-dispatch timeout). Load async (cached in VoiceGuide);
+            // render nothing until ready so there's no flash of the "no engines" hint.
+            val engines by produceState<List<VoiceEngine>?>(null, state.voiceDownloadingId) {
+                value = withContext(Dispatchers.IO) { vm.voiceEngines() }
+            }
+            val engineList = engines
+            if (engineList == null) {
+                // still loading — render nothing
+            } else if (engineList.isEmpty()) {
+                Hint(stringResource(R.string.settings_voice_none_hint))
+            } else {
+                engineList.forEach { e ->
+                    SelectableRow(
+                        label = e.label,
+                        selected = state.selectedEngine?.packageName == e.packageName,
+                        onClick = { vm.setVoiceEngine(e) },
+                    )
+                }
+                Spacer(Modifier.height(8.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    OutlinedButton(onClick = { vm.testVoice() }) { Text(stringResource(R.string.settings_voice_test)) }
+                    Spacer(Modifier.width(8.dp))
+                    OutlinedButton(onClick = {
+                        runCatching {
+                            context.startActivity(
+                                android.content.Intent("com.android.settings.TTS_SETTINGS")
+                                    .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK),
+                            )
+                        }
+                    }) { Text(stringResource(R.string.settings_voice_system_settings)) }
+                }
+                Hint(stringResource(R.string.settings_voice_test_hint))
+            }
+
+            // The voice catalog (browse / download / switch / delete) opens on its OWN screen now — it
+            // was a long inline accordion on this already-long list. A download in flight still shows
+            // its progress line above, so it's visible from here even with the browser closed.
+            Spacer(Modifier.height(8.dp))
+            OutlinedButton(onClick = { showVoiceLibrary = true }) { Text(stringResource(R.string.settings_browse_voices)) }
+            Hint(stringResource(R.string.settings_browse_voices_hint))
+
+            if (engineList?.isNotEmpty() == true) {
+                // Speed + the niche bits (playground, the multi-speaker variant picker) — most people never
+                // touch these, so tuck them behind a collapsible header (collapsed by default).
+                var voiceAdvExpanded by remember { mutableStateOf(false) }
+                CollapsibleSectionTitle(stringResource(R.string.settings_voice_advanced), voiceAdvExpanded) { voiceAdvExpanded = !voiceAdvExpanded }
+                if (voiceAdvExpanded) {
+                // Playground: hear the selected voice on any text (or a nav-style sample).
+                Spacer(Modifier.height(12.dp))
+                var tryText by remember { mutableStateOf("") }
+                OutlinedTextField(
+                    value = tryText,
+                    onValueChange = { tryText = it },
+                    modifier = Modifier.fillMaxWidth().dpadFieldEscape(),
+                    label = { Text(stringResource(R.string.settings_voice_try_label)) },
+                    maxLines = 3,
+                )
+                Spacer(Modifier.height(6.dp))
+                val navSampleText = stringResource(R.string.settings_voice_nav_sample_text)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    OutlinedButton(onClick = { vm.speakText(tryText) }, enabled = tryText.isNotBlank()) { Text(stringResource(R.string.settings_voice_speak)) }
+                    Spacer(Modifier.width(8.dp))
+                    OutlinedButton(onClick = {
+                        vm.speakText(navSampleText)
+                    }) { Text(stringResource(R.string.settings_voice_nav_sample)) }
+                }
+                // Speed applies to whichever voice is selected (neural + system TTS).
+                Spacer(Modifier.height(10.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        stringResource(R.string.settings_voice_speed, "%.2fx".format(state.voiceSpeed)),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                    OutlinedButton(onClick = { vm.setVoiceSpeed(-0.1f) }) { Text("−") }
+                    Spacer(Modifier.width(6.dp))
+                    OutlinedButton(onClick = { vm.setVoiceSpeed(0.1f) }) { Text("+") }
+                }
+                Hint(stringResource(R.string.settings_voice_speed_hint))
+                // Multi-speaker Vela voices (libritts_r=904, VCTK=109, Arctic=18) — let the user audition +
+                // pick a variant. Hidden for single-speaker voices (lessac/hfc/…), where it's meaningless.
+                if (state.selectedEngine?.packageName?.startsWith("vela.") == true && vm.voiceSpeakerCount() > 1) {
+                    Spacer(Modifier.height(10.dp))
+                    val cnt = vm.voiceSpeakerCount()
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            if (cnt > 0) stringResource(R.string.settings_voice_variant_of, state.voiceSpeaker, cnt)
+                            else stringResource(R.string.settings_voice_variant, state.voiceSpeaker),
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(1f),
+                        )
+                        OutlinedButton(onClick = { vm.stepSpeaker(-1) }) { Text("◀") }
+                        Spacer(Modifier.width(6.dp))
+                        OutlinedButton(onClick = { vm.stepSpeaker(1) }) { Text("▶") }
+                    }
+                    Spacer(Modifier.height(8.dp))
+                    // Jump straight to a variant number (904 is a lot to step through).
+                    var jump by remember { mutableStateOf("") }
+                    val goToVariant = {
+                        jump.trim().toIntOrNull()?.let { vm.setSpeaker(it) }
+                        jump = ""
+                    }
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        OutlinedTextField(
+                            value = jump,
+                            onValueChange = { s -> jump = s.filter { it.isDigit() }.take(4) },
+                            singleLine = true,
+                            label = { Text(stringResource(R.string.settings_voice_variant_field)) },
+                            keyboardOptions = KeyboardOptions(
+                                keyboardType = KeyboardType.Number,
+                                imeAction = ImeAction.Go,
+                            ),
+                            keyboardActions = KeyboardActions(onGo = { goToVariant() }),
+                            modifier = Modifier.width(150.dp).dpadFieldEscape(),
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        OutlinedButton(onClick = goToVariant, enabled = jump.isNotBlank()) { Text(stringResource(R.string.settings_voice_variant_go)) }
+                    }
+                    Hint(stringResource(R.string.settings_voice_variant_hint))
+                }
+                } // end "Advanced voice options"
+            }
+
+
+            Spacer(Modifier.height(20.dp))
             SectionTitle(stringResource(R.string.settings_saved_places))
             Hint(stringResource(R.string.settings_saved_places_hint))
             val importLauncher = rememberLauncherForActivityResult(
@@ -806,61 +794,7 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 }) { Text(stringResource(R.string.settings_diag_export)) }
             }
 
-            // Trip recording — more invasive than diagnostics (it's your exact routes),
-            // so it's a separate opt-in. Records nav GPS traces for replay testing.
-            LaunchedEffect(Unit) { vm.refreshTripRecording() }
-            var showTripConsent by remember { mutableStateOf(false) }
-            var trips by remember { mutableStateOf(vm.recordedTrips()) }
-            // Re-read on entry so a trip recorded since the app launched shows up without
-            // a restart (the list was otherwise only refreshed after a delete).
-            LaunchedEffect(Unit) { trips = vm.recordedTrips() }
-            Spacer(Modifier.height(8.dp))
-            ToggleRow(stringResource(R.string.settings_save_trips), state.tripRecordingEnabled) { on -> if (on) showTripConsent = true else vm.setTripRecording(false) }
-            Hint(stringResource(R.string.settings_save_trips_hint))
-            if (trips.isNotEmpty()) {
-                Spacer(Modifier.height(4.dp))
-                Hint(stringResource(R.string.settings_recorded_trips_hint))
-                trips.forEach { t ->
-                    Row(
-                        Modifier.fillMaxWidth().padding(vertical = 2.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Column(Modifier.weight(1f)) {
-                            Text(t.label, style = MaterialTheme.typography.bodyLarge, maxLines = 1)
-                            val recordedAt = if (t.startedAt > 0L)
-                                java.text.SimpleDateFormat("MMM d, h:mm a", java.util.Locale.getDefault())
-                                    .format(java.util.Date(t.startedAt))
-                            else null
-                            Hint(listOfNotNull(recordedAt, stringResource(R.string.settings_trip_points, t.fixCount)).joinToString(" · "))
-                        }
-                        TextButton(onClick = { vm.replayTrip(t); onBack() }) { Text(stringResource(R.string.settings_trip_replay)) }
-                        // Share the raw trace off-device — works on release builds, so a
-                        // drive can be handed over for replay/debug without a dev build.
-                        TextButton(onClick = {
-                            val intent = vm.exportTripIntent(t)
-                            if (intent != null) runCatching { context.startActivity(intent) }
-                            else android.widget.Toast.makeText(context, context.getString(R.string.settings_trip_read_error), android.widget.Toast.LENGTH_SHORT).show()
-                        }) { Text(stringResource(R.string.settings_trip_share)) }
-                        IconButton(onClick = { vm.deleteTrip(t.id); trips = vm.recordedTrips() }) {
-                            Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.settings_trip_delete))
-                        }
-                    }
-                }
-            } else if (state.tripRecordingEnabled) {
-                Spacer(Modifier.height(4.dp))
-                Hint(stringResource(R.string.settings_no_trips_hint))
-            }
-            if (showTripConsent) {
-                app.vela.ui.VelaDialog(
-                    onDismissRequest = { showTripConsent = false },
-                    title = stringResource(R.string.settings_trip_consent_title),
-                    confirmText = stringResource(R.string.settings_turn_on),
-                    onConfirm = { vm.setTripRecording(true); showTripConsent = false },
-                    dismissText = stringResource(R.string.settings_cancel),
-                    onDismiss = { showTripConsent = false },
-                    text = { Text(stringResource(R.string.settings_trip_consent_body)) },
-                )
-            }
+            // Trip recording moved to Developer (it's a testing tool that captures your exact routes).
             var crashReports by remember { mutableStateOf(app.vela.diag.CrashCatcher.pending(context)) }
             if (crashReports.isNotEmpty()) {
                 Spacer(Modifier.height(8.dp))
@@ -896,6 +830,98 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                     onDismiss = { showDiagConsent = false },
                     text = { Text(stringResource(R.string.settings_diag_consent_body)) },
                 )
+            }
+
+            // ---- Advanced: niche + experimental toggles, collapsed so they stay out of the way ----
+            Spacer(Modifier.height(20.dp))
+            var advancedExpanded by remember { mutableStateOf(false) }
+            CollapsibleSectionTitle(stringResource(R.string.settings_advanced), advancedExpanded) { advancedExpanded = !advancedExpanded }
+            if (advancedExpanded) {
+                Hint(stringResource(R.string.settings_advanced_hint))
+                ToggleRow(stringResource(R.string.settings_buildings_3d), app.vela.ui.Buildings3d.on.value) { app.vela.ui.Buildings3d.set(context, it) }
+                Hint(stringResource(R.string.settings_buildings_3d_hint))
+                ToggleRow(stringResource(R.string.settings_hide_adult), app.vela.ui.HideAdult.on.value) { app.vela.ui.HideAdult.set(context, it) }
+                Hint(stringResource(R.string.settings_hide_adult_hint))
+                ToggleRow(stringResource(R.string.settings_hide_external_links), app.vela.ui.HideExternalLinks.on.value) { app.vela.ui.HideExternalLinks.set(context, it) }
+                Hint(stringResource(R.string.settings_hide_external_links_hint))
+                var trafficLights by remember { mutableStateOf(prefs.getBoolean("nav_traffic_lights", false)) }
+                ToggleRow(stringResource(R.string.settings_traffic_lights), trafficLights) {
+                    trafficLights = it
+                    prefs.edit().putBoolean("nav_traffic_lights", it).apply()
+                }
+                Hint(stringResource(R.string.settings_traffic_lights_hint))
+            }
+
+            // ---- Developer: screenshot/testing tools, collapsed (each says "turn off for real use") ----
+            Spacer(Modifier.height(20.dp))
+            var developerExpanded by remember { mutableStateOf(false) }
+            CollapsibleSectionTitle(stringResource(R.string.settings_developer), developerExpanded) { developerExpanded = !developerExpanded }
+            if (developerExpanded) {
+                Hint(stringResource(R.string.settings_developer_hint))
+                var demoDrive by remember { mutableStateOf(prefs.getBoolean("demo_drive", false)) }
+                ToggleRow(stringResource(R.string.settings_demo_drive), demoDrive) {
+                    demoDrive = it
+                    prefs.edit().putBoolean("demo_drive", it).apply()
+                }
+                Hint(stringResource(R.string.settings_demo_drive_hint))
+                // Simulated location — pretend to be at the current map centre (demos/screenshots
+                // without leaking where you actually are). Reactive holder reflects the state.
+                ToggleRow(stringResource(R.string.settings_sim_location), app.vela.ui.SimLocation.on) { on -> if (on) vm.simulateLocationHere() else vm.stopSimulateLocation() }
+                Hint(stringResource(R.string.settings_sim_location_hint))
+
+                // Trip recording — captures your exact nav routes for replay testing (never uploaded),
+                // so it's its own opt-in with a consent step.
+                LaunchedEffect(Unit) { vm.refreshTripRecording() }
+                var showTripConsent by remember { mutableStateOf(false) }
+                var trips by remember { mutableStateOf(vm.recordedTrips()) }
+                LaunchedEffect(Unit) { trips = vm.recordedTrips() }
+                Spacer(Modifier.height(8.dp))
+                ToggleRow(stringResource(R.string.settings_save_trips), state.tripRecordingEnabled) { on -> if (on) showTripConsent = true else vm.setTripRecording(false) }
+                Hint(stringResource(R.string.settings_save_trips_hint))
+                if (trips.isNotEmpty()) {
+                    Spacer(Modifier.height(4.dp))
+                    Hint(stringResource(R.string.settings_recorded_trips_hint))
+                    trips.forEach { t ->
+                        Row(
+                            Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Column(Modifier.weight(1f)) {
+                                Text(t.label, style = MaterialTheme.typography.bodyLarge, maxLines = 1)
+                                val recordedAt = if (t.startedAt > 0L)
+                                    java.text.SimpleDateFormat("MMM d, h:mm a", java.util.Locale.getDefault())
+                                        .format(java.util.Date(t.startedAt))
+                                else null
+                                Hint(listOfNotNull(recordedAt, stringResource(R.string.settings_trip_points, t.fixCount)).joinToString(" · "))
+                            }
+                            TextButton(onClick = { vm.replayTrip(t); onBack() }) { Text(stringResource(R.string.settings_trip_replay)) }
+                            // Share the raw trace off-device — works on release builds, so a
+                            // drive can be handed over for replay/debug without a dev build.
+                            TextButton(onClick = {
+                                val intent = vm.exportTripIntent(t)
+                                if (intent != null) runCatching { context.startActivity(intent) }
+                                else android.widget.Toast.makeText(context, context.getString(R.string.settings_trip_read_error), android.widget.Toast.LENGTH_SHORT).show()
+                            }) { Text(stringResource(R.string.settings_trip_share)) }
+                            IconButton(onClick = { vm.deleteTrip(t.id); trips = vm.recordedTrips() }) {
+                                Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.settings_trip_delete))
+                            }
+                        }
+                    }
+                } else if (state.tripRecordingEnabled) {
+                    Spacer(Modifier.height(4.dp))
+                    Hint(stringResource(R.string.settings_no_trips_hint))
+                }
+                if (showTripConsent) {
+                    app.vela.ui.VelaDialog(
+                        onDismissRequest = { showTripConsent = false },
+                        title = stringResource(R.string.settings_trip_consent_title),
+                        confirmText = stringResource(R.string.settings_turn_on),
+                        onConfirm = { vm.setTripRecording(true); showTripConsent = false },
+                        dismissText = stringResource(R.string.settings_cancel),
+                        onDismiss = { showTripConsent = false },
+                        text = { Text(stringResource(R.string.settings_trip_consent_body)) },
+                    )
+                }
             }
 
             Spacer(Modifier.height(20.dp))
@@ -965,6 +991,42 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
             updateStatus?.let { Hint(it) }
             // Breathing room under the last control — the button used to sit right on the
             // gesture bar at the end of the scroll.
+            Spacer(Modifier.height(56.dp))
+        }
+    }
+}
+
+/** The voice library on its OWN screen (browse / download / switch / delete Vela's neural voices),
+ *  reached from Settings → Voice → Browse voices. Its own Back returns to Settings. Keeping the catalog
+ *  off the main Settings scroll is the whole point — it was a long inline accordion before. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun VoiceBrowseScreen(vm: MapViewModel, onClose: () -> Unit) {
+    val state by vm.state.collectAsStateWithLifecycle()
+    // System back returns to Settings, not out to the map.
+    BackHandler(onBack = onClose)
+    // D-pad-first: open already focused on the back button (docs/dpad.md).
+    val autoFocus = rememberDpadAutoFocus()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.settings_voice_library)) },
+                navigationIcon = {
+                    IconButton(onClick = onClose, modifier = Modifier.focusRequester(autoFocus)) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.settings_back))
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            Modifier
+                .padding(padding)
+                .dpadSwallowHorizontal()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp),
+        ) {
+            VoiceLibrary(vm, state)
             Spacer(Modifier.height(56.dp))
         }
     }

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -245,27 +245,6 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
             }
             Hint(stringResource(R.string.settings_language_hint))
 
-            Spacer(Modifier.height(20.dp))
-            SectionTitle(stringResource(R.string.settings_search))
-            ToggleRow(stringResource(R.string.settings_voice_search_toggle), app.vela.ui.VoiceSearch.enabled.value) {
-                app.vela.ui.VoiceSearch.set(context, it)
-            }
-            // The hint tells the truth about whether the mic can actually appear: it needs a
-            // voice-input app installed (a later build adds an on-device model as a second path).
-            val hasVoiceProvider = remember { app.vela.ui.VoiceSearch.hasProvider(context) }
-            Hint(
-                if (hasVoiceProvider) stringResource(R.string.settings_voice_search_hint)
-                else stringResource(R.string.settings_voice_search_none),
-            )
-
-            Spacer(Modifier.height(20.dp))
-            SectionTitle(stringResource(R.string.settings_map))
-            ToggleRow(stringResource(R.string.settings_live_traffic), app.vela.ui.Traffic.on.value) { app.vela.ui.Traffic.set(context, it) }
-            Hint(stringResource(R.string.settings_live_traffic_hint))
-
-            ToggleRow(stringResource(R.string.settings_transit_layer), app.vela.ui.TransitLayer.on.value) { app.vela.ui.TransitLayer.set(context, it) }
-            Hint(stringResource(R.string.settings_transit_layer_hint))
-            // 3D buildings moved to Advanced (niche + a documented z16+ perf cost).
             Spacer(Modifier.height(20.dp).onGloballyPositioned { offlineSectionY = it.positionInRoot().y })
             // Collapsed by default — the routing-region list can be long, so don't make the user
             // scroll past all of it to reach the sections below. Opens expanded when the onboarding
@@ -370,7 +349,7 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                                 }
                             }
                         },
-                        placeholder = { Text(stringResource(R.string.settings_routing_filter_placeholder, state.routingRegions.size)) },
+                        placeholder = { Text(stringResource(R.string.settings_routing_filter_placeholder)) },
                     )
                 }
                 val shown = if (routeFilter.isBlank()) ordered
@@ -444,6 +423,27 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 }
             }
             } // end if (offlineExpanded)
+            Spacer(Modifier.height(20.dp))
+            SectionTitle(stringResource(R.string.settings_search))
+            ToggleRow(stringResource(R.string.settings_voice_search_toggle), app.vela.ui.VoiceSearch.enabled.value) {
+                app.vela.ui.VoiceSearch.set(context, it)
+            }
+            // The hint tells the truth about whether the mic can actually appear: it needs a
+            // voice-input app installed (a later build adds an on-device model as a second path).
+            val hasVoiceProvider = remember { app.vela.ui.VoiceSearch.hasProvider(context) }
+            Hint(
+                if (hasVoiceProvider) stringResource(R.string.settings_voice_search_hint)
+                else stringResource(R.string.settings_voice_search_none),
+            )
+
+            Spacer(Modifier.height(20.dp))
+            SectionTitle(stringResource(R.string.settings_map))
+            ToggleRow(stringResource(R.string.settings_live_traffic), app.vela.ui.Traffic.on.value) { app.vela.ui.Traffic.set(context, it) }
+            Hint(stringResource(R.string.settings_live_traffic_hint))
+
+            ToggleRow(stringResource(R.string.settings_transit_layer), app.vela.ui.TransitLayer.on.value) { app.vela.ui.TransitLayer.set(context, it) }
+            Hint(stringResource(R.string.settings_transit_layer_hint))
+            // 3D buildings moved to Advanced (niche + a documented z16+ perf cost).
 
             Spacer(Modifier.height(20.dp))
             SectionTitle(stringResource(R.string.settings_place_pages))

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -69,16 +69,16 @@
     <string name="settings_hide_external_links">Website &amp; externe Links ausblenden</string>
     <string name="settings_hide_external_links_hint">An = Ortsseiten zeigen keine Website-, Street-View- oder Buchen / Bestellen-Schaltflächen (keine beliebigen externen Seiten geöffnet).</string>
     <string name="settings_offline">Offline-Karten</string>
-    <string name="settings_offline_hint">Lade einen Bereich herunter, um seine Karte und Wegbeschreibungen für die Offline-Nutzung auf dem Gerät zu behalten.</string>
-    <string name="settings_offline_map_area">Kartenbereich</string>
+    <string name="settings_offline_hint">Zwei Wege, Vela offline zu nutzen: Speichere den Bereich, in dem du bist, für kurze Wege, oder unten ein ganzes Bundesland oder Land für längere.</string>
+    <string name="settings_offline_map_area">Lokales Gebiet</string>
     <string name="settings_offline_download_viewport">Angezeigten Bereich herunterladen</string>
-    <string name="settings_offline_download_viewport_hint">Speichert die Karte und ihre Straßen für den angezeigten Bereich, damit er offline angezeigt wird und Routen berechnet.</string>
+    <string name="settings_offline_download_viewport_hint">Speichert die Karte, die du gerade siehst, mit ihren Straßen und Adressen, damit dieser Bereich auch ohne Empfang funktioniert.</string>
     <string name="settings_offline_no_areas">Noch keine Bereiche gespeichert.</string>
     <string name="settings_offline_addresses_missing">Vor diesem Update gespeicherte Gebiete enthalten keine Adressdaten. Aktualisiere sie, um offline nach Adressen zu suchen und dorthin zu navigieren.</string>
     <string name="settings_offline_addresses_update">Gespeicherte Gebiete aktualisieren</string>
     <string name="settings_offline_delete_area">Diesen Offline-Bereich löschen</string>
-    <string name="settings_routing_regions">Routing-Regionen</string>
-    <string name="settings_routing_regions_hint">Die Straßen einer ganzen Region (ein Bundesland oder Land), damit Wegbeschreibungen überall darin offline funktionieren. Hol dir, wohin du fährst.</string>
+    <string name="settings_routing_regions">Regionen &amp; Länder</string>
+    <string name="settings_routing_regions_hint">Alles, um offline durch ein ganzes Bundesland, eine Provinz oder ein Land zu kommen: Straßen und Orte, damit Navigation und Suche überall darin funktionieren. Hol dir, wohin du fährst.</string>
     <string name="settings_routing_no_regions">Noch keine Regionen verfügbar.</string>
     <string name="settings_clear_filter">Filter löschen</string>
     <string name="settings_routing_filter_placeholder">Suchen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -72,13 +72,13 @@
     <string name="settings_offline_hint">Lade einen Bereich herunter, um seine Karte und Wegbeschreibungen für die Offline-Nutzung auf dem Gerät zu behalten.</string>
     <string name="settings_offline_map_area">Kartenbereich</string>
     <string name="settings_offline_download_viewport">Angezeigten Bereich herunterladen</string>
-    <string name="settings_offline_download_viewport_hint">Speichert die Kacheln für den zuletzt angezeigten Kartenbereich – und die Routing-Region drumherum – sodass er später ohne Netz dargestellt und navigiert wird. Die Suche benötigt weiterhin eine Verbindung.</string>
+    <string name="settings_offline_download_viewport_hint">Speichert die Karte und ihre Straßen für den angezeigten Bereich, damit er offline angezeigt wird und Routen berechnet.</string>
     <string name="settings_offline_no_areas">Noch keine Bereiche gespeichert.</string>
     <string name="settings_offline_addresses_missing">Vor diesem Update gespeicherte Gebiete enthalten keine Adressdaten. Aktualisiere sie, um offline nach Adressen zu suchen und dorthin zu navigieren.</string>
     <string name="settings_offline_addresses_update">Gespeicherte Gebiete aktualisieren</string>
     <string name="settings_offline_delete_area">Diesen Offline-Bereich löschen</string>
     <string name="settings_routing_regions">Routing-Regionen</string>
-    <string name="settings_routing_regions_hint">Das Straßennetz einer ganzen Region (Bundesland, Land …), damit die Navigation überall darin offline funktioniert – laden Sie Ihr Reiseziel herunter. Online wird weiterhin der Live-Verkehr genutzt; dies ist die Ausweichlösung ohne Signal.</string>
+    <string name="settings_routing_regions_hint">Die Straßen einer ganzen Region (ein Bundesland oder Land), damit Wegbeschreibungen überall darin offline funktionieren. Hol dir, wohin du fährst.</string>
     <string name="settings_routing_no_regions">Noch keine Regionen verfügbar.</string>
     <string name="settings_clear_filter">Filter löschen</string>
     <string name="settings_routing_filter_placeholder">%1$d Regionen filtern … (z. B. Japan, Texas)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -69,7 +69,7 @@
     <string name="settings_hide_external_links">Website &amp; externe Links ausblenden</string>
     <string name="settings_hide_external_links_hint">An = Ortsseiten zeigen keine Website-, Street-View- oder Buchen / Bestellen-Schaltflächen (keine beliebigen externen Seiten geöffnet).</string>
     <string name="settings_offline">Offline</string>
-    <string name="settings_offline_hint">Für die Kartennutzung ohne Signal braucht es zwei Dinge – die KARTEN-Kacheln, die Sie sehen, und das STRASSENNETZ, das Sie leitet. Das Speichern eines Kartenbereichs holt beides für diesen Ort; die Regionsliste unten fügt das Straßennetz für Ihr Reiseziel hinzu.</string>
+    <string name="settings_offline_hint">Lade einen Bereich herunter, um seine Karte und Wegbeschreibungen für die Offline-Nutzung auf dem Gerät zu behalten.</string>
     <string name="settings_offline_map_area">Kartenbereich</string>
     <string name="settings_offline_download_viewport">Angezeigten Bereich herunterladen</string>
     <string name="settings_offline_download_viewport_hint">Speichert die Kacheln für den zuletzt angezeigten Kartenbereich – und die Routing-Region drumherum – sodass er später ohne Netz dargestellt und navigiert wird. Die Suche benötigt weiterhin eine Verbindung.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -68,7 +68,7 @@
     <string name="settings_hide_adult_hint">An = Bars, Clubs, Casinos, Spirituosengeschäfte und andere Erwachsenen- / Nachtleben-Orte werden aus Suche und Karte ausgeblendet.</string>
     <string name="settings_hide_external_links">Website &amp; externe Links ausblenden</string>
     <string name="settings_hide_external_links_hint">An = Ortsseiten zeigen keine Website-, Street-View- oder Buchen / Bestellen-Schaltflächen (keine beliebigen externen Seiten geöffnet).</string>
-    <string name="settings_offline">Offline</string>
+    <string name="settings_offline">Offline-Karten</string>
     <string name="settings_offline_hint">Lade einen Bereich herunter, um seine Karte und Wegbeschreibungen für die Offline-Nutzung auf dem Gerät zu behalten.</string>
     <string name="settings_offline_map_area">Kartenbereich</string>
     <string name="settings_offline_download_viewport">Angezeigten Bereich herunterladen</string>
@@ -81,7 +81,7 @@
     <string name="settings_routing_regions_hint">Die Straßen einer ganzen Region (ein Bundesland oder Land), damit Wegbeschreibungen überall darin offline funktionieren. Hol dir, wohin du fährst.</string>
     <string name="settings_routing_no_regions">Noch keine Regionen verfügbar.</string>
     <string name="settings_clear_filter">Filter löschen</string>
-    <string name="settings_routing_filter_placeholder">%1$d Regionen filtern … (z. B. Japan, Texas)</string>
+    <string name="settings_routing_filter_placeholder">Suchen</string>
     <string name="settings_routing_no_match">Keine Region passt zu „%1$s“.</string>
     <string name="settings_routing_downloading">Wird heruntergeladen … %1$d%%</string>
     <string name="settings_routing_installed">Installiert · Routen hier offline</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -14,6 +14,7 @@
     <string name="settings_units_imperial">Imperial (Meilen, Fuß)</string>
     <string name="settings_units_metric">Metrisch (Kilometer, Meter)</string>
     <string name="settings_language">Sprache</string>
+    <string name="settings_follow_system_language">Systemsprache verwenden</string>
     <string name="settings_language_hint">Legt die Sprache der gesprochenen Navigationsansagen fest (Englisch, Französisch, Deutsch, Spanisch, Italienisch, Portugiesisch, Niederländisch, Russisch, Polnisch, Schwedisch, Ukrainisch) – unabhängig von der Systemsprache Ihres Telefons. Wählen Sie unten in der Stimmenbibliothek eine passende Stimme. Der übrige Bildschirmtext der App wird als Nächstes übersetzt.</string>
     <string name="settings_search">Suche</string>
     <string name="settings_voice_search_toggle">Mikrofon für Sprachsuche</string>
@@ -478,4 +479,10 @@
     <string name="lists_empty_hint">Noch keine Listen. Tippe auf Neu oder speichere einen Ort von seiner Seite.</string>
     <string name="lists_place_count">%1$d Orte</string>
     <string name="navservice_notif_eta">Ankunft %1$s</string>
+    <string name="settings_advanced">Erweitert</string>
+    <string name="settings_advanced_hint">Nischen- und experimentelle Optionen, die die meisten nie ändern müssen.</string>
+    <string name="settings_developer">Entwickler</string>
+    <string name="settings_developer_hint">Werkzeuge für Demos, Screenshots und Tests. Schalte sie für den echten Einsatz aus.</string>
+    <string name="settings_browse_voices">Stimmen durchsuchen</string>
+    <string name="settings_browse_voices_hint">Vela-Stimmen auf dem Gerät herunterladen und wechseln.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -5,17 +5,17 @@
     <string name="settings_follow_system">System folgen</string>
     <string name="settings_theme_light">Hell</string>
     <string name="settings_theme_dark">Dunkel</string>
-    <string name="settings_appearance_hint">Hell/Dunkel gilt nur für Vela – das System-Design Ihres Telefons wird nicht verändert.</string>
-    <string name="settings_dynamic_color">Material-You-Farben</string>
-    <string name="settings_dynamic_color_hint">Färbt Schaltflächen, Chips und Akzente nach Ihrem Hintergrundbild (Android 12+). Aus = Velas eigenes Türkis. Die Karte selbst bleibt neutral, damit Straßen und Beschriftungen ihren Kontrast behalten.</string>
+    <string name="settings_appearance_hint">Gilt nur für Vela.</string>
+    <string name="settings_dynamic_color">Material You-Farben</string>
+    <string name="settings_dynamic_color_hint">Färbt Buttons und Akzente nach deinem Hintergrundbild. Die Karte bleibt neutral.</string>
     <string name="settings_map_style">Kartenstil</string>
-    <string name="settings_map_style_hint">OpenFreeMap (Standard) ist detailliert und braucht keinen Schlüssel. Protomaps benötigt einen API-Schlüssel; der Demo-Stil zeigt nur Ländergrenzen.</string>
+    <string name="settings_map_style_hint">OpenFreeMap funktioniert ohne API-Schlüssel.</string>
     <string name="settings_units">Einheiten</string>
     <string name="settings_units_imperial">Imperial (Meilen, Fuß)</string>
     <string name="settings_units_metric">Metrisch (Kilometer, Meter)</string>
     <string name="settings_language">Sprache</string>
     <string name="settings_follow_system_language">Systemsprache verwenden</string>
-    <string name="settings_language_hint">Legt die Sprache der gesprochenen Navigationsansagen fest (Englisch, Französisch, Deutsch, Spanisch, Italienisch, Portugiesisch, Niederländisch, Russisch, Polnisch, Schwedisch, Ukrainisch) – unabhängig von der Systemsprache Ihres Telefons. Wählen Sie unten in der Stimmenbibliothek eine passende Stimme. Der übrige Bildschirmtext der App wird als Nächstes übersetzt.</string>
+    <string name="settings_language_hint">Ändert die Sprache der App und der gesprochenen Ansagen. Hol dir eine passende Stimme in der Stimmbibliothek.</string>
     <string name="settings_search">Suche</string>
     <string name="settings_voice_search_toggle">Mikrofon für Sprachsuche</string>
     <string name="settings_voice_search_hint">Zeigt ein Mikrofon in der Suchleiste. Tippe darauf, um deine Suche zu sprechen, über eine Spracheingabe-App auf dem Gerät.</string>
@@ -50,16 +50,16 @@
     <string name="settings_mode_transit">ÖPNV</string>
     <string name="settings_vibrate_hint">Richtungscodierte Vibrationen bei jeder Abbiegung – unterschiedlich für links und rechts – damit Sie einer Route allein durch Fühlen folgen können. Pro Verkehrsmittel einstellbar (z. B. an beim Radfahren und Gehen, aus beim Autofahren).</string>
     <string name="settings_keep_screen_on">Bildschirm während der Navigation anlassen</string>
-    <string name="settings_keep_screen_on_hint">Verhindert, dass sich der Bildschirm während der Navigation abdunkelt oder ausschaltet, sodass die nächste Abbiegung immer sichtbar ist, ohne dass Sie ihn antippen müssen. Standardmäßig an; der Bildschirm schaltet sich wieder normal aus, sobald Sie ankommen oder die Navigation beenden.</string>
+    <string name="settings_keep_screen_on_hint">Hält das Display während der Navigation wach.</string>
     <string name="settings_map">Karte</string>
     <string name="settings_live_traffic">Live-Verkehrsanzeige</string>
-    <string name="settings_live_traffic_hint">Färbt beim Betrachten der Karte die Straßen nach Verkehrslage ein (Googles Verkehrs-Kacheln ohne Schlüssel). Standardmäßig aus – die Navigation färbt Ihre Route bereits nach Verkehr, dies dient nur zum Überblick über die weitere Umgebung. Es ist eine Raster-Anzeige und daher etwas körnig.</string>
+    <string name="settings_live_traffic_hint">Färbt Straßen beim Stöbern nach Verkehrslage. Die Navigation färbt deine Route ohnehin nach Verkehr.</string>
     <string name="settings_transit_layer">Nahverkehrslinien hervorheben</string>
-    <string name="settings_transit_layer_hint">Zeichnet Zug- und U-Bahn-Linien farbig auf die Karte, damit man Schienen leicht verfolgen kann. Nutzt die offenen Kartendaten, die schon in den Kacheln stecken, ohne Netz.</string>
+    <string name="settings_transit_layer_hint">Zeichnet Bahn- und U-Bahn-Linien auf die Karte.</string>
     <string name="settings_read_all_reviews">Schaltfläche „Alle Rezensionen lesen“</string>
-    <string name="settings_read_all_reviews_hint">Rezensionen im Ortsfenster sind immer Velas eigene, flüssige native Liste. Dies fügt eine Schaltfläche „Alle Rezensionen lesen“ hinzu, die Googles vollständige Rezensionsseite im VOLLBILD öffnet – jede Rezension (nicht nur die ersten ~50), Googles serverseitige Suche und abspielbare Video-Rezensionen. Tracker/Beacons werden blockiert, aber Googles Seite läuft dabei in der App. Aus = nur native Liste, keine Google-Seite für Rezensionen.</string>
+    <string name="settings_read_all_reviews_hint">Fügt einen Button hinzu, der Googles vollständige Bewertungsseite in der App öffnet, mit allen Bewertungen. Aus = nur Velas eigene Liste.</string>
     <string name="settings_buildings_3d">3D-Gebäude</string>
-    <string name="settings_buildings_3d_hint">Erhöhte Gebäudeformen bei starkem Zoom. Ausschalten kann das Verschieben auf älteren Handys flüssiger machen; die flachen Umrisse bleiben.</string>
+    <string name="settings_buildings_3d_hint">Erhöhte Gebäude bei starkem Zoom. Ausschalten kann das Schwenken auf älteren Geräten flüssiger machen.</string>
     <string name="settings_show_reviews">Bewertungen anzeigen</string>
     <string name="settings_show_reviews_hint">Aus = Orte zeigen keine Bewertungen, und Vela ruft sie auch nie ab.</string>
     <string name="settings_load_photos">Fotos laden</string>
@@ -101,15 +101,15 @@
     <string name="settings_export">Exportieren</string>
     <string name="settings_import">Importieren</string>
     <string name="settings_data_privacy">Datenquelle &amp; Datenschutz</string>
-    <string name="settings_data_privacy_hint">Vela kommuniziert direkt von diesem Gerät aus mit Googles öffentlichen Web-Endpunkten – kein Vela-Backend, kein Google-Konto, kein API-Schlüssel und keine Telemetrie, sofern Sie nicht unten die Diagnose aktivieren (standardmäßig aus, nur lokal). Jedes Gerät verhält sich wie ein abgemeldeter Browser; Google sieht Ihre IP, Ihre Suchanfrage und den Kartenbereich, aber kein Konto. Gespeicherte Orte und der Verlauf verlassen das Telefon nie.</string>
+    <string name="settings_data_privacy_hint">Vela spricht Googles öffentliche Endpunkte direkt von diesem Gerät an: kein Backend, kein Konto, kein API-Schlüssel. Google sieht IP, Anfrage und Kartenausschnitt, nicht wer du bist.</string>
     <string name="settings_privacy_button">Welche Daten Google erhält</string>
     <string name="settings_diagnostics">Diagnose</string>
-    <string name="settings_diagnostics_hint">Standardmäßig aus. Wenn aktiviert, führt Vela ein kurzes lokales Protokoll darüber, was es getan hat – Ihre Suchanfragen, Routen und etwaige „Neukalibrierung nötig“-Aussetzer – sodass Sie es bei Problemen exportieren und einem Entwickler übergeben können. Es bleibt auf diesem Telefon und wird nie hochgeladen; Sie wählen, wohin der Export geht. Beim Ausschalten wird das Protokoll gelöscht.</string>
+    <string name="settings_diagnostics_hint">Standardmäßig aus. Wenn an, führt Vela ein kurzes lokales Protokoll, das du exportieren und einem Entwickler geben kannst. Nichts wird hochgeladen; Ausschalten löscht es.</string>
     <string name="settings_share_diagnostics">Diagnose teilen</string>
     <string name="settings_diag_nothing">Noch nichts aufgezeichnet – nutzen Sie die App und exportieren Sie dann.</string>
     <string name="settings_diag_export">Debug-Sitzung exportieren</string>
     <string name="settings_save_trips">Meine Fahrten speichern (zur Wiedergabe)</string>
-    <string name="settings_save_trips_hint">Zeichnet die GPS-Spur jeder Navigation auf diesem Telefon auf, sodass eine Fahrt später wiedergegeben werden kann, um die Navigation zu testen, ohne sie erneut zu fahren. Aufschlussreicher als die Diagnose – es sind Ihre genauen Routen – und verlässt das Telefon nie.</string>
+    <string name="settings_save_trips_hint">Zeichnet die GPS-Spur jeder Fahrt auf diesem Gerät auf, um sie später abzuspielen. Verlässt das Gerät nie.</string>
     <string name="settings_recorded_trips_hint">Aufgezeichnete Fahrten – tippen Sie auf „Wiedergabe“, um eine auf der Karte abzuspielen (3×):</string>
     <string name="settings_trip_points">%1$d Punkte</string>
     <string name="settings_trip_replay">Wiedergabe</string>
@@ -167,7 +167,7 @@
     <string name="place_permanently_closed">Dauerhaft geschlossen</string>
     <string name="place_temporarily_closed">Vorübergehend geschlossen</string>
     <string name="settings_traffic_lights">Ampel-Hinweise</string>
-    <string name="settings_traffic_lights_hint">„Fahren Sie an der Ampel vorbei, dann abbiegen“ an Ampelkreuzungen (Ansagen vorerst nur auf Englisch)</string>
+    <string name="settings_traffic_lights_hint">Ergänzt Ansagen wie “an der Ampel vorbei, dann links abbiegen”. Vorerst nur auf Englisch.</string>
     <string name="map_voice_downloading">Vela-Stimme wird heruntergeladen · %1$d %%</string>
     <string name="map_voice_installing">Vela-Stimme wird installiert…</string>
     <string name="map_region_downloading">Routing für %1$s wird heruntergeladen · %2$d %%</string> <!-- format -->
@@ -175,9 +175,9 @@
     <string name="mapvm_poipack_ready">Orte in %1$s sind jetzt offline durchsuchbar</string> <!-- format -->
     <string name="mapvm_poipack_unavailable">Für %1$s gibt es noch kein Orte-Paket. Es erscheint hier, sobald es veröffentlicht ist.</string> <!-- format -->
     <string name="settings_demo_drive">Fahrt simulieren (Demo)</string>
-    <string name="settings_demo_drive_hint">Für Demos, Screenshots und Tests: Mit Start wird die geplante Route als simulierte GPS-Spur statt deiner echten Position gefahren — Navigation funktioniert überall. Zum echten Navigieren ausschalten.</string>
+    <string name="settings_demo_drive_hint">Start fährt die geplante Route als Simulation statt per GPS. Zum echten Navigieren ausschalten.</string>
     <string name="settings_sim_location">Standort simulieren (Demo)</string>
-    <string name="settings_sim_location_hint">Für Demos und Screenshots: Tu so, als wärst du gerade in der Mitte der Karte, sodass Standortpunkt, Entfernungen und Routen von dort statt von deiner echten Position ausgehen. Zum Ausschalten für echtes GPS.</string>
+    <string name="settings_sim_location_hint">Tut so, als wärst du in der Kartenmitte, für Demos und Screenshots. Für echtes GPS ausschalten.</string>
     <string name="place_address_copied">Adresse kopiert</string>
     <string name="place_copy_address">Adresse kopieren</string>
     <string name="place_directions">Route</string>
@@ -310,7 +310,7 @@
     <string name="mapscreen_switch">Wechseln</string>
     <string name="root_not_now">Jetzt nicht</string>
     <string name="root_voice_title">Sprachausgabe der Navigation</string>
-    <string name="root_voice_body_intro">Velas eigene Stimme läuft komplett auf deinem Gerät: natürliche Ansagen, kein Konto, keine Zusatz-App. Empfohlen, ein einmaliger ~%1$d MB Download.</string>
+    <string name="root_voice_body_intro">Velas eigene Stimme läuft komplett auf deinem Gerät: natürliche Ansagen, kein Konto, keine Extra-App. Empfohlen, ein einmaliger Download von %1$d MB.</string>
     <string name="root_voice_body_system">Lieber nicht? Nutze eine Stimme, die schon auf deinem Gerät ist.</string>
     <string name="root_voice_body_outro">Jederzeit änderbar unter Einstellungen → Stimme.</string>
     <string name="root_voice_download">Vela-Stimme herunterladen</string>
@@ -372,7 +372,7 @@
     <string name="mapvm_export_trip_subject">Vela-Fahrt: %1$s (%2$d Punkte)</string>
     <string name="mapvm_share_trip_chooser">Fahrt teilen</string>
     <string name="mapvm_voice_sample">Biegen Sie in 400 Metern rechts in die Hauptstraße ab.</string>
-    <string name="mapvm_not_enough_space">Nicht genug freier Speicher für %1$s (~%2$d MB)</string>
+    <string name="mapvm_not_enough_space">Nicht genug freier Speicher für %1$s (%2$d MB)</string>
     <string name="mapvm_voice_downloaded">%1$s heruntergeladen</string>
     <string name="mapvm_voice_download_failed">Download von %1$s fehlgeschlagen</string>
     <string name="mapvm_vela_voice_removed">Vela-Stimme entfernt</string>
@@ -412,7 +412,7 @@
     <string name="update_install">Aktualisieren</string>
     <string name="update_download_failed">Update-Download fehlgeschlagen. Versuch es später noch mal.</string>
     <string name="settings_update_auto">Beim Start nach Updates suchen</string>
-    <string name="settings_update_auto_hint">Prüft etwa einmal täglich das neueste GitHub-Release und bietet es an, wenn es neuer als dieser Build ist. Die Installation läuft über den normalen Android-Installer. Wer über Obtainium aktualisiert, kann das ausschalten.</string>
+    <string name="settings_update_auto_hint">Prüft etwa täglich auf GitHub und bietet neuere Versionen an. Ausschalten, wenn du über Obtainium aktualisierst.</string>
     <string name="settings_update_check_now">Nach Updates suchen</string>
     <string name="settings_update_checking">Wird geprüft…</string>
     <string name="settings_update_none">Du bist auf der neuesten Version.</string>
@@ -480,7 +480,7 @@
     <string name="lists_place_count">%1$d Orte</string>
     <string name="navservice_notif_eta">Ankunft %1$s</string>
     <string name="settings_advanced">Erweitert</string>
-    <string name="settings_advanced_hint">Nischen- und experimentelle Optionen, die die meisten nie ändern müssen.</string>
+    <string name="settings_advanced_hint">Optionen, die die meisten nie brauchen.</string>
     <string name="settings_developer">Entwickler</string>
     <string name="settings_developer_hint">Werkzeuge für Demos, Screenshots und Tests. Schalte sie für den echten Einsatz aus.</string>
     <string name="settings_browse_voices">Stimmen durchsuchen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -137,8 +137,8 @@
     <string name="settings_version_line">Vela %1$s  (Build %2$d)</string>
     <string name="settings_collapse">Einklappen</string>
     <string name="settings_expand">Ausklappen</string>
-    <string name="settings_voice_lib_empty_hint">Laden Sie eine natürliche Stimme direkt auf dem Gerät für gesprochene Ansagen herunter – wählen Sie unten eine aus. Die ★-Stimmen klingen am ehesten wie eine Navigationsstimme (Lessac und HFC kommen Google am nächsten). Einmaliger Download; WLAN empfohlen.</string>
-    <string name="settings_voice_lib_installed_hint">Installiert: %1$d MB · %2$d Stimme(n). Tippen Sie auf Verwenden, um zu wechseln (spielt eine Hörprobe ab); das Papierkorb-Symbol gibt den Speicherplatz frei.</string> <!-- format -->
+    <string name="settings_voice_lib_empty_hint">★ markiert die empfohlenen Stimmen. Jede Stimme läuft offline auf deinem Gerät.</string>
+    <string name="settings_voice_lib_installed_hint">Installiert: %1$d MB · %2$d Stimme(n).</string> <!-- format -->
     <string name="settings_voice_lib_lang_hint">Ihre App-Sprache ist %1$s – laden Sie unten eine %2$s-Stimme herunter, damit die Ansagen passen (eine englische Stimme würde %3$s Straßennamen falsch aussprechen).</string>
     <string name="settings_voice_search">Stimmen suchen</string>
     <string name="settings_voice_show_more">%1$d weitere anzeigen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -69,16 +69,16 @@
     <string name="settings_hide_external_links">Ocultar sitio web y enlaces externos</string>
     <string name="settings_hide_external_links_hint">Activado = las páginas de lugar no muestran los botones Sitio web, Street View ni Reservar / Pedir (no se abren sitios externos arbitrarios).</string>
     <string name="settings_offline">Mapas sin conexión</string>
-    <string name="settings_offline_hint">Descarga una zona para guardar su mapa y sus rutas en el teléfono y usarlos sin conexión.</string>
-    <string name="settings_offline_map_area">Zona del mapa</string>
+    <string name="settings_offline_hint">Dos formas de usar Vela sin conexión: guarda la zona en la que estás para trayectos cortos, o un estado o país entero más abajo para los largos.</string>
+    <string name="settings_offline_map_area">Zona local</string>
     <string name="settings_offline_download_viewport">Descargar la zona que estás viendo</string>
-    <string name="settings_offline_download_viewport_hint">Guarda el mapa y sus carreteras de la zona que ves, para que se muestre y calcule rutas sin conexión.</string>
+    <string name="settings_offline_download_viewport_hint">Guarda el mapa que estás viendo, con sus calles y direcciones, para que esta zona siga funcionando sin señal.</string>
     <string name="settings_offline_no_areas">Aún no hay zonas guardadas.</string>
     <string name="settings_offline_addresses_missing">Las áreas guardadas antes de esta actualización no incluyen datos de direcciones. Actualízalas para buscar direcciones y crear rutas sin conexión.</string>
     <string name="settings_offline_addresses_update">Actualizar áreas guardadas</string>
     <string name="settings_offline_delete_area">Eliminar esta zona sin conexión</string>
-    <string name="settings_routing_regions">Regiones de rutas</string>
-    <string name="settings_routing_regions_hint">Las carreteras de toda una región (un estado o país) para que las rutas funcionen sin conexión en todo su territorio. Descarga a donde vayas.</string>
+    <string name="settings_routing_regions">Regiones y países</string>
+    <string name="settings_routing_regions_hint">Todo lo necesario para moverte por un estado, provincia o país entero sin conexión: sus calles y lugares, para que las rutas y la búsqueda funcionen en todo su territorio. Descarga a donde vayas.</string>
     <string name="settings_routing_no_regions">Aún no hay regiones disponibles.</string>
     <string name="settings_clear_filter">Borrar filtro</string>
     <string name="settings_routing_filter_placeholder">Buscar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -72,13 +72,13 @@
     <string name="settings_offline_hint">Descarga una zona para guardar su mapa y sus rutas en el teléfono y usarlos sin conexión.</string>
     <string name="settings_offline_map_area">Zona del mapa</string>
     <string name="settings_offline_download_viewport">Descargar la zona que estás viendo</string>
-    <string name="settings_offline_download_viewport_hint">Guarda los mosaicos abiertos de la zona del mapa que tenías en pantalla por última vez, y la región de rutas que la rodea, para que se muestre y navegue más tarde sin red. La búsqueda sigue necesitando conexión.</string>
+    <string name="settings_offline_download_viewport_hint">Guarda el mapa y sus carreteras de la zona que ves, para que se muestre y calcule rutas sin conexión.</string>
     <string name="settings_offline_no_areas">Aún no hay zonas guardadas.</string>
     <string name="settings_offline_addresses_missing">Las áreas guardadas antes de esta actualización no incluyen datos de direcciones. Actualízalas para buscar direcciones y crear rutas sin conexión.</string>
     <string name="settings_offline_addresses_update">Actualizar áreas guardadas</string>
     <string name="settings_offline_delete_area">Eliminar esta zona sin conexión</string>
     <string name="settings_routing_regions">Regiones de rutas</string>
-    <string name="settings_routing_regions_hint">La red de carreteras de toda una región (estado, país…), para que la navegación giro a giro funcione sin conexión en cualquier lugar dentro de ella: obtén la de donde viajes. Con conexión se sigue usando el tráfico en directo; esto es la alternativa sin señal.</string>
+    <string name="settings_routing_regions_hint">Las carreteras de toda una región (un estado o país) para que las rutas funcionen sin conexión en todo su territorio. Descarga a donde vayas.</string>
     <string name="settings_routing_no_regions">Aún no hay regiones disponibles.</string>
     <string name="settings_clear_filter">Borrar filtro</string>
     <string name="settings_routing_filter_placeholder">Filtrar %1$d regiones… (p. ej. Japón, Texas)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,17 +5,17 @@
     <string name="settings_follow_system">Seguir el sistema</string>
     <string name="settings_theme_light">Claro</string>
     <string name="settings_theme_dark">Oscuro</string>
-    <string name="settings_appearance_hint">Claro/Oscuro se aplica solo a Vela; no cambia el tema del sistema de tu teléfono.</string>
+    <string name="settings_appearance_hint">Solo se aplica a Vela.</string>
     <string name="settings_dynamic_color">Colores Material You</string>
-    <string name="settings_dynamic_color_hint">Tiñe botones, chips y acentos según tu fondo de pantalla (Android 12+). Desactivado = el verde azulado propio de Vela. El mapa se mantiene neutro para que las carreteras y etiquetas conserven su contraste.</string>
+    <string name="settings_dynamic_color_hint">Tiñe botones y acentos según tu fondo de pantalla. El mapa se mantiene neutro.</string>
     <string name="settings_map_style">Estilo del mapa</string>
-    <string name="settings_map_style_hint">OpenFreeMap (el predeterminado) no necesita clave y es detallado. Protomaps requiere una clave de API; el estilo de demostración solo muestra los contornos de los países.</string>
+    <string name="settings_map_style_hint">OpenFreeMap funciona sin clave de API.</string>
     <string name="settings_units">Unidades</string>
     <string name="settings_units_imperial">Imperiales (millas, pies)</string>
     <string name="settings_units_metric">Métricas (kilómetros, metros)</string>
     <string name="settings_language">Idioma</string>
     <string name="settings_follow_system_language">Seguir el idioma del sistema</string>
-    <string name="settings_language_hint">Establece el idioma de las indicaciones de voz giro a giro (inglés, francés, alemán, español, italiano, portugués, neerlandés, ruso, polaco, sueco, ucraniano), independiente del idioma del sistema de tu teléfono. Elige una voz acorde en la Biblioteca de voces de más abajo. El resto del texto en pantalla de la app se traducirá próximamente.</string>
+    <string name="settings_language_hint">Cambia el idioma de la app y de las indicaciones habladas. Descarga una voz a juego en la biblioteca de voces.</string>
     <string name="settings_search">Búsqueda</string>
     <string name="settings_voice_search_toggle">Micrófono de búsqueda por voz</string>
     <string name="settings_voice_search_hint">Muestra un micrófono en la barra de búsqueda. Tócalo para dictar tu búsqueda con una app de entrada de voz del teléfono.</string>
@@ -50,16 +50,16 @@
     <string name="settings_mode_transit">Transporte público</string>
     <string name="settings_vibrate_hint">Vibraciones codificadas por dirección en cada giro, distintas para izquierda y derecha, para que sigas la ruta al tacto. Configúralo por modo de transporte (p. ej. activado para bicicleta y a pie, desactivado al conducir).</string>
     <string name="settings_keep_screen_on">Mantener la pantalla encendida al navegar</string>
-    <string name="settings_keep_screen_on_hint">Evita que la pantalla se atenúe o se apague mientras la navegación giro a giro está activa, para que el próximo giro esté siempre visible sin tener que tocar para despertarla. Activado de forma predeterminada; la pantalla vuelve a apagarse con normalidad en cuanto llegas o sales de la navegación.</string>
+    <string name="settings_keep_screen_on_hint">Mantiene la pantalla encendida durante la navegación.</string>
     <string name="settings_map">Mapa</string>
     <string name="settings_live_traffic">Capa de tráfico en directo</string>
-    <string name="settings_live_traffic_hint">Sombrea las carreteras según la congestión mientras exploras el mapa (mosaicos de tráfico de Google sin clave). Desactivado de forma predeterminada: la navegación ya colorea tu ruta según el tráfico, así que esto sirve solo para explorar la zona en general. Es una capa ráster, por lo que se ve un poco granulada.</string>
+    <string name="settings_live_traffic_hint">Sombrea las calles según el tráfico al explorar. La navegación ya colorea tu ruta según el tráfico.</string>
     <string name="settings_transit_layer">Resaltar líneas de transporte</string>
-    <string name="settings_transit_layer_hint">Dibuja las líneas de tren y metro en color sobre el mapa, para seguir el ferrocarril con facilidad. Usa los datos abiertos que ya están en los mosaicos, sin red.</string>
+    <string name="settings_transit_layer_hint">Dibuja las líneas de tren y metro en el mapa.</string>
     <string name="settings_read_all_reviews">Botón «Leer todas las reseñas»</string>
-    <string name="settings_read_all_reviews_hint">Las reseñas de la ficha del lugar son siempre la propia lista nativa y fluida de Vela. Esto añade un botón «Leer todas las reseñas» que abre la página completa de reseñas de Google a PANTALLA COMPLETA: todas las reseñas (no solo las primeras ~50), la búsqueda del lado del servidor de Google y las reseñas en vídeo se reproducen. Se bloquean rastreadores y balizas, pero sí ejecuta la página de Google dentro de la app. Desactivado = solo lista nativa, sin página de Google para las reseñas.</string>
+    <string name="settings_read_all_reviews_hint">Añade un botón que abre la página completa de reseñas de Google dentro de la app, con todas las reseñas. Desactivado = solo la lista propia de Vela.</string>
     <string name="settings_buildings_3d">Edificios en 3D</string>
-    <string name="settings_buildings_3d_hint">Formas de edificios en relieve con mucho zoom. Desactivarlo puede hacer que el desplazamiento sea más fluido en teléfonos antiguos; las siluetas planas se mantienen.</string>
+    <string name="settings_buildings_3d_hint">Edificios en relieve al acercar. Desactivarlo puede suavizar el desplazamiento en móviles antiguos.</string>
     <string name="settings_show_reviews">Mostrar reseñas</string>
     <string name="settings_show_reviews_hint">Desactivado = las páginas de sitios no muestran reseñas y Vela nunca las descarga.</string>
     <string name="settings_load_photos">Cargar fotos</string>
@@ -101,15 +101,15 @@
     <string name="settings_export">Exportar</string>
     <string name="settings_import">Importar</string>
     <string name="settings_data_privacy">Fuente de datos y privacidad</string>
-    <string name="settings_data_privacy_hint">Vela se comunica con los endpoints web públicos de Google directamente desde este dispositivo: sin servidor de Vela, sin cuenta de Google, sin clave de API y sin telemetría, salvo que actives el Diagnóstico de más abajo (desactivado de forma predeterminada, solo local). Cada dispositivo se comporta como un navegador sin sesión iniciada; Google ve tu IP, tu consulta y la zona del mapa, pero no una cuenta. Los lugares guardados y el historial nunca salen del teléfono.</string>
+    <string name="settings_data_privacy_hint">Vela habla con los endpoints públicos de Google directamente desde este dispositivo: sin backend, sin cuenta, sin clave de API. Google ve tu IP, la búsqueda y la zona del mapa, no quién eres.</string>
     <string name="settings_privacy_button">Qué datos recibe Google</string>
     <string name="settings_diagnostics">Diagnóstico</string>
-    <string name="settings_diagnostics_hint">Desactivado de forma predeterminada. Cuando está activado, Vela guarda un breve registro local de lo que hizo (tus búsquedas, rutas y cualquier fallo de «necesita recalibración») para que, si algo va mal, puedas exportarlo y entregárselo a un desarrollador. Permanece en este teléfono y nunca se sube; tú eliges dónde va la exportación. Al desactivarlo se borra el registro.</string>
+    <string name="settings_diagnostics_hint">Desactivado por defecto. Al activarlo, Vela guarda un breve registro local que puedes exportar y dar a un desarrollador. No se sube nada, y desactivarlo lo borra.</string>
     <string name="settings_share_diagnostics">Compartir diagnóstico</string>
     <string name="settings_diag_nothing">Aún no hay nada registrado: usa la app y luego exporta.</string>
     <string name="settings_diag_export">Exportar sesión de depuración</string>
     <string name="settings_save_trips">Guardar mis trayectos (para reproducir)</string>
-    <string name="settings_save_trips_hint">Registra el rastro GPS de cada navegación en este teléfono para que un trayecto pueda reproducirse más tarde y probar la navegación giro a giro sin volver a conducirlo. Revela más que el diagnóstico (son tus rutas exactas) y nunca sale del teléfono.</string>
+    <string name="settings_save_trips_hint">Graba el rastro GPS de cada viaje en este teléfono, para reproducirlo después. Nunca sale del teléfono.</string>
     <string name="settings_recorded_trips_hint">Trayectos grabados: toca Reproducir para volver a verlo en el mapa (3×):</string>
     <string name="settings_trip_points">%1$d puntos</string>
     <string name="settings_trip_replay">Reproducir</string>
@@ -167,7 +167,7 @@
     <string name="place_permanently_closed">Cerrado permanentemente</string>
     <string name="place_temporarily_closed">Cerrado temporalmente</string>
     <string name="settings_traffic_lights">Indicaciones con semáforos</string>
-    <string name="settings_traffic_lights_hint">Dice «pasa el semáforo y luego gira» en cruces con semáforo (voz solo en inglés por ahora)</string>
+    <string name="settings_traffic_lights_hint">Añade avisos como “pasa el semáforo y gira a la izquierda”. De momento solo en inglés.</string>
     <string name="map_voice_downloading">Descargando la voz Vela · %1$d %%</string>
     <string name="map_voice_installing">Instalando la voz Vela…</string>
     <string name="map_region_downloading">Descargando rutas de %1$s · %2$d %%</string> <!-- format -->
@@ -175,9 +175,9 @@
     <string name="mapvm_poipack_ready">Los lugares de %1$s ya se pueden buscar sin conexión</string> <!-- format -->
     <string name="mapvm_poipack_unavailable">Aún no hay paquete de lugares para %1$s. Aparecerá aquí cuando se publique.</string> <!-- format -->
     <string name="settings_demo_drive">Simular conducción (demo)</string>
-    <string name="settings_demo_drive_hint">Para demos, capturas y pruebas: al pulsar Iniciar se recorre la ruta como un rastro GPS simulado en lugar de tu ubicación real, así la navegación funciona en cualquier sitio. Desactívalo para navegar de verdad.</string>
+    <string name="settings_demo_drive_hint">Iniciar recorre la ruta planeada como simulación en lugar de usar GPS. Desactívalo para navegar de verdad.</string>
     <string name="settings_sim_location">Simular mi ubicación (demo)</string>
-    <string name="settings_sim_location_hint">Para demos y capturas: finge que estás en el centro del mapa ahora mismo, para que el punto de ubicación, las distancias y las rutas empiecen ahí en vez de tu posición real. Desactívalo para usar el GPS real.</string>
+    <string name="settings_sim_location_hint">Finge que estás en el centro del mapa, para demos y capturas. Desactívalo para usar el GPS real.</string>
     <string name="place_address_copied">Dirección copiada</string>
     <string name="place_copy_address">Copiar dirección</string>
     <string name="place_directions">Cómo llegar</string>
@@ -310,7 +310,7 @@
     <string name="mapscreen_switch">Cambiar</string>
     <string name="root_not_now">Ahora no</string>
     <string name="root_voice_title">Voz de navegación hablada</string>
-    <string name="root_voice_body_intro">La voz propia de Vela funciona íntegramente en tu teléfono: indicaciones naturales, sin cuenta ni app extra. Recomendada, una descarga única de ~%1$d MB.</string>
+    <string name="root_voice_body_intro">La voz propia de Vela funciona por completo en tu teléfono: indicaciones naturales, sin cuenta, sin otra app. Recomendada, una descarga única de %1$d MB.</string>
     <string name="root_voice_body_system">¿Prefieres que no? Usa una voz que ya tengas en el teléfono.</string>
     <string name="root_voice_body_outro">Cámbiala cuando quieras en Ajustes → Voz.</string>
     <string name="root_voice_download">Descargar voz de Vela</string>
@@ -372,7 +372,7 @@
     <string name="mapvm_export_trip_subject">Trayecto de Vela: %1$s (%2$d puntos)</string>
     <string name="mapvm_share_trip_chooser">Compartir trayecto</string>
     <string name="mapvm_voice_sample">En cuatrocientos metros, gira a la derecha hacia la calle Mayor.</string>
-    <string name="mapvm_not_enough_space">No hay espacio libre suficiente para %1$s (~%2$d MB)</string>
+    <string name="mapvm_not_enough_space">No hay espacio libre suficiente para %1$s (%2$d MB)</string>
     <string name="mapvm_voice_downloaded">%1$s descargada</string>
     <string name="mapvm_voice_download_failed">Error al descargar %1$s</string>
     <string name="mapvm_vela_voice_removed">Voz de Vela eliminada</string>
@@ -412,7 +412,7 @@
     <string name="update_install">Actualizar</string>
     <string name="update_download_failed">Falló la descarga de la actualización. Inténtalo más tarde.</string>
     <string name="settings_update_auto">Buscar actualizaciones al iniciar</string>
-    <string name="settings_update_auto_hint">Consulta la última versión de GitHub más o menos una vez al día y la ofrece cuando es más nueva que esta. Se instala con el instalador normal de Android. Si ya actualizas con Obtainium, puedes desactivarlo.</string>
+    <string name="settings_update_auto_hint">Consulta GitHub una vez al día y ofrece versiones más nuevas. Desactívalo si actualizas con Obtainium.</string>
     <string name="settings_update_check_now">Buscar actualizaciones</string>
     <string name="settings_update_checking">Comprobando…</string>
     <string name="settings_update_none">Tienes la versión más reciente.</string>
@@ -480,7 +480,7 @@
     <string name="lists_place_count">%1$d lugares</string>
     <string name="navservice_notif_eta">Llegada %1$s</string>
     <string name="settings_advanced">Avanzado</string>
-    <string name="settings_advanced_hint">Opciones específicas y experimentales que casi nadie necesita cambiar.</string>
+    <string name="settings_advanced_hint">Opciones que casi nadie necesita.</string>
     <string name="settings_developer">Desarrollador</string>
     <string name="settings_developer_hint">Herramientas para demostraciones, capturas y pruebas. Desactívalas para el uso real.</string>
     <string name="settings_browse_voices">Explorar voces</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -68,7 +68,7 @@
     <string name="settings_hide_adult_hint">Activado = oculta bares, discotecas, casinos, licorerías y otros lugares para adultos / de ocio nocturno de la búsqueda y el mapa.</string>
     <string name="settings_hide_external_links">Ocultar sitio web y enlaces externos</string>
     <string name="settings_hide_external_links_hint">Activado = las páginas de lugar no muestran los botones Sitio web, Street View ni Reservar / Pedir (no se abren sitios externos arbitrarios).</string>
-    <string name="settings_offline">Sin conexión</string>
+    <string name="settings_offline">Mapas sin conexión</string>
     <string name="settings_offline_hint">Descarga una zona para guardar su mapa y sus rutas en el teléfono y usarlos sin conexión.</string>
     <string name="settings_offline_map_area">Zona del mapa</string>
     <string name="settings_offline_download_viewport">Descargar la zona que estás viendo</string>
@@ -81,7 +81,7 @@
     <string name="settings_routing_regions_hint">Las carreteras de toda una región (un estado o país) para que las rutas funcionen sin conexión en todo su territorio. Descarga a donde vayas.</string>
     <string name="settings_routing_no_regions">Aún no hay regiones disponibles.</string>
     <string name="settings_clear_filter">Borrar filtro</string>
-    <string name="settings_routing_filter_placeholder">Filtrar %1$d regiones… (p. ej. Japón, Texas)</string>
+    <string name="settings_routing_filter_placeholder">Buscar</string>
     <string name="settings_routing_no_match">Ninguna región coincide con «%1$s».</string>
     <string name="settings_routing_downloading">Descargando… %1$d%%</string>
     <string name="settings_routing_installed">Instalada · rutas sin conexión aquí</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -14,6 +14,7 @@
     <string name="settings_units_imperial">Imperiales (millas, pies)</string>
     <string name="settings_units_metric">Métricas (kilómetros, metros)</string>
     <string name="settings_language">Idioma</string>
+    <string name="settings_follow_system_language">Seguir el idioma del sistema</string>
     <string name="settings_language_hint">Establece el idioma de las indicaciones de voz giro a giro (inglés, francés, alemán, español, italiano, portugués, neerlandés, ruso, polaco, sueco, ucraniano), independiente del idioma del sistema de tu teléfono. Elige una voz acorde en la Biblioteca de voces de más abajo. El resto del texto en pantalla de la app se traducirá próximamente.</string>
     <string name="settings_search">Búsqueda</string>
     <string name="settings_voice_search_toggle">Micrófono de búsqueda por voz</string>
@@ -478,4 +479,10 @@
     <string name="lists_empty_hint">Aún no hay listas. Toca Nueva o guarda un lugar desde su página.</string>
     <string name="lists_place_count">%1$d lugares</string>
     <string name="navservice_notif_eta">Llegada %1$s</string>
+    <string name="settings_advanced">Avanzado</string>
+    <string name="settings_advanced_hint">Opciones específicas y experimentales que casi nadie necesita cambiar.</string>
+    <string name="settings_developer">Desarrollador</string>
+    <string name="settings_developer_hint">Herramientas para demostraciones, capturas y pruebas. Desactívalas para el uso real.</string>
+    <string name="settings_browse_voices">Explorar voces</string>
+    <string name="settings_browse_voices_hint">Descarga y cambia entre las voces de Vela en el dispositivo.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -69,7 +69,7 @@
     <string name="settings_hide_external_links">Ocultar sitio web y enlaces externos</string>
     <string name="settings_hide_external_links_hint">Activado = las páginas de lugar no muestran los botones Sitio web, Street View ni Reservar / Pedir (no se abren sitios externos arbitrarios).</string>
     <string name="settings_offline">Sin conexión</string>
-    <string name="settings_offline_hint">Usar el mapa sin señal requiere dos cosas: los MOSAICOS del mapa que ves y la RED DE CARRETERAS que traza tus rutas. Guardar una zona del mapa obtiene ambas para ese punto; la lista de regiones de abajo añade la red de carreteras de cualquier lugar por el que viajes.</string>
+    <string name="settings_offline_hint">Descarga una zona para guardar su mapa y sus rutas en el teléfono y usarlos sin conexión.</string>
     <string name="settings_offline_map_area">Zona del mapa</string>
     <string name="settings_offline_download_viewport">Descargar la zona que estás viendo</string>
     <string name="settings_offline_download_viewport_hint">Guarda los mosaicos abiertos de la zona del mapa que tenías en pantalla por última vez, y la región de rutas que la rodea, para que se muestre y navegue más tarde sin red. La búsqueda sigue necesitando conexión.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -137,8 +137,8 @@
     <string name="settings_version_line">Vela %1$s  (compilación %2$d)</string>
     <string name="settings_collapse">Contraer</string>
     <string name="settings_expand">Expandir</string>
-    <string name="settings_voice_lib_empty_hint">Descarga una voz natural en el dispositivo para las indicaciones habladas: elige una más abajo. Las voces con ★ son las que más suenan a un navegador de mapas (Lessac y HFC son las más parecidas a Google). Descarga única; se recomienda wifi.</string>
-    <string name="settings_voice_lib_installed_hint">Instalado: %1$d MB · %2$d voz/voces. Toca Usar para cambiar (reproduce una muestra); el icono de la papelera libera el espacio.</string> <!-- format -->
+    <string name="settings_voice_lib_empty_hint">★ marca las voces recomendadas. Todas funcionan sin conexión en tu teléfono.</string>
+    <string name="settings_voice_lib_installed_hint">Instalado: %1$d MB · %2$d voz/voces.</string> <!-- format -->
     <string name="settings_voice_lib_lang_hint">El idioma de tu app es %1$s: descarga una voz en %2$s más abajo para que las indicaciones habladas coincidan (una voz en inglés pronunciaría mal los nombres de calles en %3$s).</string>
     <string name="settings_voice_search">Buscar voces</string>
     <string name="settings_voice_show_more">Mostrar %1$d más</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -72,13 +72,13 @@
     <string name="settings_offline_hint">Téléchargez une zone pour conserver sa carte et ses itinéraires sur votre téléphone, utilisables hors ligne.</string>
     <string name="settings_offline_map_area">Zone de carte</string>
     <string name="settings_offline_download_viewport">Télécharger la zone affichée</string>
-    <string name="settings_offline_download_viewport_hint">Enregistre les tuiles de la zone que vous aviez à l\'écran — ainsi que la région de routage autour — pour l\'afficher et y naviguer plus tard sans réseau. La recherche nécessite toujours une connexion.</string>
+    <string name="settings_offline_download_viewport_hint">Enregistre la carte et ses routes pour la zone affichée, pour l\'afficher et calculer des itinéraires hors ligne.</string>
     <string name="settings_offline_no_areas">Aucune zone enregistrée pour l\'instant.</string>
     <string name="settings_offline_addresses_missing">Les zones enregistrées avant cette mise à jour ne contiennent pas de données d\'adresses. Mettez-les à jour pour rechercher des adresses et calculer des itinéraires hors ligne.</string>
     <string name="settings_offline_addresses_update">Mettre à jour les zones enregistrées</string>
     <string name="settings_offline_delete_area">Supprimer cette zone hors ligne</string>
     <string name="settings_routing_regions">Régions de routage</string>
-    <string name="settings_routing_regions_hint">Le réseau routier d\'une région entière (état, pays…), pour que la navigation guidée fonctionne hors ligne partout à l\'intérieur — récupérez la région où vous voyagez. En ligne, le trafic en temps réel reste utilisé ; ceci sert de secours sans réseau.</string>
+    <string name="settings_routing_regions_hint">Les routes d\'une région entière (un état ou un pays) pour que les itinéraires fonctionnent hors ligne partout à l\'intérieur. Prenez là où vous allez.</string>
     <string name="settings_routing_no_regions">Aucune région disponible pour l\'instant.</string>
     <string name="settings_clear_filter">Effacer le filtre</string>
     <string name="settings_routing_filter_placeholder">Filtrer %1$d régions… (par ex. Japon, Texas)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -69,16 +69,16 @@
     <string name="settings_hide_external_links">Masquer le site web et les liens externes</string>
     <string name="settings_hide_external_links_hint">Activé = les pages de lieu n’affichent pas les boutons Site web, Street View ou Réserver / Commander (aucun site externe arbitraire ouvert).</string>
     <string name="settings_offline">Cartes hors ligne</string>
-    <string name="settings_offline_hint">Téléchargez une zone pour conserver sa carte et ses itinéraires sur votre téléphone, utilisables hors ligne.</string>
-    <string name="settings_offline_map_area">Zone de carte</string>
+    <string name="settings_offline_hint">Deux façons d\'utiliser Vela hors ligne : enregistrez la zone où vous êtes pour les petits trajets, ou un état ou pays entier ci-dessous pour les longs.</string>
+    <string name="settings_offline_map_area">Zone locale</string>
     <string name="settings_offline_download_viewport">Télécharger la zone affichée</string>
-    <string name="settings_offline_download_viewport_hint">Enregistre la carte et ses routes pour la zone affichée, pour l\'afficher et calculer des itinéraires hors ligne.</string>
+    <string name="settings_offline_download_viewport_hint">Enregistre la carte affichée, avec ses routes et adresses, pour que cette zone continue de fonctionner sans réseau.</string>
     <string name="settings_offline_no_areas">Aucune zone enregistrée pour l\'instant.</string>
     <string name="settings_offline_addresses_missing">Les zones enregistrées avant cette mise à jour ne contiennent pas de données d\'adresses. Mettez-les à jour pour rechercher des adresses et calculer des itinéraires hors ligne.</string>
     <string name="settings_offline_addresses_update">Mettre à jour les zones enregistrées</string>
     <string name="settings_offline_delete_area">Supprimer cette zone hors ligne</string>
-    <string name="settings_routing_regions">Régions de routage</string>
-    <string name="settings_routing_regions_hint">Les routes d\'une région entière (un état ou un pays) pour que les itinéraires fonctionnent hors ligne partout à l\'intérieur. Prenez là où vous allez.</string>
+    <string name="settings_routing_regions">Régions et pays</string>
+    <string name="settings_routing_regions_hint">Tout ce qu\'il faut pour parcourir un état, une province ou un pays entier hors ligne : ses routes et ses lieux, pour que l\'itinéraire et la recherche fonctionnent partout. Prenez là où vous allez.</string>
     <string name="settings_routing_no_regions">Aucune région disponible pour l\'instant.</string>
     <string name="settings_clear_filter">Effacer le filtre</string>
     <string name="settings_routing_filter_placeholder">Rechercher</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -14,6 +14,7 @@
     <string name="settings_units_imperial">Impériales (miles, pieds)</string>
     <string name="settings_units_metric">Métriques (kilomètres, mètres)</string>
     <string name="settings_language">Langue</string>
+    <string name="settings_follow_system_language">Suivre la langue du système</string>
     <string name="settings_language_hint">Définit la langue des instructions vocales de navigation (anglais, français, allemand, espagnol, italien, portugais, néerlandais, russe, polonais, suédois, ukrainien) — indépendamment de la langue système de votre téléphone. Choisissez une voix correspondante dans la Bibliothèque de voix ci-dessous. Le reste des textes de l\'application est en cours de traduction.</string>
     <string name="settings_search">Recherche</string>
     <string name="settings_voice_search_toggle">Micro de recherche vocale</string>
@@ -478,4 +479,10 @@
     <string name="lists_empty_hint">Pas encore de listes. Touchez Nouvelle ou enregistrez un lieu depuis sa page.</string>
     <string name="lists_place_count">%1$d lieux</string>
     <string name="navservice_notif_eta">Arrivée %1$s</string>
+    <string name="settings_advanced">Avancé</string>
+    <string name="settings_advanced_hint">Options de niche et expérimentales que la plupart des gens n\'ont jamais à changer.</string>
+    <string name="settings_developer">Développeur</string>
+    <string name="settings_developer_hint">Outils pour les démos, captures d\'écran et tests. Désactivez-les pour un usage réel.</string>
+    <string name="settings_browse_voices">Parcourir les voix</string>
+    <string name="settings_browse_voices_hint">Téléchargez et changez les voix de Vela sur l\'appareil.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -68,7 +68,7 @@
     <string name="settings_hide_adult_hint">Activé = masque les bars, clubs, casinos, cavistes et autres lieux pour adultes / de vie nocturne des résultats et de la carte.</string>
     <string name="settings_hide_external_links">Masquer le site web et les liens externes</string>
     <string name="settings_hide_external_links_hint">Activé = les pages de lieu n’affichent pas les boutons Site web, Street View ou Réserver / Commander (aucun site externe arbitraire ouvert).</string>
-    <string name="settings_offline">Hors ligne</string>
+    <string name="settings_offline">Cartes hors ligne</string>
     <string name="settings_offline_hint">Téléchargez une zone pour conserver sa carte et ses itinéraires sur votre téléphone, utilisables hors ligne.</string>
     <string name="settings_offline_map_area">Zone de carte</string>
     <string name="settings_offline_download_viewport">Télécharger la zone affichée</string>
@@ -81,7 +81,7 @@
     <string name="settings_routing_regions_hint">Les routes d\'une région entière (un état ou un pays) pour que les itinéraires fonctionnent hors ligne partout à l\'intérieur. Prenez là où vous allez.</string>
     <string name="settings_routing_no_regions">Aucune région disponible pour l\'instant.</string>
     <string name="settings_clear_filter">Effacer le filtre</string>
-    <string name="settings_routing_filter_placeholder">Filtrer %1$d régions… (par ex. Japon, Texas)</string>
+    <string name="settings_routing_filter_placeholder">Rechercher</string>
     <string name="settings_routing_no_match">Aucune région ne correspond à « %1$s ».</string>
     <string name="settings_routing_downloading">Téléchargement… %1$d %%</string>
     <string name="settings_routing_installed">Installée · routage hors ligne ici</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -5,17 +5,17 @@
     <string name="settings_follow_system">Suivre le système</string>
     <string name="settings_theme_light">Clair</string>
     <string name="settings_theme_dark">Sombre</string>
-    <string name="settings_appearance_hint">Le mode clair/sombre s\'applique uniquement à Vela — il ne modifie pas le thème système de votre téléphone.</string>
+    <string name="settings_appearance_hint">S\'applique à Vela uniquement.</string>
     <string name="settings_dynamic_color">Couleurs Material You</string>
-    <string name="settings_dynamic_color_hint">Teinte les boutons, puces et accents selon votre fond d\'écran (Android 12+). Désactivé = le bleu-vert propre à Vela. La carte reste neutre pour que routes et libellés gardent leur contraste.</string>
+    <string name="settings_dynamic_color_hint">Teinte les boutons et accents d\'après votre fond d\'écran. La carte reste neutre.</string>
     <string name="settings_map_style">Style de carte</string>
-    <string name="settings_map_style_hint">OpenFreeMap (par défaut) est détaillé et ne nécessite aucune clé. Protomaps exige une clé API ; le style de démonstration n\'affiche que les contours des pays.</string>
+    <string name="settings_map_style_hint">OpenFreeMap fonctionne sans clé d\'API.</string>
     <string name="settings_units">Unités</string>
     <string name="settings_units_imperial">Impériales (miles, pieds)</string>
     <string name="settings_units_metric">Métriques (kilomètres, mètres)</string>
     <string name="settings_language">Langue</string>
     <string name="settings_follow_system_language">Suivre la langue du système</string>
-    <string name="settings_language_hint">Définit la langue des instructions vocales de navigation (anglais, français, allemand, espagnol, italien, portugais, néerlandais, russe, polonais, suédois, ukrainien) — indépendamment de la langue système de votre téléphone. Choisissez une voix correspondante dans la Bibliothèque de voix ci-dessous. Le reste des textes de l\'application est en cours de traduction.</string>
+    <string name="settings_language_hint">Change la langue de l\'appli et des instructions vocales. Prenez une voix assortie dans la bibliothèque de voix.</string>
     <string name="settings_search">Recherche</string>
     <string name="settings_voice_search_toggle">Micro de recherche vocale</string>
     <string name="settings_voice_search_hint">Affiche un micro dans la barre de recherche. Touchez-le pour dicter votre recherche via une appli de saisie vocale du téléphone.</string>
@@ -50,16 +50,16 @@
     <string name="settings_mode_transit">Transports</string>
     <string name="settings_vibrate_hint">Des vibrations codées par direction à chaque virage — distinctes pour la gauche et la droite — pour suivre un itinéraire au ressenti. Réglable par mode de déplacement (par ex. activé à vélo et à pied, désactivé en voiture).</string>
     <string name="settings_keep_screen_on">Garder l\'écran allumé pendant la navigation</string>
-    <string name="settings_keep_screen_on_hint">Empêche l\'écran de s\'assombrir ou de se mettre en veille pendant la navigation guidée, pour que le prochain virage reste toujours visible sans avoir à toucher l\'écran. Activé par défaut ; l\'écran se remet en veille normalement dès que vous arrivez ou quittez la navigation.</string>
+    <string name="settings_keep_screen_on_hint">Garde l\'écran allumé pendant le guidage.</string>
     <string name="settings_map">Carte</string>
     <string name="settings_live_traffic">Trafic en temps réel</string>
-    <string name="settings_live_traffic_hint">Colore les routes selon la congestion pendant l\'exploration de la carte (tuiles de trafic sans clé de Google). Désactivé par défaut — la navigation colore déjà votre itinéraire selon le trafic, ceci sert donc à examiner une zone plus large. C\'est une superposition matricielle, donc légèrement granuleuse.</string>
+    <string name="settings_live_traffic_hint">Colore les routes selon le trafic pendant la consultation. La navigation colore déjà votre itinéraire.</string>
     <string name="settings_transit_layer">Mettre en évidence les lignes de transport</string>
-    <string name="settings_transit_layer_hint">Trace les lignes de train et de métro en couleur sur la carte, pour suivre le rail facilement. Utilise les données ouvertes déjà présentes dans les tuiles, sans réseau.</string>
+    <string name="settings_transit_layer_hint">Trace les lignes de train et de métro sur la carte.</string>
     <string name="settings_read_all_reviews">Bouton « Lire tous les avis »</string>
-    <string name="settings_read_all_reviews_hint">Les avis dans la fiche du lieu sont toujours affichés dans la liste native fluide de Vela. Ceci ajoute un bouton « Lire tous les avis » qui ouvre la page complète des avis Google en PLEIN ÉCRAN — tous les avis (pas seulement les ~50 premiers), la recherche côté serveur de Google et la lecture des avis vidéo. Les traqueurs et balises sont bloqués, mais la page de Google s\'exécute alors dans l\'application. Désactivé = liste native uniquement, aucune page Google pour les avis.</string>
+    <string name="settings_read_all_reviews_hint">Ajoute un bouton qui ouvre la page complète des avis Google dans l\'appli, avec tous les avis. Désactivé = seulement la liste de Vela.</string>
     <string name="settings_buildings_3d">Bâtiments en 3D</string>
-    <string name="settings_buildings_3d_hint">Formes de bâtiments en relief à fort zoom. Le désactiver peut rendre le déplacement plus fluide sur les vieux téléphones; les contours plats restent.</string>
+    <string name="settings_buildings_3d_hint">Bâtiments en relief au zoom rapproché. Le désactiver peut fluidifier le défilement sur les vieux téléphones.</string>
     <string name="settings_show_reviews">Afficher les avis</string>
     <string name="settings_show_reviews_hint">Désactivé = les fiches de lieux n\'affichent aucun avis et Vela ne les récupère jamais.</string>
     <string name="settings_load_photos">Charger les photos</string>
@@ -101,15 +101,15 @@
     <string name="settings_export">Exporter</string>
     <string name="settings_import">Importer</string>
     <string name="settings_data_privacy">Source des données et confidentialité</string>
-    <string name="settings_data_privacy_hint">Vela communique directement avec les points d\'accès web publics de Google depuis cet appareil — sans serveur Vela, sans compte Google, sans clé API et sans télémétrie, sauf si vous activez les Diagnostics ci-dessous (désactivés par défaut, en local uniquement). Chaque appareil se comporte comme un navigateur déconnecté ; Google voit votre adresse IP, votre requête et la zone de carte, mais pas de compte. Vos lieux enregistrés et votre historique ne quittent jamais le téléphone.</string>
+    <string name="settings_data_privacy_hint">Vela interroge les points publics de Google directement depuis cet appareil : pas de serveur, pas de compte, pas de clé d\'API. Google voit votre IP, la requête et la zone de carte, pas qui vous êtes.</string>
     <string name="settings_privacy_button">Données reçues par Google</string>
     <string name="settings_diagnostics">Diagnostics</string>
-    <string name="settings_diagnostics_hint">Désactivés par défaut. Lorsqu\'ils sont activés, Vela conserve un court journal local de son activité — vos recherches, vos itinéraires et tout incident « nécessite un recalibrage » — pour que vous puissiez l\'exporter et le transmettre à un développeur en cas de problème. Il reste sur ce téléphone et n\'est jamais envoyé ; vous choisissez la destination de l\'export. Les désactiver efface le journal.</string>
+    <string name="settings_diagnostics_hint">Désactivé par défaut. Activé, Vela tient un court journal local que vous pouvez exporter et donner à un développeur. Rien n\'est envoyé, et le désactiver l\'efface.</string>
     <string name="settings_share_diagnostics">Partager les diagnostics</string>
     <string name="settings_diag_nothing">Rien d\'enregistré pour l\'instant — utilisez l\'application, puis exportez.</string>
     <string name="settings_diag_export">Exporter la session de débogage</string>
     <string name="settings_save_trips">Enregistrer mes trajets (pour rejouer)</string>
-    <string name="settings_save_trips_hint">Enregistre la trace GPS de chaque navigation sur ce téléphone afin qu\'un trajet puisse être rejoué plus tard pour tester la navigation guidée sans le refaire. Plus révélateur que les diagnostics — ce sont vos itinéraires exacts — et cela ne quitte jamais le téléphone.</string>
+    <string name="settings_save_trips_hint">Enregistre la trace GPS de chaque trajet sur ce téléphone, pour la rejouer plus tard. Ne quitte jamais le téléphone.</string>
     <string name="settings_recorded_trips_hint">Trajets enregistrés — appuyez sur Rejouer pour en revoir un sur la carte (3×) :</string>
     <string name="settings_trip_points">%1$d points</string>
     <string name="settings_trip_replay">Rejouer</string>
@@ -167,7 +167,7 @@
     <string name="place_permanently_closed">Définitivement fermé</string>
     <string name="place_temporarily_closed">Fermé temporairement</string>
     <string name="settings_traffic_lights">Guidage aux feux tricolores</string>
-    <string name="settings_traffic_lights_hint">Annonce « passez le feu, puis tournez » aux intersections à feux (annonces en anglais pour l’instant)</string>
+    <string name="settings_traffic_lights_hint">Ajoute des repères comme “passez le feu, puis tournez à gauche”. En anglais seulement pour l\'instant.</string>
     <string name="map_voice_downloading">Téléchargement de la voix Vela · %1$d %%</string>
     <string name="map_voice_installing">Installation de la voix Vela…</string>
     <string name="map_region_downloading">Téléchargement de l\'itinéraire %1$s · %2$d %%</string> <!-- format -->
@@ -175,9 +175,9 @@
     <string name="mapvm_poipack_ready">Les lieux de %1$s sont désormais consultables hors ligne</string> <!-- format -->
     <string name="mapvm_poipack_unavailable">Pas encore de pack de lieux pour %1$s. Il apparaîtra ici dès sa publication.</string> <!-- format -->
     <string name="settings_demo_drive">Simuler la conduite (démo)</string>
-    <string name="settings_demo_drive_hint">Pour les démos, captures d’écran et tests : appuyer sur Démarrer parcourt l’itinéraire comme une trace GPS simulée au lieu de votre position réelle — la navigation fonctionne partout. Désactivez pour naviguer réellement.</string>
+    <string name="settings_demo_drive_hint">Démarrer parcourt l\'itinéraire prévu en simulation au lieu du GPS. Désactivez pour naviguer réellement.</string>
     <string name="settings_sim_location">Simuler ma position (démo)</string>
-    <string name="settings_sim_location_hint">Pour les démos et captures d\'écran : faites comme si vous étiez au centre de la carte, pour que le point de localisation, les distances et les itinéraires partent de là plutôt que de votre vraie position. Désactivez pour le vrai GPS.</string>
+    <string name="settings_sim_location_hint">Fait comme si vous étiez au centre de la carte, pour démos et captures. Désactivez pour le vrai GPS.</string>
     <string name="place_address_copied">Adresse copiée</string>
     <string name="place_copy_address">Copier l\'adresse</string>
     <string name="place_directions">Itinéraire</string>
@@ -310,7 +310,7 @@
     <string name="mapscreen_switch">Basculer</string>
     <string name="root_not_now">Pas maintenant</string>
     <string name="root_voice_title">Voix de navigation</string>
-    <string name="root_voice_body_intro">La voix de Vela fonctionne entièrement sur votre téléphone : instructions naturelles, sans compte ni appli en plus. Recommandée, un téléchargement unique d\'environ %1$d Mo.</string>
+    <string name="root_voice_body_intro">La voix de Vela tourne entièrement sur votre téléphone : instructions naturelles, pas de compte, pas d\'appli en plus. Recommandée, un téléchargement unique de %1$d Mo.</string>
     <string name="root_voice_body_system">Vous préférez non ? Utilisez une voix déjà sur votre téléphone.</string>
     <string name="root_voice_body_outro">Modifiable à tout moment dans Réglages → Voix.</string>
     <string name="root_voice_download">Télécharger la voix Vela</string>
@@ -372,7 +372,7 @@
     <string name="mapvm_export_trip_subject">Trajet Vela : %1$s (%2$d points)</string>
     <string name="mapvm_share_trip_chooser">Partager le trajet</string>
     <string name="mapvm_voice_sample">Dans quatre cents mètres, tournez à droite sur la rue de la Paix.</string>
-    <string name="mapvm_not_enough_space">Espace insuffisant pour %1$s (~%2$d Mo)</string>
+    <string name="mapvm_not_enough_space">Pas assez d\'espace libre pour %1$s (%2$d Mo)</string>
     <string name="mapvm_voice_downloaded">%1$s téléchargée</string>
     <string name="mapvm_voice_download_failed">Échec du téléchargement de %1$s</string>
     <string name="mapvm_vela_voice_removed">Voix Vela supprimée</string>
@@ -412,7 +412,7 @@
     <string name="update_install">Mettre à jour</string>
     <string name="update_download_failed">Le téléchargement de la mise à jour a échoué. Réessaie plus tard.</string>
     <string name="settings_update_auto">Vérifier les mises à jour au lancement</string>
-    <string name="settings_update_auto_hint">Consulte la dernière version GitHub environ une fois par jour et la propose quand elle est plus récente que celle-ci. L\'installation passe par l\'installateur Android normal. Si tu mets déjà à jour via Obtainium, tu peux désactiver.</string>
+    <string name="settings_update_auto_hint">Consulte GitHub environ une fois par jour et propose les nouvelles versions. Désactivez si vous mettez à jour via Obtainium.</string>
     <string name="settings_update_check_now">Vérifier les mises à jour</string>
     <string name="settings_update_checking">Vérification…</string>
     <string name="settings_update_none">Tu as la version la plus récente.</string>
@@ -480,7 +480,7 @@
     <string name="lists_place_count">%1$d lieux</string>
     <string name="navservice_notif_eta">Arrivée %1$s</string>
     <string name="settings_advanced">Avancé</string>
-    <string name="settings_advanced_hint">Options de niche et expérimentales que la plupart des gens n\'ont jamais à changer.</string>
+    <string name="settings_advanced_hint">Options dont la plupart des gens n\'ont jamais besoin.</string>
     <string name="settings_developer">Développeur</string>
     <string name="settings_developer_hint">Outils pour les démos, captures d\'écran et tests. Désactivez-les pour un usage réel.</string>
     <string name="settings_browse_voices">Parcourir les voix</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -137,8 +137,8 @@
     <string name="settings_version_line">Vela %1$s  (build %2$d)</string>
     <string name="settings_collapse">Réduire</string>
     <string name="settings_expand">Développer</string>
-    <string name="settings_voice_lib_empty_hint">Téléchargez une voix naturelle sur l\'appareil pour les instructions vocales — choisissez-en une ci-dessous. Les voix ★ ressemblent le plus à une voix de navigation (Lessac et HFC sont les plus proches de Google). Téléchargement unique ; le Wi-Fi est recommandé.</string>
-    <string name="settings_voice_lib_installed_hint">Installé : %1$d Mo · %2$d voix. Touchez Utiliser pour changer (joue un extrait) ; l\'icône corbeille libère l\'espace.</string> <!-- format -->
+    <string name="settings_voice_lib_empty_hint">★ signale les voix recommandées. Chaque voix fonctionne hors ligne sur votre téléphone.</string>
+    <string name="settings_voice_lib_installed_hint">Installé : %1$d Mo · %2$d voix.</string> <!-- format -->
     <string name="settings_voice_lib_lang_hint">La langue de votre application est %1$s — téléchargez une voix %2$s ci-dessous pour que les instructions vocales correspondent (une voix anglaise prononcerait mal les noms de rues en %3$s).</string>
     <string name="settings_voice_search">Rechercher des voix</string>
     <string name="settings_voice_show_more">Afficher %1$d de plus</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -69,7 +69,7 @@
     <string name="settings_hide_external_links">Masquer le site web et les liens externes</string>
     <string name="settings_hide_external_links_hint">Activé = les pages de lieu n’affichent pas les boutons Site web, Street View ou Réserver / Commander (aucun site externe arbitraire ouvert).</string>
     <string name="settings_offline">Hors ligne</string>
-    <string name="settings_offline_hint">Utiliser la carte sans réseau nécessite deux éléments — les TUILES de carte que vous voyez et le RÉSEAU ROUTIER qui vous guide. Enregistrer une zone de carte récupère les deux pour cet endroit ; la liste des régions ci-dessous ajoute le réseau routier partout où vous voyagez.</string>
+    <string name="settings_offline_hint">Téléchargez une zone pour conserver sa carte et ses itinéraires sur votre téléphone, utilisables hors ligne.</string>
     <string name="settings_offline_map_area">Zone de carte</string>
     <string name="settings_offline_download_viewport">Télécharger la zone affichée</string>
     <string name="settings_offline_download_viewport_hint">Enregistre les tuiles de la zone que vous aviez à l\'écran — ainsi que la région de routage autour — pour l\'afficher et y naviguer plus tard sans réseau. La recherche nécessite toujours une connexion.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -72,13 +72,13 @@
     <string name="settings_offline_hint">Scarica un\'area per tenere la sua mappa e le indicazioni sul telefono, per l\'uso offline.</string>
     <string name="settings_offline_map_area">Area mappa</string>
     <string name="settings_offline_download_viewport">Scarica l\'area che stai visualizzando</string>
-    <string name="settings_offline_download_viewport_hint">Salva i riquadri aperti per l\'area della mappa che avevi sullo schermo, e la regione di percorso attorno, così viene visualizzata e navigata in seguito senza rete. La ricerca richiede comunque una connessione.</string>
+    <string name="settings_offline_download_viewport_hint">Salva la mappa e le sue strade per l\'area visualizzata, così si mostra e calcola percorsi offline.</string>
     <string name="settings_offline_no_areas">Nessuna area ancora salvata.</string>
     <string name="settings_offline_addresses_missing">Le aree salvate prima di questo aggiornamento non includono i dati degli indirizzi. Aggiornale per cercare indirizzi e calcolare percorsi offline.</string>
     <string name="settings_offline_addresses_update">Aggiorna aree salvate</string>
     <string name="settings_offline_delete_area">Elimina questa area offline</string>
     <string name="settings_routing_regions">Regioni di percorso</string>
-    <string name="settings_routing_regions_hint">La rete stradale di un\'intera regione (regione, Paese…), così la navigazione passo-passo funziona offline ovunque al suo interno: scarica dove stai viaggiando. Online usa comunque il traffico in tempo reale; questa è l\'alternativa senza segnale.</string>
+    <string name="settings_routing_regions_hint">Le strade di un\'intera regione (uno stato o un paese), così le indicazioni funzionano offline ovunque al suo interno. Scarica dove sei diretto.</string>
     <string name="settings_routing_no_regions">Ancora nessuna regione disponibile.</string>
     <string name="settings_clear_filter">Cancella filtro</string>
     <string name="settings_routing_filter_placeholder">Filtra %1$d regioni… (es. Giappone, Toscana)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -69,16 +69,16 @@
     <string name="settings_hide_external_links">Nascondi sito web e link esterni</string>
     <string name="settings_hide_external_links_hint">Attivo = le pagine dei luoghi non mostrano i pulsanti Sito web, Street View o Prenota / Ordina (nessun sito esterno arbitrario aperto).</string>
     <string name="settings_offline">Mappe offline</string>
-    <string name="settings_offline_hint">Scarica un\'area per tenere la sua mappa e le indicazioni sul telefono, per l\'uso offline.</string>
-    <string name="settings_offline_map_area">Area mappa</string>
+    <string name="settings_offline_hint">Due modi per usare Vela offline: salva l\'area in cui ti trovi per i tragitti brevi, oppure un intero stato o paese qui sotto per quelli lunghi.</string>
+    <string name="settings_offline_map_area">Area locale</string>
     <string name="settings_offline_download_viewport">Scarica l\'area che stai visualizzando</string>
-    <string name="settings_offline_download_viewport_hint">Salva la mappa e le sue strade per l\'area visualizzata, così si mostra e calcola percorsi offline.</string>
+    <string name="settings_offline_download_viewport_hint">Salva la mappa che stai guardando, con strade e indirizzi, così questa zona continua a funzionare senza segnale.</string>
     <string name="settings_offline_no_areas">Nessuna area ancora salvata.</string>
     <string name="settings_offline_addresses_missing">Le aree salvate prima di questo aggiornamento non includono i dati degli indirizzi. Aggiornale per cercare indirizzi e calcolare percorsi offline.</string>
     <string name="settings_offline_addresses_update">Aggiorna aree salvate</string>
     <string name="settings_offline_delete_area">Elimina questa area offline</string>
-    <string name="settings_routing_regions">Regioni di percorso</string>
-    <string name="settings_routing_regions_hint">Le strade di un\'intera regione (uno stato o un paese), così le indicazioni funzionano offline ovunque al suo interno. Scarica dove sei diretto.</string>
+    <string name="settings_routing_regions">Regioni e paesi</string>
+    <string name="settings_routing_regions_hint">Tutto il necessario per girare un intero stato, provincia o paese offline: strade e luoghi, così indicazioni e ricerca funzionano ovunque al suo interno. Scarica dove sei diretto.</string>
     <string name="settings_routing_no_regions">Ancora nessuna regione disponibile.</string>
     <string name="settings_clear_filter">Cancella filtro</string>
     <string name="settings_routing_filter_placeholder">Cerca</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -14,6 +14,7 @@
     <string name="settings_units_imperial">Imperiali (miglia, piedi)</string>
     <string name="settings_units_metric">Metriche (chilometri, metri)</string>
     <string name="settings_language">Lingua</string>
+    <string name="settings_follow_system_language">Segui la lingua del sistema</string>
     <string name="settings_language_hint">Imposta la lingua delle indicazioni vocali passo-passo (inglese, francese, tedesco, spagnolo, italiano, portoghese, olandese, russo, polacco, svedese, ucraino), indipendente dalla lingua di sistema del telefono. Scegli una voce corrispondente nella Libreria voci qui sotto. Il resto del testo dell\'app sarà tradotto a breve.</string>
     <string name="settings_search">Ricerca</string>
     <string name="settings_voice_search_toggle">Microfono ricerca vocale</string>
@@ -478,4 +479,10 @@
     <string name="lists_empty_hint">Ancora nessuna lista. Tocca Nuova o salva un luogo dalla sua pagina.</string>
     <string name="lists_place_count">%1$d luoghi</string>
     <string name="navservice_notif_eta">Arrivo %1$s</string>
+    <string name="settings_advanced">Avanzate</string>
+    <string name="settings_advanced_hint">Opzioni di nicchia e sperimentali che quasi nessuno deve cambiare.</string>
+    <string name="settings_developer">Sviluppatore</string>
+    <string name="settings_developer_hint">Strumenti per demo, screenshot e test. Disattivali per l\'uso reale.</string>
+    <string name="settings_browse_voices">Sfoglia le voci</string>
+    <string name="settings_browse_voices_hint">Scarica e cambia le voci di Vela sul dispositivo.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -137,8 +137,8 @@
     <string name="settings_version_line">Vela %1$s  (build %2$d)</string>
     <string name="settings_collapse">Comprimi</string>
     <string name="settings_expand">Espandi</string>
-    <string name="settings_voice_lib_empty_hint">Scarica una voce naturale sul dispositivo per le indicazioni vocali: scegline una qui sotto. Le voci ★ suonano più simili a un navigatore di mappe (Lessac e HFC sono le più vicine a Google). Download una tantum; consigliato il Wi-Fi.</string>
-    <string name="settings_voice_lib_installed_hint">Installato: %1$d MB · %2$d voce/i. Tocca Usa per cambiare (riproduce un campione); l\'icona del cestino libera lo spazio.</string> <!-- format -->
+    <string name="settings_voice_lib_empty_hint">★ indica le voci consigliate. Ogni voce funziona offline sul telefono.</string>
+    <string name="settings_voice_lib_installed_hint">Installato: %1$d MB · %2$d voci.</string> <!-- format -->
     <string name="settings_voice_lib_lang_hint">La lingua dell\'app è %1$s: scarica una voce %2$s qui sotto così le indicazioni vocali corrispondono (una voce inglese pronuncerebbe male i nomi delle strade in %3$s).</string>
     <string name="settings_voice_search">Cerca voci</string>
     <string name="settings_voice_show_more">Mostra altri %1$d</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -68,7 +68,7 @@
     <string name="settings_hide_adult_hint">Attivo = nasconde bar, discoteche, casinò, enoteche e altri luoghi per adulti / della vita notturna da ricerca e mappa.</string>
     <string name="settings_hide_external_links">Nascondi sito web e link esterni</string>
     <string name="settings_hide_external_links_hint">Attivo = le pagine dei luoghi non mostrano i pulsanti Sito web, Street View o Prenota / Ordina (nessun sito esterno arbitrario aperto).</string>
-    <string name="settings_offline">Offline</string>
+    <string name="settings_offline">Mappe offline</string>
     <string name="settings_offline_hint">Scarica un\'area per tenere la sua mappa e le indicazioni sul telefono, per l\'uso offline.</string>
     <string name="settings_offline_map_area">Area mappa</string>
     <string name="settings_offline_download_viewport">Scarica l\'area che stai visualizzando</string>
@@ -81,7 +81,7 @@
     <string name="settings_routing_regions_hint">Le strade di un\'intera regione (uno stato o un paese), così le indicazioni funzionano offline ovunque al suo interno. Scarica dove sei diretto.</string>
     <string name="settings_routing_no_regions">Ancora nessuna regione disponibile.</string>
     <string name="settings_clear_filter">Cancella filtro</string>
-    <string name="settings_routing_filter_placeholder">Filtra %1$d regioni… (es. Giappone, Toscana)</string>
+    <string name="settings_routing_filter_placeholder">Cerca</string>
     <string name="settings_routing_no_match">Nessuna regione corrisponde a “%1$s”.</string>
     <string name="settings_routing_downloading">Download… %1$d%%</string>
     <string name="settings_routing_installed">Installata · percorsi offline qui</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -69,7 +69,7 @@
     <string name="settings_hide_external_links">Nascondi sito web e link esterni</string>
     <string name="settings_hide_external_links_hint">Attivo = le pagine dei luoghi non mostrano i pulsanti Sito web, Street View o Prenota / Ordina (nessun sito esterno arbitrario aperto).</string>
     <string name="settings_offline">Offline</string>
-    <string name="settings_offline_hint">Usare la mappa senza segnale richiede due cose: i RIQUADRI della mappa che vedi e la RETE STRADALE che ti guida. Salvare un\'area della mappa scarica entrambi per quel punto; l\'elenco delle regioni qui sotto aggiunge la rete stradale ovunque tu stia viaggiando.</string>
+    <string name="settings_offline_hint">Scarica un\'area per tenere la sua mappa e le indicazioni sul telefono, per l\'uso offline.</string>
     <string name="settings_offline_map_area">Area mappa</string>
     <string name="settings_offline_download_viewport">Scarica l\'area che stai visualizzando</string>
     <string name="settings_offline_download_viewport_hint">Salva i riquadri aperti per l\'area della mappa che avevi sullo schermo, e la regione di percorso attorno, così viene visualizzata e navigata in seguito senza rete. La ricerca richiede comunque una connessione.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -5,17 +5,17 @@
     <string name="settings_follow_system">Come il sistema</string>
     <string name="settings_theme_light">Chiaro</string>
     <string name="settings_theme_dark">Scuro</string>
-    <string name="settings_appearance_hint">Chiaro/Scuro si applica solo a Vela, non modifica il tema di sistema del telefono.</string>
+    <string name="settings_appearance_hint">Vale solo per Vela.</string>
     <string name="settings_dynamic_color">Colori Material You</string>
-    <string name="settings_dynamic_color_hint">Colora pulsanti, chip e accenti in base allo sfondo (Android 12+). Disattivato = il verde acqua di Vela. La mappa resta neutra così strade ed etichette mantengono il contrasto.</string>
+    <string name="settings_dynamic_color_hint">Colora pulsanti e accenti in base allo sfondo. La mappa resta neutra.</string>
     <string name="settings_map_style">Stile mappa</string>
-    <string name="settings_map_style_hint">OpenFreeMap (predefinito) è dettagliato e non richiede chiave. Protomaps richiede una chiave API; lo stile demo mostra solo i contorni dei Paesi.</string>
+    <string name="settings_map_style_hint">OpenFreeMap funziona senza chiave API.</string>
     <string name="settings_units">Unità</string>
     <string name="settings_units_imperial">Imperiali (miglia, piedi)</string>
     <string name="settings_units_metric">Metriche (chilometri, metri)</string>
     <string name="settings_language">Lingua</string>
     <string name="settings_follow_system_language">Segui la lingua del sistema</string>
-    <string name="settings_language_hint">Imposta la lingua delle indicazioni vocali passo-passo (inglese, francese, tedesco, spagnolo, italiano, portoghese, olandese, russo, polacco, svedese, ucraino), indipendente dalla lingua di sistema del telefono. Scegli una voce corrispondente nella Libreria voci qui sotto. Il resto del testo dell\'app sarà tradotto a breve.</string>
+    <string name="settings_language_hint">Cambia la lingua dell\'app e delle indicazioni vocali. Scarica una voce adatta nella libreria voci.</string>
     <string name="settings_search">Ricerca</string>
     <string name="settings_voice_search_toggle">Microfono ricerca vocale</string>
     <string name="settings_voice_search_hint">Mostra un microfono nella barra di ricerca. Toccalo per dettare la ricerca con un\'app di input vocale sul telefono.</string>
@@ -50,16 +50,16 @@
     <string name="settings_mode_transit">Mezzi</string>
     <string name="settings_vibrate_hint">Vibrazioni con direzione codificata a ogni svolta, distinte per sinistra e destra, così puoi seguire un percorso al tatto. Impostabile per ogni modalità di viaggio (es. attiva per bici e a piedi, disattiva in auto).</string>
     <string name="settings_keep_screen_on">Mantieni schermo acceso durante la navigazione</string>
-    <string name="settings_keep_screen_on_hint">Impedisce allo schermo di attenuarsi o spegnersi mentre è attiva la navigazione passo-passo, così la svolta successiva è sempre visibile senza toccare per riattivarlo. Attivo per impostazione predefinita; lo schermo torna a spegnersi normalmente non appena arrivi o esci dalla navigazione.</string>
+    <string name="settings_keep_screen_on_hint">Tiene lo schermo acceso durante la navigazione.</string>
     <string name="settings_map">Mappa</string>
     <string name="settings_live_traffic">Overlay traffico in tempo reale</string>
-    <string name="settings_live_traffic_hint">Colora le strade in base alla congestione mentre esplori la mappa (riquadri di traffico senza chiave di Google). Disattivo per impostazione predefinita: la navigazione colora già il percorso in base al traffico, quindi serve solo per osservare l\'area circostante. È un overlay raster, perciò risulta un po\' granuloso.</string>
+    <string name="settings_live_traffic_hint">Colora le strade in base al traffico mentre esplori. La navigazione colora già il tuo percorso.</string>
     <string name="settings_transit_layer">Evidenzia le linee di trasporto</string>
-    <string name="settings_transit_layer_hint">Disegna le linee di treno e metropolitana a colori sulla mappa, così è facile seguire la ferrovia. Usa i dati aperti già presenti nei riquadri, senza rete.</string>
+    <string name="settings_transit_layer_hint">Disegna le linee di treni e metro sulla mappa.</string>
     <string name="settings_read_all_reviews">Pulsante “Leggi tutte le recensioni”</string>
-    <string name="settings_read_all_reviews_hint">Le recensioni nella scheda del luogo sono sempre l\'elenco nativo e fluido di Vela. Questo aggiunge un pulsante “Leggi tutte le recensioni” che apre la pagina completa delle recensioni di Google A SCHERMO INTERO: ogni recensione (non solo le prime ~50), la ricerca lato server di Google e le recensioni video. Tracker e beacon sono bloccati, ma la pagina di Google viene comunque eseguita nell\'app. Disattivo = solo elenco nativo, nessuna pagina Google per le recensioni.</string>
+    <string name="settings_read_all_reviews_hint">Aggiunge un pulsante che apre la pagina completa delle recensioni di Google nell\'app, con tutte le recensioni. Off = solo l\'elenco di Vela.</string>
     <string name="settings_buildings_3d">Edifici 3D</string>
-    <string name="settings_buildings_3d_hint">Sagome degli edifici in rilievo a zoom elevato. Disattivarlo può rendere lo spostamento più fluido sui telefoni datati; le impronte piatte restano.</string>
+    <string name="settings_buildings_3d_hint">Edifici in rilievo a zoom ravvicinato. Disattivarlo può rendere più fluido lo scorrimento sui telefoni datati.</string>
     <string name="settings_show_reviews">Mostra recensioni</string>
     <string name="settings_show_reviews_hint">Disattivato = le pagine dei luoghi non mostrano recensioni e Vela non le scarica mai.</string>
     <string name="settings_load_photos">Carica foto</string>
@@ -101,15 +101,15 @@
     <string name="settings_export">Esporta</string>
     <string name="settings_import">Importa</string>
     <string name="settings_data_privacy">Fonte dati e privacy</string>
-    <string name="settings_data_privacy_hint">Vela comunica direttamente con gli endpoint web pubblici di Google da questo dispositivo: nessun backend Vela, nessun account Google, nessuna chiave API e nessuna telemetria a meno che non attivi la Diagnostica qui sotto (disattiva per impostazione predefinita, solo locale). Ogni dispositivo si comporta come un browser non connesso; Google vede il tuo IP, la query e l\'area della mappa ma non un account. I luoghi salvati e la cronologia non lasciano mai il telefono.</string>
+    <string name="settings_data_privacy_hint">Vela parla con gli endpoint pubblici di Google direttamente da questo dispositivo: niente backend, niente account, niente chiave API. Google vede IP, ricerca e area della mappa, non chi sei.</string>
     <string name="settings_privacy_button">Quali dati riceve Google</string>
     <string name="settings_diagnostics">Diagnostica</string>
-    <string name="settings_diagnostics_hint">Disattiva per impostazione predefinita. Quando è attiva, Vela conserva un breve registro locale di ciò che ha fatto (ricerche, percorsi ed eventuali problemi “necessita ricalibrazione”), così se qualcosa non funziona puoi esportarlo e consegnarlo a uno sviluppatore. Resta su questo telefono e non viene mai caricato; scegli tu dove va l\'esportazione. Disattivandola il registro viene cancellato.</string>
+    <string name="settings_diagnostics_hint">Disattivato di default. Se attivo, Vela tiene un breve registro locale che puoi esportare e dare a uno sviluppatore. Nulla viene caricato, e disattivarlo lo cancella.</string>
     <string name="settings_share_diagnostics">Condividi diagnostica</string>
     <string name="settings_diag_nothing">Ancora niente registrato: usa l\'app, poi esporta.</string>
     <string name="settings_diag_export">Esporta sessione di debug</string>
     <string name="settings_save_trips">Salva i miei viaggi (per la riproduzione)</string>
-    <string name="settings_save_trips_hint">Registra su questo telefono la traccia GPS di ogni navigazione, così un tragitto può essere riprodotto in seguito per testare la navigazione passo-passo senza rifarlo. Più rivelatore della diagnostica (sono i tuoi percorsi esatti) e non lascia mai il telefono.</string>
+    <string name="settings_save_trips_hint">Registra la traccia GPS di ogni viaggio su questo telefono, per riprodurla in seguito. Non lascia mai il telefono.</string>
     <string name="settings_recorded_trips_hint">Viaggi registrati: tocca Riproduci per riprodurne uno sulla mappa (3×):</string>
     <string name="settings_trip_points">%1$d punti</string>
     <string name="settings_trip_replay">Riproduci</string>
@@ -167,7 +167,7 @@
     <string name="place_permanently_closed">Chiuso definitivamente</string>
     <string name="place_temporarily_closed">Chiuso temporaneamente</string>
     <string name="settings_traffic_lights">Indicazioni con semafori</string>
-    <string name="settings_traffic_lights_hint">Dice «supera il semaforo, poi svolta» agli incroci con semaforo (voce solo in inglese per ora)</string>
+    <string name="settings_traffic_lights_hint">Aggiunge indicazioni come “supera il semaforo, poi gira a sinistra”. Per ora solo in inglese.</string>
     <string name="map_voice_downloading">Download della voce Vela · %1$d %%</string>
     <string name="map_voice_installing">Installazione della voce Vela…</string>
     <string name="map_region_downloading">Download instradamento %1$s · %2$d%%</string> <!-- format -->
@@ -175,9 +175,9 @@
     <string name="mapvm_poipack_ready">I luoghi di %1$s ora sono ricercabili offline</string> <!-- format -->
     <string name="mapvm_poipack_unavailable">Nessun pacchetto di luoghi per %1$s per ora. Comparirà qui appena pubblicato.</string> <!-- format -->
     <string name="settings_demo_drive">Simula la guida (demo)</string>
-    <string name="settings_demo_drive_hint">Per demo, screenshot e test: toccando Avvia il percorso viene guidato come una traccia GPS simulata invece della tua posizione reale, così la navigazione funziona ovunque. Disattiva per navigare davvero.</string>
+    <string name="settings_demo_drive_hint">Avvia percorre il percorso pianificato in simulazione anziché col GPS. Disattiva per navigare davvero.</string>
     <string name="settings_sim_location">Simula la mia posizione (demo)</string>
-    <string name="settings_sim_location_hint">Per demo e screenshot: fai finta di essere al centro della mappa, così il punto di posizione, le distanze e i percorsi partono da lì invece che dalla tua posizione reale. Disattiva per usare il GPS reale.</string>
+    <string name="settings_sim_location_hint">Finge che tu sia al centro della mappa, per demo e screenshot. Disattiva per usare il GPS reale.</string>
     <string name="place_address_copied">Indirizzo copiato</string>
     <string name="place_copy_address">Copia indirizzo</string>
     <string name="place_directions">Indicazioni</string>
@@ -310,7 +310,7 @@
     <string name="mapscreen_switch">Cambia</string>
     <string name="root_not_now">Non ora</string>
     <string name="root_voice_title">Voce per la navigazione</string>
-    <string name="root_voice_body_intro">La voce di Vela funziona interamente sul telefono: indicazioni naturali, senza account né app extra. Consigliata, un download una tantum di ~%1$d MB.</string>
+    <string name="root_voice_body_intro">La voce di Vela gira interamente sul telefono: indicazioni naturali, nessun account, nessun\'altra app. Consigliata, un download unico di %1$d MB.</string>
     <string name="root_voice_body_system">Preferisci di no? Usa una voce già sul telefono.</string>
     <string name="root_voice_body_outro">Cambiala quando vuoi in Impostazioni → Voce.</string>
     <string name="root_voice_download">Scarica voce Vela</string>
@@ -372,7 +372,7 @@
     <string name="mapvm_export_trip_subject">Viaggio Vela: %1$s (%2$d punti)</string>
     <string name="mapvm_share_trip_chooser">Condividi viaggio</string>
     <string name="mapvm_voice_sample">Tra quattrocento metri svolta a destra in Via Roma.</string>
-    <string name="mapvm_not_enough_space">Spazio libero insufficiente per %1$s (~%2$d MB)</string>
+    <string name="mapvm_not_enough_space">Spazio libero insufficiente per %1$s (%2$d MB)</string>
     <string name="mapvm_voice_downloaded">%1$s scaricata</string>
     <string name="mapvm_voice_download_failed">Download di %1$s non riuscito</string>
     <string name="mapvm_vela_voice_removed">Voce Vela rimossa</string>
@@ -412,7 +412,7 @@
     <string name="update_install">Aggiorna</string>
     <string name="update_download_failed">Download dell\'aggiornamento non riuscito. Riprova più tardi.</string>
     <string name="settings_update_auto">Cerca aggiornamenti all\'avvio</string>
-    <string name="settings_update_auto_hint">Controlla l\'ultima release su GitHub circa una volta al giorno e la propone quando è più recente di questa build. L\'installazione passa dal normale installer di Android. Se aggiorni già con Obtainium puoi disattivarlo.</string>
+    <string name="settings_update_auto_hint">Controlla GitHub circa una volta al giorno e propone versioni più recenti. Disattiva se aggiorni con Obtainium.</string>
     <string name="settings_update_check_now">Cerca aggiornamenti</string>
     <string name="settings_update_checking">Controllo…</string>
     <string name="settings_update_none">Hai già l\'ultima versione.</string>
@@ -480,7 +480,7 @@
     <string name="lists_place_count">%1$d luoghi</string>
     <string name="navservice_notif_eta">Arrivo %1$s</string>
     <string name="settings_advanced">Avanzate</string>
-    <string name="settings_advanced_hint">Opzioni di nicchia e sperimentali che quasi nessuno deve cambiare.</string>
+    <string name="settings_advanced_hint">Opzioni che quasi nessuno usa.</string>
     <string name="settings_developer">Sviluppatore</string>
     <string name="settings_developer_hint">Strumenti per demo, screenshot e test. Disattivali per l\'uso reale.</string>
     <string name="settings_browse_voices">Sfoglia le voci</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -72,13 +72,13 @@
     <string name="settings_offline_hint">Download een gebied om de kaart en routes ervan op je telefoon te bewaren voor offline gebruik.</string>
     <string name="settings_offline_map_area">Kaartgebied</string>
     <string name="settings_offline_download_viewport">Download het gebied dat u bekijkt</string>
-    <string name="settings_offline_download_viewport_hint">Slaat de open tegels op voor het kaartgebied dat u het laatst in beeld had — en de routeringsregio eromheen — zodat het later zonder netwerk wordt weergegeven en navigeert. Zoeken vereist nog steeds een verbinding.</string>
+    <string name="settings_offline_download_viewport_hint">Bewaart de kaart en wegen van het gebied dat je ziet, zodat het offline toont en routeert.</string>
     <string name="settings_offline_no_areas">Nog geen gebieden opgeslagen.</string>
     <string name="settings_offline_addresses_missing">Gebieden die je vóór deze update hebt opgeslagen, bevatten geen adresgegevens. Werk ze bij om offline naar adressen te zoeken en ernaartoe te navigeren.</string>
     <string name="settings_offline_addresses_update">Opgeslagen gebieden bijwerken</string>
     <string name="settings_offline_delete_area">Dit offline gebied verwijderen</string>
     <string name="settings_routing_regions">Routeringsregio\'s</string>
-    <string name="settings_routing_regions_hint">Het wegennetwerk voor een hele regio (provincie, land…), zodat navigatie overal daarbinnen offline werkt — download waar u naartoe reist. Online wordt nog steeds live verkeer gebruikt; dit is de terugval zonder signaal.</string>
+    <string name="settings_routing_regions_hint">De wegen van een hele regio (een staat of land), zodat routes overal daarin offline werken. Pak waar je heen gaat.</string>
     <string name="settings_routing_no_regions">Nog geen regio\'s beschikbaar.</string>
     <string name="settings_clear_filter">Filter wissen</string>
     <string name="settings_routing_filter_placeholder">Filter %1$d regio\'s… (bijv. Japan, Texas)</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -69,16 +69,16 @@
     <string name="settings_hide_external_links">Website en externe links verbergen</string>
     <string name="settings_hide_external_links_hint">Aan = plaatspagina’s tonen geen Website-, Street View- of Reserveren / Bestellen-knoppen (geen willekeurige externe sites geopend).</string>
     <string name="settings_offline">Offlinekaarten</string>
-    <string name="settings_offline_hint">Download een gebied om de kaart en routes ervan op je telefoon te bewaren voor offline gebruik.</string>
-    <string name="settings_offline_map_area">Kaartgebied</string>
+    <string name="settings_offline_hint">Twee manieren om Vela offline te gebruiken: bewaar het gebied waar je bent voor korte ritten, of hieronder een hele staat of een heel land voor langere.</string>
+    <string name="settings_offline_map_area">Lokaal gebied</string>
     <string name="settings_offline_download_viewport">Download het gebied dat u bekijkt</string>
-    <string name="settings_offline_download_viewport_hint">Bewaart de kaart en wegen van het gebied dat je ziet, zodat het offline toont en routeert.</string>
+    <string name="settings_offline_download_viewport_hint">Bewaart de kaart die je bekijkt, met wegen en adressen, zodat dit gebied zonder bereik blijft werken.</string>
     <string name="settings_offline_no_areas">Nog geen gebieden opgeslagen.</string>
     <string name="settings_offline_addresses_missing">Gebieden die je vóór deze update hebt opgeslagen, bevatten geen adresgegevens. Werk ze bij om offline naar adressen te zoeken en ernaartoe te navigeren.</string>
     <string name="settings_offline_addresses_update">Opgeslagen gebieden bijwerken</string>
     <string name="settings_offline_delete_area">Dit offline gebied verwijderen</string>
-    <string name="settings_routing_regions">Routeringsregio\'s</string>
-    <string name="settings_routing_regions_hint">De wegen van een hele regio (een staat of land), zodat routes overal daarin offline werken. Pak waar je heen gaat.</string>
+    <string name="settings_routing_regions">Regio\'s en landen</string>
+    <string name="settings_routing_regions_hint">Alles om offline door een hele staat, provincie of een heel land te reizen: de wegen en plekken, zodat routes en zoeken overal daarbinnen werken. Pak waar je heen gaat.</string>
     <string name="settings_routing_no_regions">Nog geen regio\'s beschikbaar.</string>
     <string name="settings_clear_filter">Filter wissen</string>
     <string name="settings_routing_filter_placeholder">Zoeken</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -14,6 +14,7 @@
     <string name="settings_units_imperial">Imperiaal (mijl, voet)</string>
     <string name="settings_units_metric">Metrisch (kilometers, meters)</string>
     <string name="settings_language">Taal</string>
+    <string name="settings_follow_system_language">Systeemtaal volgen</string>
     <string name="settings_language_hint">Stelt de taal in voor gesproken route-instructies (Engels, Frans, Duits, Spaans, Italiaans, Portugees, Nederlands, Russisch, Pools, Zweeds, Oekraïens) — los van de systeemtaal van uw telefoon. Kies hieronder een passende stem in de Stembibliotheek. De rest van de tekst in de app wordt hierna vertaald.</string>
     <string name="settings_search">Zoeken</string>
     <string name="settings_voice_search_toggle">Microfoon voor spraakzoeken</string>
@@ -478,4 +479,10 @@
     <string name="lists_empty_hint">Nog geen lijsten. Tik op Nieuw of sla een plaats op vanaf zijn pagina.</string>
     <string name="lists_place_count">%1$d plaatsen</string>
     <string name="navservice_notif_eta">Aankomst %1$s</string>
+    <string name="settings_advanced">Geavanceerd</string>
+    <string name="settings_advanced_hint">Niche- en experimentele opties die de meeste mensen nooit hoeven te wijzigen.</string>
+    <string name="settings_developer">Ontwikkelaar</string>
+    <string name="settings_developer_hint">Hulpmiddelen voor demo\'s, schermafbeeldingen en tests. Zet ze uit voor echt gebruik.</string>
+    <string name="settings_browse_voices">Stemmen bekijken</string>
+    <string name="settings_browse_voices_hint">Download en wissel tussen Vela\'s stemmen op het apparaat.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -5,17 +5,17 @@
     <string name="settings_follow_system">Systeem volgen</string>
     <string name="settings_theme_light">Licht</string>
     <string name="settings_theme_dark">Donker</string>
-    <string name="settings_appearance_hint">Licht/donker geldt alleen voor Vela — het thema van uw telefoon wordt niet gewijzigd.</string>
+    <string name="settings_appearance_hint">Geldt alleen voor Vela.</string>
     <string name="settings_dynamic_color">Material You-kleuren</string>
-    <string name="settings_dynamic_color_hint">Kleurt knoppen, chips en accenten naar je achtergrond (Android 12+). Uit = Vela\'s eigen groenblauw. De kaart zelf blijft neutraal zodat wegen en labels hun contrast houden.</string>
+    <string name="settings_dynamic_color_hint">Kleurt knoppen en accenten naar je achtergrond. De kaart blijft neutraal.</string>
     <string name="settings_map_style">Kaartstijl</string>
-    <string name="settings_map_style_hint">OpenFreeMap (de standaard) werkt zonder sleutel en is gedetailleerd. Protomaps vereist een API-sleutel; de demostijl toont alleen de contouren van landen.</string>
+    <string name="settings_map_style_hint">OpenFreeMap werkt zonder API-sleutel.</string>
     <string name="settings_units">Eenheden</string>
     <string name="settings_units_imperial">Imperiaal (mijl, voet)</string>
     <string name="settings_units_metric">Metrisch (kilometers, meters)</string>
     <string name="settings_language">Taal</string>
     <string name="settings_follow_system_language">Systeemtaal volgen</string>
-    <string name="settings_language_hint">Stelt de taal in voor gesproken route-instructies (Engels, Frans, Duits, Spaans, Italiaans, Portugees, Nederlands, Russisch, Pools, Zweeds, Oekraïens) — los van de systeemtaal van uw telefoon. Kies hieronder een passende stem in de Stembibliotheek. De rest van de tekst in de app wordt hierna vertaald.</string>
+    <string name="settings_language_hint">Wijzigt de taal van de app en de gesproken aanwijzingen. Haal een passende stem uit de stemmenbibliotheek.</string>
     <string name="settings_search">Zoeken</string>
     <string name="settings_voice_search_toggle">Microfoon voor spraakzoeken</string>
     <string name="settings_voice_search_hint">Toont een microfoon in de zoekbalk. Tik erop om je zoekopdracht in te spreken via een spraakinvoer-app op je telefoon.</string>
@@ -50,16 +50,16 @@
     <string name="settings_mode_transit">OV</string>
     <string name="settings_vibrate_hint">Richtinggecodeerde trillingen bij elke afslag — verschillend voor links en rechts — zodat u een route op gevoel kunt volgen. Stel het per vervoerswijze in (bijv. aan voor fietsen en lopen, uit tijdens het rijden).</string>
     <string name="settings_keep_screen_on">Scherm aan houden tijdens navigeren</string>
-    <string name="settings_keep_screen_on_hint">Voorkomt dat het scherm dimt of in slaapstand gaat terwijl de navigatie loopt, zodat de volgende afslag altijd zichtbaar is zonder te tikken om het scherm te wekken. Standaard aan; het scherm gaat weer normaal in slaapstand zodra u aankomt of de navigatie verlaat.</string>
+    <string name="settings_keep_screen_on_hint">Houdt het scherm aan tijdens de navigatie.</string>
     <string name="settings_map">Kaart</string>
     <string name="settings_live_traffic">Live verkeerslaag</string>
-    <string name="settings_live_traffic_hint">Kleurt wegen naar drukte terwijl u de kaart bekijkt (Googles sleutelloze verkeerstegels). Standaard uit — de navigatie kleurt uw route al op verkeer, dus dit is alleen om het bredere gebied te overzien. Het is een rasterlaag, dus iets korrelig.</string>
+    <string name="settings_live_traffic_hint">Kleurt wegen naar drukte tijdens het browsen. Navigatie kleurt je route toch al naar verkeer.</string>
     <string name="settings_transit_layer">Ov-lijnen markeren</string>
-    <string name="settings_transit_layer_hint">Tekent trein- en metrolijnen in kleur op de kaart, zodat je het spoor makkelijk volgt. Gebruikt de open kaartgegevens die al in de tegels zitten, zonder netwerk.</string>
+    <string name="settings_transit_layer_hint">Tekent trein- en metrolijnen op de kaart.</string>
     <string name="settings_read_all_reviews">Knop “Alle recensies lezen”</string>
-    <string name="settings_read_all_reviews_hint">Recensies in het plaatsvenster zijn altijd Vela\'s eigen soepele native lijst. Dit voegt een knop “Alle recensies lezen” toe die Googles volledige recensiepagina SCHERMVULLEND opent — elke recensie (niet alleen de eerste ~50), Googles serverzijdige zoekfunctie, en videorecensies spelen af. Trackers/bakens worden geblokkeerd, maar Googles pagina draait wel in de app. Uit = alleen native lijst, geen Google-pagina voor recensies.</string>
+    <string name="settings_read_all_reviews_hint">Voegt een knop toe die Googles volledige reviewpagina in de app opent, met alle reviews. Uit = alleen Vela\'s eigen lijst.</string>
     <string name="settings_buildings_3d">3D-gebouwen</string>
-    <string name="settings_buildings_3d_hint">Verhoogde gebouwvormen bij ver inzoomen. Uitzetten kan het slepen soepeler maken op oudere telefoons; de platte contouren blijven.</string>
+    <string name="settings_buildings_3d_hint">Verhoogde gebouwen bij dichtbij zoomen. Uitzetten kan het pannen soepeler maken op oudere telefoons.</string>
     <string name="settings_show_reviews">Reviews tonen</string>
     <string name="settings_show_reviews_hint">Uit = plaatspagina\'s tonen geen reviews en Vela haalt ze ook nooit op.</string>
     <string name="settings_load_photos">Foto\'s laden</string>
@@ -101,15 +101,15 @@
     <string name="settings_export">Exporteren</string>
     <string name="settings_import">Importeren</string>
     <string name="settings_data_privacy">Gegevensbron en privacy</string>
-    <string name="settings_data_privacy_hint">Vela praat rechtstreeks vanaf dit toestel met Googles openbare web-endpoints — geen Vela-backend, geen Google-account, geen API-sleutel, en geen telemetrie tenzij u hieronder Diagnostiek inschakelt (standaard uit, alleen lokaal). Elk toestel gedraagt zich als een uitgelogde browser; Google ziet uw IP-adres, zoekopdracht en kaartgebied, maar geen account. Opgeslagen plaatsen en geschiedenis verlaten de telefoon nooit.</string>
+    <string name="settings_data_privacy_hint">Vela praat rechtstreeks vanaf dit apparaat met Googles publieke endpoints: geen backend, geen account, geen API-sleutel. Google ziet je IP, zoekopdracht en kaartgebied, niet wie je bent.</string>
     <string name="settings_privacy_button">Welke gegevens Google ontvangt</string>
     <string name="settings_diagnostics">Diagnostiek</string>
-    <string name="settings_diagnostics_hint">Standaard uit. Wanneer ingeschakeld houdt Vela een kort lokaal logboek bij van wat het deed — uw zoekopdrachten, routes en eventuele “vereist herkalibratie”-haperingen — zodat u het bij problemen kunt exporteren en aan een ontwikkelaar geven. Het blijft op deze telefoon en wordt nooit geüpload; u kiest waar de export naartoe gaat. Uitschakelen wist het logboek.</string>
+    <string name="settings_diagnostics_hint">Standaard uit. Indien aan houdt Vela een kort lokaal logboek bij dat je kunt exporteren en aan een ontwikkelaar geven. Er wordt niets geüpload, en uitzetten wist het.</string>
     <string name="settings_share_diagnostics">Diagnostiek delen</string>
     <string name="settings_diag_nothing">Nog niets vastgelegd — gebruik de app en exporteer daarna.</string>
     <string name="settings_diag_export">Debugsessie exporteren</string>
     <string name="settings_save_trips">Mijn ritten opslaan (voor herhaling)</string>
-    <string name="settings_save_trips_hint">Legt het GPS-spoor van elke navigatie op deze telefoon vast, zodat een rit later kan worden herhaald om de navigatie te testen zonder opnieuw te rijden. Onthullender dan diagnostiek — het zijn uw exacte routes — en het verlaat de telefoon nooit.</string>
+    <string name="settings_save_trips_hint">Slaat het gps-spoor van elke rit op deze telefoon op, om later af te spelen. Verlaat de telefoon nooit.</string>
     <string name="settings_recorded_trips_hint">Opgenomen ritten — tik op Herhalen om er een op de kaart af te spelen (3×):</string>
     <string name="settings_trip_points">%1$d punten</string>
     <string name="settings_trip_replay">Herhalen</string>
@@ -167,7 +167,7 @@
     <string name="place_permanently_closed">Permanent gesloten</string>
     <string name="place_temporarily_closed">Tijdelijk gesloten</string>
     <string name="settings_traffic_lights">Stoplicht-aanwijzingen</string>
-    <string name="settings_traffic_lights_hint">"Rijd het stoplicht voorbij en sla dan af" bij kruispunten met verkeerslichten (voorlopig alleen Engelse spraak)</string>
+    <string name="settings_traffic_lights_hint">Voegt aanwijzingen toe zoals “voorbij het stoplicht, dan linksaf”. Voorlopig alleen Engels.</string>
     <string name="map_voice_downloading">Vela-stem wordt gedownload · %1$d %%</string>
     <string name="map_voice_installing">Vela-stem wordt geïnstalleerd…</string>
     <string name="map_region_downloading">Routes voor %1$s downloaden · %2$d%%</string> <!-- format -->
@@ -175,9 +175,9 @@
     <string name="mapvm_poipack_ready">Plaatsen in %1$s zijn nu offline doorzoekbaar</string> <!-- format -->
     <string name="mapvm_poipack_unavailable">Nog geen plaatsenpakket voor %1$s. Het verschijnt hier zodra het is gepubliceerd.</string> <!-- format -->
     <string name="settings_demo_drive">Rijden simuleren (demo)</string>
-    <string name="settings_demo_drive_hint">Voor demo’s, schermafbeeldingen en tests: op Start tikken rijdt de route als een gesimuleerd gps-spoor in plaats van je echte locatie — navigatie werkt overal. Zet uit om echt te navigeren.</string>
+    <string name="settings_demo_drive_hint">Start rijdt de geplande route als simulatie in plaats van met gps. Zet uit om echt te navigeren.</string>
     <string name="settings_sim_location">Mijn locatie simuleren (demo)</string>
-    <string name="settings_sim_location_hint">Voor demo\'s en schermafbeeldingen: doe alsof je nu in het midden van de kaart bent, zodat de locatiestip, afstanden en routes daar beginnen in plaats van je echte positie. Zet uit voor echte gps.</string>
+    <string name="settings_sim_location_hint">Doet alsof je in het midden van de kaart bent, voor demo\'s en screenshots. Zet uit voor echte gps.</string>
     <string name="place_address_copied">Adres gekopieerd</string>
     <string name="place_copy_address">Adres kopiëren</string>
     <string name="place_directions">Route</string>
@@ -310,7 +310,7 @@
     <string name="mapscreen_switch">Overschakelen</string>
     <string name="root_not_now">Niet nu</string>
     <string name="root_voice_title">Gesproken navigatiestem</string>
-    <string name="root_voice_body_intro">Vela\'s eigen stem draait volledig op je telefoon: natuurlijke aanwijzingen, geen account, geen extra app. Aanbevolen, een eenmalige download van ~%1$d MB.</string>
+    <string name="root_voice_body_intro">Vela\'s eigen stem draait volledig op je telefoon: natuurlijke aanwijzingen, geen account, geen extra app. Aanbevolen, een eenmalige download van %1$d MB.</string>
     <string name="root_voice_body_system">Liever niet? Gebruik een stem die al op je telefoon staat.</string>
     <string name="root_voice_body_outro">Wijzig het altijd in Instellingen → Stem.</string>
     <string name="root_voice_download">Vela-stem downloaden</string>
@@ -372,7 +372,7 @@
     <string name="mapvm_export_trip_subject">Vela-rit: %1$s (%2$d punten)</string>
     <string name="mapvm_share_trip_chooser">Rit delen</string>
     <string name="mapvm_voice_sample">Sla over 400 meter rechts af de Dorpsstraat in.</string>
-    <string name="mapvm_not_enough_space">Niet genoeg vrije ruimte voor %1$s (~%2$d MB)</string>
+    <string name="mapvm_not_enough_space">Niet genoeg vrije ruimte voor %1$s (%2$d MB)</string>
     <string name="mapvm_voice_downloaded">%1$s gedownload</string>
     <string name="mapvm_voice_download_failed">%1$s downloaden mislukt</string>
     <string name="mapvm_vela_voice_removed">Vela-stem verwijderd</string>
@@ -412,7 +412,7 @@
     <string name="update_install">Bijwerken</string>
     <string name="update_download_failed">Downloaden van de update is mislukt. Probeer het later opnieuw.</string>
     <string name="settings_update_auto">Bij het starten op updates controleren</string>
-    <string name="settings_update_auto_hint">Kijkt ongeveer één keer per dag naar de nieuwste GitHub-release en biedt die aan als die nieuwer is dan deze build. Installeren gaat via de normale Android-installer. Werk je al bij via Obtainium, dan kun je dit uitzetten.</string>
+    <string name="settings_update_auto_hint">Controleert GitHub ongeveer eens per dag en biedt nieuwere versies aan. Zet uit als je via Obtainium bijwerkt.</string>
     <string name="settings_update_check_now">Op updates controleren</string>
     <string name="settings_update_checking">Controleren…</string>
     <string name="settings_update_none">Je hebt de nieuwste versie.</string>
@@ -480,7 +480,7 @@
     <string name="lists_place_count">%1$d plaatsen</string>
     <string name="navservice_notif_eta">Aankomst %1$s</string>
     <string name="settings_advanced">Geavanceerd</string>
-    <string name="settings_advanced_hint">Niche- en experimentele opties die de meeste mensen nooit hoeven te wijzigen.</string>
+    <string name="settings_advanced_hint">Opties die de meesten nooit nodig hebben.</string>
     <string name="settings_developer">Ontwikkelaar</string>
     <string name="settings_developer_hint">Hulpmiddelen voor demo\'s, schermafbeeldingen en tests. Zet ze uit voor echt gebruik.</string>
     <string name="settings_browse_voices">Stemmen bekijken</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -69,7 +69,7 @@
     <string name="settings_hide_external_links">Website en externe links verbergen</string>
     <string name="settings_hide_external_links_hint">Aan = plaatspagina’s tonen geen Website-, Street View- of Reserveren / Bestellen-knoppen (geen willekeurige externe sites geopend).</string>
     <string name="settings_offline">Offline</string>
-    <string name="settings_offline_hint">De kaart zonder signaal gebruiken vereist twee dingen — de kaartTEGELS die u ziet, en het WEGENNETWERK dat uw route berekent. Een kaartgebied opslaan haalt beide op voor die plek; de regiolijst hieronder voegt het wegennetwerk toe voor waar u ook reist.</string>
+    <string name="settings_offline_hint">Download een gebied om de kaart en routes ervan op je telefoon te bewaren voor offline gebruik.</string>
     <string name="settings_offline_map_area">Kaartgebied</string>
     <string name="settings_offline_download_viewport">Download het gebied dat u bekijkt</string>
     <string name="settings_offline_download_viewport_hint">Slaat de open tegels op voor het kaartgebied dat u het laatst in beeld had — en de routeringsregio eromheen — zodat het later zonder netwerk wordt weergegeven en navigeert. Zoeken vereist nog steeds een verbinding.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -137,8 +137,8 @@
     <string name="settings_version_line">Vela %1$s  (build %2$d)</string>
     <string name="settings_collapse">Inklappen</string>
     <string name="settings_expand">Uitklappen</string>
-    <string name="settings_voice_lib_empty_hint">Download een natuurlijke stem op het toestel voor gesproken instructies — kies er hieronder een. De ★-stemmen klinken het meest als een kaartnavigator (Lessac en HFC komen het dichtst bij Google). Eenmalige download; wifi aanbevolen.</string>
-    <string name="settings_voice_lib_installed_hint">Geïnstalleerd: %1$d MB · %2$d stem(men). Tik op Gebruiken om te wisselen (speelt een voorbeeld af); het prullenbak-icoon maakt de ruimte vrij.</string> <!-- format -->
+    <string name="settings_voice_lib_empty_hint">★ markeert de aanbevolen stemmen. Elke stem werkt offline op je telefoon.</string>
+    <string name="settings_voice_lib_installed_hint">Geïnstalleerd: %1$d MB · %2$d stem(men).</string> <!-- format -->
     <string name="settings_voice_lib_lang_hint">Uw apptaal is %1$s — download hieronder een %2$s-stem zodat de gesproken instructies overeenkomen (een Engelse stem zou %3$s straatnamen verkeerd uitspreken).</string>
     <string name="settings_voice_search">Stemmen zoeken</string>
     <string name="settings_voice_show_more">%1$d meer tonen</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -68,7 +68,7 @@
     <string name="settings_hide_adult_hint">Aan = verbergt bars, clubs, casino’s, slijterijen en andere volwassen- / uitgaanslocaties uit zoekresultaten en de kaart.</string>
     <string name="settings_hide_external_links">Website en externe links verbergen</string>
     <string name="settings_hide_external_links_hint">Aan = plaatspagina’s tonen geen Website-, Street View- of Reserveren / Bestellen-knoppen (geen willekeurige externe sites geopend).</string>
-    <string name="settings_offline">Offline</string>
+    <string name="settings_offline">Offlinekaarten</string>
     <string name="settings_offline_hint">Download een gebied om de kaart en routes ervan op je telefoon te bewaren voor offline gebruik.</string>
     <string name="settings_offline_map_area">Kaartgebied</string>
     <string name="settings_offline_download_viewport">Download het gebied dat u bekijkt</string>
@@ -81,7 +81,7 @@
     <string name="settings_routing_regions_hint">De wegen van een hele regio (een staat of land), zodat routes overal daarin offline werken. Pak waar je heen gaat.</string>
     <string name="settings_routing_no_regions">Nog geen regio\'s beschikbaar.</string>
     <string name="settings_clear_filter">Filter wissen</string>
-    <string name="settings_routing_filter_placeholder">Filter %1$d regio\'s… (bijv. Japan, Texas)</string>
+    <string name="settings_routing_filter_placeholder">Zoeken</string>
     <string name="settings_routing_no_match">Geen regio\'s komen overeen met “%1$s”.</string>
     <string name="settings_routing_downloading">Downloaden… %1$d%%</string>
     <string name="settings_routing_installed">Geïnstalleerd · routes hier offline</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -69,16 +69,16 @@
     <string name="settings_hide_external_links">Ukryj stronę WWW i linki zewnętrzne</string>
     <string name="settings_hide_external_links_hint">Wł. = strony miejsc nie pokazują przycisków Strona WWW, Street View ani Rezerwuj / Zamów (bez otwierania dowolnych zewnętrznych stron).</string>
     <string name="settings_offline">Mapy offline</string>
-    <string name="settings_offline_hint">Pobierz obszar, aby zachować jego mapę i trasy w telefonie do użytku offline.</string>
-    <string name="settings_offline_map_area">Obszar mapy</string>
+    <string name="settings_offline_hint">Dwa sposoby na Velę offline: zapisz obszar, w którym jesteś, na krótkie trasy, albo poniżej cały stan lub kraj na dłuższe.</string>
+    <string name="settings_offline_map_area">Obszar lokalny</string>
     <string name="settings_offline_download_viewport">Pobierz oglądany obszar</string>
-    <string name="settings_offline_download_viewport_hint">Zapisuje mapę i drogi wyświetlanego obszaru, aby pokazywał się i wyznaczał trasy offline.</string>
+    <string name="settings_offline_download_viewport_hint">Zapisuje mapę, którą oglądasz, wraz z drogami i adresami, aby ten obszar działał bez zasięgu.</string>
     <string name="settings_offline_no_areas">Nie zapisano jeszcze żadnych obszarów.</string>
     <string name="settings_offline_addresses_missing">Obszary zapisane przed tą aktualizacją nie zawierają danych adresowych. Zaktualizuj je, aby wyszukiwać adresy i wyznaczać do nich trasy offline.</string>
     <string name="settings_offline_addresses_update">Zaktualizuj zapisane obszary</string>
     <string name="settings_offline_delete_area">Usuń ten obszar offline</string>
-    <string name="settings_routing_regions">Regiony tras</string>
-    <string name="settings_routing_regions_hint">Drogi całego regionu (stanu lub kraju), aby trasy działały offline na całym jego obszarze. Pobierz tam, dokąd jedziesz.</string>
+    <string name="settings_routing_regions">Regiony i kraje</string>
+    <string name="settings_routing_regions_hint">Wszystko, by poruszać się offline po całym stanie, prowincji lub kraju: drogi i miejsca, dzięki czemu trasy i wyszukiwanie działają na całym obszarze. Pobierz tam, dokąd jedziesz.</string>
     <string name="settings_routing_no_regions">Brak dostępnych regionów.</string>
     <string name="settings_clear_filter">Wyczyść filtr</string>
     <string name="settings_routing_filter_placeholder">Szukaj</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -72,13 +72,13 @@
     <string name="settings_offline_hint">Pobierz obszar, aby zachować jego mapę i trasy w telefonie do użytku offline.</string>
     <string name="settings_offline_map_area">Obszar mapy</string>
     <string name="settings_offline_download_viewport">Pobierz oglądany obszar</string>
-    <string name="settings_offline_download_viewport_hint">Zapisuje kafelki dla obszaru mapy, który ostatnio był na ekranie — oraz otaczający go region tras — aby później renderował się i nawigował bez sieci. Wyszukiwanie nadal wymaga połączenia.</string>
+    <string name="settings_offline_download_viewport_hint">Zapisuje mapę i drogi wyświetlanego obszaru, aby pokazywał się i wyznaczał trasy offline.</string>
     <string name="settings_offline_no_areas">Nie zapisano jeszcze żadnych obszarów.</string>
     <string name="settings_offline_addresses_missing">Obszary zapisane przed tą aktualizacją nie zawierają danych adresowych. Zaktualizuj je, aby wyszukiwać adresy i wyznaczać do nich trasy offline.</string>
     <string name="settings_offline_addresses_update">Zaktualizuj zapisane obszary</string>
     <string name="settings_offline_delete_area">Usuń ten obszar offline</string>
     <string name="settings_routing_regions">Regiony tras</string>
-    <string name="settings_routing_regions_hint">Sieć dróg dla całego regionu (województwo, kraj…), aby nawigacja zakręt po zakręcie działała offline w dowolnym miejscu wewnątrz niego — pobierz tam, gdzie podróżujesz. Online nadal używa ruchu na żywo; to rozwiązanie awaryjne bez zasięgu.</string>
+    <string name="settings_routing_regions_hint">Drogi całego regionu (stanu lub kraju), aby trasy działały offline na całym jego obszarze. Pobierz tam, dokąd jedziesz.</string>
     <string name="settings_routing_no_regions">Brak dostępnych regionów.</string>
     <string name="settings_clear_filter">Wyczyść filtr</string>
     <string name="settings_routing_filter_placeholder">Filtruj %1$d regionów… (np. Japonia, Teksas)</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -14,6 +14,7 @@
     <string name="settings_units_imperial">Imperialne (mile, stopy)</string>
     <string name="settings_units_metric">Metryczne (kilometry, metry)</string>
     <string name="settings_language">Język</string>
+    <string name="settings_follow_system_language">Zgodnie z językiem systemu</string>
     <string name="settings_language_hint">Ustawia język mówionej nawigacji zakręt po zakręcie (angielski, francuski, niemiecki, hiszpański, włoski, portugalski, niderlandzki, rosyjski, polski, szwedzki, ukraiński) — niezależnie od języka systemowego telefonu. Wybierz pasujący głos w Bibliotece głosów poniżej. Reszta tekstu w aplikacji zostanie przetłumaczona wkrótce.</string>
     <string name="settings_search">Wyszukiwanie</string>
     <string name="settings_voice_search_toggle">Mikrofon wyszukiwania głosowego</string>
@@ -478,4 +479,10 @@
     <string name="lists_empty_hint">Brak list. Dotknij Nowa lub zapisz miejsce z jego strony.</string>
     <string name="lists_place_count">%1$d miejsc</string>
     <string name="navservice_notif_eta">Przyjazd %1$s</string>
+    <string name="settings_advanced">Zaawansowane</string>
+    <string name="settings_advanced_hint">Niszowe i eksperymentalne opcje, których większość osób nigdy nie zmienia.</string>
+    <string name="settings_developer">Deweloper</string>
+    <string name="settings_developer_hint">Narzędzia do wersji demo, zrzutów ekranu i testów. Wyłącz je do zwykłego użytku.</string>
+    <string name="settings_browse_voices">Przeglądaj głosy</string>
+    <string name="settings_browse_voices_hint">Pobieraj i przełączaj głosy Vela na urządzeniu.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -68,7 +68,7 @@
     <string name="settings_hide_adult_hint">Wł. = ukrywa bary, kluby, kasyna, sklepy monopolowe i inne miejsca dla dorosłych / nocnego życia z wyników i mapy.</string>
     <string name="settings_hide_external_links">Ukryj stronę WWW i linki zewnętrzne</string>
     <string name="settings_hide_external_links_hint">Wł. = strony miejsc nie pokazują przycisków Strona WWW, Street View ani Rezerwuj / Zamów (bez otwierania dowolnych zewnętrznych stron).</string>
-    <string name="settings_offline">Offline</string>
+    <string name="settings_offline">Mapy offline</string>
     <string name="settings_offline_hint">Pobierz obszar, aby zachować jego mapę i trasy w telefonie do użytku offline.</string>
     <string name="settings_offline_map_area">Obszar mapy</string>
     <string name="settings_offline_download_viewport">Pobierz oglądany obszar</string>
@@ -81,7 +81,7 @@
     <string name="settings_routing_regions_hint">Drogi całego regionu (stanu lub kraju), aby trasy działały offline na całym jego obszarze. Pobierz tam, dokąd jedziesz.</string>
     <string name="settings_routing_no_regions">Brak dostępnych regionów.</string>
     <string name="settings_clear_filter">Wyczyść filtr</string>
-    <string name="settings_routing_filter_placeholder">Filtruj %1$d regionów… (np. Japonia, Teksas)</string>
+    <string name="settings_routing_filter_placeholder">Szukaj</string>
     <string name="settings_routing_no_match">Żaden region nie pasuje do „%1$s”.</string>
     <string name="settings_routing_downloading">Pobieranie… %1$d%%</string>
     <string name="settings_routing_installed">Zainstalowano · trasy offline tutaj</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -137,8 +137,8 @@
     <string name="settings_version_line">Vela %1$s  (kompilacja %2$d)</string>
     <string name="settings_collapse">Zwiń</string>
     <string name="settings_expand">Rozwiń</string>
-    <string name="settings_voice_lib_empty_hint">Pobierz naturalny głos działający na urządzeniu do wskazówek głosowych — wybierz jeden poniżej. Głosy oznaczone ★ brzmią najbardziej jak nawigator map (Lessac i HFC są najbliższe Google). Jednorazowe pobranie; zalecane wifi.</string>
-    <string name="settings_voice_lib_installed_hint">Zainstalowano: %1$d MB · %2$d głos(y). Dotknij Użyj, aby przełączyć (odtwarza próbkę); ikona kosza zwalnia miejsce.</string> <!-- format -->
+    <string name="settings_voice_lib_empty_hint">★ oznacza polecane głosy. Każdy głos działa offline na telefonie.</string>
+    <string name="settings_voice_lib_installed_hint">Zainstalowano: %1$d MB · %2$d głos(y).</string> <!-- format -->
     <string name="settings_voice_lib_lang_hint">Twój język aplikacji to %1$s — pobierz głos %2$s poniżej, aby wskazówki głosowe pasowały (angielski głos błędnie wymawiałby %3$s nazwy ulic).</string>
     <string name="settings_voice_search">Szukaj głosów</string>
     <string name="settings_voice_show_more">Pokaż %1$d więcej</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -5,17 +5,17 @@
     <string name="settings_follow_system">Jak w systemie</string>
     <string name="settings_theme_light">Jasny</string>
     <string name="settings_theme_dark">Ciemny</string>
-    <string name="settings_appearance_hint">Tryb jasny/ciemny dotyczy tylko Vela — nie zmienia motywu systemowego telefonu.</string>
+    <string name="settings_appearance_hint">Dotyczy tylko Veli.</string>
     <string name="settings_dynamic_color">Kolory Material You</string>
-    <string name="settings_dynamic_color_hint">Barwi przyciski, chipy i akcenty według tapety (Android 12+). Wyłączone = własny morski kolor Veli. Sama mapa pozostaje neutralna, by drogi i etykiety zachowały kontrast.</string>
+    <string name="settings_dynamic_color_hint">Barwi przyciski i akcenty według tapety. Mapa pozostaje neutralna.</string>
     <string name="settings_map_style">Styl mapy</string>
-    <string name="settings_map_style_hint">OpenFreeMap (domyślny) nie wymaga klucza i jest szczegółowy. Protomaps wymaga klucza API; styl demonstracyjny pokazuje wyłącznie zarysy granic państw.</string>
+    <string name="settings_map_style_hint">OpenFreeMap działa bez klucza API.</string>
     <string name="settings_units">Jednostki</string>
     <string name="settings_units_imperial">Imperialne (mile, stopy)</string>
     <string name="settings_units_metric">Metryczne (kilometry, metry)</string>
     <string name="settings_language">Język</string>
     <string name="settings_follow_system_language">Zgodnie z językiem systemu</string>
-    <string name="settings_language_hint">Ustawia język mówionej nawigacji zakręt po zakręcie (angielski, francuski, niemiecki, hiszpański, włoski, portugalski, niderlandzki, rosyjski, polski, szwedzki, ukraiński) — niezależnie od języka systemowego telefonu. Wybierz pasujący głos w Bibliotece głosów poniżej. Reszta tekstu w aplikacji zostanie przetłumaczona wkrótce.</string>
+    <string name="settings_language_hint">Zmienia język aplikacji i mówionych wskazówek. Pobierz pasujący głos w bibliotece głosów.</string>
     <string name="settings_search">Wyszukiwanie</string>
     <string name="settings_voice_search_toggle">Mikrofon wyszukiwania głosowego</string>
     <string name="settings_voice_search_hint">Pokazuje mikrofon na pasku wyszukiwania. Dotknij go, aby wypowiedzieć zapytanie za pomocą aplikacji do wprowadzania głosem.</string>
@@ -50,16 +50,16 @@
     <string name="settings_mode_transit">Komunikacja</string>
     <string name="settings_vibrate_hint">Wibracje zakodowane kierunkowo przy każdym zakręcie — inne dla lewego, inne dla prawego — dzięki czemu możesz podążać trasą po wyczuciu. Ustaw je osobno dla każdego trybu podróży (np. włączone dla roweru i pieszo, wyłączone podczas jazdy samochodem).</string>
     <string name="settings_keep_screen_on">Nie wygaszaj ekranu podczas nawigacji</string>
-    <string name="settings_keep_screen_on_hint">Zapobiega przyciemnianiu i wygaszaniu ekranu podczas nawigacji zakręt po zakręcie, aby następny zakręt był zawsze widoczny bez wybudzania ekranu dotknięciem. Domyślnie włączone; ekran zaczyna gasnąć normalnie w chwili dotarcia do celu lub zakończenia nawigacji.</string>
+    <string name="settings_keep_screen_on_hint">Utrzymuje włączony ekran podczas nawigacji.</string>
     <string name="settings_map">Mapa</string>
     <string name="settings_live_traffic">Warstwa ruchu na żywo</string>
-    <string name="settings_live_traffic_hint">Cieniuje drogi według natężenia ruchu podczas przeglądania mapy (bezkluczowe kafelki ruchu Google). Domyślnie wyłączone — nawigacja i tak koloruje Twoją trasę według ruchu, więc to tylko do oglądania szerszej okolicy. To warstwa rastrowa, więc jest nieco ziarnista.</string>
+    <string name="settings_live_traffic_hint">Cieniuje drogi według korków podczas przeglądania. Nawigacja i tak koloruje trasę według ruchu.</string>
     <string name="settings_transit_layer">Wyróżnij linie transportu</string>
-    <string name="settings_transit_layer_hint">Rysuje linie kolejowe i metra na mapie kolorem, aby łatwo śledzić tory. Używa otwartych danych już zawartych w kafelkach, bez sieci.</string>
+    <string name="settings_transit_layer_hint">Rysuje linie kolejowe i metra na mapie.</string>
     <string name="settings_read_all_reviews">Przycisk „Czytaj wszystkie opinie”</string>
-    <string name="settings_read_all_reviews_hint">Opinie w karcie miejsca to zawsze płynna, natywna lista Vela. To dodaje przycisk „Czytaj wszystkie opinie”, który otwiera pełną stronę opinii Google na CAŁYM EKRANIE — każdą opinię (nie tylko pierwsze ~50), wyszukiwanie po stronie serwera Google i odtwarzanie opinii wideo. Trackery i beacony są blokowane, ale strona Google działa wtedy w aplikacji. Wyłączone = tylko natywna lista, bez strony Google do opinii.</string>
+    <string name="settings_read_all_reviews_hint">Dodaje przycisk otwierający pełną stronę opinii Google w aplikacji, ze wszystkimi opiniami. Wył. = tylko lista Veli.</string>
     <string name="settings_buildings_3d">Budynki 3D</string>
-    <string name="settings_buildings_3d_hint">Wypukłe bryły budynków przy dużym zbliżeniu. Wyłączenie może poprawić płynność przesuwania na starszych telefonach; płaskie obrysy zostają.</string>
+    <string name="settings_buildings_3d_hint">Wypukłe budynki przy dużym zbliżeniu. Wyłączenie może wygładzić przesuwanie na starszych telefonach.</string>
     <string name="settings_show_reviews">Pokazuj recenzje</string>
     <string name="settings_show_reviews_hint">Wył. = strony miejsc nie pokazują recenzji i Vela nigdy ich nie pobiera.</string>
     <string name="settings_load_photos">Wczytuj zdjęcia</string>
@@ -101,15 +101,15 @@
     <string name="settings_export">Eksportuj</string>
     <string name="settings_import">Importuj</string>
     <string name="settings_data_privacy">Źródło danych i prywatność</string>
-    <string name="settings_data_privacy_hint">Vela łączy się z publicznymi punktami końcowymi Google bezpośrednio z tego urządzenia — bez zaplecza Vela, bez konta Google, bez klucza API i bez telemetrii, chyba że włączysz Diagnostykę poniżej (domyślnie wyłączona, wyłącznie lokalna). Każde urządzenie zachowuje się jak wylogowana przeglądarka; Google widzi Twój adres IP, zapytanie i obszar mapy, ale nie konto. Zapisane miejsca i historia nigdy nie opuszczają telefonu.</string>
+    <string name="settings_data_privacy_hint">Vela łączy się z publicznymi punktami Google prosto z tego urządzenia: bez backendu, konta i klucza API. Google widzi IP, zapytanie i obszar mapy, nie to, kim jesteś.</string>
     <string name="settings_privacy_button">Jakie dane otrzymuje Google</string>
     <string name="settings_diagnostics">Diagnostyka</string>
-    <string name="settings_diagnostics_hint">Domyślnie wyłączona. Po włączeniu Vela prowadzi krótki lokalny dziennik swoich działań — Twoich wyszukiwań, tras i wszelkich potknięć „wymaga rekalibracji” — dzięki czemu w razie problemów możesz go wyeksportować i przekazać deweloperowi. Pozostaje na tym telefonie i nigdy nie jest przesyłany; Ty wybierasz, gdzie trafia eksport. Wyłączenie kasuje dziennik.</string>
+    <string name="settings_diagnostics_hint">Domyślnie wyłączone. Po włączeniu Vela prowadzi krótki lokalny dziennik, który możesz wyeksportować i przekazać deweloperowi. Nic nie jest wysyłane, a wyłączenie go czyści.</string>
     <string name="settings_share_diagnostics">Udostępnij diagnostykę</string>
     <string name="settings_diag_nothing">Nic jeszcze nie zapisano — użyj aplikacji, a następnie wyeksportuj.</string>
     <string name="settings_diag_export">Eksportuj sesję debugowania</string>
     <string name="settings_save_trips">Zapisuj moje podróże (do odtworzenia)</string>
-    <string name="settings_save_trips_hint">Zapisuje ślad GPS każdej nawigacji na tym telefonie, aby przejazd można było później odtworzyć i przetestować nawigację bez ponownej jazdy. Bardziej ujawniające niż diagnostyka — to Twoje dokładne trasy — i nigdy nie opuszcza telefonu.</string>
+    <string name="settings_save_trips_hint">Zapisuje ślad GPS każdej trasy na tym telefonie, do późniejszego odtworzenia. Nigdy nie opuszcza telefonu.</string>
     <string name="settings_recorded_trips_hint">Zapisane podróże — dotknij Odtwórz, aby odtworzyć jedną na mapie (3×):</string>
     <string name="settings_trip_points">%1$d punktów</string>
     <string name="settings_trip_replay">Odtwórz</string>
@@ -167,7 +167,7 @@
     <string name="place_permanently_closed">Zamknięte na stałe</string>
     <string name="place_temporarily_closed">Tymczasowo zamknięte</string>
     <string name="settings_traffic_lights">Wskazówki przy sygnalizacji</string>
-    <string name="settings_traffic_lights_hint">„Minij światła, potem skręć” na skrzyżowaniach z sygnalizacją (głos na razie tylko po angielsku)</string>
+    <string name="settings_traffic_lights_hint">Dodaje wskazówki typu “minąć światła, potem w lewo”. Na razie tylko po angielsku.</string>
     <string name="map_voice_downloading">Pobieranie głosu Vela · %1$d %%</string>
     <string name="map_voice_installing">Instalowanie głosu Vela…</string>
     <string name="map_region_downloading">Pobieranie tras: %1$s · %2$d%%</string> <!-- format -->
@@ -175,9 +175,9 @@
     <string name="mapvm_poipack_ready">Miejsca regionu %1$s można teraz wyszukiwać offline</string> <!-- format -->
     <string name="mapvm_poipack_unavailable">Brak jeszcze pakietu miejsc dla regionu %1$s. Pojawi się tutaj po opublikowaniu.</string> <!-- format -->
     <string name="settings_demo_drive">Symuluj jazdę (demo)</string>
-    <string name="settings_demo_drive_hint">Do demonstracji, zrzutów ekranu i testów: dotknięcie Start prowadzi trasą jako symulowany ślad GPS zamiast Twojej rzeczywistej lokalizacji — nawigacja działa wszędzie. Wyłącz, aby nawigować naprawdę.</string>
+    <string name="settings_demo_drive_hint">Start jedzie zaplanowaną trasą jako symulacja zamiast GPS. Wyłącz, aby nawigować naprawdę.</string>
     <string name="settings_sim_location">Symuluj moją lokalizację (demo)</string>
-    <string name="settings_sim_location_hint">Do prezentacji i zrzutów ekranu: udawaj, że jesteś teraz na środku mapy, aby kropka lokalizacji, odległości i trasy zaczynały się stamtąd, a nie z Twojej prawdziwej pozycji. Wyłącz, aby używać prawdziwego GPS.</string>
+    <string name="settings_sim_location_hint">Udaje, że jesteś w środku mapy, do demo i zrzutów. Wyłącz, aby używać prawdziwego GPS.</string>
     <string name="place_address_copied">Skopiowano adres</string>
     <string name="place_copy_address">Kopiuj adres</string>
     <string name="place_directions">Trasa</string>
@@ -310,7 +310,7 @@
     <string name="mapscreen_switch">Przełącz</string>
     <string name="root_not_now">Nie teraz</string>
     <string name="root_voice_title">Głos nawigacji mówionej</string>
-    <string name="root_voice_body_intro">Własny głos Vela działa w całości na telefonie: naturalne wskazówki, bez konta i dodatkowej aplikacji. Zalecany, jednorazowe pobranie ~%1$d MB.</string>
+    <string name="root_voice_body_intro">Własny głos Veli działa w całości na telefonie: naturalne wskazówki, bez konta i dodatkowej aplikacji. Polecany, jednorazowe pobranie %1$d MB.</string>
     <string name="root_voice_body_system">Wolisz nie? Użyj głosu, który już masz w telefonie.</string>
     <string name="root_voice_body_outro">Zmienisz to kiedykolwiek w Ustawieniach → Głos.</string>
     <string name="root_voice_download">Pobierz głos Vela</string>
@@ -372,7 +372,7 @@
     <string name="mapvm_export_trip_subject">Podróż Vela: %1$s (%2$d punktów)</string>
     <string name="mapvm_share_trip_chooser">Udostępnij podróż</string>
     <string name="mapvm_voice_sample">Za czterysta metrów skręć w prawo w ulicę Główną.</string>
-    <string name="mapvm_not_enough_space">Za mało wolnego miejsca na %1$s (~%2$d MB)</string>
+    <string name="mapvm_not_enough_space">Za mało wolnego miejsca na %1$s (%2$d MB)</string>
     <string name="mapvm_voice_downloaded">Pobrano %1$s</string>
     <string name="mapvm_voice_download_failed">Pobieranie %1$s nie powiodło się</string>
     <string name="mapvm_vela_voice_removed">Usunięto głos Vela</string>
@@ -412,7 +412,7 @@
     <string name="update_install">Aktualizuj</string>
     <string name="update_download_failed">Pobieranie aktualizacji nie powiodło się. Spróbuj później.</string>
     <string name="settings_update_auto">Sprawdzaj aktualizacje przy starcie</string>
-    <string name="settings_update_auto_hint">Mniej więcej raz dziennie sprawdza najnowsze wydanie na GitHubie i proponuje je, gdy jest nowsze niż ta wersja. Instalacja przebiega przez zwykły instalator Androida. Jeśli aktualizujesz przez Obtainium, możesz to wyłączyć.</string>
+    <string name="settings_update_auto_hint">Sprawdza GitHub mniej więcej raz dziennie i proponuje nowsze wydania. Wyłącz, jeśli aktualizujesz przez Obtainium.</string>
     <string name="settings_update_check_now">Sprawdź aktualizacje</string>
     <string name="settings_update_checking">Sprawdzanie…</string>
     <string name="settings_update_none">Masz najnowszą wersję.</string>
@@ -480,7 +480,7 @@
     <string name="lists_place_count">%1$d miejsc</string>
     <string name="navservice_notif_eta">Przyjazd %1$s</string>
     <string name="settings_advanced">Zaawansowane</string>
-    <string name="settings_advanced_hint">Niszowe i eksperymentalne opcje, których większość osób nigdy nie zmienia.</string>
+    <string name="settings_advanced_hint">Opcje, których większość nigdy nie potrzebuje.</string>
     <string name="settings_developer">Deweloper</string>
     <string name="settings_developer_hint">Narzędzia do wersji demo, zrzutów ekranu i testów. Wyłącz je do zwykłego użytku.</string>
     <string name="settings_browse_voices">Przeglądaj głosy</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -69,7 +69,7 @@
     <string name="settings_hide_external_links">Ukryj stronę WWW i linki zewnętrzne</string>
     <string name="settings_hide_external_links_hint">Wł. = strony miejsc nie pokazują przycisków Strona WWW, Street View ani Rezerwuj / Zamów (bez otwierania dowolnych zewnętrznych stron).</string>
     <string name="settings_offline">Offline</string>
-    <string name="settings_offline_hint">Korzystanie z mapy bez zasięgu wymaga dwóch rzeczy — KAFELKÓW mapy, które widzisz, oraz SIECI DRÓG, która wyznacza trasę. Zapisanie obszaru mapy pobiera oba dla tego miejsca; lista regionów poniżej dodaje sieć dróg wszędzie tam, gdzie podróżujesz.</string>
+    <string name="settings_offline_hint">Pobierz obszar, aby zachować jego mapę i trasy w telefonie do użytku offline.</string>
     <string name="settings_offline_map_area">Obszar mapy</string>
     <string name="settings_offline_download_viewport">Pobierz oglądany obszar</string>
     <string name="settings_offline_download_viewport_hint">Zapisuje kafelki dla obszaru mapy, który ostatnio był na ekranie — oraz otaczający go region tras — aby później renderował się i nawigował bez sieci. Wyszukiwanie nadal wymaga połączenia.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -69,16 +69,16 @@
     <string name="settings_hide_external_links">Ocultar site e links externos</string>
     <string name="settings_hide_external_links_hint">Ativado = as páginas de locais não mostram os botões Site, Street View ou Reservar / Pedir (não abre sites externos arbitrários).</string>
     <string name="settings_offline">Mapas offline</string>
-    <string name="settings_offline_hint">Transfira uma área para manter o mapa e as direções no telemóvel para uso offline.</string>
-    <string name="settings_offline_map_area">Área do mapa</string>
+    <string name="settings_offline_hint">Duas formas de usar a Vela offline: guarda a zona onde estás para trajetos curtos, ou um estado ou país inteiro abaixo para os longos.</string>
+    <string name="settings_offline_map_area">Área local</string>
     <string name="settings_offline_download_viewport">Transferir a área que está a ver</string>
-    <string name="settings_offline_download_viewport_hint">Guarda o mapa e as estradas da área que estás a ver, para mostrar e traçar rotas sem ligação.</string>
+    <string name="settings_offline_download_viewport_hint">Guarda o mapa que estás a ver, com as estradas e moradas, para que esta zona continue a funcionar sem rede.</string>
     <string name="settings_offline_no_areas">Ainda sem áreas guardadas.</string>
     <string name="settings_offline_addresses_missing">As áreas guardadas antes desta atualização não incluem dados de moradas. Atualize-as para pesquisar moradas e traçar rotas offline.</string>
     <string name="settings_offline_addresses_update">Atualizar áreas guardadas</string>
     <string name="settings_offline_delete_area">Eliminar esta área offline</string>
-    <string name="settings_routing_regions">Regiões de percursos</string>
-    <string name="settings_routing_regions_hint">As estradas de uma região inteira (um estado ou país) para as direções funcionarem sem ligação em toda ela. Transfere para onde vais.</string>
+    <string name="settings_routing_regions">Regiões e países</string>
+    <string name="settings_routing_regions_hint">Tudo o que precisas para percorrer um estado, província ou país inteiro offline: as estradas e os lugares, para que as direções e a pesquisa funcionem em toda a área. Transfere para onde vais.</string>
     <string name="settings_routing_no_regions">Ainda sem regiões disponíveis.</string>
     <string name="settings_clear_filter">Limpar filtro</string>
     <string name="settings_routing_filter_placeholder">Pesquisar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -72,13 +72,13 @@
     <string name="settings_offline_hint">Transfira uma área para manter o mapa e as direções no telemóvel para uso offline.</string>
     <string name="settings_offline_map_area">Área do mapa</string>
     <string name="settings_offline_download_viewport">Transferir a área que está a ver</string>
-    <string name="settings_offline_download_viewport_hint">Guarda os mosaicos abertos da área do mapa que teve no ecrã por último — e a região de percursos à sua volta — para que renderize e navegue mais tarde sem rede. A pesquisa continua a precisar de ligação.</string>
+    <string name="settings_offline_download_viewport_hint">Guarda o mapa e as estradas da área que estás a ver, para mostrar e traçar rotas sem ligação.</string>
     <string name="settings_offline_no_areas">Ainda sem áreas guardadas.</string>
     <string name="settings_offline_addresses_missing">As áreas guardadas antes desta atualização não incluem dados de moradas. Atualize-as para pesquisar moradas e traçar rotas offline.</string>
     <string name="settings_offline_addresses_update">Atualizar áreas guardadas</string>
     <string name="settings_offline_delete_area">Eliminar esta área offline</string>
     <string name="settings_routing_regions">Regiões de percursos</string>
-    <string name="settings_routing_regions_hint">A rede viária de toda uma região (estado, país…), para que a navegação curva a curva funcione offline em qualquer ponto dentro dela — obtenha por onde estiver a viajar. Online continua a usar o trânsito em direto; isto é a alternativa sem sinal.</string>
+    <string name="settings_routing_regions_hint">As estradas de uma região inteira (um estado ou país) para as direções funcionarem sem ligação em toda ela. Transfere para onde vais.</string>
     <string name="settings_routing_no_regions">Ainda sem regiões disponíveis.</string>
     <string name="settings_clear_filter">Limpar filtro</string>
     <string name="settings_routing_filter_placeholder">Filtrar %1$d regiões… (p. ex. Japão, Texas)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -137,8 +137,8 @@
     <string name="settings_version_line">Vela %1$s  (compilação %2$d)</string>
     <string name="settings_collapse">Recolher</string>
     <string name="settings_expand">Expandir</string>
-    <string name="settings_voice_lib_empty_hint">Transfira uma voz natural no dispositivo para as indicações faladas — escolha uma abaixo. As vozes ★ soam mais como um navegador de mapas (Lessac e HFC são as mais próximas da Google). Transferência única; recomenda-se Wi-Fi.</string>
-    <string name="settings_voice_lib_installed_hint">Instalado: %1$d MB · %2$d voz(es). Toque em Usar para mudar (reproduz uma amostra); o ícone do lixo liberta o espaço.</string> <!-- format -->
+    <string name="settings_voice_lib_empty_hint">★ assinala as vozes recomendadas. Todas funcionam offline no telemóvel.</string>
+    <string name="settings_voice_lib_installed_hint">Instalado: %1$d MB · %2$d voz(es).</string> <!-- format -->
     <string name="settings_voice_lib_lang_hint">O idioma da sua aplicação é %1$s — transfira uma voz de %2$s abaixo para que as indicações faladas correspondam (uma voz de inglês pronunciaria mal os nomes das ruas em %3$s).</string>
     <string name="settings_voice_search">Pesquisar vozes</string>
     <string name="settings_voice_show_more">Mostrar mais %1$d</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -5,17 +5,17 @@
     <string name="settings_follow_system">Seguir o sistema</string>
     <string name="settings_theme_light">Claro</string>
     <string name="settings_theme_dark">Escuro</string>
-    <string name="settings_appearance_hint">Claro/Escuro aplica-se apenas ao Vela — não altera o tema do sistema do seu telemóvel.</string>
+    <string name="settings_appearance_hint">Aplica-se apenas à Vela.</string>
     <string name="settings_dynamic_color">Cores Material You</string>
-    <string name="settings_dynamic_color_hint">Pinta botões, chips e destaques a partir do seu fundo de ecrã (Android 12+). Desligado = o verde-azulado da Vela. O mapa mantém-se neutro para que estradas e etiquetas conservem o contraste.</string>
+    <string name="settings_dynamic_color_hint">Colore botões e detalhes conforme o fundo. O mapa continua neutro.</string>
     <string name="settings_map_style">Estilo do mapa</string>
-    <string name="settings_map_style_hint">O OpenFreeMap (predefinição) é detalhado e não requer chave. O Protomaps precisa de uma chave de API; o estilo de demonstração mostra apenas contornos de países.</string>
+    <string name="settings_map_style_hint">O OpenFreeMap funciona sem chave de API.</string>
     <string name="settings_units">Unidades</string>
     <string name="settings_units_imperial">Imperial (milhas, pés)</string>
     <string name="settings_units_metric">Métrico (quilómetros, metros)</string>
     <string name="settings_language">Idioma</string>
     <string name="settings_follow_system_language">Seguir o idioma do sistema</string>
-    <string name="settings_language_hint">Define o idioma das indicações de voz curva a curva (inglês, francês, alemão, espanhol, italiano, português, neerlandês, russo, polaco, sueco, ucraniano) — independente do idioma do sistema do seu telemóvel. Escolha uma voz correspondente na Biblioteca de vozes abaixo. O restante texto no ecrã da aplicação será traduzido a seguir.</string>
+    <string name="settings_language_hint">Muda o idioma da app e das indicações faladas. Escolhe uma voz correspondente na biblioteca de vozes.</string>
     <string name="settings_search">Pesquisa</string>
     <string name="settings_voice_search_toggle">Microfone de pesquisa por voz</string>
     <string name="settings_voice_search_hint">Mostra um microfone na barra de pesquisa. Toque para ditar a pesquisa com uma app de entrada de voz do telemóvel.</string>
@@ -50,16 +50,16 @@
     <string name="settings_mode_transit">Transportes públicos</string>
     <string name="settings_vibrate_hint">Vibrações codificadas por direção em cada curva — distintas para esquerda e direita — para poder seguir um percurso pelo tato. Configure por modo de viagem (p. ex. ligado para bicicleta e a pé, desligado de carro).</string>
     <string name="settings_keep_screen_on">Manter o ecrã ligado durante a navegação</string>
-    <string name="settings_keep_screen_on_hint">Impede que o ecrã escureça ou adormeça enquanto a navegação curva a curva está ativa, para que a próxima curva esteja sempre visível sem ter de tocar para o ativar. Ligado por predefinição; o ecrã volta a adormecer normalmente assim que chega ou sai da navegação.</string>
+    <string name="settings_keep_screen_on_hint">Mantém o ecrã aceso durante a navegação.</string>
     <string name="settings_map">Mapa</string>
     <string name="settings_live_traffic">Camada de trânsito em direto</string>
-    <string name="settings_live_traffic_hint">Sombreia as estradas por congestionamento ao explorar o mapa (mosaicos de trânsito sem chave da Google). Desligado por predefinição — a navegação já colore o seu percurso pelo trânsito, portanto isto serve apenas para observar a área envolvente. É uma sobreposição raster, por isso fica um pouco granulada.</string>
+    <string name="settings_live_traffic_hint">Sombreia as estradas conforme o trânsito ao explorar. A navegação já colore a tua rota pelo trânsito.</string>
     <string name="settings_transit_layer">Destacar linhas de transporte</string>
-    <string name="settings_transit_layer_hint">Desenha as linhas de comboio e metro a cores no mapa, para seguir o carril com facilidade. Usa os dados abertos já presentes nos mosaicos, sem rede.</string>
+    <string name="settings_transit_layer_hint">Desenha as linhas de comboio e metro no mapa.</string>
     <string name="settings_read_all_reviews">Botão “Ler todas as avaliações”</string>
-    <string name="settings_read_all_reviews_hint">As avaliações na ficha do local são sempre a lista nativa e fluida do próprio Vela. Isto adiciona um botão “Ler todas as avaliações” que abre a página completa de avaliações da Google em ECRÃ INTEIRO — todas as avaliações (não apenas as primeiras ~50), a pesquisa no servidor da Google e a reprodução de avaliações em vídeo. Rastreadores/balizas são bloqueados, mas executa a página da Google dentro da aplicação. Desligado = apenas a lista nativa, sem página da Google para avaliações.</string>
+    <string name="settings_read_all_reviews_hint">Adiciona um botão que abre a página completa de avaliações do Google na app, com todas as avaliações. Desligado = apenas a lista da Vela.</string>
     <string name="settings_buildings_3d">Edifícios em 3D</string>
-    <string name="settings_buildings_3d_hint">Formas de edifícios em relevo com muito zoom. Desligar pode deixar o arrastar mais fluido em telefones antigos; os contornos planos continuam.</string>
+    <string name="settings_buildings_3d_hint">Edifícios em relevo com zoom próximo. Desligar pode tornar o arrastar mais suave em telemóveis antigos.</string>
     <string name="settings_show_reviews">Mostrar avaliações</string>
     <string name="settings_show_reviews_hint">Desligado = as páginas de locais não mostram avaliações e o Vela nunca as transfere.</string>
     <string name="settings_load_photos">Carregar fotos</string>
@@ -101,15 +101,15 @@
     <string name="settings_export">Exportar</string>
     <string name="settings_import">Importar</string>
     <string name="settings_data_privacy">Fonte de dados e privacidade</string>
-    <string name="settings_data_privacy_hint">O Vela comunica diretamente com os pontos de acesso web públicos da Google a partir deste dispositivo — sem servidor Vela, sem conta Google, sem chave de API e sem telemetria, a menos que ative o Diagnóstico abaixo (desligado por predefinição, apenas local). Cada dispositivo comporta-se como um navegador sem sessão iniciada; a Google vê o seu IP, pesquisa e área do mapa, mas não uma conta. Os locais guardados e o histórico nunca saem do telemóvel.</string>
+    <string name="settings_data_privacy_hint">A Vela fala com os endpoints públicos do Google diretamente deste aparelho: sem backend, sem conta, sem chave de API. O Google vê o teu IP, a pesquisa e a área do mapa, não quem és.</string>
     <string name="settings_privacy_button">Que dados a Google recebe</string>
     <string name="settings_diagnostics">Diagnóstico</string>
-    <string name="settings_diagnostics_hint">Desligado por predefinição. Quando ligado, o Vela mantém um breve registo local do que fez — as suas pesquisas, percursos e quaisquer falhas de “necessita recalibração” — para que, se algo se comportar mal, possa exportá-lo e entregá-lo a um programador. Permanece neste telemóvel e nunca é carregado; é você que escolhe para onde vai a exportação. Desligá-lo apaga o registo.</string>
+    <string name="settings_diagnostics_hint">Desligado por predefinição. Ligado, a Vela mantém um pequeno registo local que podes exportar e entregar a um programador. Nada é enviado, e desligar apaga-o.</string>
     <string name="settings_share_diagnostics">Partilhar diagnóstico</string>
     <string name="settings_diag_nothing">Ainda nada registado — use a aplicação e depois exporte.</string>
     <string name="settings_diag_export">Exportar sessão de depuração</string>
     <string name="settings_save_trips">Guardar as minhas viagens (para reprodução)</string>
-    <string name="settings_save_trips_hint">Regista o traço GPS de cada navegação neste telemóvel para que uma viagem possa ser reproduzida mais tarde e testar a navegação curva a curva sem a percorrer novamente. Mais revelador do que o diagnóstico — são os seus percursos exatos — e nunca sai do telemóvel.</string>
+    <string name="settings_save_trips_hint">Grava o rasto GPS de cada viagem neste telemóvel, para reproduzir depois. Nunca sai do telemóvel.</string>
     <string name="settings_recorded_trips_hint">Viagens gravadas — toque em Reproduzir para reproduzir uma no mapa (3×):</string>
     <string name="settings_trip_points">%1$d pontos</string>
     <string name="settings_trip_replay">Reproduzir</string>
@@ -167,7 +167,7 @@
     <string name="place_permanently_closed">Fechado permanentemente</string>
     <string name="place_temporarily_closed">Fechado temporariamente</string>
     <string name="settings_traffic_lights">Orientação por semáforos</string>
-    <string name="settings_traffic_lights_hint">Diz «passe o semáforo e depois vire» em cruzamentos com semáforo (voz apenas em inglês por enquanto)</string>
+    <string name="settings_traffic_lights_hint">Adiciona pistas como “passa o semáforo e vira à esquerda”. Por agora só em inglês.</string>
     <string name="map_voice_downloading">Baixando a voz Vela · %1$d %%</string>
     <string name="map_voice_installing">Instalando a voz Vela…</string>
     <string name="map_region_downloading">A transferir rotas de %1$s · %2$d%%</string> <!-- format -->
@@ -175,9 +175,9 @@
     <string name="mapvm_poipack_ready">Os locais de %1$s já podem ser pesquisados offline</string> <!-- format -->
     <string name="mapvm_poipack_unavailable">Ainda não há pacote de locais para %1$s. Aparecerá aqui assim que for publicado.</string> <!-- format -->
     <string name="settings_demo_drive">Simular condução (demo)</string>
-    <string name="settings_demo_drive_hint">Para demonstrações, capturas e testes: tocar em Iniciar percorre a rota como um rasto de GPS simulado em vez da tua localização real — a navegação funciona em qualquer lugar. Desliga para navegar a sério.</string>
+    <string name="settings_demo_drive_hint">Iniciar percorre a rota planeada como simulação em vez de usar GPS. Desliga para navegar a sério.</string>
     <string name="settings_sim_location">Simular a minha localização (demo)</string>
-    <string name="settings_sim_location_hint">Para demos e capturas de ecrã: finja que está no centro do mapa agora, para que o ponto de localização, as distâncias e as rotas comecem daí em vez da sua posição real. Desligue para usar o GPS real.</string>
+    <string name="settings_sim_location_hint">Finge que estás no centro do mapa, para demos e capturas. Desliga para usar o GPS real.</string>
     <string name="place_address_copied">Morada copiada</string>
     <string name="place_copy_address">Copiar morada</string>
     <string name="place_directions">Direções</string>
@@ -310,7 +310,7 @@
     <string name="mapscreen_switch">Mudar</string>
     <string name="root_not_now">Agora não</string>
     <string name="root_voice_title">Voz de navegação falada</string>
-    <string name="root_voice_body_intro">A voz própria da Vela funciona inteiramente no telemóvel: indicações naturais, sem conta nem app extra. Recomendada, uma transferência única de ~%1$d MB.</string>
+    <string name="root_voice_body_intro">A voz própria da Vela corre inteiramente no telemóvel: indicações naturais, sem conta, sem outra app. Recomendada, uma transferência única de %1$d MB.</string>
     <string name="root_voice_body_system">Prefere que não? Use uma voz que já tem no telemóvel.</string>
     <string name="root_voice_body_outro">Mude quando quiser em Definições → Voz.</string>
     <string name="root_voice_download">Transferir voz Vela</string>
@@ -372,7 +372,7 @@
     <string name="mapvm_export_trip_subject">Viagem do Vela: %1$s (%2$d pontos)</string>
     <string name="mapvm_share_trip_chooser">Partilhar viagem</string>
     <string name="mapvm_voice_sample">Dentro de 400 metros, vire à direita para a Rua Principal.</string>
-    <string name="mapvm_not_enough_space">Espaço livre insuficiente para %1$s (~%2$d MB)</string>
+    <string name="mapvm_not_enough_space">Espaço livre insuficiente para %1$s (%2$d MB)</string>
     <string name="mapvm_voice_downloaded">%1$s transferida</string>
     <string name="mapvm_voice_download_failed">Falha na transferência de %1$s</string>
     <string name="mapvm_vela_voice_removed">Voz Vela removida</string>
@@ -412,7 +412,7 @@
     <string name="update_install">Atualizar</string>
     <string name="update_download_failed">A transferência da atualização falhou. Tente de novo mais tarde.</string>
     <string name="settings_update_auto">Procurar atualizações ao iniciar</string>
-    <string name="settings_update_auto_hint">Consulta a versão mais recente no GitHub cerca de uma vez por dia e oferece quando é mais nova que esta. A instalação usa o instalador normal do Android. Se já atualiza pelo Obtainium, pode desligar.</string>
+    <string name="settings_update_auto_hint">Verifica o GitHub cerca de uma vez por dia e propõe versões mais recentes. Desliga se atualizas pelo Obtainium.</string>
     <string name="settings_update_check_now">Procurar atualizações</string>
     <string name="settings_update_checking">Verificando…</string>
     <string name="settings_update_none">Você está na versão mais recente.</string>
@@ -480,7 +480,7 @@
     <string name="lists_place_count">%1$d locais</string>
     <string name="navservice_notif_eta">Chegada %1$s</string>
     <string name="settings_advanced">Avançado</string>
-    <string name="settings_advanced_hint">Opções específicas e experimentais que quase ninguém precisa de alterar.</string>
+    <string name="settings_advanced_hint">Opções de que quase ninguém precisa.</string>
     <string name="settings_developer">Programador</string>
     <string name="settings_developer_hint">Ferramentas para demos, capturas de ecrã e testes. Desative-as para uso real.</string>
     <string name="settings_browse_voices">Explorar vozes</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -14,6 +14,7 @@
     <string name="settings_units_imperial">Imperial (milhas, pés)</string>
     <string name="settings_units_metric">Métrico (quilómetros, metros)</string>
     <string name="settings_language">Idioma</string>
+    <string name="settings_follow_system_language">Seguir o idioma do sistema</string>
     <string name="settings_language_hint">Define o idioma das indicações de voz curva a curva (inglês, francês, alemão, espanhol, italiano, português, neerlandês, russo, polaco, sueco, ucraniano) — independente do idioma do sistema do seu telemóvel. Escolha uma voz correspondente na Biblioteca de vozes abaixo. O restante texto no ecrã da aplicação será traduzido a seguir.</string>
     <string name="settings_search">Pesquisa</string>
     <string name="settings_voice_search_toggle">Microfone de pesquisa por voz</string>
@@ -478,4 +479,10 @@
     <string name="lists_empty_hint">Ainda sem listas. Toque em Nova ou guarde um local a partir da sua página.</string>
     <string name="lists_place_count">%1$d locais</string>
     <string name="navservice_notif_eta">Chegada %1$s</string>
+    <string name="settings_advanced">Avançado</string>
+    <string name="settings_advanced_hint">Opções específicas e experimentais que quase ninguém precisa de alterar.</string>
+    <string name="settings_developer">Programador</string>
+    <string name="settings_developer_hint">Ferramentas para demos, capturas de ecrã e testes. Desative-as para uso real.</string>
+    <string name="settings_browse_voices">Explorar vozes</string>
+    <string name="settings_browse_voices_hint">Transfira e alterne entre as vozes da Vela no dispositivo.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -68,7 +68,7 @@
     <string name="settings_hide_adult_hint">Ativado = oculta bares, casas noturnas, casinos, lojas de bebidas e outros locais adultos / noturnos da pesquisa e do mapa.</string>
     <string name="settings_hide_external_links">Ocultar site e links externos</string>
     <string name="settings_hide_external_links_hint">Ativado = as páginas de locais não mostram os botões Site, Street View ou Reservar / Pedir (não abre sites externos arbitrários).</string>
-    <string name="settings_offline">Offline</string>
+    <string name="settings_offline">Mapas offline</string>
     <string name="settings_offline_hint">Transfira uma área para manter o mapa e as direções no telemóvel para uso offline.</string>
     <string name="settings_offline_map_area">Área do mapa</string>
     <string name="settings_offline_download_viewport">Transferir a área que está a ver</string>
@@ -81,7 +81,7 @@
     <string name="settings_routing_regions_hint">As estradas de uma região inteira (um estado ou país) para as direções funcionarem sem ligação em toda ela. Transfere para onde vais.</string>
     <string name="settings_routing_no_regions">Ainda sem regiões disponíveis.</string>
     <string name="settings_clear_filter">Limpar filtro</string>
-    <string name="settings_routing_filter_placeholder">Filtrar %1$d regiões… (p. ex. Japão, Texas)</string>
+    <string name="settings_routing_filter_placeholder">Pesquisar</string>
     <string name="settings_routing_no_match">Nenhuma região corresponde a “%1$s”.</string>
     <string name="settings_routing_downloading">A transferir… %1$d%%</string>
     <string name="settings_routing_installed">Instalado · percursos offline aqui</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -69,7 +69,7 @@
     <string name="settings_hide_external_links">Ocultar site e links externos</string>
     <string name="settings_hide_external_links_hint">Ativado = as páginas de locais não mostram os botões Site, Street View ou Reservar / Pedir (não abre sites externos arbitrários).</string>
     <string name="settings_offline">Offline</string>
-    <string name="settings_offline_hint">Usar o mapa sem sinal requer duas coisas — os MOSAICOS do mapa que vê e a REDE VIÁRIA que traça os percursos. Guardar uma área do mapa obtém ambos para esse local; a lista de regiões abaixo adiciona a rede viária para onde estiver a viajar.</string>
+    <string name="settings_offline_hint">Transfira uma área para manter o mapa e as direções no telemóvel para uso offline.</string>
     <string name="settings_offline_map_area">Área do mapa</string>
     <string name="settings_offline_download_viewport">Transferir a área que está a ver</string>
     <string name="settings_offline_download_viewport_hint">Guarda os mosaicos abertos da área do mapa que teve no ecrã por último — e a região de percursos à sua volta — para que renderize e navegue mais tarde sem rede. A pesquisa continua a precisar de ligação.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -69,16 +69,16 @@
     <string name="settings_hide_external_links">Скрывать веб-сайт и внешние ссылки</string>
     <string name="settings_hide_external_links_hint">Вкл. = на страницах мест нет кнопок «Сайт», Street View и «Забронировать / Заказать» (произвольные внешние сайты не открываются).</string>
     <string name="settings_offline">Офлайн-карты</string>
-    <string name="settings_offline_hint">Загрузите область, чтобы сохранить её карту и маршруты на телефоне для работы офлайн.</string>
-    <string name="settings_offline_map_area">Область карты</string>
+    <string name="settings_offline_hint">Два способа пользоваться Vela офлайн: сохраните область, где вы находитесь, для коротких поездок, или целый регион или страну ниже для дальних.</string>
+    <string name="settings_offline_map_area">Местная область</string>
     <string name="settings_offline_download_viewport">Загрузить видимую область</string>
-    <string name="settings_offline_download_viewport_hint">Сохраняет карту и её дороги для показанной области, чтобы она отображалась и строила маршруты офлайн.</string>
+    <string name="settings_offline_download_viewport_hint">Сохраняет карту, которую вы видите, вместе с дорогами и адресами, чтобы эта область работала без связи.</string>
     <string name="settings_offline_no_areas">Области ещё не сохранены.</string>
     <string name="settings_offline_addresses_missing">Области, сохранённые до этого обновления, не содержат данные адресов. Обновите их, чтобы искать адреса и строить маршруты офлайн.</string>
     <string name="settings_offline_addresses_update">Обновить сохранённые области</string>
     <string name="settings_offline_delete_area">Удалить эту офлайн-область</string>
-    <string name="settings_routing_regions">Регионы маршрутизации</string>
-    <string name="settings_routing_regions_hint">Дороги целого региона (штата или страны), чтобы маршруты работали офлайн на всей территории. Скачайте туда, куда едете.</string>
+    <string name="settings_routing_regions">Регионы и страны</string>
+    <string name="settings_routing_regions_hint">Всё, чтобы передвигаться по целому региону, области или стране офлайн: дороги и места, чтобы маршруты и поиск работали на всей территории. Скачайте туда, куда едете.</string>
     <string name="settings_routing_no_regions">Регионы пока недоступны.</string>
     <string name="settings_clear_filter">Очистить фильтр</string>
     <string name="settings_routing_filter_placeholder">Поиск</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -72,13 +72,13 @@
     <string name="settings_offline_hint">Загрузите область, чтобы сохранить её карту и маршруты на телефоне для работы офлайн.</string>
     <string name="settings_offline_map_area">Область карты</string>
     <string name="settings_offline_download_viewport">Загрузить видимую область</string>
-    <string name="settings_offline_download_viewport_hint">Сохраняет открытые тайлы для области карты, которая последней была на экране, — и дорожный регион вокруг неё — чтобы позже она отображалась и вела навигацию без сети. Для поиска всё ещё нужно подключение.</string>
+    <string name="settings_offline_download_viewport_hint">Сохраняет карту и её дороги для показанной области, чтобы она отображалась и строила маршруты офлайн.</string>
     <string name="settings_offline_no_areas">Области ещё не сохранены.</string>
     <string name="settings_offline_addresses_missing">Области, сохранённые до этого обновления, не содержат данные адресов. Обновите их, чтобы искать адреса и строить маршруты офлайн.</string>
     <string name="settings_offline_addresses_update">Обновить сохранённые области</string>
     <string name="settings_offline_delete_area">Удалить эту офлайн-область</string>
     <string name="settings_routing_regions">Регионы маршрутизации</string>
-    <string name="settings_routing_regions_hint">Дорожная сеть для целого региона (области, страны…), чтобы навигация работала офлайн в любой его точке — загрузите тот, куда едете. При наличии сети по-прежнему используются актуальные пробки; это запасной вариант без сигнала.</string>
+    <string name="settings_routing_regions_hint">Дороги целого региона (штата или страны), чтобы маршруты работали офлайн на всей территории. Скачайте туда, куда едете.</string>
     <string name="settings_routing_no_regions">Регионы пока недоступны.</string>
     <string name="settings_clear_filter">Очистить фильтр</string>
     <string name="settings_routing_filter_placeholder">Фильтр по %1$d регионам… (напр. Япония, Техас)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -69,7 +69,7 @@
     <string name="settings_hide_external_links">Скрывать веб-сайт и внешние ссылки</string>
     <string name="settings_hide_external_links_hint">Вкл. = на страницах мест нет кнопок «Сайт», Street View и «Забронировать / Заказать» (произвольные внешние сайты не открываются).</string>
     <string name="settings_offline">Офлайн</string>
-    <string name="settings_offline_hint">Для работы карты без сигнала нужны две вещи — ТАЙЛЫ карты, которые вы видите, и ДОРОЖНАЯ СЕТЬ, которая строит маршруты. Сохранение области карты загружает и то, и другое для этого места; список регионов ниже добавляет дорожную сеть для любого места, куда вы едете.</string>
+    <string name="settings_offline_hint">Загрузите область, чтобы сохранить её карту и маршруты на телефоне для работы офлайн.</string>
     <string name="settings_offline_map_area">Область карты</string>
     <string name="settings_offline_download_viewport">Загрузить видимую область</string>
     <string name="settings_offline_download_viewport_hint">Сохраняет открытые тайлы для области карты, которая последней была на экране, — и дорожный регион вокруг неё — чтобы позже она отображалась и вела навигацию без сети. Для поиска всё ещё нужно подключение.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -14,6 +14,7 @@
     <string name="settings_units_imperial">Имперские (мили, футы)</string>
     <string name="settings_units_metric">Метрические (километры, метры)</string>
     <string name="settings_language">Язык</string>
+    <string name="settings_follow_system_language">Язык системы</string>
     <string name="settings_language_hint">Задаёт язык голосовых подсказок при навигации (английский, французский, немецкий, испанский, итальянский, португальский, нидерландский, русский, польский, шведский, украинский) — независимо от системного языка телефона. Выберите подходящий голос в разделе «Библиотека голосов» ниже. Остальной текст интерфейса будет переведён в ближайшее время.</string>
     <string name="settings_search">Поиск</string>
     <string name="settings_voice_search_toggle">Микрофон голосового поиска</string>
@@ -478,4 +479,10 @@
     <string name="lists_empty_hint">Пока нет списков. Нажмите «Новый» или сохраните место с его страницы.</string>
     <string name="lists_place_count">%1$d мест</string>
     <string name="navservice_notif_eta">Прибытие %1$s</string>
+    <string name="settings_advanced">Дополнительно</string>
+    <string name="settings_advanced_hint">Нишевые и экспериментальные параметры, которые большинству не нужны.</string>
+    <string name="settings_developer">Разработчик</string>
+    <string name="settings_developer_hint">Инструменты для демо, скриншотов и тестов. Отключайте их для реальной работы.</string>
+    <string name="settings_browse_voices">Выбрать голос</string>
+    <string name="settings_browse_voices_hint">Загружайте и переключайте голоса Vela на устройстве.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -68,7 +68,7 @@
     <string name="settings_hide_adult_hint">Вкл. = скрывает бары, клубы, казино, алкогольные магазины и другие места для взрослых / ночной жизни из поиска и карты.</string>
     <string name="settings_hide_external_links">Скрывать веб-сайт и внешние ссылки</string>
     <string name="settings_hide_external_links_hint">Вкл. = на страницах мест нет кнопок «Сайт», Street View и «Забронировать / Заказать» (произвольные внешние сайты не открываются).</string>
-    <string name="settings_offline">Офлайн</string>
+    <string name="settings_offline">Офлайн-карты</string>
     <string name="settings_offline_hint">Загрузите область, чтобы сохранить её карту и маршруты на телефоне для работы офлайн.</string>
     <string name="settings_offline_map_area">Область карты</string>
     <string name="settings_offline_download_viewport">Загрузить видимую область</string>
@@ -81,7 +81,7 @@
     <string name="settings_routing_regions_hint">Дороги целого региона (штата или страны), чтобы маршруты работали офлайн на всей территории. Скачайте туда, куда едете.</string>
     <string name="settings_routing_no_regions">Регионы пока недоступны.</string>
     <string name="settings_clear_filter">Очистить фильтр</string>
-    <string name="settings_routing_filter_placeholder">Фильтр по %1$d регионам… (напр. Япония, Техас)</string>
+    <string name="settings_routing_filter_placeholder">Поиск</string>
     <string name="settings_routing_no_match">Нет регионов по запросу «%1$s».</string>
     <string name="settings_routing_downloading">Загрузка… %1$d%%</string>
     <string name="settings_routing_installed">Установлено · маршруты офлайн здесь</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -5,17 +5,17 @@
     <string name="settings_follow_system">Как в системе</string>
     <string name="settings_theme_light">Светлая</string>
     <string name="settings_theme_dark">Тёмная</string>
-    <string name="settings_appearance_hint">Светлая или тёмная тема применяется только к Vela — системная тема телефона не меняется.</string>
+    <string name="settings_appearance_hint">Действует только в Vela.</string>
     <string name="settings_dynamic_color">Цвета Material You</string>
-    <string name="settings_dynamic_color_hint">Окрашивает кнопки, чипы и акценты по обоям (Android 12+). Выключено = фирменный бирюзовый Vela. Сама карта остаётся нейтральной, чтобы дороги и подписи сохраняли контраст.</string>
+    <string name="settings_dynamic_color_hint">Окрашивает кнопки и акценты под обои. Карта остаётся нейтральной.</string>
     <string name="settings_map_style">Стиль карты</string>
-    <string name="settings_map_style_hint">OpenFreeMap (по умолчанию) не требует ключа и содержит много деталей. Для Protomaps нужен ключ API; демо-стиль показывает только контуры стран.</string>
+    <string name="settings_map_style_hint">OpenFreeMap работает без ключа API.</string>
     <string name="settings_units">Единицы измерения</string>
     <string name="settings_units_imperial">Имперские (мили, футы)</string>
     <string name="settings_units_metric">Метрические (километры, метры)</string>
     <string name="settings_language">Язык</string>
     <string name="settings_follow_system_language">Язык системы</string>
-    <string name="settings_language_hint">Задаёт язык голосовых подсказок при навигации (английский, французский, немецкий, испанский, итальянский, португальский, нидерландский, русский, польский, шведский, украинский) — независимо от системного языка телефона. Выберите подходящий голос в разделе «Библиотека голосов» ниже. Остальной текст интерфейса будет переведён в ближайшее время.</string>
+    <string name="settings_language_hint">Меняет язык приложения и голосовых подсказок. Скачайте подходящий голос в библиотеке голосов.</string>
     <string name="settings_search">Поиск</string>
     <string name="settings_voice_search_toggle">Микрофон голосового поиска</string>
     <string name="settings_voice_search_hint">Показывает микрофон в строке поиска. Нажмите, чтобы продиктовать запрос через приложение голосового ввода на телефоне.</string>
@@ -50,16 +50,16 @@
     <string name="settings_mode_transit">Транспорт</string>
     <string name="settings_vibrate_hint">Вибросигналы на каждом повороте закодированы по направлению — разные для левого и правого — чтобы следовать маршруту на ощупь. Настраивается для каждого способа передвижения (например, включено для велосипеда и ходьбы, выключено за рулём).</string>
     <string name="settings_keep_screen_on">Не выключать экран при навигации</string>
-    <string name="settings_keep_screen_on_hint">Не даёт экрану гаснуть или уходить в сон во время навигации, чтобы следующий поворот всегда был виден без касания для пробуждения. Включено по умолчанию; экран снова засыпает как обычно, как только вы прибудете или выйдете из навигации.</string>
+    <string name="settings_keep_screen_on_hint">Не даёт экрану гаснуть во время навигации.</string>
     <string name="settings_map">Карта</string>
     <string name="settings_live_traffic">Слой пробок в реальном времени</string>
-    <string name="settings_live_traffic_hint">Окрашивает дороги по загруженности при просмотре карты (бесключевые тайлы пробок Google). Выключено по умолчанию — навигация и так окрашивает ваш маршрут по пробкам, так что это лишь для обзора окрестностей. Это растровый слой, поэтому он слегка зернистый.</string>
+    <string name="settings_live_traffic_hint">Подкрашивает дороги по загруженности при просмотре. Навигация и так раскрашивает маршрут по пробкам.</string>
     <string name="settings_transit_layer">Выделять линии транспорта</string>
-    <string name="settings_transit_layer_hint">Рисует линии поездов и метро на карте цветом, чтобы рельсы было легко проследить. Использует открытые данные, уже вложенные в тайлы, без сети.</string>
+    <string name="settings_transit_layer_hint">Рисует на карте линии поездов и метро.</string>
     <string name="settings_read_all_reviews">Кнопка «Все отзывы»</string>
-    <string name="settings_read_all_reviews_hint">Отзывы в карточке места всегда показываются в собственном плавном списке Vela. Эта настройка добавляет кнопку «Все отзывы», которая открывает полную страницу отзывов Google НА ВЕСЬ ЭКРАН — все отзывы (не только первые ~50), серверный поиск Google и воспроизведение видеоотзывов. Трекеры и маяки блокируются, но страница Google всё же запускается внутри приложения. Выключено = только собственный список, без страницы отзывов Google.</string>
+    <string name="settings_read_all_reviews_hint">Добавляет кнопку, открывающую полную страницу отзывов Google в приложении, со всеми отзывами. Выкл. = только собственный список Vela.</string>
     <string name="settings_buildings_3d">3D-здания</string>
-    <string name="settings_buildings_3d_hint">Объёмные здания при сильном приближении. Отключение может сделать перемещение плавнее на старых телефонах; плоские контуры остаются.</string>
+    <string name="settings_buildings_3d_hint">Объёмные здания при сильном приближении. Отключение может сделать прокрутку плавнее на старых телефонах.</string>
     <string name="settings_show_reviews">Показывать отзывы</string>
     <string name="settings_show_reviews_hint">Выкл. = страницы мест не показывают отзывы, и Vela их никогда не загружает.</string>
     <string name="settings_load_photos">Загружать фото</string>
@@ -101,15 +101,15 @@
     <string name="settings_export">Экспорт</string>
     <string name="settings_import">Импорт</string>
     <string name="settings_data_privacy">Источник данных и конфиденциальность</string>
-    <string name="settings_data_privacy_hint">Vela обращается к публичным веб-сервисам Google напрямую с этого устройства — без сервера Vela, без учётной записи Google, без ключа API и без телеметрии, пока вы не включите «Диагностику» ниже (выключена по умолчанию, только локально). Каждое устройство ведёт себя как браузер без входа в аккаунт; Google видит ваш IP, запрос и область карты, но не аккаунт. Сохранённые места и история никогда не покидают телефон.</string>
+    <string name="settings_data_privacy_hint">Vela обращается к публичным точкам Google прямо с этого устройства: без сервера, аккаунта и ключа API. Google видит IP, запрос и область карты, но не вас.</string>
     <string name="settings_privacy_button">Какие данные получает Google</string>
     <string name="settings_diagnostics">Диагностика</string>
-    <string name="settings_diagnostics_hint">Выключена по умолчанию. Когда включена, Vela ведёт короткий локальный журнал своих действий — ваших поисков, маршрутов и любых сбоев вроде «нужна перекалибровка» — чтобы при неполадке вы могли экспортировать его и передать разработчику. Журнал остаётся на телефоне и никогда не выгружается; место экспорта выбираете вы. При выключении журнал стирается.</string>
+    <string name="settings_diagnostics_hint">По умолчанию выключено. При включении Vela ведёт короткий локальный журнал, который можно экспортировать и передать разработчику. Ничего не выгружается, а отключение стирает его.</string>
     <string name="settings_share_diagnostics">Поделиться диагностикой</string>
     <string name="settings_diag_nothing">Пока ничего не записано — воспользуйтесь приложением, затем экспортируйте.</string>
     <string name="settings_diag_export">Экспортировать сеанс отладки</string>
     <string name="settings_save_trips">Сохранять мои поездки (для воспроизведения)</string>
-    <string name="settings_save_trips_hint">Записывает GPS-трек каждой навигации на этом телефоне, чтобы позже воспроизвести поездку и проверить навигацию без повторной поездки. Раскрывает больше, чем диагностика, — это ваши точные маршруты — и никогда не покидает телефон.</string>
+    <string name="settings_save_trips_hint">Записывает GPS-след каждой поездки на этом телефоне для повтора позже. Никогда не покидает телефон.</string>
     <string name="settings_recorded_trips_hint">Записанные поездки — нажмите «Воспроизвести», чтобы проиграть одну на карте (3×):</string>
     <string name="settings_trip_points">%1$d точек</string>
     <string name="settings_trip_replay">Воспроизвести</string>
@@ -167,7 +167,7 @@
     <string name="place_permanently_closed">Закрыто навсегда</string>
     <string name="place_temporarily_closed">Временно закрыто</string>
     <string name="settings_traffic_lights">Подсказки по светофорам</string>
-    <string name="settings_traffic_lights_hint">«Проедьте светофор, затем поверните» на перекрёстках со светофорами (голос пока только на английском)</string>
+    <string name="settings_traffic_lights_hint">Добавляет подсказки вида “проедьте светофор, затем налево”. Пока только на английском.</string>
     <string name="map_voice_downloading">Загрузка голоса Vela · %1$d %%</string>
     <string name="map_voice_installing">Установка голоса Vela…</string>
     <string name="map_region_downloading">Загрузка маршрутов: %1$s · %2$d%%</string> <!-- format -->
@@ -175,9 +175,9 @@
     <string name="mapvm_poipack_ready">Места региона %1$s теперь доступны для офлайн-поиска</string> <!-- format -->
     <string name="mapvm_poipack_unavailable">Для региона %1$s пока нет пакета мест. Он появится здесь после публикации.</string> <!-- format -->
     <string name="settings_demo_drive">Симуляция поездки (демо)</string>
-    <string name="settings_demo_drive_hint">Для демонстраций, скриншотов и тестов: нажатие «Начать» ведёт по маршруту как смоделированный GPS-трек вместо вашего реального местоположения — навигация работает где угодно. Выключите для настоящей навигации.</string>
+    <string name="settings_demo_drive_hint">Кнопка Старт проезжает маршрут как симуляцию вместо GPS. Отключите для настоящей навигации.</string>
     <string name="settings_sim_location">Симулировать местоположение (демо)</string>
-    <string name="settings_sim_location_hint">Для демонстраций и скриншотов: притворитесь, что вы сейчас в центре карты, чтобы точка местоположения, расстояния и маршруты начинались оттуда, а не от вашего реального положения. Выключите для настоящего GPS.</string>
+    <string name="settings_sim_location_hint">Делает вид, что вы в центре карты, для демо и скриншотов. Отключите для реального GPS.</string>
     <string name="place_address_copied">Адрес скопирован</string>
     <string name="place_copy_address">Скопировать адрес</string>
     <string name="place_directions">Маршрут</string>
@@ -310,7 +310,7 @@
     <string name="mapscreen_switch">Переключить</string>
     <string name="root_not_now">Не сейчас</string>
     <string name="root_voice_title">Голос навигации</string>
-    <string name="root_voice_body_intro">Собственный голос Vela работает полностью на телефоне: естественные подсказки, без аккаунта и лишних приложений. Рекомендуется, разовая загрузка ~%1$d МБ.</string>
+    <string name="root_voice_body_intro">Собственный голос Vela работает целиком на телефоне: естественные подсказки, без аккаунта и лишних приложений. Рекомендуем, разовая загрузка %1$d МБ.</string>
     <string name="root_voice_body_system">Не хотите? Используйте голос, уже установленный на телефоне.</string>
     <string name="root_voice_body_outro">Измените в любой момент в Настройках → Голос.</string>
     <string name="root_voice_download">Загрузить голос Vela</string>
@@ -372,7 +372,7 @@
     <string name="mapvm_export_trip_subject">Поездка Vela: %1$s (%2$d точек)</string>
     <string name="mapvm_share_trip_chooser">Поделиться поездкой</string>
     <string name="mapvm_voice_sample">Через четыреста метров поверните направо на Тверскую улицу.</string>
-    <string name="mapvm_not_enough_space">Недостаточно свободного места для %1$s (~%2$d МБ)</string>
+    <string name="mapvm_not_enough_space">Недостаточно свободного места для %1$s (%2$d МБ)</string>
     <string name="mapvm_voice_downloaded">%1$s загружен</string>
     <string name="mapvm_voice_download_failed">Не удалось загрузить %1$s</string>
     <string name="mapvm_vela_voice_removed">Голос Vela удалён</string>
@@ -412,7 +412,7 @@
     <string name="update_install">Обновить</string>
     <string name="update_download_failed">Не удалось скачать обновление. Попробуйте позже.</string>
     <string name="settings_update_auto">Проверять обновления при запуске</string>
-    <string name="settings_update_auto_hint">Примерно раз в день проверяет свежий релиз на GitHub и предлагает его, если он новее этой сборки. Установка идёт через обычный установщик Android. Если вы обновляетесь через Obtainium, это можно выключить.</string>
+    <string name="settings_update_auto_hint">Проверяет GitHub примерно раз в день и предлагает новые версии. Отключите, если обновляетесь через Obtainium.</string>
     <string name="settings_update_check_now">Проверить обновления</string>
     <string name="settings_update_checking">Проверка…</string>
     <string name="settings_update_none">У вас самая новая версия.</string>
@@ -480,7 +480,7 @@
     <string name="lists_place_count">%1$d мест</string>
     <string name="navservice_notif_eta">Прибытие %1$s</string>
     <string name="settings_advanced">Дополнительно</string>
-    <string name="settings_advanced_hint">Нишевые и экспериментальные параметры, которые большинству не нужны.</string>
+    <string name="settings_advanced_hint">Параметры, которые большинству не нужны.</string>
     <string name="settings_developer">Разработчик</string>
     <string name="settings_developer_hint">Инструменты для демо, скриншотов и тестов. Отключайте их для реальной работы.</string>
     <string name="settings_browse_voices">Выбрать голос</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -137,8 +137,8 @@
     <string name="settings_version_line">Vela %1$s  (сборка %2$d)</string>
     <string name="settings_collapse">Свернуть</string>
     <string name="settings_expand">Развернуть</string>
-    <string name="settings_voice_lib_empty_hint">Загрузите естественный голос на устройство для голосовых подсказок — выберите один из списка ниже. Голоса, отмеченные ★, звучат наиболее похоже на навигатор (Lessac и HFC ближе всего к Google). Разовая загрузка; рекомендуется Wi-Fi.</string>
-    <string name="settings_voice_lib_installed_hint">Установлено: %1$d МБ · голосов: %2$d. Нажмите «Выбрать», чтобы переключиться (проигрывается образец); значок корзины освобождает место.</string> <!-- format -->
+    <string name="settings_voice_lib_empty_hint">★ отмечает рекомендуемые голоса. Все голоса работают офлайн на телефоне.</string>
+    <string name="settings_voice_lib_installed_hint">Установлено: %1$d МБ · %2$d голос(ов).</string> <!-- format -->
     <string name="settings_voice_lib_lang_hint">Язык приложения — %1$s. Загрузите голос (%2$s) ниже, чтобы голосовые подсказки совпадали (английский голос неправильно произнёс бы названия улиц (%3$s)).</string>
     <string name="settings_voice_search">Поиск голосов</string>
     <string name="settings_voice_show_more">Показать ещё %1$d</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -72,13 +72,13 @@
     <string name="settings_offline_hint">Ladda ner ett område för att spara dess karta och vägbeskrivningar på telefonen för offline-bruk.</string>
     <string name="settings_offline_map_area">Kartområde</string>
     <string name="settings_offline_download_viewport">Hämta området du tittar på</string>
-    <string name="settings_offline_download_viewport_hint">Sparar de öppna rutorna för kartområdet du senast hade på skärmen – och ruttregionen runt det – så att det ritas upp och navigerar senare utan nätverk. Sökning kräver fortfarande anslutning.</string>
+    <string name="settings_offline_download_viewport_hint">Sparar kartan och dess vägar för området du tittar på, så att det visas och beräknar rutter offline.</string>
     <string name="settings_offline_no_areas">Inga områden sparade ännu.</string>
     <string name="settings_offline_addresses_missing">Områden du sparade före den här uppdateringen innehåller inga adressdata. Uppdatera dem för att söka och navigera till adresser offline.</string>
     <string name="settings_offline_addresses_update">Uppdatera sparade områden</string>
     <string name="settings_offline_delete_area">Ta bort det här offlineområdet</string>
     <string name="settings_routing_regions">Ruttregioner</string>
-    <string name="settings_routing_regions_hint">Vägnätet för en hel region (delstat, land …), så att sväng-för-sväng fungerar offline var som helst inuti den – hämta där du reser. Online används fortfarande realtidstrafik; det här är reserven utan täckning.</string>
+    <string name="settings_routing_regions_hint">Vägarna för en hel region (en delstat eller ett land), så att vägbeskrivningar fungerar offline i hela den. Hämta dit du ska.</string>
     <string name="settings_routing_no_regions">Inga regioner tillgängliga ännu.</string>
     <string name="settings_clear_filter">Rensa filter</string>
     <string name="settings_routing_filter_placeholder">Filtrera %1$d regioner… (t.ex. Japan, Texas)</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -69,16 +69,16 @@
     <string name="settings_hide_external_links">Dölj webbplats och externa länkar</string>
     <string name="settings_hide_external_links_hint">På = platssidor visar inte knapparna Webbplats, Street View eller Boka / Beställ (inga godtyckliga externa webbplatser öppnas).</string>
     <string name="settings_offline">Offlinekartor</string>
-    <string name="settings_offline_hint">Ladda ner ett område för att spara dess karta och vägbeskrivningar på telefonen för offline-bruk.</string>
-    <string name="settings_offline_map_area">Kartområde</string>
+    <string name="settings_offline_hint">Två sätt att använda Vela offline: spara området där du är för korta resor, eller en hel delstat eller ett helt land nedan för längre.</string>
+    <string name="settings_offline_map_area">Lokalt område</string>
     <string name="settings_offline_download_viewport">Hämta området du tittar på</string>
-    <string name="settings_offline_download_viewport_hint">Sparar kartan och dess vägar för området du tittar på, så att det visas och beräknar rutter offline.</string>
+    <string name="settings_offline_download_viewport_hint">Sparar kartan du tittar på, med vägar och adresser, så att området fortsätter fungera utan täckning.</string>
     <string name="settings_offline_no_areas">Inga områden sparade ännu.</string>
     <string name="settings_offline_addresses_missing">Områden du sparade före den här uppdateringen innehåller inga adressdata. Uppdatera dem för att söka och navigera till adresser offline.</string>
     <string name="settings_offline_addresses_update">Uppdatera sparade områden</string>
     <string name="settings_offline_delete_area">Ta bort det här offlineområdet</string>
-    <string name="settings_routing_regions">Ruttregioner</string>
-    <string name="settings_routing_regions_hint">Vägarna för en hel region (en delstat eller ett land), så att vägbeskrivningar fungerar offline i hela den. Hämta dit du ska.</string>
+    <string name="settings_routing_regions">Regioner och länder</string>
+    <string name="settings_routing_regions_hint">Allt som behövs för att ta sig runt i en hel delstat, provins eller ett helt land offline: vägar och platser, så att vägbeskrivningar och sökning fungerar överallt där. Hämta dit du ska.</string>
     <string name="settings_routing_no_regions">Inga regioner tillgängliga ännu.</string>
     <string name="settings_clear_filter">Rensa filter</string>
     <string name="settings_routing_filter_placeholder">Sök</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -68,7 +68,7 @@
     <string name="settings_hide_adult_hint">På = döljer barer, klubbar, kasinon, spritbutiker och andra vuxen- / nöjeslivsplatser från sökning och karta.</string>
     <string name="settings_hide_external_links">Dölj webbplats och externa länkar</string>
     <string name="settings_hide_external_links_hint">På = platssidor visar inte knapparna Webbplats, Street View eller Boka / Beställ (inga godtyckliga externa webbplatser öppnas).</string>
-    <string name="settings_offline">Offline</string>
+    <string name="settings_offline">Offlinekartor</string>
     <string name="settings_offline_hint">Ladda ner ett område för att spara dess karta och vägbeskrivningar på telefonen för offline-bruk.</string>
     <string name="settings_offline_map_area">Kartområde</string>
     <string name="settings_offline_download_viewport">Hämta området du tittar på</string>
@@ -81,7 +81,7 @@
     <string name="settings_routing_regions_hint">Vägarna för en hel region (en delstat eller ett land), så att vägbeskrivningar fungerar offline i hela den. Hämta dit du ska.</string>
     <string name="settings_routing_no_regions">Inga regioner tillgängliga ännu.</string>
     <string name="settings_clear_filter">Rensa filter</string>
-    <string name="settings_routing_filter_placeholder">Filtrera %1$d regioner… (t.ex. Japan, Texas)</string>
+    <string name="settings_routing_filter_placeholder">Sök</string>
     <string name="settings_routing_no_match">Inga regioner matchar ”%1$s”.</string>
     <string name="settings_routing_downloading">Hämtar… %1$d %%</string>
     <string name="settings_routing_installed">Installerad · ruttar offline här</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -14,6 +14,7 @@
     <string name="settings_units_imperial">Brittiskt (miles, fot)</string>
     <string name="settings_units_metric">Metriskt (kilometer, meter)</string>
     <string name="settings_language">Språk</string>
+    <string name="settings_follow_system_language">Följ systemspråket</string>
     <string name="settings_language_hint">Anger språket för talade vägbeskrivningar sväng för sväng (engelska, franska, tyska, spanska, italienska, portugisiska, nederländska, ryska, polska, svenska, ukrainska) – oberoende av telefonens systemspråk. Välj en röst som matchar i Röstbiblioteket nedan. Resten av appens skärmtext översätts härnäst.</string>
     <string name="settings_search">Sök</string>
     <string name="settings_voice_search_toggle">Mikrofon för röstsökning</string>
@@ -478,4 +479,10 @@
     <string name="lists_empty_hint">Inga listor än. Tryck på Ny eller spara en plats från dess sida.</string>
     <string name="lists_place_count">%1$d platser</string>
     <string name="navservice_notif_eta">Ankomst %1$s</string>
+    <string name="settings_advanced">Avancerat</string>
+    <string name="settings_advanced_hint">Nisch- och experimentella alternativ som de flesta aldrig behöver ändra.</string>
+    <string name="settings_developer">Utvecklare</string>
+    <string name="settings_developer_hint">Verktyg för demos, skärmbilder och tester. Stäng av dem för verklig användning.</string>
+    <string name="settings_browse_voices">Bläddra bland röster</string>
+    <string name="settings_browse_voices_hint">Ladda ner och växla mellan Velas röster på enheten.</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -137,8 +137,8 @@
     <string name="settings_version_line">Vela %1$s  (bygge %2$d)</string>
     <string name="settings_collapse">Fäll ihop</string>
     <string name="settings_expand">Expandera</string>
-    <string name="settings_voice_lib_empty_hint">Hämta en naturlig röst på enheten för talade vägbeskrivningar – välj en nedan. ★-rösterna låter mest som en kartnavigator (Lessac och HFC ligger närmast Google). Engångshämtning; wifi rekommenderas.</string>
-    <string name="settings_voice_lib_installed_hint">Installerat: %1$d MB · %2$d röst(er). Tryck på Använd för att byta (spelar upp ett prov); papperskorgsikonen frigör utrymmet.</string> <!-- format -->
+    <string name="settings_voice_lib_empty_hint">★ markerar de rekommenderade rösterna. Varje röst fungerar offline på telefonen.</string>
+    <string name="settings_voice_lib_installed_hint">Installerat: %1$d MB · %2$d röst(er).</string> <!-- format -->
     <string name="settings_voice_lib_lang_hint">Ditt appspråk är %1$s – hämta en %2$s-röst nedan så att talade vägbeskrivningar matchar (en engelsk röst skulle uttala %3$s gatunamn fel).</string>
     <string name="settings_voice_search">Sök röster</string>
     <string name="settings_voice_show_more">Visa %1$d till</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -5,17 +5,17 @@
     <string name="settings_follow_system">Följ systemet</string>
     <string name="settings_theme_light">Ljust</string>
     <string name="settings_theme_dark">Mörkt</string>
-    <string name="settings_appearance_hint">Ljust/Mörkt gäller endast Vela – det påverkar inte telefonens systemtema.</string>
+    <string name="settings_appearance_hint">Gäller endast Vela.</string>
     <string name="settings_dynamic_color">Material You-färger</string>
-    <string name="settings_dynamic_color_hint">Färgar knappar, chips och accenter efter din bakgrund (Android 12+). Av = Velas egen turkos. Själva kartan förblir neutral så att vägar och etiketter behåller kontrasten.</string>
+    <string name="settings_dynamic_color_hint">Färgar knappar och accenter efter bakgrunden. Kartan förblir neutral.</string>
     <string name="settings_map_style">Kartstil</string>
-    <string name="settings_map_style_hint">OpenFreeMap (standard) är nyckellös och detaljerad. Protomaps kräver en API-nyckel; demostilen visar bara landsgränser.</string>
+    <string name="settings_map_style_hint">OpenFreeMap fungerar utan API-nyckel.</string>
     <string name="settings_units">Enheter</string>
     <string name="settings_units_imperial">Brittiskt (miles, fot)</string>
     <string name="settings_units_metric">Metriskt (kilometer, meter)</string>
     <string name="settings_language">Språk</string>
     <string name="settings_follow_system_language">Följ systemspråket</string>
-    <string name="settings_language_hint">Anger språket för talade vägbeskrivningar sväng för sväng (engelska, franska, tyska, spanska, italienska, portugisiska, nederländska, ryska, polska, svenska, ukrainska) – oberoende av telefonens systemspråk. Välj en röst som matchar i Röstbiblioteket nedan. Resten av appens skärmtext översätts härnäst.</string>
+    <string name="settings_language_hint">Ändrar appens språk och de talade anvisningarna. Hämta en matchande röst i röstbiblioteket.</string>
     <string name="settings_search">Sök</string>
     <string name="settings_voice_search_toggle">Mikrofon för röstsökning</string>
     <string name="settings_voice_search_hint">Visar en mikrofon i sökfältet. Tryck för att tala din sökning via en röstinmatnings-app på telefonen.</string>
@@ -50,16 +50,16 @@
     <string name="settings_mode_transit">Kollektivt</string>
     <string name="settings_vibrate_hint">Riktningskodade vibrationer vid varje sväng – olika för vänster och höger – så att du kan följa en rutt på känsla. Ställ in per färdsätt (t.ex. på för cykel och gång, av vid bilkörning).</string>
     <string name="settings_keep_screen_on">Håll skärmen på under navigering</string>
-    <string name="settings_keep_screen_on_hint">Hindrar skärmen från att dimmas eller släckas medan navigering pågår, så att nästa sväng alltid syns utan att du behöver väcka skärmen. På som standard; skärmen släcks som vanligt så snart du är framme eller lämnar navigeringen.</string>
+    <string name="settings_keep_screen_on_hint">Håller skärmen vaken under navigering.</string>
     <string name="settings_map">Karta</string>
     <string name="settings_live_traffic">Trafiklager i realtid</string>
-    <string name="settings_live_traffic_hint">Färglägger vägar efter trafik när du bläddrar i kartan (Googles nyckellösa trafikrutor). Av som standard – navigeringen färglägger redan din rutt efter trafik, så det här är bara för att överblicka ett större område. Det är ett rasterlager, så det är lite grovkornigt.</string>
+    <string name="settings_live_traffic_hint">Skuggar vägar efter trafik när du utforskar. Navigeringen färgar redan din rutt efter trafiken.</string>
     <string name="settings_transit_layer">Markera kollektivtrafiklinjer</string>
-    <string name="settings_transit_layer_hint">Ritar tåg- och tunnelbanelinjer i färg på kartan, så att spåren är lätta att följa. Använder de öppna kartdata som redan finns i rutorna, utan nätverk.</string>
+    <string name="settings_transit_layer_hint">Ritar tåg- och tunnelbanelinjer på kartan.</string>
     <string name="settings_read_all_reviews">Knappen ”Läs alla recensioner”</string>
-    <string name="settings_read_all_reviews_hint">Recensioner i platsvyn är alltid Velas egen smidiga inbyggda lista. Detta lägger till en knapp ”Läs alla recensioner” som öppnar Googles fullständiga recensionssida i HELSKÄRM – alla recensioner (inte bara de första ~50), Googles serversökning och videorecensioner spelas upp. Spårare/beacons blockeras, men Googles sida körs inuti appen. Av = endast inbyggd lista, ingen Google-sida för recensioner.</string>
+    <string name="settings_read_all_reviews_hint">Lägger till en knapp som öppnar Googles fullständiga recensionssida i appen, med alla recensioner. Av = endast Velas egen lista.</string>
     <string name="settings_buildings_3d">3D-byggnader</string>
-    <string name="settings_buildings_3d_hint">Upphöjda byggnadsformer vid hög zoom. Att stänga av kan göra panorering mjukare på äldre telefoner; de platta konturerna finns kvar.</string>
+    <string name="settings_buildings_3d_hint">Upphöjda byggnader vid nära zoom. Att stänga av kan göra panorering mjukare på äldre telefoner.</string>
     <string name="settings_show_reviews">Visa recensioner</string>
     <string name="settings_show_reviews_hint">Av = platssidor visar inga recensioner och Vela hämtar dem aldrig.</string>
     <string name="settings_load_photos">Ladda foton</string>
@@ -101,15 +101,15 @@
     <string name="settings_export">Exportera</string>
     <string name="settings_import">Importera</string>
     <string name="settings_data_privacy">Datakälla &amp;amp; integritet</string>
-    <string name="settings_data_privacy_hint">Vela pratar med Googles offentliga webbtjänster direkt från den här enheten – ingen Vela-server, inget Google-konto, ingen API-nyckel och ingen telemetri om du inte slår på Diagnostik nedan (av som standard, endast lokalt). Varje enhet beter sig som en utloggad webbläsare; Google ser din IP, sökning och kartområde men inget konto. Sparade platser och historik lämnar aldrig telefonen.</string>
+    <string name="settings_data_privacy_hint">Vela pratar med Googles publika endpoints direkt från den här enheten: ingen backend, inget konto, ingen API-nyckel. Google ser din IP, sökning och kartområde, inte vem du är.</string>
     <string name="settings_privacy_button">Vilka data Google får</string>
     <string name="settings_diagnostics">Diagnostik</string>
-    <string name="settings_diagnostics_hint">Av som standard. När den är på håller Vela en kort lokal logg över vad den gjorde – dina sökningar, rutter och eventuella ”behöver omkalibrering”-hicka – så att du kan exportera den och lämna den till en utvecklare om något krånglar. Den stannar på telefonen och laddas aldrig upp; du väljer var exporten hamnar. Att slå av den raderar loggen.</string>
+    <string name="settings_diagnostics_hint">Av som standard. När på för Vela en kort lokal logg som du kan exportera och ge till en utvecklare. Inget laddas upp, och att stänga av rensar den.</string>
     <string name="settings_share_diagnostics">Dela diagnostik</string>
     <string name="settings_diag_nothing">Inget inspelat ännu – använd appen och exportera sedan.</string>
     <string name="settings_diag_export">Exportera felsökningssession</string>
     <string name="settings_save_trips">Spara mina resor (för uppspelning)</string>
-    <string name="settings_save_trips_hint">Spelar in varje navigerings GPS-spår på den här telefonen så att en körning kan spelas upp senare för att testa sväng-för-sväng utan att köra den igen. Avslöjar mer än diagnostik – det är dina exakta rutter – och lämnar aldrig telefonen.</string>
+    <string name="settings_save_trips_hint">Sparar varje resas GPS-spår på den här telefonen, för uppspelning senare. Lämnar aldrig telefonen.</string>
     <string name="settings_recorded_trips_hint">Inspelade resor – tryck på Spela upp för att spela upp en på kartan (3×):</string>
     <string name="settings_trip_points">%1$d punkter</string>
     <string name="settings_trip_replay">Spela upp</string>
@@ -167,7 +167,7 @@
     <string name="place_permanently_closed">Permanent stängt</string>
     <string name="place_temporarily_closed">Tillfälligt stängt</string>
     <string name="settings_traffic_lights">Trafikljusvägledning</string>
-    <string name="settings_traffic_lights_hint">"Passera trafikljuset och sväng sedan" vid ljusreglerade korsningar (röst endast på engelska än så länge)</string>
+    <string name="settings_traffic_lights_hint">Lägger till ledtrådar som “passera trafikljuset, sväng sedan vänster”. Endast engelska än så länge.</string>
     <string name="map_voice_downloading">Laddar ner Vela-rösten · %1$d %%</string>
     <string name="map_voice_installing">Installerar Vela-rösten…</string>
     <string name="map_region_downloading">Laddar ner rutter för %1$s · %2$d%%</string> <!-- format -->
@@ -175,9 +175,9 @@
     <string name="mapvm_poipack_ready">Platser i %1$s går nu att söka offline</string> <!-- format -->
     <string name="mapvm_poipack_unavailable">Inget platspaket för %1$s ännu. Det dyker upp här när det publicerats.</string> <!-- format -->
     <string name="settings_demo_drive">Simulera körning (demo)</string>
-    <string name="settings_demo_drive_hint">För demos, skärmbilder och tester: att trycka på Starta kör rutten som ett simulerat GPS-spår i stället för din verkliga plats — navigering fungerar var som helst. Stäng av för att navigera på riktigt.</string>
+    <string name="settings_demo_drive_hint">Start kör den planerade rutten som simulering i stället för GPS. Stäng av för att navigera på riktigt.</string>
     <string name="settings_sim_location">Simulera min plats (demo)</string>
-    <string name="settings_sim_location_hint">För demos och skärmbilder: låtsas att du är mitt på kartan just nu, så att platsprick, avstånd och vägbeskrivningar utgår därifrån i stället för din verkliga position. Stäng av för riktig GPS.</string>
+    <string name="settings_sim_location_hint">Låtsas att du är i kartans mitt, för demos och skärmbilder. Stäng av för riktig GPS.</string>
     <string name="place_address_copied">Adress kopierad</string>
     <string name="place_copy_address">Kopiera adress</string>
     <string name="place_directions">Vägbeskrivning</string>
@@ -310,7 +310,7 @@
     <string name="mapscreen_switch">Byt</string>
     <string name="root_not_now">Inte nu</string>
     <string name="root_voice_title">Röst för talad navigering</string>
-    <string name="root_voice_body_intro">Velas egen röst körs helt på telefonen: naturliga anvisningar, utan konto eller extra app. Rekommenderas, en engångshämtning på ~%1$d MB.</string>
+    <string name="root_voice_body_intro">Velas egen röst körs helt på din telefon: naturliga anvisningar, inget konto, ingen extra app. Rekommenderas, en engångsnedladdning på %1$d MB.</string>
     <string name="root_voice_body_system">Vill du hellre inte? Använd en röst du redan har i telefonen.</string>
     <string name="root_voice_body_outro">Ändra det när som helst i Inställningar → Röst.</string>
     <string name="root_voice_download">Hämta Vela-röst</string>
@@ -372,7 +372,7 @@
     <string name="mapvm_export_trip_subject">Vela-resa: %1$s (%2$d punkter)</string>
     <string name="mapvm_share_trip_chooser">Dela resa</string>
     <string name="mapvm_voice_sample">Om 400 meter, sväng höger in på Storgatan.</string>
-    <string name="mapvm_not_enough_space">Inte tillräckligt med ledigt utrymme för %1$s (~%2$d MB)</string>
+    <string name="mapvm_not_enough_space">Inte tillräckligt med ledigt utrymme för %1$s (%2$d MB)</string>
     <string name="mapvm_voice_downloaded">%1$s hämtad</string>
     <string name="mapvm_voice_download_failed">Hämtning av %1$s misslyckades</string>
     <string name="mapvm_vela_voice_removed">Vela-röst borttagen</string>
@@ -412,7 +412,7 @@
     <string name="update_install">Uppdatera</string>
     <string name="update_download_failed">Nedladdningen av uppdateringen misslyckades. Försök igen senare.</string>
     <string name="settings_update_auto">Sök efter uppdateringar vid start</string>
-    <string name="settings_update_auto_hint">Tittar på den senaste GitHub-releasen ungefär en gång om dagen och erbjuder den när den är nyare än den här versionen. Installationen sker via Androids vanliga installerare. Uppdaterar du redan via Obtainium kan du stänga av detta.</string>
+    <string name="settings_update_auto_hint">Kollar GitHub ungefär en gång om dagen och erbjuder nyare versioner. Stäng av om du uppdaterar via Obtainium.</string>
     <string name="settings_update_check_now">Sök efter uppdateringar</string>
     <string name="settings_update_checking">Kontrollerar…</string>
     <string name="settings_update_none">Du har den senaste versionen.</string>
@@ -480,7 +480,7 @@
     <string name="lists_place_count">%1$d platser</string>
     <string name="navservice_notif_eta">Ankomst %1$s</string>
     <string name="settings_advanced">Avancerat</string>
-    <string name="settings_advanced_hint">Nisch- och experimentella alternativ som de flesta aldrig behöver ändra.</string>
+    <string name="settings_advanced_hint">Alternativ som de flesta aldrig behöver.</string>
     <string name="settings_developer">Utvecklare</string>
     <string name="settings_developer_hint">Verktyg för demos, skärmbilder och tester. Stäng av dem för verklig användning.</string>
     <string name="settings_browse_voices">Bläddra bland röster</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -69,7 +69,7 @@
     <string name="settings_hide_external_links">Dölj webbplats och externa länkar</string>
     <string name="settings_hide_external_links_hint">På = platssidor visar inte knapparna Webbplats, Street View eller Boka / Beställ (inga godtyckliga externa webbplatser öppnas).</string>
     <string name="settings_offline">Offline</string>
-    <string name="settings_offline_hint">Att använda kartan utan täckning kräver två saker – KARTRUTORNA du ser och VÄGNÄTET som beräknar rutter åt dig. Att spara ett kartområde hämtar båda för den platsen; regionlistan nedan lägger till vägnätet för dit du reser.</string>
+    <string name="settings_offline_hint">Ladda ner ett område för att spara dess karta och vägbeskrivningar på telefonen för offline-bruk.</string>
     <string name="settings_offline_map_area">Kartområde</string>
     <string name="settings_offline_download_viewport">Hämta området du tittar på</string>
     <string name="settings_offline_download_viewport_hint">Sparar de öppna rutorna för kartområdet du senast hade på skärmen – och ruttregionen runt det – så att det ritas upp och navigerar senare utan nätverk. Sökning kräver fortfarande anslutning.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -72,13 +72,13 @@
     <string name="settings_offline_hint">Завантажте область, щоб зберегти її карту та маршрути на телефоні для офлайн-використання.</string>
     <string name="settings_offline_map_area">Ділянка карти</string>
     <string name="settings_offline_download_viewport">Завантажити ділянку, яку ви переглядаєте</string>
-    <string name="settings_offline_download_viewport_hint">Зберігає відкриті плитки для ділянки карти, яку ви востаннє бачили на екрані — та регіон маршрутизації навколо неї — щоб згодом усе відображалося й прокладалося без мережі. Пошук усе ще потребує з’єднання.</string>
+    <string name="settings_offline_download_viewport_hint">Зберігає карту та її дороги для показаної області, щоб вона показувалася й прокладала маршрути офлайн.</string>
     <string name="settings_offline_no_areas">Поки що немає збережених ділянок.</string>
     <string name="settings_offline_addresses_missing">Області, збережені до цього оновлення, не містять даних адрес. Оновіть їх, щоб шукати адреси та прокладати до них маршрути офлайн.</string>
     <string name="settings_offline_addresses_update">Оновити збережені області</string>
     <string name="settings_offline_delete_area">Видалити цю офлайн-ділянку</string>
     <string name="settings_routing_regions">Регіони маршрутизації</string>
-    <string name="settings_routing_regions_hint">Дорожня мережа цілого регіону (область, країна…), щоб покрокова навігація працювала офлайн будь-де всередині нього — завантажте, куди прямуєте. Онлайн усе ще використовує трафік у реальному часі; це резерв на випадок відсутності зв’язку.</string>
+    <string name="settings_routing_regions_hint">Дороги цілого регіону (штату чи країни), щоб маршрути працювали офлайн на всій території. Завантажте туди, куди їдете.</string>
     <string name="settings_routing_no_regions">Поки що немає доступних регіонів.</string>
     <string name="settings_clear_filter">Очистити фільтр</string>
     <string name="settings_routing_filter_placeholder">Фільтр %1$d регіонів… (напр. Японія, Техас)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -69,16 +69,16 @@
     <string name="settings_hide_external_links">Приховати вебсайт і зовнішні посилання</string>
     <string name="settings_hide_external_links_hint">Увімк. = на сторінках місць немає кнопок «Сайт», Street View та «Забронювати / Замовити» (довільні зовнішні сайти не відкриваються).</string>
     <string name="settings_offline">Офлайн-карти</string>
-    <string name="settings_offline_hint">Завантажте область, щоб зберегти її карту та маршрути на телефоні для офлайн-використання.</string>
-    <string name="settings_offline_map_area">Ділянка карти</string>
+    <string name="settings_offline_hint">Два способи користуватися Vela офлайн: збережіть область, де ви є, для коротких поїздок, або цілий регіон чи країну нижче для дальших.</string>
+    <string name="settings_offline_map_area">Місцева область</string>
     <string name="settings_offline_download_viewport">Завантажити ділянку, яку ви переглядаєте</string>
-    <string name="settings_offline_download_viewport_hint">Зберігає карту та її дороги для показаної області, щоб вона показувалася й прокладала маршрути офлайн.</string>
+    <string name="settings_offline_download_viewport_hint">Зберігає карту, яку ви бачите, разом із дорогами та адресами, щоб ця область працювала без зв\'язку.</string>
     <string name="settings_offline_no_areas">Поки що немає збережених ділянок.</string>
     <string name="settings_offline_addresses_missing">Області, збережені до цього оновлення, не містять даних адрес. Оновіть їх, щоб шукати адреси та прокладати до них маршрути офлайн.</string>
     <string name="settings_offline_addresses_update">Оновити збережені області</string>
     <string name="settings_offline_delete_area">Видалити цю офлайн-ділянку</string>
-    <string name="settings_routing_regions">Регіони маршрутизації</string>
-    <string name="settings_routing_regions_hint">Дороги цілого регіону (штату чи країни), щоб маршрути працювали офлайн на всій території. Завантажте туди, куди їдете.</string>
+    <string name="settings_routing_regions">Регіони та країни</string>
+    <string name="settings_routing_regions_hint">Усе, щоб пересуватися цілим регіоном, областю чи країною офлайн: дороги та місця, щоб маршрути й пошук працювали всюди. Завантажте туди, куди їдете.</string>
     <string name="settings_routing_no_regions">Поки що немає доступних регіонів.</string>
     <string name="settings_clear_filter">Очистити фільтр</string>
     <string name="settings_routing_filter_placeholder">Пошук</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -69,7 +69,7 @@
     <string name="settings_hide_external_links">Приховати вебсайт і зовнішні посилання</string>
     <string name="settings_hide_external_links_hint">Увімк. = на сторінках місць немає кнопок «Сайт», Street View та «Забронювати / Замовити» (довільні зовнішні сайти не відкриваються).</string>
     <string name="settings_offline">Офлайн</string>
-    <string name="settings_offline_hint">Щоб користуватися картою без зв’язку, потрібні дві речі — ПЛИТКИ карти, які ви бачите, і ДОРОЖНЯ МЕРЕЖА, яка прокладає маршрут. Збереження ділянки карти завантажує обидві для цього місця; список регіонів нижче додає дорожню мережу для будь-де, куди ви прямуєте.</string>
+    <string name="settings_offline_hint">Завантажте область, щоб зберегти її карту та маршрути на телефоні для офлайн-використання.</string>
     <string name="settings_offline_map_area">Ділянка карти</string>
     <string name="settings_offline_download_viewport">Завантажити ділянку, яку ви переглядаєте</string>
     <string name="settings_offline_download_viewport_hint">Зберігає відкриті плитки для ділянки карти, яку ви востаннє бачили на екрані — та регіон маршрутизації навколо неї — щоб згодом усе відображалося й прокладалося без мережі. Пошук усе ще потребує з’єднання.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -137,8 +137,8 @@
     <string name="settings_version_line">Vela %1$s  (збірка %2$d)</string>
     <string name="settings_collapse">Згорнути</string>
     <string name="settings_expand">Розгорнути</string>
-    <string name="settings_voice_lib_empty_hint">Завантажте природний голос на пристрій для голосових вказівок — виберіть один нижче. Голоси з ★ звучать найбільше схоже на навігатор карт (Lessac і HFC найближчі до Google). Одноразове завантаження; рекомендовано Wi-Fi.</string>
-    <string name="settings_voice_lib_installed_hint">Встановлено: %1$d МБ · голосів: %2$d. Торкніться «Використати», щоб перемкнути (відтворюється зразок); значок кошика звільняє місце.</string> <!-- format -->
+    <string name="settings_voice_lib_empty_hint">★ позначає рекомендовані голоси. Усі голоси працюють офлайн на телефоні.</string>
+    <string name="settings_voice_lib_installed_hint">Встановлено: %1$d МБ · %2$d голос(ів).</string> <!-- format -->
     <string name="settings_voice_lib_lang_hint">Мова застосунку — %1$s. Завантажте голос %2$s нижче, щоб голосові вказівки відповідали (англійський голос неправильно вимовляв би назви вулиць мовою %3$s).</string>
     <string name="settings_voice_search">Пошук голосів</string>
     <string name="settings_voice_show_more">Показати ще %1$d</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -68,7 +68,7 @@
     <string name="settings_hide_adult_hint">Увімк. = приховує бари, клуби, казино, магазини алкоголю та інші дорослі / нічні місця з пошуку та карти.</string>
     <string name="settings_hide_external_links">Приховати вебсайт і зовнішні посилання</string>
     <string name="settings_hide_external_links_hint">Увімк. = на сторінках місць немає кнопок «Сайт», Street View та «Забронювати / Замовити» (довільні зовнішні сайти не відкриваються).</string>
-    <string name="settings_offline">Офлайн</string>
+    <string name="settings_offline">Офлайн-карти</string>
     <string name="settings_offline_hint">Завантажте область, щоб зберегти її карту та маршрути на телефоні для офлайн-використання.</string>
     <string name="settings_offline_map_area">Ділянка карти</string>
     <string name="settings_offline_download_viewport">Завантажити ділянку, яку ви переглядаєте</string>
@@ -81,7 +81,7 @@
     <string name="settings_routing_regions_hint">Дороги цілого регіону (штату чи країни), щоб маршрути працювали офлайн на всій території. Завантажте туди, куди їдете.</string>
     <string name="settings_routing_no_regions">Поки що немає доступних регіонів.</string>
     <string name="settings_clear_filter">Очистити фільтр</string>
-    <string name="settings_routing_filter_placeholder">Фільтр %1$d регіонів… (напр. Японія, Техас)</string>
+    <string name="settings_routing_filter_placeholder">Пошук</string>
     <string name="settings_routing_no_match">Жоден регіон не збігається з «%1$s».</string>
     <string name="settings_routing_downloading">Завантаження… %1$d%%</string>
     <string name="settings_routing_installed">Встановлено · маршрути тут офлайн</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -5,17 +5,17 @@
     <string name="settings_follow_system">Як у системі</string>
     <string name="settings_theme_light">Світла</string>
     <string name="settings_theme_dark">Темна</string>
-    <string name="settings_appearance_hint">Світла/темна тема застосовується лише до Vela — системна тема телефона не змінюється.</string>
+    <string name="settings_appearance_hint">Стосується лише Vela.</string>
     <string name="settings_dynamic_color">Кольори Material You</string>
-    <string name="settings_dynamic_color_hint">Забарвлює кнопки, чипи й акценти за шпалерами (Android 12+). Вимкнено = фірмовий бірюзовий Vela. Сама карта лишається нейтральною, щоб дороги й підписи зберігали контраст.</string>
+    <string name="settings_dynamic_color_hint">Забарвлює кнопки й акценти під шпалери. Карта лишається нейтральною.</string>
     <string name="settings_map_style">Стиль карти</string>
-    <string name="settings_map_style_hint">OpenFreeMap (за замовчуванням) не потребує ключа й має детальні дані. Protomaps потребує ключ API; демонстраційний стиль показує лише контури країн.</string>
+    <string name="settings_map_style_hint">OpenFreeMap працює без ключа API.</string>
     <string name="settings_units">Одиниці</string>
     <string name="settings_units_imperial">Імперські (милі, фути)</string>
     <string name="settings_units_metric">Метричні (кілометри, метри)</string>
     <string name="settings_language">Мова</string>
     <string name="settings_follow_system_language">Мова системи</string>
-    <string name="settings_language_hint">Задає мову голосових покрокових вказівок (англійська, французька, німецька, іспанська, італійська, португальська, нідерландська, російська, польська, шведська, українська) — незалежно від системної мови телефона. Виберіть відповідний голос у розділі «Бібліотека голосів» нижче. Решту тексту в застосунку буде перекладено далі.</string>
+    <string name="settings_language_hint">Змінює мову застосунку та голосових підказок. Завантажте відповідний голос у бібліотеці голосів.</string>
     <string name="settings_search">Пошук</string>
     <string name="settings_voice_search_toggle">Мікрофон голосового пошуку</string>
     <string name="settings_voice_search_hint">Показує мікрофон у рядку пошуку. Торкніться, щоб продиктувати запит через застосунок голосового введення.</string>
@@ -50,16 +50,16 @@
     <string name="settings_mode_transit">Транспорт</string>
     <string name="settings_vibrate_hint">Вібросигнали з кодуванням напрямку на кожному повороті — різні для лівого та правого — щоб рухатися маршрутом на дотик. Налаштовується для кожного режиму руху (наприклад, увімкнено для велосипеда й пішки, вимкнено за кермом).</string>
     <string name="settings_keep_screen_on">Не вимикати екран під час навігації</string>
-    <string name="settings_keep_screen_on_hint">Не дає екрану тьмяніти чи засинати, поки триває покрокова навігація, тож наступний поворот завжди видно без потреби торкатися екрана. Увімкнено за замовчуванням; екран знову засинає як завжди, щойно ви прибудете або вийдете з навігації.</string>
+    <string name="settings_keep_screen_on_hint">Не дає екрану згаснути під час навігації.</string>
     <string name="settings_map">Карта</string>
     <string name="settings_live_traffic">Шар заторів у реальному часі</string>
-    <string name="settings_live_traffic_hint">Затінює дороги за завантаженістю під час перегляду карти (безключові плитки заторів Google). Вимкнено за замовчуванням — навігація вже забарвлює ваш маршрут за трафіком, тож це лише для огляду ширшої зони. Це растровий шар, тому трохи зернистий.</string>
+    <string name="settings_live_traffic_hint">Підфарбовує дороги за заторами під час перегляду. Навігація й так розфарбовує маршрут за трафіком.</string>
     <string name="settings_transit_layer">Виділяти лінії транспорту</string>
-    <string name="settings_transit_layer_hint">Малює лінії потягів і метро на карті кольором, щоб колію було легко простежити. Використовує відкриті дані, уже вбудовані в плитки, без мережі.</string>
+    <string name="settings_transit_layer_hint">Малює на карті лінії поїздів і метро.</string>
     <string name="settings_read_all_reviews">Кнопка «Читати всі відгуки»</string>
-    <string name="settings_read_all_reviews_hint">Відгуки на картці місця завжди відображаються у власному плавному нативному списку Vela. Це додає кнопку «Читати всі відгуки», яка відкриває повну сторінку відгуків Google НА ВЕСЬ ЕКРАН — усі відгуки (не лише перші ~50), серверний пошук Google і відтворення відеовідгуків. Трекери й маячки блокуються, але сторінка Google все ж працює в застосунку. Вимкнено = лише нативний список, без сторінки Google для відгуків.</string>
+    <string name="settings_read_all_reviews_hint">Додає кнопку, що відкриває повну сторінку відгуків Google у застосунку, з усіма відгуками. Вимк. = лише власний список Vela.</string>
     <string name="settings_buildings_3d">3D-будівлі</string>
-    <string name="settings_buildings_3d_hint">Об\'ємні будівлі при сильному наближенні. Вимкнення може зробити переміщення плавнішим на старих телефонах; плоскі контури залишаються.</string>
+    <string name="settings_buildings_3d_hint">Об\'ємні будівлі при сильному наближенні. Вимкнення може зробити прокручування плавнішим на старих телефонах.</string>
     <string name="settings_show_reviews">Показувати відгуки</string>
     <string name="settings_show_reviews_hint">Вимк. = сторінки місць не показують відгуки, і Vela ніколи їх не завантажує.</string>
     <string name="settings_load_photos">Завантажувати фото</string>
@@ -101,15 +101,15 @@
     <string name="settings_export">Експорт</string>
     <string name="settings_import">Імпорт</string>
     <string name="settings_data_privacy">Джерело даних і конфіденційність</string>
-    <string name="settings_data_privacy_hint">Vela звертається до публічних вебточок Google безпосередньо з цього пристрою — без бекенду Vela, без облікового запису Google, без ключа API та без телеметрії, доки ви не ввімкнете «Діагностику» нижче (вимкнено за замовчуванням, лише локально). Кожен пристрій поводиться як браузер без входу; Google бачить вашу IP-адресу, запит і ділянку карти, але не обліковий запис. Збережені місця та історія ніколи не залишають телефон.</string>
+    <string name="settings_data_privacy_hint">Vela звертається до публічних точок Google просто з цього пристрою: без бекенда, акаунта і ключа API. Google бачить IP, запит і область карти, але не вас.</string>
     <string name="settings_privacy_button">Які дані отримує Google</string>
     <string name="settings_diagnostics">Діагностика</string>
-    <string name="settings_diagnostics_hint">Вимкнено за замовчуванням. Коли ввімкнено, Vela веде короткий локальний журнал своїх дій — ваших пошуків, маршрутів і будь-яких збоїв «потрібне перекалібрування» — тож якщо щось працює неправильно, ви можете експортувати його й передати розробнику. Він залишається на цьому телефоні й ніколи не завантажується; ви обираєте, куди зберегти експорт. Вимкнення стирає журнал.</string>
+    <string name="settings_diagnostics_hint">Типово вимкнено. Якщо ввімкнено, Vela веде короткий локальний журнал, який можна експортувати й передати розробнику. Нічого не надсилається, а вимкнення стирає його.</string>
     <string name="settings_share_diagnostics">Поділитися діагностикою</string>
     <string name="settings_diag_nothing">Поки що нічого не записано — скористайтеся застосунком, потім експортуйте.</string>
     <string name="settings_diag_export">Експортувати сеанс налагодження</string>
     <string name="settings_save_trips">Зберігати мої поїздки (для відтворення)</string>
-    <string name="settings_save_trips_hint">Записує GPS-трек кожної навігації на цьому телефоні, щоб поїздку можна було відтворити пізніше для перевірки покрокової навігації, не проїжджаючи її знову. Розкриває більше, ніж діагностика — це ваші точні маршрути — і ніколи не залишає телефон.</string>
+    <string name="settings_save_trips_hint">Записує GPS-слід кожної поїздки на цьому телефоні для відтворення пізніше. Ніколи не залишає телефон.</string>
     <string name="settings_recorded_trips_hint">Записані поїздки — натисніть «Відтворити», щоб програти одну на карті (3×):</string>
     <string name="settings_trip_points">%1$d точок</string>
     <string name="settings_trip_replay">Відтворити</string>
@@ -167,7 +167,7 @@
     <string name="place_permanently_closed">Закрито назавжди</string>
     <string name="place_temporarily_closed">Тимчасово зачинено</string>
     <string name="settings_traffic_lights">Підказки за світлофорами</string>
-    <string name="settings_traffic_lights_hint">«Проїдьте світлофор, потім поверніть» на перехрестях зі світлофорами (голос поки лише англійською)</string>
+    <string name="settings_traffic_lights_hint">Додає підказки на кшталт “проїдьте світлофор, потім ліворуч”. Поки лише англійською.</string>
     <string name="map_voice_downloading">Завантаження голосу Vela · %1$d %%</string>
     <string name="map_voice_installing">Встановлення голосу Vela…</string>
     <string name="map_region_downloading">Завантаження маршрутів: %1$s · %2$d%%</string> <!-- format -->
@@ -175,9 +175,9 @@
     <string name="mapvm_poipack_ready">Місця регіону %1$s тепер доступні для офлайн-пошуку</string> <!-- format -->
     <string name="mapvm_poipack_unavailable">Для регіону %1$s ще немає пакета місць. Він з\'явиться тут після публікації.</string> <!-- format -->
     <string name="settings_demo_drive">Симуляція поїздки (демо)</string>
-    <string name="settings_demo_drive_hint">Для демонстрацій, знімків екрана й тестів: натискання «Почати» веде маршрутом як змодельований GPS-трек замість вашого справжнього розташування — навігація працює будь-де. Вимкніть для справжньої навігації.</string>
+    <string name="settings_demo_drive_hint">Кнопка Старт проїжджає маршрут як симуляцію замість GPS. Вимкніть для справжньої навігації.</string>
     <string name="settings_sim_location">Симулювати місцезнаходження (демо)</string>
-    <string name="settings_sim_location_hint">Для демонстрацій і знімків екрана: удавайте, що ви зараз у центрі карти, щоб точка місцезнаходження, відстані та маршрути починалися звідти, а не з вашої справжньої позиції. Вимкніть для справжнього GPS.</string>
+    <string name="settings_sim_location_hint">Вдає, що ви в центрі карти, для демо та знімків. Вимкніть для справжнього GPS.</string>
     <string name="place_address_copied">Адресу скопійовано</string>
     <string name="place_copy_address">Копіювати адресу</string>
     <string name="place_directions">Маршрут</string>
@@ -310,7 +310,7 @@
     <string name="mapscreen_switch">Перемкнути</string>
     <string name="root_not_now">Не зараз</string>
     <string name="root_voice_title">Голос навігації</string>
-    <string name="root_voice_body_intro">Власний голос Vela працює повністю на телефоні: природні підказки, без облікового запису та зайвих застосунків. Рекомендовано, одноразове завантаження ~%1$d МБ.</string>
+    <string name="root_voice_body_intro">Власний голос Vela працює цілком на телефоні: природні підказки, без акаунта та зайвих застосунків. Рекомендовано, одноразове завантаження %1$d МБ.</string>
     <string name="root_voice_body_system">Не хочете? Скористайтеся голосом, який уже є на телефоні.</string>
     <string name="root_voice_body_outro">Змініть будь-коли в Налаштуваннях → Голос.</string>
     <string name="root_voice_download">Завантажити голос Vela</string>
@@ -372,7 +372,7 @@
     <string name="mapvm_export_trip_subject">Поїздка Vela: %1$s (%2$d точок)</string>
     <string name="mapvm_share_trip_chooser">Поділитися поїздкою</string>
     <string name="mapvm_voice_sample">Через чверть кілометра поверніть праворуч на вулицю Хрещатик.</string>
-    <string name="mapvm_not_enough_space">Недостатньо вільного місця для %1$s (~%2$d МБ)</string>
+    <string name="mapvm_not_enough_space">Недостатньо вільного місця для %1$s (%2$d МБ)</string>
     <string name="mapvm_voice_downloaded">%1$s завантажено</string>
     <string name="mapvm_voice_download_failed">Не вдалося завантажити %1$s</string>
     <string name="mapvm_vela_voice_removed">Голос Vela видалено</string>
@@ -412,7 +412,7 @@
     <string name="update_install">Оновити</string>
     <string name="update_download_failed">Не вдалося завантажити оновлення. Спробуйте пізніше.</string>
     <string name="settings_update_auto">Перевіряти оновлення під час запуску</string>
-    <string name="settings_update_auto_hint">Приблизно раз на день перевіряє найновіший реліз на GitHub і пропонує його, якщо він новіший за цю збірку. Встановлення відбувається через звичайний інсталятор Android. Якщо ви оновлюєтеся через Obtainium, це можна вимкнути.</string>
+    <string name="settings_update_auto_hint">Перевіряє GitHub приблизно раз на день і пропонує новіші версії. Вимкніть, якщо оновлюєтеся через Obtainium.</string>
     <string name="settings_update_check_now">Перевірити оновлення</string>
     <string name="settings_update_checking">Перевірка…</string>
     <string name="settings_update_none">У вас найновіша версія.</string>
@@ -480,7 +480,7 @@
     <string name="lists_place_count">%1$d місць</string>
     <string name="navservice_notif_eta">Прибуття %1$s</string>
     <string name="settings_advanced">Додатково</string>
-    <string name="settings_advanced_hint">Нішеві та експериментальні параметри, які більшості не потрібні.</string>
+    <string name="settings_advanced_hint">Параметри, які більшості не потрібні.</string>
     <string name="settings_developer">Розробник</string>
     <string name="settings_developer_hint">Інструменти для демо, знімків екрана та тестів. Вимикайте їх для реального використання.</string>
     <string name="settings_browse_voices">Огляд голосів</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -14,6 +14,7 @@
     <string name="settings_units_imperial">Імперські (милі, фути)</string>
     <string name="settings_units_metric">Метричні (кілометри, метри)</string>
     <string name="settings_language">Мова</string>
+    <string name="settings_follow_system_language">Мова системи</string>
     <string name="settings_language_hint">Задає мову голосових покрокових вказівок (англійська, французька, німецька, іспанська, італійська, португальська, нідерландська, російська, польська, шведська, українська) — незалежно від системної мови телефона. Виберіть відповідний голос у розділі «Бібліотека голосів» нижче. Решту тексту в застосунку буде перекладено далі.</string>
     <string name="settings_search">Пошук</string>
     <string name="settings_voice_search_toggle">Мікрофон голосового пошуку</string>
@@ -478,4 +479,10 @@
     <string name="lists_empty_hint">Поки немає списків. Натисніть «Новий» або збережіть місце з його сторінки.</string>
     <string name="lists_place_count">%1$d місць</string>
     <string name="navservice_notif_eta">Прибуття %1$s</string>
+    <string name="settings_advanced">Додатково</string>
+    <string name="settings_advanced_hint">Нішеві та експериментальні параметри, які більшості не потрібні.</string>
+    <string name="settings_developer">Розробник</string>
+    <string name="settings_developer_hint">Інструменти для демо, знімків екрана та тестів. Вимикайте їх для реального використання.</string>
+    <string name="settings_browse_voices">Огляд голосів</string>
+    <string name="settings_browse_voices_hint">Завантажуйте та перемикайте голоси Vela на пристрої.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,13 +98,13 @@
     <string name="settings_offline_hint">Download an area to keep its map and directions on your phone for offline use.</string>
     <string name="settings_offline_map_area">Map area</string>
     <string name="settings_offline_download_viewport">Download the area you\'re viewing</string>
-    <string name="settings_offline_download_viewport_hint">Saves the open tiles for the map area you last had on screen, and the routing region around it, so it renders and navigates later with no network. Search still needs a connection.</string>
+    <string name="settings_offline_download_viewport_hint">Saves the map and its roads for the area you\'re viewing, so it shows and routes offline.</string>
     <string name="settings_offline_no_areas">No areas saved yet.</string>
     <string name="settings_offline_addresses_missing">Areas you saved before this update don\'t include address data. Update them to search and route to addresses offline.</string>
     <string name="settings_offline_addresses_update">Update saved areas</string>
     <string name="settings_offline_delete_area">Delete this offline area</string>
     <string name="settings_routing_regions">Routing regions</string>
-    <string name="settings_routing_regions_hint">The road network for a whole region (state, country…), so turn-by-turn works offline anywhere inside it. Grab where you\'re travelling. Online still uses live traffic; this is the no-signal fallback.</string>
+    <string name="settings_routing_regions_hint">The roads for a whole region (a state or country) so directions work offline everywhere inside it. Grab wherever you\'re headed.</string>
     <string name="settings_routing_no_regions">No regions available yet.</string>
     <string name="settings_clear_filter">Clear filter</string>
     <string name="settings_routing_filter_placeholder">Filter %1$d regions… (e.g. Japan, Texas)</string> <!-- format -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,16 +95,16 @@
     <string name="settings_hide_external_links">Hide website &amp; external links</string>
     <string name="settings_hide_external_links_hint">On = place pages don’t show the Website, Street View, or Book / Reserve / Order buttons (no launching arbitrary external sites).</string>
     <string name="settings_offline">Offline maps</string>
-    <string name="settings_offline_hint">Download an area to keep its map and directions on your phone for offline use.</string>
-    <string name="settings_offline_map_area">Map area</string>
+    <string name="settings_offline_hint">Two ways to take Vela offline: save the area you\'re in for quick trips, or a whole state or country below for longer ones.</string>
+    <string name="settings_offline_map_area">Local area</string>
     <string name="settings_offline_download_viewport">Download the area you\'re viewing</string>
-    <string name="settings_offline_download_viewport_hint">Saves the map and its roads for the area you\'re viewing, so it shows and routes offline.</string>
+    <string name="settings_offline_download_viewport_hint">Saves the map you\'re looking at, with its roads and addresses, so this area keeps working with no signal.</string>
     <string name="settings_offline_no_areas">No areas saved yet.</string>
     <string name="settings_offline_addresses_missing">Areas you saved before this update don\'t include address data. Update them to search and route to addresses offline.</string>
     <string name="settings_offline_addresses_update">Update saved areas</string>
     <string name="settings_offline_delete_area">Delete this offline area</string>
-    <string name="settings_routing_regions">Routing regions</string>
-    <string name="settings_routing_regions_hint">The roads for a whole region (a state or country) so directions work offline everywhere inside it. Grab wherever you\'re headed.</string>
+    <string name="settings_routing_regions">States &amp; countries</string>
+    <string name="settings_routing_regions_hint">Everything needed to get around a whole state, province or country offline: its roads and places, so directions and search work anywhere inside it. Grab wherever you\'re headed.</string>
     <string name="settings_routing_no_regions">No regions available yet.</string>
     <string name="settings_clear_filter">Clear filter</string>
     <string name="settings_routing_filter_placeholder">Search</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,7 +94,7 @@
     <string name="settings_hide_adult_hint">On = hide bars, clubs, casinos, liquor stores and other adult / nightlife places from search and the map.</string>
     <string name="settings_hide_external_links">Hide website &amp; external links</string>
     <string name="settings_hide_external_links_hint">On = place pages don’t show the Website, Street View, or Book / Reserve / Order buttons (no launching arbitrary external sites).</string>
-    <string name="settings_offline">Offline</string>
+    <string name="settings_offline">Offline maps</string>
     <string name="settings_offline_hint">Download an area to keep its map and directions on your phone for offline use.</string>
     <string name="settings_offline_map_area">Map area</string>
     <string name="settings_offline_download_viewport">Download the area you\'re viewing</string>
@@ -107,7 +107,7 @@
     <string name="settings_routing_regions_hint">The roads for a whole region (a state or country) so directions work offline everywhere inside it. Grab wherever you\'re headed.</string>
     <string name="settings_routing_no_regions">No regions available yet.</string>
     <string name="settings_clear_filter">Clear filter</string>
-    <string name="settings_routing_filter_placeholder">Filter %1$d regions… (e.g. Japan, Texas)</string> <!-- format -->
+    <string name="settings_routing_filter_placeholder">Search</string>
     <string name="settings_routing_no_match">No regions match “%1$s”.</string> <!-- format -->
     <string name="settings_routing_downloading">Downloading… %1$d%%</string> <!-- format -->
     <string name="settings_routing_installed">Installed · routes offline here</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="settings_units_imperial">Imperial (miles, feet)</string>
     <string name="settings_units_metric">Metric (kilometers, meters)</string>
     <string name="settings_language">Language</string>
+    <string name="settings_follow_system_language">Follow system language</string>
     <string name="settings_language_hint">Sets the language for spoken turn-by-turn directions (English, French, German, Spanish, Italian, Portuguese, Dutch, Russian, Polish, Swedish, Ukrainian), independent of your phone\'s system language. Pick a matching voice in Voice library below. The rest of the app\'s on-screen text is being translated next.</string>
     <string name="settings_search">Search</string>
     <string name="settings_voice_search_toggle">Voice search mic</string>
@@ -501,4 +502,10 @@
     <string name="lists_empty_hint">No lists yet. Tap New to create one, or save a place from its page.</string>
     <string name="lists_place_count">%1$d places</string>
     <string name="navservice_notif_eta">Arrive %1$s</string>
+    <string name="settings_advanced">Advanced</string>
+    <string name="settings_advanced_hint">Niche and experimental options most people never need to change.</string>
+    <string name="settings_developer">Developer</string>
+    <string name="settings_developer_hint">Tools for demos, screenshots and testing. Turn each off for real use.</string>
+    <string name="settings_browse_voices">Browse voices</string>
+    <string name="settings_browse_voices_hint">Download and switch between Vela\'s on-device voices.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="settings_voice_none_hint">No voice yet. Open Voice library below to download a natural on-device voice (no account, real-time even on old phones). A system TTS engine you install will also appear here to pick.</string>
     <string name="settings_voice_test">Test voice</string>
     <string name="settings_voice_system_settings">System voice settings</string>
-    <string name="settings_voice_test_hint">Tap Test voice to hear it. The Vela voice is recommended; you can override to any installed text-to-speech engine.</string>
+    <string name="settings_voice_test_hint">Tap Test voice to hear it. The Vela Voice is recommended; you can override to any installed text-to-speech engine.</string>
     <string name="settings_voice_library">Voice library</string>
     <string name="settings_voice_advanced">Advanced voice options</string>
     <string name="settings_voice_try_label">Try the voice on any text</string>
@@ -67,8 +67,8 @@
     <string name="settings_keep_screen_on_hint">Keeps the screen awake during turn-by-turn.</string>
     <string name="settings_traffic_lights">Traffic-light guidance</string>
     <string name="settings_traffic_lights_hint">Adds cues like “pass the traffic light, then turn left” to spoken directions. English only for now.</string>
-    <string name="map_voice_downloading">Downloading Vela voice · %1$d%%</string>
-    <string name="map_voice_installing">Installing Vela voice…</string>
+    <string name="map_voice_downloading">Downloading Vela Voice · %1$d%%</string>
+    <string name="map_voice_installing">Installing Vela Voice…</string>
     <string name="map_region_downloading">Downloading %1$s routing · %2$d%%</string> <!-- format -->
     <string name="map_region_places_downloading">Saving %1$s places for offline search · %2$d%%</string> <!-- format -->
     <string name="mapvm_poipack_ready">Places in %1$s are now searchable offline</string> <!-- format -->
@@ -163,15 +163,15 @@
     <string name="settings_version_line">Vela %1$s  (build %2$d)</string> <!-- format -->
     <string name="settings_collapse">Collapse</string>
     <string name="settings_expand">Expand</string>
-    <string name="settings_voice_lib_empty_hint">Download a natural on-device voice for spoken directions. Pick one below. The ★ voices sound the most like a maps navigator (Lessac and HFC are closest to Google). One-time download; wifi recommended.</string>
-    <string name="settings_voice_lib_installed_hint">Installed: %1$d MB · %2$d voice(s). Tap Use to switch (plays a sample); the trash icon frees the space.</string> <!-- format -->
+    <string name="settings_voice_lib_empty_hint">★ marks the recommended voices. Every voice runs offline on your phone.</string>
+    <string name="settings_voice_lib_installed_hint">Installed: %1$d MB · %2$d voice(s).</string> <!-- format -->
     <string name="settings_voice_lib_lang_hint">Your app language is %1$s. Download a %2$s voice below so spoken directions match (an English voice would mispronounce %3$s street names).</string> <!-- format -->
     <string name="settings_voice_search">Search voices</string>
     <string name="settings_voice_show_more">Show %1$d more</string>
     <string name="settings_voice_show_less">Show less</string>
     <string name="settings_voice_this_voice">this voice</string>
     <string name="settings_voice_remove_title">Remove %1$s?</string> <!-- format -->
-    <string name="settings_voice_remove_body">This is your only Vela voice. Spoken directions fall back to a system text-to-speech engine (or go silent if none is installed) until you download another.</string>
+    <string name="settings_voice_remove_body">This is your only Vela Voice. Spoken directions fall back to a system text-to-speech engine (or go silent if none is installed) until you download another.</string>
     <string name="settings_voice_remove">Remove</string>
     <string name="settings_voice_gender_female">Female</string>
     <string name="settings_voice_gender_male">Male</string>
@@ -336,7 +336,7 @@
     <string name="root_voice_body_intro">Vela\'s own voice runs entirely on your phone: natural spoken directions, no account, no extra app. Recommended, a one-time %1$d MB download.</string>
     <string name="root_voice_body_system">Prefer not to? Use a voice already on your phone.</string>
     <string name="root_voice_body_outro">Change it any time in Settings → Voice.</string>
-    <string name="root_voice_download">Download Vela voice</string>
+    <string name="root_voice_download">Download Vela Voice</string>
     <string name="root_voice_use_system">Use system voice</string>
 
     <!-- nav: NavOverlays.kt -->
@@ -410,7 +410,7 @@
     <string name="mapvm_not_enough_space">Not enough free space for %1$s (%2$d MB)</string> <!-- format -->
     <string name="mapvm_voice_downloaded">%1$s downloaded</string> <!-- format -->
     <string name="mapvm_voice_download_failed">%1$s download failed</string> <!-- format -->
-    <string name="mapvm_vela_voice_removed">Vela voice removed</string>
+    <string name="mapvm_vela_voice_removed">Vela Voice removed</string>
     <string name="mapvm_opening_installer">Opening installer for %1$s…</string> <!-- format -->
     <string name="mapvm_pan_to_area_first">Open the map and pan to an area first</string>
     <string name="mapvm_offline_routing_ready">Offline routing ready: %1$s</string> <!-- format -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,7 +95,7 @@
     <string name="settings_hide_external_links">Hide website &amp; external links</string>
     <string name="settings_hide_external_links_hint">On = place pages don’t show the Website, Street View, or Book / Reserve / Order buttons (no launching arbitrary external sites).</string>
     <string name="settings_offline">Offline</string>
-    <string name="settings_offline_hint">Using the map without signal takes two things: the map TILES you see, and the ROAD NETWORK that routes you. Saving a map area grabs both for that spot; the region list below adds the road network for anywhere you\'re travelling.</string>
+    <string name="settings_offline_hint">Download an area to keep its map and directions on your phone for offline use.</string>
     <string name="settings_offline_map_area">Map area</string>
     <string name="settings_offline_download_viewport">Download the area you\'re viewing</string>
     <string name="settings_offline_download_viewport_hint">Saves the open tiles for the map area you last had on screen, and the routing region around it, so it renders and navigates later with no network. Search still needs a connection.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,17 +19,17 @@
     <string name="settings_follow_system">Follow system</string>
     <string name="settings_theme_light">Light</string>
     <string name="settings_theme_dark">Dark</string>
-    <string name="settings_appearance_hint">Light/Dark applies to Vela only. It won\'t touch your phone\'s system theme.</string>
-    <string name="settings_dynamic_color">Material You colours</string>
-    <string name="settings_dynamic_color_hint">Tints buttons, chips and accents from your wallpaper (Android 12+). Off = Vela\'s own teal. The map itself stays neutral so roads and labels keep their contrast.</string>
+    <string name="settings_appearance_hint">Applies to Vela only.</string>
+    <string name="settings_dynamic_color">Material You colors</string>
+    <string name="settings_dynamic_color_hint">Tints buttons and accents from your wallpaper. The map stays neutral.</string>
     <string name="settings_map_style">Map style</string>
-    <string name="settings_map_style_hint">OpenFreeMap (the default) is keyless and detailed. Protomaps needs an API key; the demo style is country outlines only.</string>
+    <string name="settings_map_style_hint">OpenFreeMap works without any API key.</string>
     <string name="settings_units">Units</string>
     <string name="settings_units_imperial">Imperial (miles, feet)</string>
     <string name="settings_units_metric">Metric (kilometers, meters)</string>
     <string name="settings_language">Language</string>
     <string name="settings_follow_system_language">Follow system language</string>
-    <string name="settings_language_hint">Sets the language for spoken turn-by-turn directions (English, French, German, Spanish, Italian, Portuguese, Dutch, Russian, Polish, Swedish, Ukrainian), independent of your phone\'s system language. Pick a matching voice in Voice library below. The rest of the app\'s on-screen text is being translated next.</string>
+    <string name="settings_language_hint">Changes the app\'s language and the spoken directions. Grab a matching voice in the Voice library.</string>
     <string name="settings_search">Search</string>
     <string name="settings_voice_search_toggle">Voice search mic</string>
     <string name="settings_voice_search_hint">Shows a mic in the search bar. Tap it to speak your search, using a voice-input app on your phone.</string>
@@ -64,9 +64,9 @@
     <string name="settings_mode_transit">Transit</string>
     <string name="settings_vibrate_hint">Direction-coded buzzes at each turn, distinct for left vs right, so you can follow a route by feel. Set it per travel mode (e.g. on for cycling and walking, off while driving).</string>
     <string name="settings_keep_screen_on">Keep screen on while navigating</string>
-    <string name="settings_keep_screen_on_hint">Stops the display from dimming or sleeping while turn-by-turn is running, so the next turn is always visible without tapping to wake it. On by default; the screen sleeps normally again the moment you arrive or leave navigation.</string>
+    <string name="settings_keep_screen_on_hint">Keeps the screen awake during turn-by-turn.</string>
     <string name="settings_traffic_lights">Traffic-light guidance</string>
-    <string name="settings_traffic_lights_hint">Adds Google-style landmark cues to spoken directions (\"pass the traffic light, then turn left\") using open OpenStreetMap signal data (keyless), fetched once when you start a drive. Only added when it helps (one or two lights right before a surface-street turn). Off by default; English only for now, and coverage follows how well signals are mapped in your area.</string>
+    <string name="settings_traffic_lights_hint">Adds cues like “pass the traffic light, then turn left” to spoken directions. English only for now.</string>
     <string name="map_voice_downloading">Downloading Vela voice · %1$d%%</string>
     <string name="map_voice_installing">Installing Vela voice…</string>
     <string name="map_region_downloading">Downloading %1$s routing · %2$d%%</string> <!-- format -->
@@ -74,18 +74,18 @@
     <string name="mapvm_poipack_ready">Places in %1$s are now searchable offline</string> <!-- format -->
     <string name="mapvm_poipack_unavailable">No place pack for %1$s yet. It\'ll appear here once it\'s published.</string> <!-- format -->
     <string name="settings_demo_drive">Simulate driving (demo)</string>
-    <string name="settings_demo_drive_hint">For demos, screenshots and testing: tapping Start drives the planned route as a simulated GPS trace instead of using your real location, so navigation works anywhere. Turn off to navigate for real.</string>
+    <string name="settings_demo_drive_hint">Start drives the planned route as a simulation instead of using GPS. Turn off to navigate for real.</string>
     <string name="settings_sim_location">Simulate my location (demo)</string>
-    <string name="settings_sim_location_hint">For demos and screenshots: pretend you\'re at the centre of the map right now, so the location dot, distances and directions all start from there instead of your real position. Turn off to use real GPS.</string>
+    <string name="settings_sim_location_hint">Pretends you\'re at the map\'s center, for demos and screenshots. Turn off to use real GPS.</string>
     <string name="settings_map">Map</string>
     <string name="settings_live_traffic">Live traffic overlay</string>
-    <string name="settings_live_traffic_hint">Shades roads by congestion while browsing the map (Google\'s keyless traffic tiles). Off by default. Navigation already colours your route by traffic, so this is just for scanning the wider area. It\'s a raster overlay, so it\'s a touch grainy.</string>
+    <string name="settings_live_traffic_hint">Shades roads by congestion while browsing. Navigation already colors your route by traffic.</string>
     <string name="settings_transit_layer">Highlight transit lines</string>
-    <string name="settings_transit_layer_hint">Draws train and subway lines on the map in colour, so rail is easy to follow. Uses the open map data already in the tiles, no network.</string>
+    <string name="settings_transit_layer_hint">Draws train and subway lines on the map.</string>
     <string name="settings_read_all_reviews">“Read all reviews” button</string>
-    <string name="settings_read_all_reviews_hint">Reviews in the place sheet are always Vela\'s own smooth native list. This adds a “Read all reviews” button that opens Google\'s full reviews page FULL-SCREEN, with every review (not just the first ~50), Google\'s server-side search, and video reviews that play. Trackers/beacons are blocked, but it does run Google\'s page inside the app. Off = native list only, no Google page for reviews.</string>
+    <string name="settings_read_all_reviews_hint">Adds a “Read all reviews” button that opens Google\'s full reviews page inside the app, with every review. Off = Vela\'s own review list only.</string>
     <string name="settings_buildings_3d">3D buildings</string>
-    <string name="settings_buildings_3d_hint">Raised building shapes when zoomed right in. Turning this off can make panning smoother on older phones; the flat footprints stay either way.</string>
+    <string name="settings_buildings_3d_hint">Raised buildings at close zoom. Turning this off can make panning smoother on older phones.</string>
     <string name="settings_show_reviews">Show reviews</string>
     <string name="settings_show_reviews_hint">Off = place pages show no reviews, and Vela never fetches them.</string>
     <string name="settings_load_photos">Load photos</string>
@@ -127,15 +127,15 @@
     <string name="settings_export">Export</string>
     <string name="settings_import">Import</string>
     <string name="settings_data_privacy">Data source &amp; privacy</string>
-    <string name="settings_data_privacy_hint">Vela talks to Google\'s public web endpoints directly from this device. No Vela backend, no Google account, no API key, and no telemetry unless you turn on Diagnostics below (off by default, local-only). Each device behaves like a logged-out browser; Google sees your IP, query and map area but not an account. Saved places and history never leave the phone.</string>
+    <string name="settings_data_privacy_hint">Vela talks to Google\'s public endpoints straight from this device: no backend, no account, no API key. Google sees your IP, query and map area, not who you are.</string>
     <string name="settings_privacy_button">What data Google receives</string>
     <string name="settings_diagnostics">Diagnostics</string>
-    <string name="settings_diagnostics_hint">Off by default. When on, Vela keeps a short local log of what it did (your searches, routes, and any “needs recalibration” hiccups) so if something misbehaves you can export it and hand it to a developer. It stays on this phone and is never uploaded; you pick where the export goes. Turning it off wipes the log.</string>
+    <string name="settings_diagnostics_hint">Off by default. When on, Vela keeps a short local log you can export and hand to a developer. Nothing is uploaded, and turning it off wipes the log.</string>
     <string name="settings_share_diagnostics">Share diagnostics</string>
     <string name="settings_diag_nothing">Nothing recorded yet. Use the app, then export.</string>
     <string name="settings_diag_export">Export debug session</string>
     <string name="settings_save_trips">Save my trips (for replay)</string>
-    <string name="settings_save_trips_hint">Records each navigation\'s GPS trace on this phone so a drive can be replayed later to test turn-by-turn without driving it again. More revealing than diagnostics (it\'s your exact routes) and never leaves the phone.</string>
+    <string name="settings_save_trips_hint">Records each drive\'s GPS trace on this phone, so it can be replayed later. Never leaves the phone.</string>
     <string name="settings_recorded_trips_hint">Recorded trips. Tap Replay to play one back on the map (3×):</string>
     <string name="settings_trip_points">%1$d points</string> <!-- format -->
     <string name="settings_trip_replay">Replay</string>
@@ -333,7 +333,7 @@
     <!-- root: VelaRoot.kt -->
     <string name="root_not_now">Not now</string>
     <string name="root_voice_title">Spoken navigation voice</string>
-    <string name="root_voice_body_intro">Vela\'s own voice runs entirely on your phone: natural spoken directions, no account, no extra app. Recommended, a one-time ~%1$d MB download.</string>
+    <string name="root_voice_body_intro">Vela\'s own voice runs entirely on your phone: natural spoken directions, no account, no extra app. Recommended, a one-time %1$d MB download.</string>
     <string name="root_voice_body_system">Prefer not to? Use a voice already on your phone.</string>
     <string name="root_voice_body_outro">Change it any time in Settings → Voice.</string>
     <string name="root_voice_download">Download Vela voice</string>
@@ -407,7 +407,7 @@
     <string name="mapvm_export_trip_subject">Vela trip: %1$s (%2$d points)</string> <!-- format -->
     <string name="mapvm_share_trip_chooser">Share trip</string>
     <string name="mapvm_voice_sample">In a quarter mile, turn right onto Main Street.</string>
-    <string name="mapvm_not_enough_space">Not enough free space for %1$s (~%2$d MB)</string> <!-- format -->
+    <string name="mapvm_not_enough_space">Not enough free space for %1$s (%2$d MB)</string> <!-- format -->
     <string name="mapvm_voice_downloaded">%1$s downloaded</string> <!-- format -->
     <string name="mapvm_voice_download_failed">%1$s download failed</string> <!-- format -->
     <string name="mapvm_vela_voice_removed">Vela voice removed</string>
@@ -435,7 +435,7 @@
     <string name="update_install">Update</string>
     <string name="update_download_failed">Update download failed. Try again later.</string>
     <string name="settings_update_auto">Check for updates on launch</string>
-    <string name="settings_update_auto_hint">Looks at the newest GitHub release about once a day and offers it when it is newer than this build. The update installs through Android\'s normal installer. If you already update through Obtainium you can turn this off.</string>
+    <string name="settings_update_auto_hint">Checks GitHub about once a day and offers newer releases. Turn off if you update through Obtainium.</string>
     <string name="settings_update_check_now">Check for updates</string>
     <string name="settings_update_checking">Checking…</string>
     <string name="settings_update_none">You\'re on the latest version.</string>
@@ -503,7 +503,7 @@
     <string name="lists_place_count">%1$d places</string>
     <string name="navservice_notif_eta">Arrive %1$s</string>
     <string name="settings_advanced">Advanced</string>
-    <string name="settings_advanced_hint">Niche and experimental options most people never need to change.</string>
+    <string name="settings_advanced_hint">Options most people never need.</string>
     <string name="settings_developer">Developer</string>
     <string name="settings_developer_hint">Tools for demos, screenshots and testing. Turn each off for real use.</string>
     <string name="settings_browse_voices">Browse voices</string>


### PR DESCRIPTION
Shortens the Settings page and gives it two collapsed buckets for the rarely-touched toggles.

**Stacked on #23** (base branch is `onboarding-declutter`). Retarget to `main` after #23 merges.

**Two collapsible groups at the bottom** hold the toggles most people never change, moved out of their old sections:
- **Advanced** — 3D buildings, hide adult categories, hide website & external links, traffic-light guidance.
- **Developer** — simulate driving, simulate location, save trips. These are the demo/screenshot/testing tools; each says "turn off for real use," so they no longer clutter Navigation and Diagnostics.

**Offline moved up** to right after the Map section, since it's reached often (was buried below Voice).

**Language is a "Follow system language" switch** now. On by default with no picker shown; turn it off and the 11-language list appears (seeded to the language closest to your device locale so it opens on a real choice). Most people never see the list.

**The voice library is a dedicated screen** reached by a "Browse voices" button in the Voice section, instead of a long accordion unrolling inline on the Settings scroll. Its own Back returns to Settings. An in-flight voice download still shows its progress line in the Voice section with the browser closed.

**D-pad:** every new collapsible header is a focusable row with the standard ring; the Browse-voices screen opens focused on its back button; all the moved toggles keep the `ToggleRow` single-focus-stop pattern. Static D-pad audit is clean for the touched file.

**Testing:** compiles; device-verified on a Pixel 4a 5G — walked the whole page top to bottom. Confirmed the new order (Appearance → Map style → Units → Language → Search → Map → Offline → Place pages → Navigation → Voice → Saved → Lists → Data & privacy → Diagnostics → Advanced → Developer → About), that Advanced and Developer expand with exactly the moved toggles (state preserved, e.g. 3D buildings stayed on), that the language switch reveals/hides the picker, and that Browse voices opens the dedicated screen and Back returns to Settings. New section/label strings translated across all 11 languages.
