### PR TITLE
On-device voice search (Whisper), no third-party app needed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,6 +466,14 @@ Defaults that make the safe path the easy one:
   kept (it's still the reusable pre-permission screen the **PR3 voice-search mic** uses at
   point-of-use for RECORD_AUDIO) - it's just no longer used for location. Don't re-request location
   straight from the map.
+- **Vague fixes draw an ACCURACY HALO (2026-07-10).** `MapUiState.myAccuracyM` carries the live
+  fix's reported accuracy (null for sim/unknown); `applyData` draws a translucent meter-true disc
+  (`ACCURACY_LAYER`, a 64-point polygon from `accuracyCircle`, fill #4285F4 at 0.12) under the dot
+  when accuracy > `ACCURACY_HALO_MIN_M` (100 m) and NOT navigating - so an approximate-only
+  permission or a weak network fix reads as "somewhere in this blob" instead of a falsely precise
+  dot, and ordinary GPS (3-30 m) stays a plain dot. Identity-gated like the other applyData uploads.
+  Render verified on-device via a temporary forced-1500 m build (a real coarse fix is
+  interval-throttled by Android, too slow to wait out in a test loop).
 - **Onboarding is deliberately SHORT - three steps, no more (declutter 2026-07-10).** Welcome →
   location → voice, then the map. The old **offline-maps** onboarding prompt and the **diagnostics/
   trip-recording** onboarding prompt were CUT (they made a long wall of asks a first-run user has no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,8 +442,17 @@ Defaults that make the safe path the easy one:
   Done - VelaDialog D-pad pattern). Settings -> Search has the download/remove + the engine picker
   (shown only when BOTH model and a provider exist). R8 keeps `com.k2fsa.sherpa.onnx.**` (already for
   Piper). Verified: download+install, mic appears, POU permission, VAD auto-stop, transcript -> query;
-  Auto uses on-device, "Other voice app" launches the provider. Accuracy of tiny-int8 is the known
-  tradeoff for size/speed; a larger model could be a future catalog entry.
+  Auto uses on-device, "Other voice app" launches the provider. **User-facing name is "Vela voice"**
+  (2026-07-10): the model row, hint and picker all say Vela voice, and the picker is TWO options
+  (Vela voice = AUTO, Other voice app = SYSTEM) - the explicit local-only third choice was dropped as
+  jargon (Engine.LOCAL still exists, just not offered). **Whisper is PINNED to the app language**
+  (`whisperLang()` = `AppLocale.effective().language` when in SUPPORTED, else auto; recognizer
+  rebuilds if the language changes) - auto-detect transcribed a noisy far-field capture into
+  CYRILLIC, don't revert to `language = ""`. **Transcripts are cleaned** (`cleanTranscript`): Whisper
+  writes prose ("Coffee shops near me.") so terminal ./!/?/,/;/: and wrapping quotes are stripped;
+  inner periods stay (St. Paul). The listening pulse uses tween(90) + 1.4x ring travel + a 7x RMS
+  gain - the default spring smoothed the ~32 ms level updates into near-stillness. Accuracy of
+  tiny-int8 is the known tradeoff for size/speed; a larger model could be a future catalog entry.
 - **Location is requested in onboarding, NOT on map load (2026-07-10).** `MapScreen`'s
   `LaunchedEffect` only STARTS location when it's already granted; it no longer fires the raw
   system dialog. The first ask lives in `VelaRoot`: when onboarding reaches the location step

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,6 +466,17 @@ Defaults that make the safe path the easy one:
   kept (it's still the reusable pre-permission screen the **PR3 voice-search mic** uses at
   point-of-use for RECORD_AUDIO) - it's just no longer used for location. Don't re-request location
   straight from the map.
+- **Location-permission UX gates (2026-07-10).** Turn-by-turn REQUIRES precise location (coarse
+  fixes are ~2 km; the nav fix discipline correctly refuses non-GPS and >50 m fixes, so nav on
+  coarse sat at "Searching for GPS" forever with no explanation). `onStartNav` in MapScreen now
+  gates on FINE: without it (and demo-drive off - `vm.demoDriveOn()` skips the gate since demo
+  simulates), a VelaDialog explains and "Allow precise" fires the FINE+COARSE request, which Android
+  renders as its approximate-to-precise UPGRADE dialog; on grant it starts location + continues
+  through the notification gate into nav. Declining the upgrade toasts `nav_precise_toast`. The
+  locate FAB's re-request now also handles the DEAD-BUTTON case: a fully-denied result (including
+  Android's instant deny after "don't ask again") opens a dialog with an Open-settings deep link
+  (ACTION_APPLICATION_DETAILS_SETTINGS). Device-verified end to end: Start on coarse -> gate ->
+  upgrade dialog -> precise -> notification permission -> nav running.
 - **Vague fixes draw an ACCURACY HALO (2026-07-10).** `MapUiState.myAccuracyM` carries the live
   fix's reported accuracy (null for sim/unknown); `applyData` draws a translucent meter-true disc
   (`ACCURACY_LAYER`, a 64-point polygon from `accuracyCircle`, fill #4285F4 at 0.22 + a 1.5 px edge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,7 +424,26 @@ Defaults that make the safe path the easy one:
   does - confirmed in its manifest). Keyboard/IME voice (Sayboard, FUTO Keyboard) provides a
   RecognitionService or in-IME mic, NOT the activity, so `queryIntentActivities` returns empty and
   the mic correctly hides - Vela can't `startActivityForResult` to them. That's intended: those
-  users use the keyboard mic, and tier-1 (PR3, on-device Whisper) will serve everyone regardless.
+  users use the keyboard mic, and tier-1 (on-device Whisper) serves everyone regardless.
+- **Voice search TIER-1 is on-device Whisper, in-process (2026-07-10, device-verified end to end).**
+  The second path: Vela's own model records + transcribes on the phone, no other app. `WhisperRecognizer`
+  (`:app/voice`) loads **Whisper tiny int8 multilingual + Silero VAD** through the bundled sherpa-onnx
+  runtime (same AAR as Piper TTS - `OfflineRecognizer(config=...)` with `assetManager` defaulting null
+  = filesystem load; VAD via `Vad(config=...)`), records with `AudioRecord` (VOICE_RECOGNITION, 16 kHz
+  mono), feeds the VAD in 512-sample windows, and transcribes the detected speech segment. `AsrModel`
+  (`:app/voice`) is the descriptor + install check (`filesDir/asr/whisper-tiny/`, 4 files present =
+  installed). The **~47 MB model is a download-on-demand from the `asr-models` release** (built by
+  `tools/build-asr-model.sh` = slim the upstream sherpa whisper-tiny to int8 + silero, tar.bz2;
+  reuses `KokoroInstaller.download` + its no-call-timeout client). RECORD_AUDIO is asked **at point
+  of use** (first mic tap), never for tier-2. `VoiceSearch.resolvedMode(context)` picks LOCAL / SYSTEM
+  / NONE from the `voice_search_engine` pref (AUTO=on-device-wins / LOCAL / SYSTEM) x availability;
+  MapScreen mirrors it reactively (keyed on `state.asrInstalled` so a fresh download flips the mic
+  without relaunch). The capture UI is `VoiceCaptureDialog` (listening sheet, level ring, auto-focus
+  Done - VelaDialog D-pad pattern). Settings -> Search has the download/remove + the engine picker
+  (shown only when BOTH model and a provider exist). R8 keeps `com.k2fsa.sherpa.onnx.**` (already for
+  Piper). Verified: download+install, mic appears, POU permission, VAD auto-stop, transcript -> query;
+  Auto uses on-device, "Other voice app" launches the provider. Accuracy of tiny-int8 is the known
+  tradeoff for size/speed; a larger model could be a future catalog entry.
 - **Location is requested in onboarding, NOT on map load (2026-07-10).** `MapScreen`'s
   `LaunchedEffect` only STARTS location when it's already granted; it no longer fires the raw
   system dialog. The first ask lives in `VelaRoot`: when onboarding reaches the location step

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -468,8 +468,13 @@ Defaults that make the safe path the easy one:
   straight from the map.
 - **Vague fixes draw an ACCURACY HALO (2026-07-10).** `MapUiState.myAccuracyM` carries the live
   fix's reported accuracy (null for sim/unknown); `applyData` draws a translucent meter-true disc
-  (`ACCURACY_LAYER`, a 64-point polygon from `accuracyCircle`, fill #4285F4 at 0.12) under the dot
-  when accuracy > `ACCURACY_HALO_MIN_M` (100 m) and NOT navigating - so an approximate-only
+  (`ACCURACY_LAYER`, a 64-point polygon from `accuracyCircle`, fill #4285F4 at 0.22 + a 1.5 px edge
+  LineLayer - 0.12-0.15 vanished into the dark basemap's own blue) under the dot
+  when accuracy > `ACCURACY_HALO_MIN_M` (100 m) and NOT navigating. With a COARSE-ONLY permission
+  MapScreen falls back to 2000 m when the fix hasn't reported accuracy yet (Android hands coarse
+  apps a fix only every few minutes), and the recenter tap ZOOM-FITS the circle (at street zoom a
+  2 km halo covers the whole screen as an invisible uniform wash; the blob only reads when its edge
+  is on screen) - so an approximate-only
   permission or a weak network fix reads as "somewhere in this blob" instead of a falsely precise
   dot, and ordinary GPS (3-30 m) stays a plain dot. Identity-gated like the other applyData uploads.
   Render verified on-device via a temporary forced-1500 m build (a real coarse fix is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,7 +451,7 @@ Defaults that make the safe path the easy one:
   CYRILLIC, don't revert to `language = ""`. **Transcripts are cleaned** (`cleanTranscript`): Whisper
   writes prose ("Coffee shops near me.") so terminal ./!/?/,/;/: and wrapping quotes are stripped;
   inner periods stay (St. Paul). The listening pulse uses tween(90) + 1.4x ring travel + a 7x RMS
-  gain - the default spring smoothed the ~32 ms level updates into near-stillness. Accuracy of
+  gain - the default spring smoothed the ~32 ms level updates into near-stillness. **The mic always shows when the toggle is on** (2026-07-10): with neither the model nor a provider, tapping it OFFERS the Vela voice download (VelaDialog in MapScreen -> `downloadAsrModel()`, the map shows the same VoiceDownloadCard) - a hidden mic made the feature undiscoverable. **The archive is tar.GZIP on `asr-models`** (58 MB vs 47 bz2): bzip2 unpacked at ~15 MB/s on-device (a ~30 s hang); gzip installs in ~2 s. `KokoroInstaller.extractTar` picks the decompressor by magic bytes (upstream Piper voices are still bz2). Accuracy of
   tiny-int8 is the known tradeoff for size/speed; a larger model could be a future catalog entry.
 - **Location is requested in onboarding, NOT on map load (2026-07-10).** `MapScreen`'s
   `LaunchedEffect` only STARTS location when it's already granted; it no longer fires the raw

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -187,6 +187,15 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   and Settings says why. Keyboard-only dictation (Sayboard, FUTO Keyboard) doesn't trigger it since
   apps can't invoke a keyboard's mic; those users keep using the keyboard mic, and a later build
   adds an on-device model so voice search works with no third-party app at all.
+- ✅ **On-device voice search (2026-07-10).** Voice search now works with **no other app at all**:
+  download Vela's own ~47 MB speech model (Settings -> Search) and tapping the mic records and
+  transcribes **entirely on your phone** with a bundled Whisper model, then runs the text as a
+  search. Nothing is uploaded, no account, and it covers all 11 of Vela's languages. A listening
+  sheet shows the mic pulsing with your voice; it stops on its own after a beat of silence (or tap
+  Done), and the microphone permission is asked only the first time you tap the mic. When both the
+  on-device model and a voice-input app are present, a Settings picker chooses which to use (on-device
+  by default). Device-verified end to end: download, install, the mic appears, the permission prompt,
+  the listening sheet, and the model transcribing back into the search box.
 - ✅ **Location asked at "Get started", not on the map (2026-07-10).** The location permission used
   to pop the instant the map first loaded, out of nowhere. It now fires as soon as you tap Get
   started on the welcome screen: the welcome screen already says what Vela is, so a maps app asking

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -195,6 +195,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   Done), and the microphone permission is asked only the first time you tap the mic. When both Vela voice and a
   voice-input app are present, a Settings picker chooses which to use (Vela voice by default). Device-verified end to end: download, install, the mic appears, the permission prompt,
   the listening sheet, and the model transcribing back into the search box.
+- ✅ **Navigation asks for precise location instead of failing silently (2026-07-10).** Turn-by-turn
+  needs GPS, and with approximate-only permission it used to start and sit at "Searching for GPS"
+  forever. Tapping Start now explains it plainly and offers to allow precise location; Android shows
+  its own upgrade choice and navigation begins as soon as it's granted. And if location is fully
+  denied, the locate button explains itself and links to system settings instead of doing nothing.
 - ✅ **Approximate location shows honestly (2026-07-10).** If you grant only approximate location
   (or the fix is just weak), the map now draws a soft translucent circle around the dot at the fix's
   real uncertainty radius, so "somewhere in this area" looks like what it is instead of a

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -195,6 +195,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   Done), and the microphone permission is asked only the first time you tap the mic. When both Vela voice and a
   voice-input app are present, a Settings picker chooses which to use (Vela voice by default). Device-verified end to end: download, install, the mic appears, the permission prompt,
   the listening sheet, and the model transcribing back into the search box.
+- ✅ **Approximate location shows honestly (2026-07-10).** If you grant only approximate location
+  (or the fix is just weak), the map now draws a soft translucent circle around the dot at the fix's
+  real uncertainty radius, so "somewhere in this area" looks like what it is instead of a
+  falsely precise point. Normal GPS keeps the plain dot, and the circle never shows during
+  navigation.
 - ✅ **Location asked at "Get started", not on the map (2026-07-10).** The location permission used
   to pop the instant the map first loaded, out of nowhere. It now fires as soon as you tap Get
   started on the welcome screen: the welcome screen already says what Vela is, so a maps app asking

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -188,13 +188,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   apps can't invoke a keyboard's mic; those users keep using the keyboard mic, and a later build
   adds an on-device model so voice search works with no third-party app at all.
 - ✅ **On-device voice search (2026-07-10).** Voice search now works with **no other app at all**:
-  download Vela's own ~47 MB speech model (Settings -> Search) and tapping the mic records and
+  the mic is always in the search bar, and with nothing installed tapping it offers the one-time 58 MB Vela voice download. Once it's there, tapping the mic records and
   transcribes **entirely on your phone** with a bundled Whisper model, then runs the text as a
   search. Nothing is uploaded, no account, and it covers all 11 of Vela's languages. A listening
   sheet shows the mic pulsing with your voice; it stops on its own after a beat of silence (or tap
-  Done), and the microphone permission is asked only the first time you tap the mic. When both the
-  on-device model and a voice-input app are present, a Settings picker chooses which to use (on-device
-  by default). Device-verified end to end: download, install, the mic appears, the permission prompt,
+  Done), and the microphone permission is asked only the first time you tap the mic. When both Vela voice and a
+  voice-input app are present, a Settings picker chooses which to use (Vela voice by default). Device-verified end to end: download, install, the mic appears, the permission prompt,
   the listening sheet, and the model transcribing back into the search box.
 - ✅ **Location asked at "Get started", not on the map (2026-07-10).** The location permission used
   to pop the instant the map first loaded, out of nowhere. It now fires as soon as you tap Get

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -89,6 +89,24 @@ app makes network requests only to the services in the table above, only when a 
 needs them. It's GPLv3 - you can read every request the code makes in
 [`core/data/google`](core/src/main/java/app/vela/core/data/google) and [`SPEC.md`](SPEC.md).
 
+## Voice search (optional)
+
+The search-bar mic turns speech into a query one of two ways, both privacy-preserving:
+
+- **On your phone (Vela's own model).** If you download the ~47 MB speech model
+  (Settings -> Search), tapping the mic records into Vela and transcribes **entirely on
+  the device** with a bundled Whisper model. The audio is never written to disk and never
+  leaves the phone; there is no account and no network request for the transcription. Vela
+  asks for the microphone permission only the first time you tap the mic.
+- **Another voice app.** If instead you use an installed voice-input app (for example FUTO
+  Voice Input), tapping the mic hands off to that app through Android's standard
+  speech-recognition intent. **That app records the audio, not Vela** - Vela sends it
+  nothing and only gets the recognized text back to drop into the search box, so it needs
+  no microphone permission for this path.
+
+The mic only appears when one of these is available, and the whole feature can be turned
+off in Settings -> Search.
+
 ## Diagnostics (opt-in, off by default)
 
 Settings → **Diagnostics** has one switch, **off by default**. When you turn it on, Vela

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,9 @@
 
     <!-- Haptic turn cues during navigation (normal permission, auto-granted). -->
     <uses-permission android:name="android.permission.VIBRATE" />
+    <!-- Voice search, tier-1 ONLY: recording the mic for the on-device Whisper model. Requested
+         at point of use, and never needed for tier-2 (the RECOGNIZE_SPEECH provider records). -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <!-- Android Auto: navigation-category templates + drawing the map onto the
          car screen's surface. Both are car-library permissions, not runtime ones. -->

--- a/app/src/main/java/app/vela/ui/VoiceCaptureDialog.kt
+++ b/app/src/main/java/app/vela/ui/VoiceCaptureDialog.kt
@@ -1,0 +1,132 @@
+package app.vela.ui
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import app.vela.R
+
+/**
+ * The listening sheet for on-device voice search (tier-1): a mic that pulses with your voice while
+ * Vela's own model records + transcribes on the phone. Back or tapping outside cancels; **Done**
+ * stops early and searches whatever was heard (the VAD also auto-stops after a beat of silence).
+ *
+ * D-pad-first (docs/dpad.md): a raw [Dialog] with a directly-`.focusable()` Done button that
+ * auto-focuses (the VelaDialog pattern), so OK activates it with no wasted "enter the dialog" press.
+ */
+@Composable
+fun VoiceCaptureDialog(
+    level: Float,
+    listening: Boolean,
+    onDone: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Dialog(onDismissRequest = onCancel) {
+        Surface(
+            shape = RoundedCornerShape(28.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            tonalElevation = 6.dp,
+        ) {
+            Column(
+                Modifier.padding(28.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // A soft ring that swells with loudness (0..1), so you can see it's hearing you.
+                val ring by animateFloatAsState(1f + level.coerceIn(0f, 1f) * 0.9f, label = "voiceLevel")
+                Box(contentAlignment = Alignment.Center) {
+                    Box(
+                        Modifier
+                            .size(84.dp)
+                            .scale(if (listening) ring else 1f)
+                            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.16f), CircleShape),
+                    )
+                    Box(
+                        Modifier.size(60.dp).background(MaterialTheme.colorScheme.primary, CircleShape),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            Icons.Default.Mic,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    }
+                }
+                Spacer(Modifier.height(20.dp))
+                Text(
+                    stringResource(if (listening) R.string.voice_capture_listening else R.string.voice_capture_starting),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(24.dp))
+                DoneButton(onDone)
+            }
+        }
+    }
+}
+
+/** A filled pill "Done" that auto-focuses in the raw Dialog (the VelaDialog DialogButton pattern). */
+@Composable
+private fun DoneButton(onClick: () -> Unit) {
+    val fr = remember { FocusRequester() }
+    val dpadFirst = rememberDpadFirstDevice()
+    LaunchedEffect(dpadFirst) {
+        if (dpadFirst) repeat(30) {
+            if (runCatching { fr.requestFocus() }.isSuccess) return@LaunchedEffect
+            kotlinx.coroutines.delay(50)
+        }
+    }
+    Text(
+        stringResource(R.string.voice_capture_done),
+        color = MaterialTheme.colorScheme.onPrimary,
+        style = MaterialTheme.typography.labelLarge,
+        modifier = Modifier
+            .focusRequester(fr)
+            .dpadHighlight(CircleShape)
+            .background(MaterialTheme.colorScheme.primary, CircleShape)
+            .onKeyEvent { ev ->
+                if ((ev.key == Key.DirectionCenter || ev.key == Key.Enter) && ev.type == KeyEventType.KeyUp) {
+                    onClick(); true
+                } else {
+                    false
+                }
+            }
+            .focusable()
+            .pointerInput(Unit) { detectTapGestures { onClick() } }
+            .padding(horizontal = 28.dp, vertical = 10.dp),
+    )
+}

--- a/app/src/main/java/app/vela/ui/VoiceCaptureDialog.kt
+++ b/app/src/main/java/app/vela/ui/VoiceCaptureDialog.kt
@@ -1,6 +1,7 @@
 package app.vela.ui
 
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -65,17 +66,28 @@ fun VoiceCaptureDialog(
                 Modifier.padding(28.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                // A soft ring that swells with loudness (0..1), so you can see it's hearing you.
-                val ring by animateFloatAsState(1f + level.coerceIn(0f, 1f) * 0.9f, label = "voiceLevel")
+                // A ring that swells with loudness (0..1), so you can see it's hearing you. Short
+                // tween instead of the default spring: the level updates every ~32 ms and a spring
+                // smoothed the pulse into near-stillness; 1.4x travel so speech visibly moves it.
+                val ring by animateFloatAsState(
+                    1f + level.coerceIn(0f, 1f) * 1.4f,
+                    animationSpec = tween(90),
+                    label = "voiceLevel",
+                )
+                val pulse by animateFloatAsState(
+                    1f + level.coerceIn(0f, 1f) * 0.15f,
+                    animationSpec = tween(90),
+                    label = "voicePulse",
+                )
                 Box(contentAlignment = Alignment.Center) {
                     Box(
                         Modifier
                             .size(84.dp)
                             .scale(if (listening) ring else 1f)
-                            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.16f), CircleShape),
+                            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.20f), CircleShape),
                     )
                     Box(
-                        Modifier.size(60.dp).background(MaterialTheme.colorScheme.primary, CircleShape),
+                        Modifier.size(60.dp).scale(if (listening) pulse else 1f).background(MaterialTheme.colorScheme.primary, CircleShape),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(

--- a/app/src/main/java/app/vela/ui/VoiceCaptureDialog.kt
+++ b/app/src/main/java/app/vela/ui/VoiceCaptureDialog.kt
@@ -68,15 +68,15 @@ fun VoiceCaptureDialog(
             ) {
                 // A ring that swells with loudness (0..1), so you can see it's hearing you. Short
                 // tween instead of the default spring: the level updates every ~32 ms and a spring
-                // smoothed the pulse into near-stillness; 1.4x travel so speech visibly moves it.
+                // smoothed the pulse into near-stillness; 2x travel so speech visibly moves it.
                 val ring by animateFloatAsState(
-                    1f + level.coerceIn(0f, 1f) * 1.4f,
-                    animationSpec = tween(90),
+                    1f + level.coerceIn(0f, 1f) * 2.0f,
+                    animationSpec = tween(70),
                     label = "voiceLevel",
                 )
                 val pulse by animateFloatAsState(
-                    1f + level.coerceIn(0f, 1f) * 0.15f,
-                    animationSpec = tween(90),
+                    1f + level.coerceIn(0f, 1f) * 0.28f,
+                    animationSpec = tween(70),
                     label = "voicePulse",
                 )
                 Box(contentAlignment = Alignment.Center) {

--- a/app/src/main/java/app/vela/ui/VoiceSearch.kt
+++ b/app/src/main/java/app/vela/ui/VoiceSearch.kt
@@ -4,27 +4,37 @@ import android.content.Context
 import android.content.Intent
 import android.speech.RecognizerIntent
 import androidx.compose.runtime.mutableStateOf
+import app.vela.voice.AsrModel
 
 /**
- * Voice search for the search bar: tap a mic, an installed voice-input app (FUTO Voice Input,
- * Sayboard, Google's recognizer on GMS phones, …) captures speech and hands back text, which
- * fills the query and runs the search. Vela never records audio itself for this - the provider
- * does, so no microphone permission is needed here.
+ * Voice search for the search bar. TWO ways to turn speech into a query:
+ *  - **tier-1 (on-device):** Vela's own Whisper model records + transcribes on the phone
+ *    ([app.vela.voice.WhisperRecognizer]); works with no third-party app and no account.
+ *  - **tier-2 (provider):** an installed voice-input app (FUTO Voice Input, Google's recognizer on
+ *    GMS phones, …) captures speech via the RECOGNIZE_SPEECH intent and hands back text. Vela records
+ *    nothing itself for this - the provider does.
  *
- * The mic only appears when it can actually do something: the toggle is on AND some provider
- * resolves the recognize-speech intent. When nothing can service it the button is hidden, never
- * shown dead. (A later branch adds an on-device Whisper model as a second path; this same holder
- * will report that too, so the mic shows when EITHER is available.)
+ * The mic only appears when SOMETHING can service it (the resolved [Mode] is not NONE), so it's never
+ * a dead button. Which one runs is the [engine] preference: **Auto** prefers on-device when the model
+ * is installed, else the provider; or the user can pin On-device / System provider in Settings.
  *
  * Process-wide reactive holder, same shape as [Units]/[DynamicColor]; `init()`-ed in [VelaApp].
  */
 object VoiceSearch {
-    /** User toggle (Settings). On by default - it only renders when a provider exists anyway, so
-     *  "on" costs nothing to someone with no voice app. */
+    /** User toggle (Settings → Search). On by default - it only renders when a path exists anyway. */
     val enabled = mutableStateOf(true)
+
+    /** Which speech path to use. Reactive so the Settings picker updates the mic live. */
+    val engine = mutableStateOf(Engine.AUTO)
+
+    enum class Engine { AUTO, LOCAL, SYSTEM }
+
+    /** What the mic will actually do when tapped, given the toggle + engine pref + what's available. */
+    enum class Mode { LOCAL, SYSTEM, NONE }
 
     fun init(context: Context) {
         enabled.value = prefs(context).getBoolean(KEY, true)
+        engine.value = readEngine(prefs(context).getString(ENGINE_KEY, null))
     }
 
     fun set(context: Context, value: Boolean) {
@@ -32,13 +42,42 @@ object VoiceSearch {
         prefs(context).edit().putBoolean(KEY, value).apply()
     }
 
-    /** Is there an app that can handle voice input right now? Cheap PackageManager query;
-     *  providers don't install mid-session, so callers can treat it as stable per launch. */
+    fun setEngine(context: Context, value: Engine) {
+        engine.value = value
+        prefs(context).edit().putString(ENGINE_KEY, value.name).apply()
+    }
+
+    /** Is a third-party voice-input APP installed (tier-2)? Cheap PackageManager query; only apps that
+     *  register the RECOGNIZE_SPEECH ACTIVITY count (an IME/keyboard mic is a RecognitionService, which
+     *  we can't `startActivityForResult` to). Stable per launch (providers don't install mid-session). */
     fun hasProvider(context: Context): Boolean = runCatching {
         val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
         context.packageManager.queryIntentActivities(intent, 0).isNotEmpty()
     }.getOrDefault(false)
 
+    /** Is Vela's own on-device model downloaded (tier-1)? File-existence check, no model load. */
+    fun localReady(context: Context): Boolean = AsrModel.isInstalled(context)
+
+    /** Resolve what the mic should do right now. NONE → hide the mic. */
+    fun resolvedMode(context: Context): Mode {
+        if (!enabled.value) return Mode.NONE
+        val local = localReady(context)
+        val provider = hasProvider(context)
+        return when (engine.value) {
+            Engine.LOCAL -> if (local) Mode.LOCAL else Mode.NONE
+            Engine.SYSTEM -> if (provider) Mode.SYSTEM else Mode.NONE
+            Engine.AUTO -> when {
+                local -> Mode.LOCAL       // on-device wins when it's there
+                provider -> Mode.SYSTEM
+                else -> Mode.NONE
+            }
+        }
+    }
+
+    private fun readEngine(s: String?): Engine =
+        runCatching { if (s == null) Engine.AUTO else Engine.valueOf(s) }.getOrDefault(Engine.AUTO)
+
     private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
     private const val KEY = "voice_search_button"
+    private const val ENGINE_KEY = "voice_search_engine"
 }

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -103,6 +103,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -406,10 +408,10 @@ fun MapScreen(
     LaunchedEffect(Unit) {
         if (hasLocation()) vm.startLocation()
     }
-    // Voice search: launch a system speech recognizer (FUTO Voice Input etc.), drop the recognised
-    // text into the query and search. Vela records nothing itself - the provider does, so no mic
-    // permission here. The mic only shows when a provider exists (VoiceSearch.hasProvider + toggle);
-    // a later branch adds an on-device model as a second path.
+    // Voice search has TWO paths (see VoiceSearch): tier-1 records + transcribes on-device with Vela's
+    // own Whisper model (needs RECORD_AUDIO, asked at point of use); tier-2 hands off to an installed
+    // voice-input app via the RECOGNIZE_SPEECH intent (that app records, so no mic permission). Which
+    // runs is the engine pref, resolved against what's actually available; NONE hides the mic.
     val voiceLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
     ) { result ->
@@ -425,24 +427,78 @@ fun MapScreen(
             }
         }
     }
-    val voiceAvailable = remember { app.vela.ui.VoiceSearch.hasProvider(context) }
-    val voicePrompt = stringResource(R.string.search_voice_prompt)
-    val onMic: (() -> Unit)? = if (app.vela.ui.VoiceSearch.enabled.value && voiceAvailable) {
-        {
-            val intent = Intent(android.speech.RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-                putExtra(
-                    android.speech.RecognizerIntent.EXTRA_LANGUAGE_MODEL,
-                    android.speech.RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
-                )
-                putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE, app.vela.ui.AppLocale.effective().toLanguageTag())
-                putExtra(android.speech.RecognizerIntent.EXTRA_PROMPT, voicePrompt)
+    // Tier-1 capture state: the listening dialog, live loudness, an early-stop flag (Done) and an
+    // abort flag (Back/cancel → don't apply the partial transcript).
+    val voiceScope = rememberCoroutineScope()
+    var voiceListening by remember { mutableStateOf(false) }
+    var voiceStarted by remember { mutableStateOf(false) }
+    var voiceLevel by remember { mutableStateOf(0f) }
+    var voiceStop by remember { mutableStateOf(false) }
+    var voiceAbort by remember { mutableStateOf(false) }
+    fun startLocalVoice() {
+        voiceStop = false; voiceAbort = false; voiceStarted = false; voiceLevel = 0f; voiceListening = true
+        voiceScope.launch {
+            val text = vm.voiceListen(
+                onLevel = { voiceLevel = it },
+                onListening = { voiceStarted = true },
+                cancelled = { voiceStop },
+            )
+            voiceListening = false
+            if (!voiceAbort && !text.isNullOrBlank()) {
+                focusManager.clearFocus()
+                vm.applyVoiceQuery(text)
             }
-            // The resolver check can go stale (provider uninstalled since launch); catch it so a
-            // tap can never crash - it just does nothing.
-            runCatching { voiceLauncher.launch(intent) }
+        }
+    }
+    val recordAudioLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted -> if (granted) startLocalVoice() }
+
+    val voiceProviderAvailable = remember { app.vela.ui.VoiceSearch.hasProvider(context) }
+    val voicePrompt = stringResource(R.string.search_voice_prompt)
+    // Reactive resolve (mirrors VoiceSearch.resolvedMode but keyed on vm state so the mic reflects a
+    // just-downloaded model without a relaunch): enabled/engine are mutableState, local rides state.
+    val micMode = when {
+        !app.vela.ui.VoiceSearch.enabled.value -> app.vela.ui.VoiceSearch.Mode.NONE
+        app.vela.ui.VoiceSearch.engine.value == app.vela.ui.VoiceSearch.Engine.LOCAL ->
+            if (state.asrInstalled) app.vela.ui.VoiceSearch.Mode.LOCAL else app.vela.ui.VoiceSearch.Mode.NONE
+        app.vela.ui.VoiceSearch.engine.value == app.vela.ui.VoiceSearch.Engine.SYSTEM ->
+            if (voiceProviderAvailable) app.vela.ui.VoiceSearch.Mode.SYSTEM else app.vela.ui.VoiceSearch.Mode.NONE
+        state.asrInstalled -> app.vela.ui.VoiceSearch.Mode.LOCAL       // Auto: on-device wins
+        voiceProviderAvailable -> app.vela.ui.VoiceSearch.Mode.SYSTEM
+        else -> app.vela.ui.VoiceSearch.Mode.NONE
+    }
+    val onMic: (() -> Unit)? = if (micMode != app.vela.ui.VoiceSearch.Mode.NONE) {
+        {
+            when (micMode) {
+                app.vela.ui.VoiceSearch.Mode.SYSTEM -> {
+                    val intent = Intent(android.speech.RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                        putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE_MODEL, android.speech.RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+                        putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE, app.vela.ui.AppLocale.effective().toLanguageTag())
+                        putExtra(android.speech.RecognizerIntent.EXTRA_PROMPT, voicePrompt)
+                    }
+                    // The resolver check can go stale (provider uninstalled since launch); catch so a
+                    // tap can never crash - it just does nothing.
+                    runCatching { voiceLauncher.launch(intent) }
+                }
+                app.vela.ui.VoiceSearch.Mode.LOCAL ->
+                    if (vm.voiceMicGranted()) startLocalVoice()
+                    else recordAudioLauncher.launch(android.Manifest.permission.RECORD_AUDIO)
+                else -> {}
+            }
         }
     } else {
         null
+    }
+    // Reflect whether the on-device model is present, so the mic + Settings update without a relaunch.
+    LaunchedEffect(Unit) { vm.refreshAsr() }
+    if (voiceListening) {
+        app.vela.ui.VoiceCaptureDialog(
+            level = voiceLevel,
+            listening = voiceStarted,
+            onDone = { voiceStop = true },                    // stop early, keep + search what was heard
+            onCancel = { voiceAbort = true; voiceStop = true }, // Back/outside: abort, don't apply
+        )
     }
 
     // Tapping the locate button with no permission is an unambiguous "I want my location" - request

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -391,10 +391,13 @@ fun MapScreen(
         }
     }
 
+    // When the request comes back fully denied (including Android's instant deny after a permanent
+    // "don't ask again"), the locate button used to just do nothing. Explain and point at settings.
+    var showLocationOff by remember { mutableStateOf(false) }
     val permLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions(),
     ) { result ->
-        if (result.values.any { it }) vm.startLocation()
+        if (result.values.any { it }) vm.startLocation() else showLocationOff = true
     }
     // Only START location if it's already granted. The raw system dialog is NOT fired here anymore:
     // the onboarding rationale (VelaRoot) owns the first ask so it comes with an explanation, and the
@@ -536,7 +539,7 @@ fun MapScreen(
     val notifPermLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { vm.startNav() }
-    val onStartNav: () -> Unit = {
+    fun proceedStartNav() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             ContextCompat.checkSelfPermission(
                 context, Manifest.permission.POST_NOTIFICATIONS,
@@ -546,6 +549,66 @@ fun MapScreen(
         } else {
             vm.startNav()
         }
+    }
+    fun fineGranted() = ContextCompat.checkSelfPermission(
+        context, Manifest.permission.ACCESS_FINE_LOCATION,
+    ) == PackageManager.PERMISSION_GRANTED
+    // Turn-by-turn follows you with GPS, which needs PRECISE location: coarse fixes are ~2 km and
+    // the nav engine (correctly) refuses them, so starting nav without precise just sat forever at
+    // "Searching for GPS" with no explanation. Gate the Start button on it instead - the request
+    // doubles as Android's approximate-to-precise upgrade dialog. Demo drive simulates and skips this.
+    var showPreciseNeeded by remember { mutableStateOf(false) }
+    val finePermLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions(),
+    ) { result ->
+        if (result[Manifest.permission.ACCESS_FINE_LOCATION] == true) {
+            vm.startLocation()
+            proceedStartNav()
+        } else {
+            android.widget.Toast.makeText(context, context.getString(R.string.nav_precise_toast), android.widget.Toast.LENGTH_LONG).show()
+        }
+    }
+    val onStartNav: () -> Unit = {
+        if (!fineGranted() && !vm.demoDriveOn()) showPreciseNeeded = true else proceedStartNav()
+    }
+    if (showPreciseNeeded) {
+        app.vela.ui.VelaDialog(
+            onDismissRequest = { showPreciseNeeded = false },
+            title = stringResource(R.string.nav_precise_title),
+            confirmText = stringResource(R.string.nav_precise_allow),
+            onConfirm = {
+                showPreciseNeeded = false
+                finePermLauncher.launch(
+                    arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION),
+                )
+            },
+            dismissText = stringResource(R.string.root_not_now),
+            onDismiss = { showPreciseNeeded = false },
+            dismissLowEmphasis = true,
+            text = { Text(stringResource(R.string.nav_precise_body)) },
+        )
+    }
+    if (showLocationOff) {
+        app.vela.ui.VelaDialog(
+            onDismissRequest = { showLocationOff = false },
+            title = stringResource(R.string.loc_off_title),
+            confirmText = stringResource(R.string.loc_off_settings),
+            onConfirm = {
+                showLocationOff = false
+                runCatching {
+                    context.startActivity(
+                        Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                            data = android.net.Uri.fromParts("package", context.packageName, null)
+                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        },
+                    )
+                }
+            },
+            dismissText = stringResource(R.string.root_not_now),
+            onDismiss = { showLocationOff = false },
+            dismissLowEmphasis = true,
+            text = { Text(stringResource(R.string.loc_off_body)) },
+        )
     }
 
     Box(Modifier.fillMaxSize()) {

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -468,9 +468,13 @@ fun MapScreen(
         voiceProviderAvailable -> app.vela.ui.VoiceSearch.Mode.SYSTEM
         else -> app.vela.ui.VoiceSearch.Mode.NONE
     }
-    val onMic: (() -> Unit)? = if (micMode != app.vela.ui.VoiceSearch.Mode.NONE) {
+    // With nothing installed the mic still shows (when the toggle is on) and tapping it OFFERS the
+    // Vela voice download - a hidden mic made the whole feature undiscoverable on a fresh install.
+    var showAsrOffer by remember { mutableStateOf(false) }
+    val onMic: (() -> Unit)? = if (app.vela.ui.VoiceSearch.enabled.value) {
         {
             when (micMode) {
+                app.vela.ui.VoiceSearch.Mode.NONE -> showAsrOffer = true
                 app.vela.ui.VoiceSearch.Mode.SYSTEM -> {
                     val intent = Intent(android.speech.RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
                         putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE_MODEL, android.speech.RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
@@ -484,11 +488,22 @@ fun MapScreen(
                 app.vela.ui.VoiceSearch.Mode.LOCAL ->
                     if (vm.voiceMicGranted()) startLocalVoice()
                     else recordAudioLauncher.launch(android.Manifest.permission.RECORD_AUDIO)
-                else -> {}
             }
         }
     } else {
         null
+    }
+    if (showAsrOffer) {
+        app.vela.ui.VelaDialog(
+            onDismissRequest = { showAsrOffer = false },
+            title = stringResource(R.string.map_asr_offer_title),
+            confirmText = stringResource(R.string.settings_voice_search_download, app.vela.voice.AsrModel.SIZE_MB),
+            onConfirm = { showAsrOffer = false; vm.downloadAsrModel() },
+            dismissText = stringResource(R.string.root_not_now),
+            onDismiss = { showAsrOffer = false },
+            dismissLowEmphasis = true,
+            text = { Text(stringResource(R.string.map_asr_offer_body)) },
+        )
     }
     // Reflect whether the on-device model is present, so the mic + Settings update without a relaunch.
     LaunchedEffect(Unit) { vm.refreshAsr() }
@@ -1447,6 +1462,11 @@ fun MapScreen(
             ) {
                 if (downloadingVoiceId != null) {
                     VoiceDownloadCard(installing = state.voiceInstalling, pct = state.voiceDownloadPct ?: 0f)
+                }
+                // The speech model download (started from the mic offer or Settings) gets the same
+                // card - it's also called Vela voice, so the one label fits both.
+                if (state.asrDownloadPct != null) {
+                    VoiceDownloadCard(installing = state.asrInstalling, pct = state.asrDownloadPct ?: 0f)
                 }
                 // A region (state/country) download: the routing graph first, then its place pack —
                 // same progress card treatment as the voice download, so a Settings-started state

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -419,7 +419,9 @@ fun MapScreen(
             val heard = result.data
                 ?.getStringArrayListExtra(android.speech.RecognizerIntent.EXTRA_RESULTS)
                 ?.firstOrNull()
-                ?.trim()
+                // Providers write prose too ("Okay."): strip the trailing sentence punctuation the
+                // same way the on-device path does, so no voice query searches with a period.
+                ?.trim()?.trimEnd('.', '!', '?', ',', ';', ':')?.trim()
             if (!heard.isNullOrEmpty()) {
                 focusManager.clearFocus()
                 vm.onQueryChange(heard)
@@ -551,6 +553,7 @@ fun MapScreen(
             styleUri = mapStyleUri,
             myLocation = state.myLocation,
             myBearing = state.myBearing,
+            myAccuracyM = state.myAccuracyM,
             mySpeed = state.mySpeed,
             mySpeedRaw = state.mySpeedRaw,
             replaySpeedup = if (state.replaying) MapViewModel.REPLAY_SPEEDUP else 1f,

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -553,7 +553,13 @@ fun MapScreen(
             styleUri = mapStyleUri,
             myLocation = state.myLocation,
             myBearing = state.myBearing,
-            myAccuracyM = state.myAccuracyM,
+            // Coarse-only permission always means a vague position, even before a fresh fix
+            // reports its accuracy (Android hands coarse apps a fix only every few minutes): fall
+            // back to the ~2 km grid Android fuzzes coarse locations to, so the halo shows at once.
+            myAccuracyM = state.myAccuracyM ?: if (hasLocation() && androidx.core.content.ContextCompat.checkSelfPermission(
+                    context, android.Manifest.permission.ACCESS_FINE_LOCATION,
+                ) != PackageManager.PERMISSION_GRANTED
+            ) 2000f else null,
             mySpeed = state.mySpeed,
             mySpeedRaw = state.mySpeedRaw,
             replaySpeedup = if (state.replaying) MapViewModel.REPLAY_SPEEDUP else 1f,
@@ -1460,7 +1466,7 @@ fun MapScreen(
                 Modifier
                     .align(Alignment.TopCenter)
                     .statusBarsPadding()
-                    .padding(top = 84.dp, start = 12.dp, end = 12.dp),
+                    .padding(top = 140.dp, start = 12.dp, end = 12.dp), // below the search bar AND the chips
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 if (downloadingVoiceId != null) {

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -167,6 +167,9 @@ data class MapUiState(
     val selectedVoiceId: String? = null, // the active Piper voice id (null = none installed)
     val voiceDownloadingId: String? = null, // the ONE voice currently downloading (one-at-a-time), else null
     val voiceInstalling: Boolean = false,   // download done, unpacking the archive (the map card shows "Installing…")
+    val asrDownloadPct: Float? = null,      // 0f..1f while the on-device voice-search model downloads; null = idle
+    val asrInstalling: Boolean = false,     // ASR download done, unpacking
+    val asrInstalled: Boolean = false,      // Whisper voice-search model present on disk (Settings shows Download vs Remove)
     val voiceSpeaker: Int = 0, // chosen speaker # for the multi-speaker Vela voice (playground stepper)
     val voiceSpeed: Float = 1.0f, // spoken-directions speed multiplier (1.0 = normal, >1 = faster)
     val showPsdsTip: Boolean = false,
@@ -239,6 +242,7 @@ class MapViewModel @Inject constructor(
     private val routeEngine: app.vela.core.data.RouteEngine,
     private val http: okhttp3.OkHttpClient,
     private val selfUpdater: app.vela.update.SelfUpdater,
+    private val whisperRecognizer: app.vela.voice.WhisperRecognizer,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(MapUiState())
@@ -2703,6 +2707,50 @@ class MapViewModel @Inject constructor(
                 showStatus(appContext.getString(R.string.mapvm_voice_download_failed, v.displayName))
             }
         }
+    }
+
+    // ---- On-device voice search (tier-1 Whisper ASR) ----
+
+    /** Reflect whether the on-device speech model is present (Settings shows Download vs Remove). */
+    fun refreshAsr() { _state.update { it.copy(asrInstalled = whisperRecognizer.isInstalled()) } }
+
+    /** Download the ~47 MB on-device speech-to-text model, reusing the neural-voice installer + its
+     *  no-call-timeout client (the shared 12 s cap would abort a download this size). */
+    fun downloadAsrModel() {
+        if (_state.value.asrDownloadPct != null) return // serialize
+        val bytes = app.vela.voice.AsrModel.SIZE_MB.toLong() * 1024 * 1024
+        if (appContext.filesDir.usableSpace < bytes * 13 / 10) {
+            showStatus(appContext.getString(R.string.mapvm_not_enough_space, appContext.getString(R.string.settings_voice_search_model), app.vela.voice.AsrModel.SIZE_MB))
+            return
+        }
+        _state.update { it.copy(asrDownloadPct = 0f, asrInstalling = false) }
+        viewModelScope.launch {
+            val ok = kokoroInstaller.download(
+                app.vela.voice.AsrModel.URL, app.vela.voice.AsrModel.dir(appContext), bytes,
+                onExtracting = { _state.update { it.copy(asrInstalling = true) } },
+            ) { p -> _state.update { it.copy(asrDownloadPct = p) } }
+            _state.update { it.copy(asrDownloadPct = null, asrInstalling = false, asrInstalled = whisperRecognizer.isInstalled()) }
+            if (ok && whisperRecognizer.isInstalled()) flashStatus(appContext.getString(R.string.mapvm_asr_ready))
+            else showStatus(appContext.getString(R.string.mapvm_asr_download_failed))
+        }
+    }
+
+    fun deleteAsrModel() {
+        app.vela.voice.AsrModel.dir(appContext).deleteRecursively()
+        _state.update { it.copy(asrInstalled = false) }
+    }
+
+    fun voiceMicGranted(): Boolean = whisperRecognizer.hasMicPermission()
+
+    /** Record + transcribe on-device (tier-1); returns the heard text or null. Driven by the capture
+     *  dialog, which supplies the loudness sink, a start callback and an early-stop check. */
+    suspend fun voiceListen(onLevel: (Float) -> Unit, onListening: () -> Unit, cancelled: () -> Boolean): String? =
+        whisperRecognizer.listen(onLevel, onListening, cancelled)
+
+    /** Apply a transcript from either voice tier as the query and run the search. */
+    fun applyVoiceQuery(text: String) {
+        onQueryChange(text)
+        search()
     }
 
     /** Make an already-downloaded voice active: persist the pick, reload the synth (the single switch

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -95,6 +95,7 @@ data class MapUiState(
                                      // when coarse fixes keep the ordinary stale timer from firing
     val compassHeading: Float? = null, // device facing (rotation-vector sensor) — browse cone when stopped
     val myLocationStale: Boolean = true, // grey the dot until/unless a live fix is recent
+    val myAccuracyM: Float? = null, // the last live fix's reported accuracy radius (m); null = unknown/simulated
     val parkingSpot: LatLng? = null, // one-tap "parked here" pin — survives restarts (prefs)
     val parkedAtMillis: Long = 0L,   // when it was saved (for the sheet/history labels)
     val parkingHistory: List<app.vela.core.model.ParkedSpot> = emptyList(), // recent saves, newest first — accidental-overwrite insurance
@@ -467,7 +468,7 @@ class MapViewModel @Inject constructor(
             // Kill any stale-timer armed by the last REAL fix: the pinned demo dot gets no fresh
             // fixes, so a leftover timer greyed it ~30 s in and nothing ever turned it blue again.
             staleTimerJob?.cancel(); staleTimerJob = null
-            _state.update { it.copy(myLocation = sim, center = it.center ?: sim, myLocationStale = false, showPsdsTip = false) }
+            _state.update { it.copy(myLocation = sim, center = it.center ?: sim, myLocationStale = false, showPsdsTip = false, myAccuracyM = null) }
             return
         }
         locationJob = viewModelScope.launch {
@@ -580,6 +581,9 @@ class MapViewModel @Inject constructor(
                         // rejected it) — the puck Kalman's measurement stream must never see a
                         // held display value or a rejected glitch.
                         mySpeedRaw = measured,
+                        // Drives the map's accuracy halo: a coarse-permission or network fix reports
+                        // hundreds-to-thousands of meters and gets an honest circle; GPS won't.
+                        myAccuracyM = if (loc.hasAccuracy()) loc.accuracy else null,
                         showPsdsTip = false, center = it.center ?: here, myLocationStale = false,
                     )
                 }

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -2856,6 +2856,10 @@ class MapViewModel @Inject constructor(
 
     fun recenter() = _state.update { it.copy(center = it.myLocation, recenterTick = it.recenterTick + 1) }
 
+    /** Demo-drive simulates the route with no GPS, so the precise-location nav gate skips it. */
+    fun demoDriveOn(): Boolean =
+        appContext.getSharedPreferences("vela_settings", android.content.Context.MODE_PRIVATE).getBoolean("demo_drive", false)
+
     /** Screenshot/demo tool (Settings → "Simulate my location"): pretend to be at the current map
      *  centre. While on, the live GPS collector is suspended and every "your location" (the dot,
      *  the search-distance bias, the directions origin, recenter) reads this point, so the app can

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1080,7 +1080,19 @@ fun VelaMapView(
                 val t = myLocation ?: cameraTarget
                 if (t != null) {
                     lastCameraTarget = t
-                    val zoom = if (cameraBottomInsetPx > 0) 16.5 else 15.0
+                    // A vague fix (approximate permission / weak network) zooms out to FIT the
+                    // accuracy circle: at street zoom a 2 km halo covers the whole screen as an
+                    // invisible uniform wash - the blob only reads when its edge is on screen.
+                    val acc = myAccuracyM
+                    val zoom = when {
+                        acc != null && acc > 100f -> {
+                            val screenPx = mapView.width.coerceAtLeast(1)
+                            val mpp = (acc.toDouble() * 2 / 0.7) / screenPx
+                            (Math.log((156543.03392 * Math.cos(Math.toRadians(t.lat))) / mpp) / Math.log(2.0)).coerceIn(3.0, 15.0)
+                        }
+                        cameraBottomInsetPx > 0 -> 16.5
+                        else -> 15.0
+                    }
                     map.animateCamera(CameraUpdateFactory.newLatLngZoom(MLLatLng(t.lat, t.lng), zoom), 500)
                 }
             }
@@ -1436,8 +1448,15 @@ private fun ensureLayers(style: Style) {
         style.addLayer(
             FillLayer(ACCURACY_LAYER, ACCURACY_SRC).withProperties(
                 PropertyFactory.fillColor("#4285F4"),
-                PropertyFactory.fillOpacity(0.12f),
-                PropertyFactory.fillOutlineColor("#664285F4"),
+                // 0.22 + a real edge line: 0.12-0.15 vanished into the dark basemap's own blue.
+                PropertyFactory.fillOpacity(0.22f),
+            ),
+        )
+        style.addLayer(
+            LineLayer(ACCURACY_LAYER + "-edge", ACCURACY_SRC).withProperties(
+                PropertyFactory.lineColor("#4285F4"),
+                PropertyFactory.lineOpacity(0.8f),
+                PropertyFactory.lineWidth(1.5f),
             ),
         )
     }

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -103,6 +103,11 @@ private const val CONTROLS_CLAIM_LAYER = "vela-controls-claim" // invisible coll
 private const val SIGNAL_IMG = "vela-signal"
 private const val STOP_IMG = "vela-stop"
 private const val AMBIENT_INDEX_PROP = "vela-ambient-index"
+private const val ACCURACY_SRC = "vela-me-accuracy-src"
+private const val ACCURACY_LAYER = "vela-me-accuracy"
+// Only a genuinely vague fix earns the halo: coarse-permission and network fixes report hundreds to
+// thousands of meters; normal GPS (3-30 m) stays a plain dot.
+private const val ACCURACY_HALO_MIN_M = 100f
 private const val ME_SRC = "vela-me-src"
 private const val ME_LAYER = "vela-me"
 private const val ME_ARROW_LAYER = "vela-me-arrow"
@@ -141,6 +146,8 @@ data class MapMarker(val name: String, val location: LatLng, val category: Strin
 private var lastAppliedMarkers: List<MapMarker>? = null
 private var lastAppliedAmbient: List<MapMarker>? = null
 private var lastAppliedParking: LatLng? = null
+private var lastAccuracyLoc: LatLng? = null
+private var lastAccuracyM: Float? = null
 private var parkingApplied = false // distinguishes "never applied" from "applied null"
 private var lastAppliedControls: List<app.vela.core.data.TrafficControl>? = null
 private var lastAppliedRouteLine: List<LatLng>? = null // identity-gate the route upload — applyData runs
@@ -161,6 +168,7 @@ fun VelaMapView(
     styleUri: String,
     myLocation: LatLng?,
     myBearing: Float?,
+    myAccuracyM: Float? = null,
     mySpeed: Float? = null,
     mySpeedRaw: Float? = null, // THIS fix's own measurement (null = fix had none) — Kalman feed
     // Trip-replay time scale (1 = live). The recorded fixes arrive speedup× faster than real time
@@ -1033,13 +1041,13 @@ fun VelaMapView(
                 lastGradM[0] = -1e9 // force the nav split to re-render on the fresh style
                 PoiIcons.addTo(context, style)
                 if (applyKeylessTheme) applyMapTheme(style, darkTheme) else tuneMapTiler(style, darkTheme)
-                applyData(map, style, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, displayLoc, displayBearing, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
+                applyData(map, style, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, displayLoc, displayBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
                 ensureTraffic(style, trafficOn)
                 ensureTransit(style, transitOn)
             }
         } else {
             styleRef?.let {
-                applyData(map, it, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, displayLoc, displayBearing, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
+                applyData(map, it, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, displayLoc, displayBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
                 ensureTraffic(it, trafficOn)
                 ensureTransit(it, transitOn)
             }
@@ -1418,6 +1426,19 @@ private fun ensureLayers(style: Style) {
                 )
             },
             AMBIENT_LAYER,
+        )
+    }
+    if (style.getSource(ACCURACY_SRC) == null) {
+        style.addSource(GeoJsonSource(ACCURACY_SRC))
+        // The accuracy halo: a translucent disc drawn at the fix's REAL uncertainty radius, so an
+        // approximate-only permission (or a weak network fix) reads as "somewhere in this
+        // blob" instead of a falsely-precise dot. A polygon in meters, so it scales with zoom.
+        style.addLayer(
+            FillLayer(ACCURACY_LAYER, ACCURACY_SRC).withProperties(
+                PropertyFactory.fillColor("#4285F4"),
+                PropertyFactory.fillOpacity(0.12f),
+                PropertyFactory.fillOutlineColor("#664285F4"),
+            ),
         )
     }
     if (style.getSource(ME_SRC) == null) {
@@ -1965,6 +1986,19 @@ private fun setMeSource(style: Style, p: LatLng, bearing: Float) {
     )
 }
 
+/** A 64-point geodesic circle polygon of [radiusM] meters around [center] - the accuracy halo's
+ *  geometry (drawn in real meters, so it grows and shrinks with the zoom like the world does). */
+private fun accuracyCircle(center: LatLng, radiusM: Double): org.maplibre.geojson.Polygon {
+    val latR = Math.toRadians(center.lat)
+    val dLat = radiusM / 111_320.0
+    val dLng = radiusM / (111_320.0 * Math.cos(latR)).coerceAtLeast(1.0)
+    val pts = (0..64).map { i ->
+        val a = 2.0 * Math.PI * i / 64
+        Point.fromLngLat(center.lng + dLng * Math.sin(a), center.lat + dLat * Math.cos(a))
+    }
+    return org.maplibre.geojson.Polygon.fromLngLats(listOf(pts))
+}
+
 /** Compass bearing (deg, 0 = N) from [a] to [b]. */
 private fun bearingDeg(a: LatLng, b: LatLng): Float {
     val dLng = Math.toRadians(b.lng - a.lng)
@@ -2058,12 +2092,23 @@ private fun applyData(
     trafficControls: List<app.vela.core.data.TrafficControl>,
     me: LatLng?,
     bearing: Float?,
+    meAccuracyM: Float?,
     meStale: Boolean,
     preview: LatLng?,
     routeProgress: Float,
     navMode: Boolean,
     parkingSpot: LatLng? = null,
 ) {
+    // Accuracy halo: shown only for a vague fix (see ACCURACY_HALO_MIN_M) and never during nav,
+    // where the puck snaps to the road anyway. Identity-gated like everything else here.
+    val wantAcc = if (!navMode && me != null && meAccuracyM != null && meAccuracyM > ACCURACY_HALO_MIN_M) meAccuracyM else null
+    if (me !== lastAccuracyLoc || wantAcc != lastAccuracyM) {
+        val fc = if (wantAcc == null || me == null) FeatureCollection.fromFeatures(emptyList<Feature>())
+        else FeatureCollection.fromFeature(Feature.fromGeometry(accuracyCircle(me, wantAcc.toDouble())))
+        style.getSourceAs<GeoJsonSource>(ACCURACY_SRC)?.setGeoJson(fc)
+        lastAccuracyLoc = me
+        lastAccuracyM = wantAcc
+    }
     // The parking pin (identity-gated like the markers below).
     if (!parkingApplied || parkingSpot != lastAppliedParking) {
         val fc = if (parkingSpot == null) FeatureCollection.fromFeatures(emptyList<Feature>())

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -436,6 +436,43 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 else stringResource(R.string.settings_voice_search_none),
             )
 
+            // On-device voice search (tier-1): download Vela's own Whisper model, or remove it. Works
+            // with no other app and uploads nothing; Auto uses it over a provider when it's installed.
+            LaunchedEffect(Unit) { vm.refreshAsr() }
+            Spacer(Modifier.height(8.dp))
+            Hint(stringResource(R.string.settings_voice_search_model_hint, app.vela.voice.AsrModel.SIZE_MB))
+            when {
+                state.asrDownloadPct != null -> {
+                    val pct = state.asrDownloadPct ?: 0f
+                    Text(
+                        if (state.asrInstalling) stringResource(R.string.settings_voice_search_installing)
+                        else stringResource(R.string.settings_voice_search_downloading, (pct * 100).toInt()),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                    LinearProgressIndicator(progress = { pct }, modifier = Modifier.fillMaxWidth())
+                }
+                state.asrInstalled -> {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(stringResource(R.string.settings_voice_search_model), style = MaterialTheme.typography.bodyLarge, modifier = Modifier.weight(1f))
+                        TextButton(onClick = { vm.deleteAsrModel() }) { Text(stringResource(R.string.settings_voice_search_remove)) }
+                    }
+                }
+                else -> OutlinedButton(onClick = { vm.downloadAsrModel() }) {
+                    Text(stringResource(R.string.settings_voice_search_download, app.vela.voice.AsrModel.SIZE_MB))
+                }
+            }
+            // The engine picker only matters when there's actually a choice (the model AND a voice app);
+            // otherwise Auto already does the one available thing.
+            if (state.asrInstalled && hasVoiceProvider) {
+                Spacer(Modifier.height(12.dp))
+                SubHead(stringResource(R.string.settings_voice_search_engine_title))
+                val eng = app.vela.ui.VoiceSearch.engine.value
+                SelectableRow(stringResource(R.string.settings_voice_search_engine_auto), eng == app.vela.ui.VoiceSearch.Engine.AUTO, onClick = { app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.AUTO) })
+                SelectableRow(stringResource(R.string.settings_voice_search_engine_local), eng == app.vela.ui.VoiceSearch.Engine.LOCAL, onClick = { app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.LOCAL) })
+                SelectableRow(stringResource(R.string.settings_voice_search_engine_system), eng == app.vela.ui.VoiceSearch.Engine.SYSTEM, onClick = { app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.SYSTEM) })
+            }
+
             Spacer(Modifier.height(20.dp))
             SectionTitle(stringResource(R.string.settings_map))
             ToggleRow(stringResource(R.string.settings_live_traffic), app.vela.ui.Traffic.on.value) { app.vela.ui.Traffic.set(context, it) }

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -428,13 +428,8 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
             ToggleRow(stringResource(R.string.settings_voice_search_toggle), app.vela.ui.VoiceSearch.enabled.value) {
                 app.vela.ui.VoiceSearch.set(context, it)
             }
-            // The hint tells the truth about whether the mic can actually appear: it needs a
-            // voice-input app installed (a later build adds an on-device model as a second path).
             val hasVoiceProvider = remember { app.vela.ui.VoiceSearch.hasProvider(context) }
-            Hint(
-                if (hasVoiceProvider) stringResource(R.string.settings_voice_search_hint)
-                else stringResource(R.string.settings_voice_search_none),
-            )
+            Hint(stringResource(R.string.settings_voice_search_hint))
 
             // On-device voice search (tier-1): download Vela's own Whisper model, or remove it. Works
             // with no other app and uploads nothing; Auto uses it over a provider when it's installed.

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -463,13 +463,14 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 }
             }
             // The engine picker only matters when there's actually a choice (the model AND a voice app);
-            // otherwise Auto already does the one available thing.
+            // otherwise the resolver already does the one available thing. TWO options, not three:
+            // "Vela voice" maps to AUTO (Vela's model wins, with the provider as a graceful fallback
+            // if the model is ever removed) - an explicit local-only third choice read as jargon.
             if (state.asrInstalled && hasVoiceProvider) {
                 Spacer(Modifier.height(12.dp))
                 SubHead(stringResource(R.string.settings_voice_search_engine_title))
                 val eng = app.vela.ui.VoiceSearch.engine.value
-                SelectableRow(stringResource(R.string.settings_voice_search_engine_auto), eng == app.vela.ui.VoiceSearch.Engine.AUTO, onClick = { app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.AUTO) })
-                SelectableRow(stringResource(R.string.settings_voice_search_engine_local), eng == app.vela.ui.VoiceSearch.Engine.LOCAL, onClick = { app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.LOCAL) })
+                SelectableRow(stringResource(R.string.settings_voice_search_engine_auto), eng != app.vela.ui.VoiceSearch.Engine.SYSTEM, onClick = { app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.AUTO) })
                 SelectableRow(stringResource(R.string.settings_voice_search_engine_system), eng == app.vela.ui.VoiceSearch.Engine.SYSTEM, onClick = { app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.SYSTEM) })
             }
 

--- a/app/src/main/java/app/vela/voice/AsrModel.kt
+++ b/app/src/main/java/app/vela/voice/AsrModel.kt
@@ -1,0 +1,35 @@
+package app.vela.voice
+
+import android.content.Context
+import java.io.File
+
+/**
+ * The on-device speech-to-text model Vela downloads for voice search (tier-1): **Whisper tiny
+ * multilingual (int8) + Silero VAD**, hosted on the `asr-models` GitHub release (like the
+ * `tts-runtime`/`routing-graphs` infra releases - the asset lives nowhere else). ~47 MB one-time,
+ * optional download; everything runs on the phone, no account and no third-party voice app.
+ *
+ * This holds only the metadata + a cheap install check. Actually loading + running the model needs
+ * the sherpa-onnx AAR, which lives in [WhisperRecognizer] (`:app`, not `:core`).
+ */
+object AsrModel {
+    const val ID = "whisper-tiny"
+    const val URL = "https://github.com/PimpinPumpkin/Vela/releases/download/asr-models/vela-asr-whisper-tiny.tar.bz2"
+    const val SIZE_MB = 47
+
+    const val ENCODER = "tiny-encoder.int8.onnx"
+    const val DECODER = "tiny-decoder.int8.onnx"
+    const val TOKENS = "tiny-tokens.txt"
+    const val VAD = "silero_vad.onnx"
+
+    /** `filesDir/asr/whisper-tiny/` - the extracted archive's single top-level folder. */
+    fun dir(context: Context): File = File(context.filesDir, "asr/$ID")
+
+    /** True only when EVERY model file is present and non-empty, so a partial or aborted download
+     *  self-heals (a missing file reads as not-installed → re-download). Pure file check, no model
+     *  load, so it's safe to call from the UI thread / availability gates. */
+    fun isInstalled(context: Context): Boolean {
+        val d = dir(context)
+        return listOf(ENCODER, DECODER, TOKENS, VAD).all { File(d, it).length() > 0L }
+    }
+}

--- a/app/src/main/java/app/vela/voice/AsrModel.kt
+++ b/app/src/main/java/app/vela/voice/AsrModel.kt
@@ -14,8 +14,8 @@ import java.io.File
  */
 object AsrModel {
     const val ID = "whisper-tiny"
-    const val URL = "https://github.com/PimpinPumpkin/Vela/releases/download/asr-models/vela-asr-whisper-tiny.tar.bz2"
-    const val SIZE_MB = 47
+    const val URL = "https://github.com/PimpinPumpkin/Vela/releases/download/asr-models/vela-asr-whisper-tiny.tar.gz"
+    const val SIZE_MB = 58
 
     const val ENCODER = "tiny-encoder.int8.onnx"
     const val DECODER = "tiny-decoder.int8.onnx"

--- a/app/src/main/java/app/vela/voice/KokoroInstaller.kt
+++ b/app/src/main/java/app/vela/voice/KokoroInstaller.kt
@@ -8,6 +8,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -50,7 +51,7 @@ class KokoroInstaller @Inject constructor(
 
             onExtracting()
             staging.deleteRecursively(); staging.mkdirs()
-            extractTarBz2(tmp, staging)
+            extractTar(tmp, staging)
             val inner = staging.listFiles()?.firstOrNull { it.isDirectory } ?: staging
             destDir.deleteRecursively()
             if (!inner.renameTo(destDir)) inner.copyRecursively(destDir, overwrite = true)
@@ -87,9 +88,14 @@ class KokoroInstaller @Inject constructor(
             true
         }
 
-    private fun extractTarBz2(src: File, destDir: File) {
+    private fun extractTar(src: File, destDir: File) {
+        // Pick the decompressor by magic bytes: Vela's own archives are gzip (bzip2 unpacked at
+        // ~15 MB/s on a phone core, a visible half-minute hang for a model; gzip is ~10x that for a
+        // slightly larger file), while the upstream Piper voice tarballs are still bzip2.
+        val magic = ByteArray(2).also { m -> src.inputStream().use { it.read(m) } }
+        val gzip = magic[0] == 0x1f.toByte() && magic[1] == 0x8b.toByte()
         src.inputStream().buffered().use { fin ->
-            BZip2CompressorInputStream(fin).use { bz ->
+            (if (gzip) GzipCompressorInputStream(fin) else BZip2CompressorInputStream(fin)).use { bz ->
                 TarArchiveInputStream(bz).use { tar ->
                     var entry = tar.nextEntry
                     while (entry != null) {

--- a/app/src/main/java/app/vela/voice/WhisperRecognizer.kt
+++ b/app/src/main/java/app/vela/voice/WhisperRecognizer.kt
@@ -209,7 +209,7 @@ class WhisperRecognizer @Inject constructor(
         var sum = 0.0
         for (v in f) sum += v.toDouble() * v
         // Scale so a normal speaking level reads near the top of the 0..1 range for the animation
-        // (raised from 4x: speech at arm's length has RMS around 0.05 to 0.15 and the pulse read flat).
-        return (sqrt(sum / f.size) * 7f).toFloat().coerceIn(0f, 1f)
+        // (speech at arm's length has RMS around 0.05 to 0.15; scaled so it sweeps most of the range).
+        return (sqrt(sum / f.size) * 8.5f).toFloat().coerceIn(0f, 1f)
     }
 }

--- a/app/src/main/java/app/vela/voice/WhisperRecognizer.kt
+++ b/app/src/main/java/app/vela/voice/WhisperRecognizer.kt
@@ -1,0 +1,196 @@
+package app.vela.voice
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
+import androidx.core.content.ContextCompat
+import com.k2fsa.sherpa.onnx.FeatureConfig
+import com.k2fsa.sherpa.onnx.OfflineModelConfig
+import com.k2fsa.sherpa.onnx.OfflineRecognizer
+import com.k2fsa.sherpa.onnx.OfflineRecognizerConfig
+import com.k2fsa.sherpa.onnx.OfflineWhisperModelConfig
+import com.k2fsa.sherpa.onnx.SileroVadModelConfig
+import com.k2fsa.sherpa.onnx.Vad
+import com.k2fsa.sherpa.onnx.VadModelConfig
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.min
+import kotlin.math.sqrt
+
+/**
+ * On-device speech-to-text for voice search (tier-1). Loads **Whisper tiny (int8, multilingual)** +
+ * **Silero VAD** through the bundled sherpa-onnx runtime, records from the mic, uses the VAD to spot
+ * the end of speech, and returns the transcript. Nothing leaves the phone and no third-party voice
+ * app is needed (that's tier-2 - the RECOGNIZE_SPEECH intent handoff in MapScreen).
+ *
+ * The Whisper recognizer loads lazily and is kept for the process lifetime (~1 s to load); the VAD is
+ * created per listen (it's tiny and holds streaming state). R8 must keep `com.k2fsa.sherpa.onnx.**`
+ * (JNI resolves classes by name) - already in `consumer-rules`/`proguard` for Piper.
+ */
+@Singleton
+class WhisperRecognizer @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val loadLock = Any()
+    @Volatile private var recognizer: OfflineRecognizer? = null
+
+    private companion object {
+        const val SAMPLE_RATE = 16000
+        const val VAD_WINDOW = 512            // Silero v4/v5 window at 16 kHz
+        const val MAX_SECONDS = 15            // hard cap on one utterance
+    }
+
+    fun isInstalled(): Boolean = AsrModel.isInstalled(context)
+
+    fun hasMicPermission(): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+            PackageManager.PERMISSION_GRANTED
+
+    /** Load the Whisper recognizer once, off the model files (language auto-detect handles all 11 of
+     *  Vela's languages without reconfiguration). Returns null if the model isn't installed or the
+     *  native load fails - callers then fall back to the provider intent or hide the mic. */
+    private fun ensureRecognizer(): OfflineRecognizer? {
+        recognizer?.let { return it }
+        synchronized(loadLock) {
+            recognizer?.let { return it }
+            if (!AsrModel.isInstalled(context)) return null
+            val dir = AsrModel.dir(context)
+            val r = runCatching {
+                OfflineRecognizer(
+                    config = OfflineRecognizerConfig(
+                        featConfig = FeatureConfig(sampleRate = SAMPLE_RATE, featureDim = 80),
+                        modelConfig = OfflineModelConfig(
+                            whisper = OfflineWhisperModelConfig(
+                                encoder = File(dir, AsrModel.ENCODER).absolutePath,
+                                decoder = File(dir, AsrModel.DECODER).absolutePath,
+                                language = "",        // auto-detect
+                                task = "transcribe",
+                                tailPaddings = -1,
+                            ),
+                            tokens = File(dir, AsrModel.TOKENS).absolutePath,
+                            numThreads = 2,
+                            modelType = "whisper",
+                        ),
+                    ),
+                )
+            }.getOrNull()
+            recognizer = r
+            return r
+        }
+    }
+
+    /**
+     * Record from the mic and return what was said, or null if nothing usable was heard (or the
+     * model/permission isn't there). [onLevel] gets a 0..1 loudness for the listening animation,
+     * [onListening] fires once recording actually starts, and [cancelled] lets the UI stop early
+     * (the user tapped done/close). Runs off the main thread; safe to cancel via coroutine too.
+     */
+    suspend fun listen(
+        onLevel: (Float) -> Unit,
+        onListening: () -> Unit,
+        cancelled: () -> Boolean,
+    ): String? = withContext(Dispatchers.Default) {
+        val rec = ensureRecognizer() ?: return@withContext null
+        if (!hasMicPermission()) return@withContext null
+
+        val vad = runCatching {
+            Vad(
+                config = VadModelConfig(
+                    sileroVadModelConfig = SileroVadModelConfig(
+                        model = File(AsrModel.dir(context), AsrModel.VAD).absolutePath,
+                        threshold = 0.5f,
+                        minSilenceDuration = 0.6f,   // ~0.6 s of quiet ends the utterance
+                        minSpeechDuration = 0.25f,
+                        windowSize = VAD_WINDOW,
+                        maxSpeechDuration = MAX_SECONDS.toFloat(),
+                    ),
+                    sampleRate = SAMPLE_RATE,
+                    numThreads = 1,
+                ),
+            )
+        }.getOrNull() ?: return@withContext null
+
+        val minBuf = AudioRecord.getMinBufferSize(
+            SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT,
+        )
+        val audio = runCatching {
+            AudioRecord(
+                MediaRecorder.AudioSource.VOICE_RECOGNITION,
+                SAMPLE_RATE,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+                maxOf(minBuf, SAMPLE_RATE * 2),
+            )
+        }.getOrNull()
+        if (audio == null || audio.state != AudioRecord.STATE_INITIALIZED) {
+            audio?.release(); vad.release(); return@withContext null
+        }
+
+        val buf = ShortArray(VAD_WINDOW)
+        val chunks = ArrayList<FloatArray>()
+        var total = 0
+        var sawSpeech = false
+        var segment: FloatArray? = null
+        try {
+            audio.startRecording()
+            onListening()
+            while (!cancelled() && segment == null && total < SAMPLE_RATE * MAX_SECONDS) {
+                val n = audio.read(buf, 0, VAD_WINDOW)
+                if (n <= 0) continue
+                val f = FloatArray(n) { buf[it] / 32768f }
+                onLevel(rms(f))
+                chunks.add(f)
+                total += n
+                if (n == VAD_WINDOW) vad.acceptWaveform(f)
+                if (vad.isSpeechDetected()) sawSpeech = true
+                // A finished speech segment (speech then a beat of silence) = the utterance.
+                if (!vad.empty()) {
+                    segment = vad.front().samples
+                    vad.pop()
+                }
+            }
+        } catch (t: Throwable) {
+            return@withContext null
+        } finally {
+            runCatching { audio.stop() }
+            audio.release()
+        }
+
+        // Prefer the VAD-trimmed segment (leading/trailing silence stripped → cleaner transcript);
+        // fall back to everything captured if the user stopped before a segment closed.
+        val samples = segment ?: run {
+            if (!sawSpeech && total < SAMPLE_RATE / 2) { vad.release(); return@withContext null }
+            val out = FloatArray(total)
+            var off = 0
+            for (c in chunks) { c.copyInto(out, off, 0, min(c.size, out.size - off)); off += c.size }
+            out
+        }
+        vad.release()
+
+        val text = runCatching {
+            val stream = rec.createStream()
+            stream.acceptWaveform(samples, SAMPLE_RATE)
+            rec.decode(stream)
+            val t = rec.getResult(stream).text
+            stream.release()
+            t
+        }.getOrNull()?.trim().orEmpty()
+
+        text.ifBlank { null }
+    }
+
+    private fun rms(f: FloatArray): Float {
+        if (f.isEmpty()) return 0f
+        var sum = 0.0
+        for (v in f) sum += v.toDouble() * v
+        // Scale so a normal speaking level reads near the top of the 0..1 range for the animation.
+        return (sqrt(sum / f.size) * 4f).toFloat().coerceIn(0f, 1f)
+    }
+}

--- a/app/src/main/java/app/vela/voice/WhisperRecognizer.kt
+++ b/app/src/main/java/app/vela/voice/WhisperRecognizer.kt
@@ -40,6 +40,7 @@ class WhisperRecognizer @Inject constructor(
 ) {
     private val loadLock = Any()
     @Volatile private var recognizer: OfflineRecognizer? = null
+    @Volatile private var loadedLang: String? = null
 
     private companion object {
         const val SAMPLE_RATE = 16000
@@ -53,13 +54,22 @@ class WhisperRecognizer @Inject constructor(
         ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
             PackageManager.PERMISSION_GRANTED
 
-    /** Load the Whisper recognizer once, off the model files (language auto-detect handles all 11 of
-     *  Vela's languages without reconfiguration). Returns null if the model isn't installed or the
-     *  native load fails - callers then fall back to the provider intent or hide the mic. */
+    /** The language Whisper is pinned to: the app language when it's one Vela supports, else
+     *  auto-detect. Pinning matters - with auto-detect, a noisy capture can be misread as a whole
+     *  other language and come back in the wrong script (a garbled far-field test transcribed to
+     *  Cyrillic). The app language is what the user speaks to a maps app in practice. */
+    private fun whisperLang(): String =
+        app.vela.ui.AppLocale.effective().language.takeIf { it in app.vela.ui.AppLocale.SUPPORTED } ?: ""
+
+    /** Load the Whisper recognizer once per language (rebuilt if the app language changes). Returns
+     *  null if the model isn't installed or the native load fails - callers then fall back to the
+     *  provider intent or hide the mic. */
     private fun ensureRecognizer(): OfflineRecognizer? {
-        recognizer?.let { return it }
+        val lang = whisperLang()
+        recognizer?.let { if (loadedLang == lang) return it }
         synchronized(loadLock) {
-            recognizer?.let { return it }
+            recognizer?.let { if (loadedLang == lang) return it else runCatching { it.release() } }
+            recognizer = null
             if (!AsrModel.isInstalled(context)) return null
             val dir = AsrModel.dir(context)
             val r = runCatching {
@@ -70,7 +80,7 @@ class WhisperRecognizer @Inject constructor(
                             whisper = OfflineWhisperModelConfig(
                                 encoder = File(dir, AsrModel.ENCODER).absolutePath,
                                 decoder = File(dir, AsrModel.DECODER).absolutePath,
-                                language = "",        // auto-detect
+                                language = lang,      // pinned to the app language ("" = auto)
                                 task = "transcribe",
                                 tailPaddings = -1,
                             ),
@@ -82,6 +92,7 @@ class WhisperRecognizer @Inject constructor(
                 )
             }.getOrNull()
             recognizer = r
+            loadedLang = lang
             return r
         }
     }
@@ -181,16 +192,24 @@ class WhisperRecognizer @Inject constructor(
             val t = rec.getResult(stream).text
             stream.release()
             t
-        }.getOrNull()?.trim().orEmpty()
+        }.getOrNull().orEmpty()
 
-        text.ifBlank { null }
+        cleanTranscript(text).ifBlank { null }
     }
+
+    /** Whisper writes prose: it capitalizes and ends with a period ("Coffee shops near me.").
+     *  A search query wants neither the trailing sentence punctuation nor stray wrapping, so strip
+     *  terminal . ! ? , ; : and quotes from the ends. Periods INSIDE the text are left alone,
+     *  they can be real ("St. Paul"). */
+    private fun cleanTranscript(raw: String): String =
+        raw.trim().trim('"', '\u201C', '\u201D').trimEnd('.', '!', '?', ',', ';', ':', '\u2026').trim()
 
     private fun rms(f: FloatArray): Float {
         if (f.isEmpty()) return 0f
         var sum = 0.0
         for (v in f) sum += v.toDouble() * v
-        // Scale so a normal speaking level reads near the top of the 0..1 range for the animation.
-        return (sqrt(sum / f.size) * 4f).toFloat().coerceIn(0f, 1f)
+        // Scale so a normal speaking level reads near the top of the 0..1 range for the animation
+        // (raised from 4x: speech at arm's length has RMS around 0.05 to 0.15 and the pulse read flat).
+        return (sqrt(sum / f.size) * 7f).toFloat().coerceIn(0f, 1f)
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -485,4 +485,19 @@
     <string name="settings_developer_hint">Werkzeuge für Demos, Screenshots und Tests. Schalte sie für den echten Einsatz aus.</string>
     <string name="settings_browse_voices">Stimmen durchsuchen</string>
     <string name="settings_browse_voices_hint">Vela-Stimmen auf dem Gerät herunterladen und wechseln.</string>
+    <string name="voice_capture_listening">Höre zu…</string>
+    <string name="voice_capture_starting">Wird vorbereitet…</string>
+    <string name="voice_capture_done">Fertig</string>
+    <string name="mapvm_asr_ready">On-Device-Sprachsuche ist bereit</string>
+    <string name="mapvm_asr_download_failed">Sprachmodell konnte nicht geladen werden. Prüfe deine Verbindung und versuche es erneut.</string>
+    <string name="settings_voice_search_model">On-Device-Sprachsuche</string>
+    <string name="settings_voice_search_model_hint">Vela\'s eigene Spracherkennung läuft auf dem Gerät, sodass die Sprachsuche ohne andere App funktioniert und nichts hochgeladen wird. Einmaliger Download von ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_download">Herunterladen (%1$d MB)</string>  <!-- format -->
+    <string name="settings_voice_search_remove">Entfernen</string>
+    <string name="settings_voice_search_downloading">Wird geladen… %1$d%%</string>  <!-- format -->
+    <string name="settings_voice_search_installing">Wird installiert…</string>
+    <string name="settings_voice_search_engine_title">Beim Tippen auf das Mikrofon</string>
+    <string name="settings_voice_search_engine_auto">Auf dem Gerät, wenn verfügbar</string>
+    <string name="settings_voice_search_engine_local">Nur auf dem Gerät</string>
+    <string name="settings_voice_search_engine_system">Andere Sprach-App</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -488,16 +488,15 @@
     <string name="voice_capture_listening">Höre zu…</string>
     <string name="voice_capture_starting">Wird vorbereitet…</string>
     <string name="voice_capture_done">Fertig</string>
-    <string name="mapvm_asr_ready">On-Device-Sprachsuche ist bereit</string>
+    <string name="mapvm_asr_ready">Die Vela-Stimme ist bereit</string>
     <string name="mapvm_asr_download_failed">Sprachmodell konnte nicht geladen werden. Prüfe deine Verbindung und versuche es erneut.</string>
-    <string name="settings_voice_search_model">On-Device-Sprachsuche</string>
-    <string name="settings_voice_search_model_hint">Vela\'s eigene Spracherkennung läuft auf dem Gerät, sodass die Sprachsuche ohne andere App funktioniert und nichts hochgeladen wird. Einmaliger Download von ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model">Vela-Stimme</string>
+    <string name="settings_voice_search_model_hint">Die Vela-Stimme macht aus Sprache direkt auf deinem Gerät eine Suche: keine andere App nötig, nichts wird hochgeladen. Einmaliger Download von ~%1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Herunterladen (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Entfernen</string>
     <string name="settings_voice_search_downloading">Wird geladen… %1$d%%</string>  <!-- format -->
     <string name="settings_voice_search_installing">Wird installiert…</string>
     <string name="settings_voice_search_engine_title">Beim Tippen auf das Mikrofon</string>
-    <string name="settings_voice_search_engine_auto">Auf dem Gerät, wenn verfügbar</string>
-    <string name="settings_voice_search_engine_local">Nur auf dem Gerät</string>
+    <string name="settings_voice_search_engine_auto">Vela-Stimme</string>
     <string name="settings_voice_search_engine_system">Andere Sprach-App</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -18,8 +18,7 @@
     <string name="settings_language_hint">Ändert die Sprache der App und der gesprochenen Ansagen. Hol dir eine passende Stimme in der Stimmbibliothek.</string>
     <string name="settings_search">Suche</string>
     <string name="settings_voice_search_toggle">Mikrofon für Sprachsuche</string>
-    <string name="settings_voice_search_hint">Zeigt ein Mikrofon in der Suchleiste. Tippe darauf, um deine Suche zu sprechen, über eine Spracheingabe-App auf dem Gerät.</string>
-    <string name="settings_voice_search_none">Zeigt ein Mikrofon in der Suchleiste zum Sprechen deiner Suche. Benötigt eine Spracheingabe-App wie FUTO Voice Input; noch keine installiert.</string>
+    <string name="settings_voice_search_hint">Zeigt ein Mikrofon in der Suchleiste, um die Suche zu sprechen.</string>
     <string name="search_voice_cd">Sprachsuche</string>
     <string name="search_voice_prompt">Zum Suchen sprechen</string>
     <string name="settings_voice">Stimme</string>
@@ -491,7 +490,7 @@
     <string name="mapvm_asr_ready">Die Vela-Stimme ist bereit</string>
     <string name="mapvm_asr_download_failed">Sprachmodell konnte nicht geladen werden. Prüfe deine Verbindung und versuche es erneut.</string>
     <string name="settings_voice_search_model">Vela-Stimme</string>
-    <string name="settings_voice_search_model_hint">Die Vela-Stimme macht aus Sprache direkt auf deinem Gerät eine Suche: keine andere App nötig, nichts wird hochgeladen. Einmaliger Download von ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model_hint">Die Vela-Stimme macht aus Sprache direkt auf deinem Gerät eine Suche: keine andere App nötig, nichts wird hochgeladen. Einmaliger Download von %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Herunterladen (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Entfernen</string>
     <string name="settings_voice_search_downloading">Wird geladen… %1$d%%</string>  <!-- format -->
@@ -499,4 +498,6 @@
     <string name="settings_voice_search_engine_title">Beim Tippen auf das Mikrofon</string>
     <string name="settings_voice_search_engine_auto">Vela-Stimme</string>
     <string name="settings_voice_search_engine_system">Andere Sprach-App</string>
+    <string name="map_asr_offer_title">Sprachsuche</string>
+    <string name="map_asr_offer_body">Lade die Vela-Stimme herunter, um Suchen zu sprechen. Sie läuft komplett auf deinem Gerät und lädt nichts hoch.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -500,4 +500,11 @@
     <string name="settings_voice_search_engine_system">Andere Sprach-App</string>
     <string name="map_asr_offer_title">Sprachsuche</string>
     <string name="map_asr_offer_body">Lade die Vela-Stimme herunter, um Suchen zu sprechen. Sie läuft komplett auf deinem Gerät und lädt nichts hoch.</string>
+    <string name="nav_precise_title">Genauer Standort nötig</string>
+    <string name="nav_precise_body">Die Navigation folgt dir per GPS und braucht dafür den genauen Standort. Ungefähr liefert nur ein grobes Gebiet, die Navigation würde dich nie finden.</string>
+    <string name="nav_precise_allow">Genau erlauben</string>
+    <string name="nav_precise_toast">Die Navigation braucht den genauen Standort</string>
+    <string name="loc_off_title">Standort ist aus</string>
+    <string name="loc_off_body">Vela hat keinen Standortzugriff. Du kannst ihn in den Systemeinstellungen erlauben.</string>
+    <string name="loc_off_settings">Einstellungen öffnen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -485,4 +485,19 @@
     <string name="settings_developer_hint">Herramientas para demostraciones, capturas y pruebas. Desactívalas para el uso real.</string>
     <string name="settings_browse_voices">Explorar voces</string>
     <string name="settings_browse_voices_hint">Descarga y cambia entre las voces de Vela en el dispositivo.</string>
+    <string name="voice_capture_listening">Escuchando…</string>
+    <string name="voice_capture_starting">Preparando…</string>
+    <string name="voice_capture_done">Listo</string>
+    <string name="mapvm_asr_ready">La búsqueda por voz en el dispositivo está lista</string>
+    <string name="mapvm_asr_download_failed">No se pudo descargar el modelo de voz. Revisa tu conexión e inténtalo de nuevo.</string>
+    <string name="settings_voice_search_model">Búsqueda por voz en el dispositivo</string>
+    <string name="settings_voice_search_model_hint">El reconocimiento de voz propio de Vela funciona en tu teléfono, así que la búsqueda por voz no necesita otra app y no se sube nada. Descarga única de ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_download">Descargar (%1$d MB)</string>  <!-- format -->
+    <string name="settings_voice_search_remove">Quitar</string>
+    <string name="settings_voice_search_downloading">Descargando… %1$d%%</string>  <!-- format -->
+    <string name="settings_voice_search_installing">Instalando…</string>
+    <string name="settings_voice_search_engine_title">Al tocar el micrófono</string>
+    <string name="settings_voice_search_engine_auto">En el dispositivo cuando esté disponible</string>
+    <string name="settings_voice_search_engine_local">Solo en el dispositivo</string>
+    <string name="settings_voice_search_engine_system">Otra app de voz</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -18,8 +18,7 @@
     <string name="settings_language_hint">Cambia el idioma de la app y de las indicaciones habladas. Descarga una voz a juego en la biblioteca de voces.</string>
     <string name="settings_search">Búsqueda</string>
     <string name="settings_voice_search_toggle">Micrófono de búsqueda por voz</string>
-    <string name="settings_voice_search_hint">Muestra un micrófono en la barra de búsqueda. Tócalo para dictar tu búsqueda con una app de entrada de voz del teléfono.</string>
-    <string name="settings_voice_search_none">Muestra un micrófono en la barra de búsqueda para dictar tu búsqueda. Necesita una app de voz como FUTO Voice Input; aún no hay ninguna instalada.</string>
+    <string name="settings_voice_search_hint">Muestra un micrófono en la barra de búsqueda para dictar la búsqueda.</string>
     <string name="search_voice_cd">Búsqueda por voz</string>
     <string name="search_voice_prompt">Habla para buscar</string>
     <string name="settings_voice">Voz</string>
@@ -491,7 +490,7 @@
     <string name="mapvm_asr_ready">La voz de Vela está lista</string>
     <string name="mapvm_asr_download_failed">No se pudo descargar el modelo de voz. Revisa tu conexión e inténtalo de nuevo.</string>
     <string name="settings_voice_search_model">Voz de Vela</string>
-    <string name="settings_voice_search_model_hint">La voz de Vela convierte tu voz en una búsqueda directamente en el teléfono: sin otra app y sin subir nada. Descarga única de ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model_hint">La voz de Vela convierte tu voz en una búsqueda directamente en el teléfono: sin otra app y sin subir nada. Descarga única de %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Descargar (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Quitar</string>
     <string name="settings_voice_search_downloading">Descargando… %1$d%%</string>  <!-- format -->
@@ -499,4 +498,6 @@
     <string name="settings_voice_search_engine_title">Al tocar el micrófono</string>
     <string name="settings_voice_search_engine_auto">Voz de Vela</string>
     <string name="settings_voice_search_engine_system">Otra app de voz</string>
+    <string name="map_asr_offer_title">Búsqueda por voz</string>
+    <string name="map_asr_offer_body">Descarga la voz de Vela para dictar tus búsquedas. Funciona por completo en tu teléfono y no sube nada.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -488,16 +488,15 @@
     <string name="voice_capture_listening">Escuchando…</string>
     <string name="voice_capture_starting">Preparando…</string>
     <string name="voice_capture_done">Listo</string>
-    <string name="mapvm_asr_ready">La búsqueda por voz en el dispositivo está lista</string>
+    <string name="mapvm_asr_ready">La voz de Vela está lista</string>
     <string name="mapvm_asr_download_failed">No se pudo descargar el modelo de voz. Revisa tu conexión e inténtalo de nuevo.</string>
-    <string name="settings_voice_search_model">Búsqueda por voz en el dispositivo</string>
-    <string name="settings_voice_search_model_hint">El reconocimiento de voz propio de Vela funciona en tu teléfono, así que la búsqueda por voz no necesita otra app y no se sube nada. Descarga única de ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model">Voz de Vela</string>
+    <string name="settings_voice_search_model_hint">La voz de Vela convierte tu voz en una búsqueda directamente en el teléfono: sin otra app y sin subir nada. Descarga única de ~%1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Descargar (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Quitar</string>
     <string name="settings_voice_search_downloading">Descargando… %1$d%%</string>  <!-- format -->
     <string name="settings_voice_search_installing">Instalando…</string>
     <string name="settings_voice_search_engine_title">Al tocar el micrófono</string>
-    <string name="settings_voice_search_engine_auto">En el dispositivo cuando esté disponible</string>
-    <string name="settings_voice_search_engine_local">Solo en el dispositivo</string>
+    <string name="settings_voice_search_engine_auto">Voz de Vela</string>
     <string name="settings_voice_search_engine_system">Otra app de voz</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -500,4 +500,11 @@
     <string name="settings_voice_search_engine_system">Otra app de voz</string>
     <string name="map_asr_offer_title">Búsqueda por voz</string>
     <string name="map_asr_offer_body">Descarga la voz de Vela para dictar tus búsquedas. Funciona por completo en tu teléfono y no sube nada.</string>
+    <string name="nav_precise_title">Se necesita ubicación precisa</string>
+    <string name="nav_precise_body">La navegación te sigue por GPS, que necesita la ubicación precisa. La aproximada solo da una zona general, así que la navegación nunca te encontraría.</string>
+    <string name="nav_precise_allow">Permitir precisa</string>
+    <string name="nav_precise_toast">La navegación necesita la ubicación precisa</string>
+    <string name="loc_off_title">La ubicación está desactivada</string>
+    <string name="loc_off_body">Vela no tiene acceso a la ubicación. Puedes permitirlo en los ajustes del sistema.</string>
+    <string name="loc_off_settings">Abrir ajustes</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -485,4 +485,19 @@
     <string name="settings_developer_hint">Outils pour les démos, captures d\'écran et tests. Désactivez-les pour un usage réel.</string>
     <string name="settings_browse_voices">Parcourir les voix</string>
     <string name="settings_browse_voices_hint">Téléchargez et changez les voix de Vela sur l\'appareil.</string>
+    <string name="voice_capture_listening">Écoute…</string>
+    <string name="voice_capture_starting">Préparation…</string>
+    <string name="voice_capture_done">Terminé</string>
+    <string name="mapvm_asr_ready">La recherche vocale sur l\'appareil est prête</string>
+    <string name="mapvm_asr_download_failed">Impossible de télécharger le modèle vocal. Vérifiez votre connexion et réessayez.</string>
+    <string name="settings_voice_search_model">Recherche vocale sur l\'appareil</string>
+    <string name="settings_voice_search_model_hint">La reconnaissance vocale de Vela fonctionne sur votre téléphone : la recherche vocale marche sans autre appli et rien n\'est envoyé. Téléchargement unique d\'environ %1$d Mo.</string>  <!-- format -->
+    <string name="settings_voice_search_download">Télécharger (%1$d Mo)</string>  <!-- format -->
+    <string name="settings_voice_search_remove">Supprimer</string>
+    <string name="settings_voice_search_downloading">Téléchargement… %1$d%%</string>  <!-- format -->
+    <string name="settings_voice_search_installing">Installation…</string>
+    <string name="settings_voice_search_engine_title">Quand vous touchez le micro</string>
+    <string name="settings_voice_search_engine_auto">Sur l\'appareil si disponible</string>
+    <string name="settings_voice_search_engine_local">Sur l\'appareil uniquement</string>
+    <string name="settings_voice_search_engine_system">Autre appli vocale</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -500,4 +500,11 @@
     <string name="settings_voice_search_engine_system">Autre appli vocale</string>
     <string name="map_asr_offer_title">Recherche vocale</string>
     <string name="map_asr_offer_body">Téléchargez la voix Vela pour dicter vos recherches. Elle tourne entièrement sur votre téléphone et n\'envoie rien.</string>
+    <string name="nav_precise_title">Position précise requise</string>
+    <string name="nav_precise_body">Le guidage vous suit par GPS, ce qui demande la position précise. L\'approximative ne donne qu\'une zone grossière, la navigation ne vous trouverait jamais.</string>
+    <string name="nav_precise_allow">Autoriser la précision</string>
+    <string name="nav_precise_toast">Le guidage a besoin de la position précise</string>
+    <string name="loc_off_title">La localisation est désactivée</string>
+    <string name="loc_off_body">Vela n\'a pas accès à la localisation. Vous pouvez l\'autoriser dans les réglages du système.</string>
+    <string name="loc_off_settings">Ouvrir les réglages</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -488,16 +488,15 @@
     <string name="voice_capture_listening">Écoute…</string>
     <string name="voice_capture_starting">Préparation…</string>
     <string name="voice_capture_done">Terminé</string>
-    <string name="mapvm_asr_ready">La recherche vocale sur l\'appareil est prête</string>
+    <string name="mapvm_asr_ready">La voix Vela est prête</string>
     <string name="mapvm_asr_download_failed">Impossible de télécharger le modèle vocal. Vérifiez votre connexion et réessayez.</string>
-    <string name="settings_voice_search_model">Recherche vocale sur l\'appareil</string>
-    <string name="settings_voice_search_model_hint">La reconnaissance vocale de Vela fonctionne sur votre téléphone : la recherche vocale marche sans autre appli et rien n\'est envoyé. Téléchargement unique d\'environ %1$d Mo.</string>  <!-- format -->
+    <string name="settings_voice_search_model">Voix Vela</string>
+    <string name="settings_voice_search_model_hint">La voix Vela transforme la parole en recherche directement sur votre téléphone : aucune autre appli et rien n\'est envoyé. Téléchargement unique d\'environ %1$d Mo.</string>  <!-- format -->
     <string name="settings_voice_search_download">Télécharger (%1$d Mo)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Supprimer</string>
     <string name="settings_voice_search_downloading">Téléchargement… %1$d%%</string>  <!-- format -->
     <string name="settings_voice_search_installing">Installation…</string>
     <string name="settings_voice_search_engine_title">Quand vous touchez le micro</string>
-    <string name="settings_voice_search_engine_auto">Sur l\'appareil si disponible</string>
-    <string name="settings_voice_search_engine_local">Sur l\'appareil uniquement</string>
+    <string name="settings_voice_search_engine_auto">Voix Vela</string>
     <string name="settings_voice_search_engine_system">Autre appli vocale</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -18,8 +18,7 @@
     <string name="settings_language_hint">Change la langue de l\'appli et des instructions vocales. Prenez une voix assortie dans la bibliothèque de voix.</string>
     <string name="settings_search">Recherche</string>
     <string name="settings_voice_search_toggle">Micro de recherche vocale</string>
-    <string name="settings_voice_search_hint">Affiche un micro dans la barre de recherche. Touchez-le pour dicter votre recherche via une appli de saisie vocale du téléphone.</string>
-    <string name="settings_voice_search_none">Affiche un micro dans la barre de recherche pour dicter votre recherche. Nécessite une appli vocale comme FUTO Voice Input ; aucune installée pour l\'instant.</string>
+    <string name="settings_voice_search_hint">Affiche un micro dans la barre de recherche pour dicter votre recherche.</string>
     <string name="search_voice_cd">Recherche vocale</string>
     <string name="search_voice_prompt">Parlez pour rechercher</string>
     <string name="settings_voice">Voix</string>
@@ -499,4 +498,6 @@
     <string name="settings_voice_search_engine_title">Quand vous touchez le micro</string>
     <string name="settings_voice_search_engine_auto">Voix Vela</string>
     <string name="settings_voice_search_engine_system">Autre appli vocale</string>
+    <string name="map_asr_offer_title">Recherche vocale</string>
+    <string name="map_asr_offer_body">Téléchargez la voix Vela pour dicter vos recherches. Elle tourne entièrement sur votre téléphone et n\'envoie rien.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -485,4 +485,19 @@
     <string name="settings_developer_hint">Strumenti per demo, screenshot e test. Disattivali per l\'uso reale.</string>
     <string name="settings_browse_voices">Sfoglia le voci</string>
     <string name="settings_browse_voices_hint">Scarica e cambia le voci di Vela sul dispositivo.</string>
+    <string name="voice_capture_listening">In ascolto…</string>
+    <string name="voice_capture_starting">Preparazione…</string>
+    <string name="voice_capture_done">Fatto</string>
+    <string name="mapvm_asr_ready">La ricerca vocale sul dispositivo è pronta</string>
+    <string name="mapvm_asr_download_failed">Impossibile scaricare il modello vocale. Controlla la connessione e riprova.</string>
+    <string name="settings_voice_search_model">Ricerca vocale sul dispositivo</string>
+    <string name="settings_voice_search_model_hint">Il riconoscimento vocale di Vela gira sul telefono, quindi la ricerca vocale funziona senza altre app e non viene caricato nulla. Download una tantum di ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_download">Scarica (%1$d MB)</string>  <!-- format -->
+    <string name="settings_voice_search_remove">Rimuovi</string>
+    <string name="settings_voice_search_downloading">Download… %1$d%%</string>  <!-- format -->
+    <string name="settings_voice_search_installing">Installazione…</string>
+    <string name="settings_voice_search_engine_title">Quando tocchi il microfono</string>
+    <string name="settings_voice_search_engine_auto">Sul dispositivo se disponibile</string>
+    <string name="settings_voice_search_engine_local">Solo sul dispositivo</string>
+    <string name="settings_voice_search_engine_system">Altra app vocale</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -500,4 +500,11 @@
     <string name="settings_voice_search_engine_system">Altra app vocale</string>
     <string name="map_asr_offer_title">Ricerca vocale</string>
     <string name="map_asr_offer_body">Scarica la voce Vela per dettare le ricerche. Gira interamente sul telefono e non carica nulla.</string>
+    <string name="nav_precise_title">Serve la posizione precisa</string>
+    <string name="nav_precise_body">La navigazione ti segue col GPS, che richiede la posizione precisa. Quella approssimativa dà solo un\'area generica, la navigazione non ti troverebbe mai.</string>
+    <string name="nav_precise_allow">Consenti precisa</string>
+    <string name="nav_precise_toast">La navigazione richiede la posizione precisa</string>
+    <string name="loc_off_title">La posizione è disattivata</string>
+    <string name="loc_off_body">Vela non ha accesso alla posizione. Puoi consentirlo nelle impostazioni di sistema.</string>
+    <string name="loc_off_settings">Apri impostazioni</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -18,8 +18,7 @@
     <string name="settings_language_hint">Cambia la lingua dell\'app e delle indicazioni vocali. Scarica una voce adatta nella libreria voci.</string>
     <string name="settings_search">Ricerca</string>
     <string name="settings_voice_search_toggle">Microfono ricerca vocale</string>
-    <string name="settings_voice_search_hint">Mostra un microfono nella barra di ricerca. Toccalo per dettare la ricerca con un\'app di input vocale sul telefono.</string>
-    <string name="settings_voice_search_none">Mostra un microfono nella barra di ricerca per dettare la ricerca. Serve un\'app vocale come FUTO Voice Input; nessuna ancora installata.</string>
+    <string name="settings_voice_search_hint">Mostra un microfono nella barra di ricerca per dettare la ricerca.</string>
     <string name="search_voice_cd">Ricerca vocale</string>
     <string name="search_voice_prompt">Parla per cercare</string>
     <string name="settings_voice">Voce</string>
@@ -491,7 +490,7 @@
     <string name="mapvm_asr_ready">La voce Vela è pronta</string>
     <string name="mapvm_asr_download_failed">Impossibile scaricare il modello vocale. Controlla la connessione e riprova.</string>
     <string name="settings_voice_search_model">Voce Vela</string>
-    <string name="settings_voice_search_model_hint">La voce Vela trasforma il parlato in una ricerca direttamente sul telefono: nessun\'altra app e nulla viene caricato. Download una tantum di ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model_hint">La voce Vela trasforma il parlato in una ricerca direttamente sul telefono: nessun\'altra app e nulla viene caricato. Download una tantum di %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Scarica (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Rimuovi</string>
     <string name="settings_voice_search_downloading">Download… %1$d%%</string>  <!-- format -->
@@ -499,4 +498,6 @@
     <string name="settings_voice_search_engine_title">Quando tocchi il microfono</string>
     <string name="settings_voice_search_engine_auto">Voce Vela</string>
     <string name="settings_voice_search_engine_system">Altra app vocale</string>
+    <string name="map_asr_offer_title">Ricerca vocale</string>
+    <string name="map_asr_offer_body">Scarica la voce Vela per dettare le ricerche. Gira interamente sul telefono e non carica nulla.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -488,16 +488,15 @@
     <string name="voice_capture_listening">In ascolto…</string>
     <string name="voice_capture_starting">Preparazione…</string>
     <string name="voice_capture_done">Fatto</string>
-    <string name="mapvm_asr_ready">La ricerca vocale sul dispositivo è pronta</string>
+    <string name="mapvm_asr_ready">La voce Vela è pronta</string>
     <string name="mapvm_asr_download_failed">Impossibile scaricare il modello vocale. Controlla la connessione e riprova.</string>
-    <string name="settings_voice_search_model">Ricerca vocale sul dispositivo</string>
-    <string name="settings_voice_search_model_hint">Il riconoscimento vocale di Vela gira sul telefono, quindi la ricerca vocale funziona senza altre app e non viene caricato nulla. Download una tantum di ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model">Voce Vela</string>
+    <string name="settings_voice_search_model_hint">La voce Vela trasforma il parlato in una ricerca direttamente sul telefono: nessun\'altra app e nulla viene caricato. Download una tantum di ~%1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Scarica (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Rimuovi</string>
     <string name="settings_voice_search_downloading">Download… %1$d%%</string>  <!-- format -->
     <string name="settings_voice_search_installing">Installazione…</string>
     <string name="settings_voice_search_engine_title">Quando tocchi il microfono</string>
-    <string name="settings_voice_search_engine_auto">Sul dispositivo se disponibile</string>
-    <string name="settings_voice_search_engine_local">Solo sul dispositivo</string>
+    <string name="settings_voice_search_engine_auto">Voce Vela</string>
     <string name="settings_voice_search_engine_system">Altra app vocale</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -485,4 +485,19 @@
     <string name="settings_developer_hint">Hulpmiddelen voor demo\'s, schermafbeeldingen en tests. Zet ze uit voor echt gebruik.</string>
     <string name="settings_browse_voices">Stemmen bekijken</string>
     <string name="settings_browse_voices_hint">Download en wissel tussen Vela\'s stemmen op het apparaat.</string>
+    <string name="voice_capture_listening">Luisteren…</string>
+    <string name="voice_capture_starting">Voorbereiden…</string>
+    <string name="voice_capture_done">Klaar</string>
+    <string name="mapvm_asr_ready">Spraakzoeken op het apparaat is klaar</string>
+    <string name="mapvm_asr_download_failed">Kan het spraakmodel niet downloaden. Controleer je verbinding en probeer opnieuw.</string>
+    <string name="settings_voice_search_model">Spraakzoeken op het apparaat</string>
+    <string name="settings_voice_search_model_hint">Vela\'s eigen spraakherkenning draait op je telefoon, dus spraakzoeken werkt zonder andere app en er wordt niets geüpload. Eenmalige download van ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_download">Downloaden (%1$d MB)</string>  <!-- format -->
+    <string name="settings_voice_search_remove">Verwijderen</string>
+    <string name="settings_voice_search_downloading">Downloaden… %1$d%%</string>  <!-- format -->
+    <string name="settings_voice_search_installing">Installeren…</string>
+    <string name="settings_voice_search_engine_title">Als je op de microfoon tikt</string>
+    <string name="settings_voice_search_engine_auto">Op het apparaat indien beschikbaar</string>
+    <string name="settings_voice_search_engine_local">Alleen op het apparaat</string>
+    <string name="settings_voice_search_engine_system">Andere spraak-app</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -488,16 +488,15 @@
     <string name="voice_capture_listening">Luisteren…</string>
     <string name="voice_capture_starting">Voorbereiden…</string>
     <string name="voice_capture_done">Klaar</string>
-    <string name="mapvm_asr_ready">Spraakzoeken op het apparaat is klaar</string>
+    <string name="mapvm_asr_ready">De Vela-stem is klaar</string>
     <string name="mapvm_asr_download_failed">Kan het spraakmodel niet downloaden. Controleer je verbinding en probeer opnieuw.</string>
-    <string name="settings_voice_search_model">Spraakzoeken op het apparaat</string>
-    <string name="settings_voice_search_model_hint">Vela\'s eigen spraakherkenning draait op je telefoon, dus spraakzoeken werkt zonder andere app en er wordt niets geüpload. Eenmalige download van ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model">Vela-stem</string>
+    <string name="settings_voice_search_model_hint">De Vela-stem zet spraak direct op je telefoon om in een zoekopdracht: geen andere app nodig en er wordt niets geüpload. Eenmalige download van ~%1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Downloaden (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Verwijderen</string>
     <string name="settings_voice_search_downloading">Downloaden… %1$d%%</string>  <!-- format -->
     <string name="settings_voice_search_installing">Installeren…</string>
     <string name="settings_voice_search_engine_title">Als je op de microfoon tikt</string>
-    <string name="settings_voice_search_engine_auto">Op het apparaat indien beschikbaar</string>
-    <string name="settings_voice_search_engine_local">Alleen op het apparaat</string>
+    <string name="settings_voice_search_engine_auto">Vela-stem</string>
     <string name="settings_voice_search_engine_system">Andere spraak-app</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -500,4 +500,11 @@
     <string name="settings_voice_search_engine_system">Andere spraak-app</string>
     <string name="map_asr_offer_title">Spraakzoeken</string>
     <string name="map_asr_offer_body">Download de Vela-stem om je zoekopdrachten in te spreken. Hij draait volledig op je telefoon en uploadt niets.</string>
+    <string name="nav_precise_title">Precieze locatie nodig</string>
+    <string name="nav_precise_body">Navigatie volgt je met gps en heeft daarvoor je precieze locatie nodig. Bij benadering geeft alleen een ruw gebied, dus navigatie zou je nooit vinden.</string>
+    <string name="nav_precise_allow">Precies toestaan</string>
+    <string name="nav_precise_toast">Navigatie heeft je precieze locatie nodig</string>
+    <string name="loc_off_title">Locatie staat uit</string>
+    <string name="loc_off_body">Vela heeft geen locatietoegang. Je kunt dit toestaan in de systeeminstellingen.</string>
+    <string name="loc_off_settings">Instellingen openen</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -18,8 +18,7 @@
     <string name="settings_language_hint">Wijzigt de taal van de app en de gesproken aanwijzingen. Haal een passende stem uit de stemmenbibliotheek.</string>
     <string name="settings_search">Zoeken</string>
     <string name="settings_voice_search_toggle">Microfoon voor spraakzoeken</string>
-    <string name="settings_voice_search_hint">Toont een microfoon in de zoekbalk. Tik erop om je zoekopdracht in te spreken via een spraakinvoer-app op je telefoon.</string>
-    <string name="settings_voice_search_none">Toont een microfoon in de zoekbalk om je zoekopdracht in te spreken. Vereist een spraak-app zoals FUTO Voice Input; nog geen geïnstalleerd.</string>
+    <string name="settings_voice_search_hint">Toont een microfoon in de zoekbalk om je zoekopdracht in te spreken.</string>
     <string name="search_voice_cd">Zoeken met stem</string>
     <string name="search_voice_prompt">Spreek om te zoeken</string>
     <string name="settings_voice">Stem</string>
@@ -491,7 +490,7 @@
     <string name="mapvm_asr_ready">De Vela-stem is klaar</string>
     <string name="mapvm_asr_download_failed">Kan het spraakmodel niet downloaden. Controleer je verbinding en probeer opnieuw.</string>
     <string name="settings_voice_search_model">Vela-stem</string>
-    <string name="settings_voice_search_model_hint">De Vela-stem zet spraak direct op je telefoon om in een zoekopdracht: geen andere app nodig en er wordt niets geüpload. Eenmalige download van ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model_hint">De Vela-stem zet spraak direct op je telefoon om in een zoekopdracht: geen andere app nodig en er wordt niets geüpload. Eenmalige download van %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Downloaden (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Verwijderen</string>
     <string name="settings_voice_search_downloading">Downloaden… %1$d%%</string>  <!-- format -->
@@ -499,4 +498,6 @@
     <string name="settings_voice_search_engine_title">Als je op de microfoon tikt</string>
     <string name="settings_voice_search_engine_auto">Vela-stem</string>
     <string name="settings_voice_search_engine_system">Andere spraak-app</string>
+    <string name="map_asr_offer_title">Spraakzoeken</string>
+    <string name="map_asr_offer_body">Download de Vela-stem om je zoekopdrachten in te spreken. Hij draait volledig op je telefoon en uploadt niets.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -485,4 +485,19 @@
     <string name="settings_developer_hint">Narzędzia do wersji demo, zrzutów ekranu i testów. Wyłącz je do zwykłego użytku.</string>
     <string name="settings_browse_voices">Przeglądaj głosy</string>
     <string name="settings_browse_voices_hint">Pobieraj i przełączaj głosy Vela na urządzeniu.</string>
+    <string name="voice_capture_listening">Słucham…</string>
+    <string name="voice_capture_starting">Przygotowywanie…</string>
+    <string name="voice_capture_done">Gotowe</string>
+    <string name="mapvm_asr_ready">Wyszukiwanie głosowe na urządzeniu jest gotowe</string>
+    <string name="mapvm_asr_download_failed">Nie udało się pobrać modelu głosu. Sprawdź połączenie i spróbuj ponownie.</string>
+    <string name="settings_voice_search_model">Wyszukiwanie głosowe na urządzeniu</string>
+    <string name="settings_voice_search_model_hint">Rozpoznawanie mowy Vela działa na telefonie, więc wyszukiwanie głosowe działa bez innej aplikacji i nic nie jest wysyłane. Jednorazowe pobranie ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_download">Pobierz (%1$d MB)</string>  <!-- format -->
+    <string name="settings_voice_search_remove">Usuń</string>
+    <string name="settings_voice_search_downloading">Pobieranie… %1$d%%</string>  <!-- format -->
+    <string name="settings_voice_search_installing">Instalowanie…</string>
+    <string name="settings_voice_search_engine_title">Po dotknięciu mikrofonu</string>
+    <string name="settings_voice_search_engine_auto">Na urządzeniu, gdy dostępne</string>
+    <string name="settings_voice_search_engine_local">Tylko na urządzeniu</string>
+    <string name="settings_voice_search_engine_system">Inna aplikacja głosowa</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -18,8 +18,7 @@
     <string name="settings_language_hint">Zmienia język aplikacji i mówionych wskazówek. Pobierz pasujący głos w bibliotece głosów.</string>
     <string name="settings_search">Wyszukiwanie</string>
     <string name="settings_voice_search_toggle">Mikrofon wyszukiwania głosowego</string>
-    <string name="settings_voice_search_hint">Pokazuje mikrofon na pasku wyszukiwania. Dotknij go, aby wypowiedzieć zapytanie za pomocą aplikacji do wprowadzania głosem.</string>
-    <string name="settings_voice_search_none">Pokazuje mikrofon na pasku wyszukiwania do wypowiedzenia zapytania. Wymaga aplikacji głosowej, np. FUTO Voice Input; żadna nie jest zainstalowana.</string>
+    <string name="settings_voice_search_hint">Pokazuje mikrofon w pasku wyszukiwania do dyktowania.</string>
     <string name="search_voice_cd">Wyszukiwanie głosowe</string>
     <string name="search_voice_prompt">Mów, aby wyszukać</string>
     <string name="settings_voice">Głos</string>
@@ -491,7 +490,7 @@
     <string name="mapvm_asr_ready">Głos Vela jest gotowy</string>
     <string name="mapvm_asr_download_failed">Nie udało się pobrać modelu głosu. Sprawdź połączenie i spróbuj ponownie.</string>
     <string name="settings_voice_search_model">Głos Vela</string>
-    <string name="settings_voice_search_model_hint">Głos Vela zamienia mowę w wyszukiwanie bezpośrednio na telefonie: bez innej aplikacji i bez wysyłania czegokolwiek. Jednorazowe pobranie ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model_hint">Głos Vela zamienia mowę w wyszukiwanie bezpośrednio na telefonie: bez innej aplikacji i bez wysyłania czegokolwiek. Jednorazowe pobranie %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Pobierz (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Usuń</string>
     <string name="settings_voice_search_downloading">Pobieranie… %1$d%%</string>  <!-- format -->
@@ -499,4 +498,6 @@
     <string name="settings_voice_search_engine_title">Po dotknięciu mikrofonu</string>
     <string name="settings_voice_search_engine_auto">Głos Vela</string>
     <string name="settings_voice_search_engine_system">Inna aplikacja głosowa</string>
+    <string name="map_asr_offer_title">Wyszukiwanie głosowe</string>
+    <string name="map_asr_offer_body">Pobierz głos Vela, aby dyktować wyszukiwania. Działa w całości na telefonie i niczego nie wysyła.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -488,16 +488,15 @@
     <string name="voice_capture_listening">Słucham…</string>
     <string name="voice_capture_starting">Przygotowywanie…</string>
     <string name="voice_capture_done">Gotowe</string>
-    <string name="mapvm_asr_ready">Wyszukiwanie głosowe na urządzeniu jest gotowe</string>
+    <string name="mapvm_asr_ready">Głos Vela jest gotowy</string>
     <string name="mapvm_asr_download_failed">Nie udało się pobrać modelu głosu. Sprawdź połączenie i spróbuj ponownie.</string>
-    <string name="settings_voice_search_model">Wyszukiwanie głosowe na urządzeniu</string>
-    <string name="settings_voice_search_model_hint">Rozpoznawanie mowy Vela działa na telefonie, więc wyszukiwanie głosowe działa bez innej aplikacji i nic nie jest wysyłane. Jednorazowe pobranie ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model">Głos Vela</string>
+    <string name="settings_voice_search_model_hint">Głos Vela zamienia mowę w wyszukiwanie bezpośrednio na telefonie: bez innej aplikacji i bez wysyłania czegokolwiek. Jednorazowe pobranie ~%1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Pobierz (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Usuń</string>
     <string name="settings_voice_search_downloading">Pobieranie… %1$d%%</string>  <!-- format -->
     <string name="settings_voice_search_installing">Instalowanie…</string>
     <string name="settings_voice_search_engine_title">Po dotknięciu mikrofonu</string>
-    <string name="settings_voice_search_engine_auto">Na urządzeniu, gdy dostępne</string>
-    <string name="settings_voice_search_engine_local">Tylko na urządzeniu</string>
+    <string name="settings_voice_search_engine_auto">Głos Vela</string>
     <string name="settings_voice_search_engine_system">Inna aplikacja głosowa</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -500,4 +500,11 @@
     <string name="settings_voice_search_engine_system">Inna aplikacja głosowa</string>
     <string name="map_asr_offer_title">Wyszukiwanie głosowe</string>
     <string name="map_asr_offer_body">Pobierz głos Vela, aby dyktować wyszukiwania. Działa w całości na telefonie i niczego nie wysyła.</string>
+    <string name="nav_precise_title">Potrzebna dokładna lokalizacja</string>
+    <string name="nav_precise_body">Nawigacja śledzi cię przez GPS, co wymaga dokładnej lokalizacji. Przybliżona daje tylko ogólny obszar, więc nawigacja nigdy by cię nie znalazła.</string>
+    <string name="nav_precise_allow">Zezwól na dokładną</string>
+    <string name="nav_precise_toast">Nawigacja wymaga dokładnej lokalizacji</string>
+    <string name="loc_off_title">Lokalizacja jest wyłączona</string>
+    <string name="loc_off_body">Vela nie ma dostępu do lokalizacji. Możesz go włączyć w ustawieniach systemu.</string>
+    <string name="loc_off_settings">Otwórz ustawienia</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -485,4 +485,19 @@
     <string name="settings_developer_hint">Ferramentas para demos, capturas de ecrã e testes. Desative-as para uso real.</string>
     <string name="settings_browse_voices">Explorar vozes</string>
     <string name="settings_browse_voices_hint">Transfira e alterne entre as vozes da Vela no dispositivo.</string>
+    <string name="voice_capture_listening">A ouvir…</string>
+    <string name="voice_capture_starting">A preparar…</string>
+    <string name="voice_capture_done">Concluído</string>
+    <string name="mapvm_asr_ready">A pesquisa por voz no dispositivo está pronta</string>
+    <string name="mapvm_asr_download_failed">Não foi possível transferir o modelo de voz. Verifica a ligação e tenta novamente.</string>
+    <string name="settings_voice_search_model">Pesquisa por voz no dispositivo</string>
+    <string name="settings_voice_search_model_hint">O reconhecimento de voz da Vela corre no telemóvel, por isso a pesquisa por voz funciona sem outra app e nada é enviado. Transferência única de ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_download">Transferir (%1$d MB)</string>  <!-- format -->
+    <string name="settings_voice_search_remove">Remover</string>
+    <string name="settings_voice_search_downloading">A transferir… %1$d%%</string>  <!-- format -->
+    <string name="settings_voice_search_installing">A instalar…</string>
+    <string name="settings_voice_search_engine_title">Ao tocar no microfone</string>
+    <string name="settings_voice_search_engine_auto">No dispositivo quando disponível</string>
+    <string name="settings_voice_search_engine_local">Apenas no dispositivo</string>
+    <string name="settings_voice_search_engine_system">Outra app de voz</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -18,8 +18,7 @@
     <string name="settings_language_hint">Muda o idioma da app e das indicações faladas. Escolhe uma voz correspondente na biblioteca de vozes.</string>
     <string name="settings_search">Pesquisa</string>
     <string name="settings_voice_search_toggle">Microfone de pesquisa por voz</string>
-    <string name="settings_voice_search_hint">Mostra um microfone na barra de pesquisa. Toque para ditar a pesquisa com uma app de entrada de voz do telemóvel.</string>
-    <string name="settings_voice_search_none">Mostra um microfone na barra de pesquisa para ditar a pesquisa. Precisa de uma app de voz como o FUTO Voice Input; nenhuma instalada ainda.</string>
+    <string name="settings_voice_search_hint">Mostra um microfone na barra de pesquisa para ditar a pesquisa.</string>
     <string name="search_voice_cd">Pesquisa por voz</string>
     <string name="search_voice_prompt">Fale para pesquisar</string>
     <string name="settings_voice">Voz</string>
@@ -491,7 +490,7 @@
     <string name="mapvm_asr_ready">A voz Vela está pronta</string>
     <string name="mapvm_asr_download_failed">Não foi possível transferir o modelo de voz. Verifica a ligação e tenta novamente.</string>
     <string name="settings_voice_search_model">Voz Vela</string>
-    <string name="settings_voice_search_model_hint">A voz Vela transforma a fala numa pesquisa diretamente no telemóvel: sem outra app e sem enviar nada. Transferência única de ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model_hint">A voz Vela transforma a fala numa pesquisa diretamente no telemóvel: sem outra app e sem enviar nada. Transferência única de %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Transferir (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Remover</string>
     <string name="settings_voice_search_downloading">A transferir… %1$d%%</string>  <!-- format -->
@@ -499,4 +498,6 @@
     <string name="settings_voice_search_engine_title">Ao tocar no microfone</string>
     <string name="settings_voice_search_engine_auto">Voz Vela</string>
     <string name="settings_voice_search_engine_system">Outra app de voz</string>
+    <string name="map_asr_offer_title">Pesquisa por voz</string>
+    <string name="map_asr_offer_body">Transfere a voz Vela para ditar as tuas pesquisas. Corre inteiramente no telemóvel e não envia nada.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -500,4 +500,11 @@
     <string name="settings_voice_search_engine_system">Outra app de voz</string>
     <string name="map_asr_offer_title">Pesquisa por voz</string>
     <string name="map_asr_offer_body">Transfere a voz Vela para ditar as tuas pesquisas. Corre inteiramente no telemóvel e não envia nada.</string>
+    <string name="nav_precise_title">Localização precisa necessária</string>
+    <string name="nav_precise_body">A navegação segue-te por GPS, o que exige a localização precisa. A aproximada só dá uma zona geral, por isso a navegação nunca te encontraria.</string>
+    <string name="nav_precise_allow">Permitir precisa</string>
+    <string name="nav_precise_toast">A navegação precisa da localização precisa</string>
+    <string name="loc_off_title">A localização está desligada</string>
+    <string name="loc_off_body">A Vela não tem acesso à localização. Podes permitir nas definições do sistema.</string>
+    <string name="loc_off_settings">Abrir definições</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -488,16 +488,15 @@
     <string name="voice_capture_listening">A ouvir…</string>
     <string name="voice_capture_starting">A preparar…</string>
     <string name="voice_capture_done">Concluído</string>
-    <string name="mapvm_asr_ready">A pesquisa por voz no dispositivo está pronta</string>
+    <string name="mapvm_asr_ready">A voz Vela está pronta</string>
     <string name="mapvm_asr_download_failed">Não foi possível transferir o modelo de voz. Verifica a ligação e tenta novamente.</string>
-    <string name="settings_voice_search_model">Pesquisa por voz no dispositivo</string>
-    <string name="settings_voice_search_model_hint">O reconhecimento de voz da Vela corre no telemóvel, por isso a pesquisa por voz funciona sem outra app e nada é enviado. Transferência única de ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model">Voz Vela</string>
+    <string name="settings_voice_search_model_hint">A voz Vela transforma a fala numa pesquisa diretamente no telemóvel: sem outra app e sem enviar nada. Transferência única de ~%1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Transferir (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Remover</string>
     <string name="settings_voice_search_downloading">A transferir… %1$d%%</string>  <!-- format -->
     <string name="settings_voice_search_installing">A instalar…</string>
     <string name="settings_voice_search_engine_title">Ao tocar no microfone</string>
-    <string name="settings_voice_search_engine_auto">No dispositivo quando disponível</string>
-    <string name="settings_voice_search_engine_local">Apenas no dispositivo</string>
+    <string name="settings_voice_search_engine_auto">Voz Vela</string>
     <string name="settings_voice_search_engine_system">Outra app de voz</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -485,4 +485,19 @@
     <string name="settings_developer_hint">Инструменты для демо, скриншотов и тестов. Отключайте их для реальной работы.</string>
     <string name="settings_browse_voices">Выбрать голос</string>
     <string name="settings_browse_voices_hint">Загружайте и переключайте голоса Vela на устройстве.</string>
+    <string name="voice_capture_listening">Слушаю…</string>
+    <string name="voice_capture_starting">Подготовка…</string>
+    <string name="voice_capture_done">Готово</string>
+    <string name="mapvm_asr_ready">Голосовой поиск на устройстве готов</string>
+    <string name="mapvm_asr_download_failed">Не удалось загрузить голосовую модель. Проверьте подключение и повторите попытку.</string>
+    <string name="settings_voice_search_model">Голосовой поиск на устройстве</string>
+    <string name="settings_voice_search_model_hint">Собственное распознавание речи Vela работает на телефоне, поэтому голосовой поиск не требует других приложений и ничего не выгружается. Разовая загрузка ~%1$d МБ.</string>  <!-- format -->
+    <string name="settings_voice_search_download">Загрузить (%1$d МБ)</string>  <!-- format -->
+    <string name="settings_voice_search_remove">Удалить</string>
+    <string name="settings_voice_search_downloading">Загрузка… %1$d%%</string>  <!-- format -->
+    <string name="settings_voice_search_installing">Установка…</string>
+    <string name="settings_voice_search_engine_title">При нажатии на микрофон</string>
+    <string name="settings_voice_search_engine_auto">На устройстве, если доступно</string>
+    <string name="settings_voice_search_engine_local">Только на устройстве</string>
+    <string name="settings_voice_search_engine_system">Другое голосовое приложение</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -500,4 +500,11 @@
     <string name="settings_voice_search_engine_system">Другое голосовое приложение</string>
     <string name="map_asr_offer_title">Голосовой поиск</string>
     <string name="map_asr_offer_body">Загрузите голос Vela, чтобы диктовать запросы. Он работает целиком на телефоне и ничего не выгружает.</string>
+    <string name="nav_precise_title">Нужна точная геолокация</string>
+    <string name="nav_precise_body">Навигация ведёт вас по GPS, для этого нужна точная геолокация. Приблизительная даёт лишь общий район, и навигация вас не найдёт.</string>
+    <string name="nav_precise_allow">Разрешить точную</string>
+    <string name="nav_precise_toast">Навигации нужна точная геолокация</string>
+    <string name="loc_off_title">Геолокация выключена</string>
+    <string name="loc_off_body">У Vela нет доступа к геолокации. Разрешить его можно в настройках системы.</string>
+    <string name="loc_off_settings">Открыть настройки</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -488,16 +488,15 @@
     <string name="voice_capture_listening">Слушаю…</string>
     <string name="voice_capture_starting">Подготовка…</string>
     <string name="voice_capture_done">Готово</string>
-    <string name="mapvm_asr_ready">Голосовой поиск на устройстве готов</string>
+    <string name="mapvm_asr_ready">Голос Vela готов</string>
     <string name="mapvm_asr_download_failed">Не удалось загрузить голосовую модель. Проверьте подключение и повторите попытку.</string>
-    <string name="settings_voice_search_model">Голосовой поиск на устройстве</string>
-    <string name="settings_voice_search_model_hint">Собственное распознавание речи Vela работает на телефоне, поэтому голосовой поиск не требует других приложений и ничего не выгружается. Разовая загрузка ~%1$d МБ.</string>  <!-- format -->
+    <string name="settings_voice_search_model">Голос Vela</string>
+    <string name="settings_voice_search_model_hint">Голос Vela превращает речь в поиск прямо на телефоне: без других приложений и без выгрузки данных. Разовая загрузка ~%1$d МБ.</string>  <!-- format -->
     <string name="settings_voice_search_download">Загрузить (%1$d МБ)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Удалить</string>
     <string name="settings_voice_search_downloading">Загрузка… %1$d%%</string>  <!-- format -->
     <string name="settings_voice_search_installing">Установка…</string>
     <string name="settings_voice_search_engine_title">При нажатии на микрофон</string>
-    <string name="settings_voice_search_engine_auto">На устройстве, если доступно</string>
-    <string name="settings_voice_search_engine_local">Только на устройстве</string>
+    <string name="settings_voice_search_engine_auto">Голос Vela</string>
     <string name="settings_voice_search_engine_system">Другое голосовое приложение</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -18,8 +18,7 @@
     <string name="settings_language_hint">Меняет язык приложения и голосовых подсказок. Скачайте подходящий голос в библиотеке голосов.</string>
     <string name="settings_search">Поиск</string>
     <string name="settings_voice_search_toggle">Микрофон голосового поиска</string>
-    <string name="settings_voice_search_hint">Показывает микрофон в строке поиска. Нажмите, чтобы продиктовать запрос через приложение голосового ввода на телефоне.</string>
-    <string name="settings_voice_search_none">Показывает микрофон в строке поиска для диктовки запроса. Нужно приложение голосового ввода, например FUTO Voice Input; пока не установлено.</string>
+    <string name="settings_voice_search_hint">Показывает микрофон в строке поиска, чтобы диктовать запрос.</string>
     <string name="search_voice_cd">Голосовой поиск</string>
     <string name="search_voice_prompt">Говорите для поиска</string>
     <string name="settings_voice">Голос</string>
@@ -491,7 +490,7 @@
     <string name="mapvm_asr_ready">Голос Vela готов</string>
     <string name="mapvm_asr_download_failed">Не удалось загрузить голосовую модель. Проверьте подключение и повторите попытку.</string>
     <string name="settings_voice_search_model">Голос Vela</string>
-    <string name="settings_voice_search_model_hint">Голос Vela превращает речь в поиск прямо на телефоне: без других приложений и без выгрузки данных. Разовая загрузка ~%1$d МБ.</string>  <!-- format -->
+    <string name="settings_voice_search_model_hint">Голос Vela превращает речь в поиск прямо на телефоне: без других приложений и без выгрузки данных. Разовая загрузка %1$d МБ.</string>  <!-- format -->
     <string name="settings_voice_search_download">Загрузить (%1$d МБ)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Удалить</string>
     <string name="settings_voice_search_downloading">Загрузка… %1$d%%</string>  <!-- format -->
@@ -499,4 +498,6 @@
     <string name="settings_voice_search_engine_title">При нажатии на микрофон</string>
     <string name="settings_voice_search_engine_auto">Голос Vela</string>
     <string name="settings_voice_search_engine_system">Другое голосовое приложение</string>
+    <string name="map_asr_offer_title">Голосовой поиск</string>
+    <string name="map_asr_offer_body">Загрузите голос Vela, чтобы диктовать запросы. Он работает целиком на телефоне и ничего не выгружает.</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -485,4 +485,19 @@
     <string name="settings_developer_hint">Verktyg för demos, skärmbilder och tester. Stäng av dem för verklig användning.</string>
     <string name="settings_browse_voices">Bläddra bland röster</string>
     <string name="settings_browse_voices_hint">Ladda ner och växla mellan Velas röster på enheten.</string>
+    <string name="voice_capture_listening">Lyssnar…</string>
+    <string name="voice_capture_starting">Förbereder…</string>
+    <string name="voice_capture_done">Klar</string>
+    <string name="mapvm_asr_ready">Röstsökning på enheten är klar</string>
+    <string name="mapvm_asr_download_failed">Det gick inte att ladda ner röstmodellen. Kontrollera anslutningen och försök igen.</string>
+    <string name="settings_voice_search_model">Röstsökning på enheten</string>
+    <string name="settings_voice_search_model_hint">Velas egen taligenkänning körs på telefonen, så röstsökning fungerar utan någon annan app och inget laddas upp. Engångsnedladdning på ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_download">Ladda ner (%1$d MB)</string>  <!-- format -->
+    <string name="settings_voice_search_remove">Ta bort</string>
+    <string name="settings_voice_search_downloading">Laddar ner… %1$d%%</string>  <!-- format -->
+    <string name="settings_voice_search_installing">Installerar…</string>
+    <string name="settings_voice_search_engine_title">När du trycker på mikrofonen</string>
+    <string name="settings_voice_search_engine_auto">På enheten när tillgängligt</string>
+    <string name="settings_voice_search_engine_local">Endast på enheten</string>
+    <string name="settings_voice_search_engine_system">Annan röstapp</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -500,4 +500,11 @@
     <string name="settings_voice_search_engine_system">Annan röstapp</string>
     <string name="map_asr_offer_title">Röstsökning</string>
     <string name="map_asr_offer_body">Ladda ner Vela-rösten för att tala in dina sökningar. Den körs helt på telefonen och laddar inte upp något.</string>
+    <string name="nav_precise_title">Exakt plats krävs</string>
+    <string name="nav_precise_body">Navigeringen följer dig med GPS, vilket kräver exakt plats. Ungefärlig ger bara ett grovt område, så navigeringen skulle aldrig hitta dig.</string>
+    <string name="nav_precise_allow">Tillåt exakt</string>
+    <string name="nav_precise_toast">Navigering kräver exakt plats</string>
+    <string name="loc_off_title">Platsen är av</string>
+    <string name="loc_off_body">Vela har inte platsåtkomst. Du kan tillåta det i systeminställningarna.</string>
+    <string name="loc_off_settings">Öppna inställningar</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -18,8 +18,7 @@
     <string name="settings_language_hint">Ändrar appens språk och de talade anvisningarna. Hämta en matchande röst i röstbiblioteket.</string>
     <string name="settings_search">Sök</string>
     <string name="settings_voice_search_toggle">Mikrofon för röstsökning</string>
-    <string name="settings_voice_search_hint">Visar en mikrofon i sökfältet. Tryck för att tala din sökning via en röstinmatnings-app på telefonen.</string>
-    <string name="settings_voice_search_none">Visar en mikrofon i sökfältet för att tala din sökning. Kräver en röst-app som FUTO Voice Input; ingen är installerad ännu.</string>
+    <string name="settings_voice_search_hint">Visar en mikrofon i sökfältet för att tala in sökningen.</string>
     <string name="search_voice_cd">Röstsökning</string>
     <string name="search_voice_prompt">Tala för att söka</string>
     <string name="settings_voice">Röst</string>
@@ -491,7 +490,7 @@
     <string name="mapvm_asr_ready">Vela-rösten är klar</string>
     <string name="mapvm_asr_download_failed">Det gick inte att ladda ner röstmodellen. Kontrollera anslutningen och försök igen.</string>
     <string name="settings_voice_search_model">Vela-röst</string>
-    <string name="settings_voice_search_model_hint">Vela-rösten gör tal till en sökning direkt på telefonen: ingen annan app behövs och inget laddas upp. Engångsnedladdning på ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model_hint">Vela-rösten gör tal till en sökning direkt på telefonen: ingen annan app behövs och inget laddas upp. Engångsnedladdning på %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Ladda ner (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Ta bort</string>
     <string name="settings_voice_search_downloading">Laddar ner… %1$d%%</string>  <!-- format -->
@@ -499,4 +498,6 @@
     <string name="settings_voice_search_engine_title">När du trycker på mikrofonen</string>
     <string name="settings_voice_search_engine_auto">Vela-röst</string>
     <string name="settings_voice_search_engine_system">Annan röstapp</string>
+    <string name="map_asr_offer_title">Röstsökning</string>
+    <string name="map_asr_offer_body">Ladda ner Vela-rösten för att tala in dina sökningar. Den körs helt på telefonen och laddar inte upp något.</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -488,16 +488,15 @@
     <string name="voice_capture_listening">Lyssnar…</string>
     <string name="voice_capture_starting">Förbereder…</string>
     <string name="voice_capture_done">Klar</string>
-    <string name="mapvm_asr_ready">Röstsökning på enheten är klar</string>
+    <string name="mapvm_asr_ready">Vela-rösten är klar</string>
     <string name="mapvm_asr_download_failed">Det gick inte att ladda ner röstmodellen. Kontrollera anslutningen och försök igen.</string>
-    <string name="settings_voice_search_model">Röstsökning på enheten</string>
-    <string name="settings_voice_search_model_hint">Velas egen taligenkänning körs på telefonen, så röstsökning fungerar utan någon annan app och inget laddas upp. Engångsnedladdning på ~%1$d MB.</string>  <!-- format -->
+    <string name="settings_voice_search_model">Vela-röst</string>
+    <string name="settings_voice_search_model_hint">Vela-rösten gör tal till en sökning direkt på telefonen: ingen annan app behövs och inget laddas upp. Engångsnedladdning på ~%1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Ladda ner (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Ta bort</string>
     <string name="settings_voice_search_downloading">Laddar ner… %1$d%%</string>  <!-- format -->
     <string name="settings_voice_search_installing">Installerar…</string>
     <string name="settings_voice_search_engine_title">När du trycker på mikrofonen</string>
-    <string name="settings_voice_search_engine_auto">På enheten när tillgängligt</string>
-    <string name="settings_voice_search_engine_local">Endast på enheten</string>
+    <string name="settings_voice_search_engine_auto">Vela-röst</string>
     <string name="settings_voice_search_engine_system">Annan röstapp</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -485,4 +485,19 @@
     <string name="settings_developer_hint">Інструменти для демо, знімків екрана та тестів. Вимикайте їх для реального використання.</string>
     <string name="settings_browse_voices">Огляд голосів</string>
     <string name="settings_browse_voices_hint">Завантажуйте та перемикайте голоси Vela на пристрої.</string>
+    <string name="voice_capture_listening">Слухаю…</string>
+    <string name="voice_capture_starting">Підготовка…</string>
+    <string name="voice_capture_done">Готово</string>
+    <string name="mapvm_asr_ready">Голосовий пошук на пристрої готовий</string>
+    <string name="mapvm_asr_download_failed">Не вдалося завантажити голосову модель. Перевірте з\'єднання та повторіть спробу.</string>
+    <string name="settings_voice_search_model">Голосовий пошук на пристрої</string>
+    <string name="settings_voice_search_model_hint">Власне розпізнавання мовлення Vela працює на телефоні, тож голосовий пошук працює без інших застосунків і нічого не надсилається. Одноразове завантаження ~%1$d МБ.</string>  <!-- format -->
+    <string name="settings_voice_search_download">Завантажити (%1$d МБ)</string>  <!-- format -->
+    <string name="settings_voice_search_remove">Видалити</string>
+    <string name="settings_voice_search_downloading">Завантаження… %1$d%%</string>  <!-- format -->
+    <string name="settings_voice_search_installing">Встановлення…</string>
+    <string name="settings_voice_search_engine_title">Коли торкаєтеся мікрофона</string>
+    <string name="settings_voice_search_engine_auto">На пристрої, якщо доступно</string>
+    <string name="settings_voice_search_engine_local">Лише на пристрої</string>
+    <string name="settings_voice_search_engine_system">Інший голосовий застосунок</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -500,4 +500,11 @@
     <string name="settings_voice_search_engine_system">Інший голосовий застосунок</string>
     <string name="map_asr_offer_title">Голосовий пошук</string>
     <string name="map_asr_offer_body">Завантажте голос Vela, щоб диктувати запити. Він працює цілком на телефоні й нічого не надсилає.</string>
+    <string name="nav_precise_title">Потрібна точна геолокація</string>
+    <string name="nav_precise_body">Навігація веде вас за GPS, для цього потрібна точна геолокація. Приблизна дає лише загальний район, тож навігація вас не знайде.</string>
+    <string name="nav_precise_allow">Дозволити точну</string>
+    <string name="nav_precise_toast">Навігації потрібна точна геолокація</string>
+    <string name="loc_off_title">Геолокацію вимкнено</string>
+    <string name="loc_off_body">Vela не має доступу до геолокації. Дозволити його можна в налаштуваннях системи.</string>
+    <string name="loc_off_settings">Відкрити налаштування</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -18,8 +18,7 @@
     <string name="settings_language_hint">Змінює мову застосунку та голосових підказок. Завантажте відповідний голос у бібліотеці голосів.</string>
     <string name="settings_search">Пошук</string>
     <string name="settings_voice_search_toggle">Мікрофон голосового пошуку</string>
-    <string name="settings_voice_search_hint">Показує мікрофон у рядку пошуку. Торкніться, щоб продиктувати запит через застосунок голосового введення.</string>
-    <string name="settings_voice_search_none">Показує мікрофон у рядку пошуку для диктування запиту. Потрібен застосунок голосового введення, як-от FUTO Voice Input; ще не встановлено.</string>
+    <string name="settings_voice_search_hint">Показує мікрофон у рядку пошуку, щоб диктувати запит.</string>
     <string name="search_voice_cd">Голосовий пошук</string>
     <string name="search_voice_prompt">Говоріть, щоб шукати</string>
     <string name="settings_voice">Голос</string>
@@ -491,7 +490,7 @@
     <string name="mapvm_asr_ready">Голос Vela готовий</string>
     <string name="mapvm_asr_download_failed">Не вдалося завантажити голосову модель. Перевірте з\'єднання та повторіть спробу.</string>
     <string name="settings_voice_search_model">Голос Vela</string>
-    <string name="settings_voice_search_model_hint">Голос Vela перетворює мовлення на пошук просто на телефоні: без інших застосунків і без надсилання даних. Одноразове завантаження ~%1$d МБ.</string>  <!-- format -->
+    <string name="settings_voice_search_model_hint">Голос Vela перетворює мовлення на пошук просто на телефоні: без інших застосунків і без надсилання даних. Одноразове завантаження %1$d МБ.</string>  <!-- format -->
     <string name="settings_voice_search_download">Завантажити (%1$d МБ)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Видалити</string>
     <string name="settings_voice_search_downloading">Завантаження… %1$d%%</string>  <!-- format -->
@@ -499,4 +498,6 @@
     <string name="settings_voice_search_engine_title">Коли торкаєтеся мікрофона</string>
     <string name="settings_voice_search_engine_auto">Голос Vela</string>
     <string name="settings_voice_search_engine_system">Інший голосовий застосунок</string>
+    <string name="map_asr_offer_title">Голосовий пошук</string>
+    <string name="map_asr_offer_body">Завантажте голос Vela, щоб диктувати запити. Він працює цілком на телефоні й нічого не надсилає.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -488,16 +488,15 @@
     <string name="voice_capture_listening">Слухаю…</string>
     <string name="voice_capture_starting">Підготовка…</string>
     <string name="voice_capture_done">Готово</string>
-    <string name="mapvm_asr_ready">Голосовий пошук на пристрої готовий</string>
+    <string name="mapvm_asr_ready">Голос Vela готовий</string>
     <string name="mapvm_asr_download_failed">Не вдалося завантажити голосову модель. Перевірте з\'єднання та повторіть спробу.</string>
-    <string name="settings_voice_search_model">Голосовий пошук на пристрої</string>
-    <string name="settings_voice_search_model_hint">Власне розпізнавання мовлення Vela працює на телефоні, тож голосовий пошук працює без інших застосунків і нічого не надсилається. Одноразове завантаження ~%1$d МБ.</string>  <!-- format -->
+    <string name="settings_voice_search_model">Голос Vela</string>
+    <string name="settings_voice_search_model_hint">Голос Vela перетворює мовлення на пошук просто на телефоні: без інших застосунків і без надсилання даних. Одноразове завантаження ~%1$d МБ.</string>  <!-- format -->
     <string name="settings_voice_search_download">Завантажити (%1$d МБ)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Видалити</string>
     <string name="settings_voice_search_downloading">Завантаження… %1$d%%</string>  <!-- format -->
     <string name="settings_voice_search_installing">Встановлення…</string>
     <string name="settings_voice_search_engine_title">Коли торкаєтеся мікрофона</string>
-    <string name="settings_voice_search_engine_auto">На пристрої, якщо доступно</string>
-    <string name="settings_voice_search_engine_local">Лише на пристрої</string>
+    <string name="settings_voice_search_engine_auto">Голос Vela</string>
     <string name="settings_voice_search_engine_system">Інший голосовий застосунок</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -508,4 +508,19 @@
     <string name="settings_developer_hint">Tools for demos, screenshots and testing. Turn each off for real use.</string>
     <string name="settings_browse_voices">Browse voices</string>
     <string name="settings_browse_voices_hint">Download and switch between Vela\'s on-device voices.</string>
+    <string name="voice_capture_listening">Listening…</string>
+    <string name="voice_capture_starting">Getting ready…</string>
+    <string name="voice_capture_done">Done</string>
+    <string name="mapvm_asr_ready">On-device voice search is ready</string>
+    <string name="mapvm_asr_download_failed">Couldn\'t download the voice model. Check your connection and try again.</string>
+    <string name="settings_voice_search_model">On-device voice search</string>
+    <string name="settings_voice_search_model_hint">Vela\'s own speech-to-text runs on your phone, so voice search works with no other app and nothing is uploaded. One-time ~%1$d MB download.</string>  <!-- format -->
+    <string name="settings_voice_search_download">Download (%1$d MB)</string>  <!-- format -->
+    <string name="settings_voice_search_remove">Remove</string>
+    <string name="settings_voice_search_downloading">Downloading… %1$d%%</string>  <!-- format -->
+    <string name="settings_voice_search_installing">Installing…</string>
+    <string name="settings_voice_search_engine_title">When you tap the mic</string>
+    <string name="settings_voice_search_engine_auto">On-device when available</string>
+    <string name="settings_voice_search_engine_local">On-device only</string>
+    <string name="settings_voice_search_engine_system">Other voice app</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -523,4 +523,11 @@
     <string name="settings_voice_search_engine_system">Other voice app</string>
     <string name="map_asr_offer_title">Voice search</string>
     <string name="map_asr_offer_body">Download Vela Voice to speak your searches. It runs entirely on your phone and uploads nothing.</string>
+    <string name="nav_precise_title">Precise location needed</string>
+    <string name="nav_precise_body">Turn-by-turn follows you with GPS, which needs precise location. Approximate only gives a rough area, so navigation would never find you.</string>
+    <string name="nav_precise_allow">Allow precise</string>
+    <string name="nav_precise_toast">Turn-by-turn needs precise location</string>
+    <string name="loc_off_title">Location is off</string>
+    <string name="loc_off_body">Vela doesn\'t have location access. You can allow it in system settings.</string>
+    <string name="loc_off_settings">Open settings</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -511,16 +511,15 @@
     <string name="voice_capture_listening">Listening…</string>
     <string name="voice_capture_starting">Getting ready…</string>
     <string name="voice_capture_done">Done</string>
-    <string name="mapvm_asr_ready">On-device voice search is ready</string>
+    <string name="mapvm_asr_ready">Vela voice is ready</string>
     <string name="mapvm_asr_download_failed">Couldn\'t download the voice model. Check your connection and try again.</string>
-    <string name="settings_voice_search_model">On-device voice search</string>
-    <string name="settings_voice_search_model_hint">Vela\'s own speech-to-text runs on your phone, so voice search works with no other app and nothing is uploaded. One-time ~%1$d MB download.</string>  <!-- format -->
+    <string name="settings_voice_search_model">Vela voice</string>
+    <string name="settings_voice_search_model_hint">Vela voice turns speech into a search right on your phone: no other app needed and nothing is uploaded. One-time ~%1$d MB download.</string>  <!-- format -->
     <string name="settings_voice_search_download">Download (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Remove</string>
     <string name="settings_voice_search_downloading">Downloading… %1$d%%</string>  <!-- format -->
     <string name="settings_voice_search_installing">Installing…</string>
     <string name="settings_voice_search_engine_title">When you tap the mic</string>
-    <string name="settings_voice_search_engine_auto">On-device when available</string>
-    <string name="settings_voice_search_engine_local">On-device only</string>
+    <string name="settings_voice_search_engine_auto">Vela voice</string>
     <string name="settings_voice_search_engine_system">Other voice app</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -510,17 +510,17 @@
     <string name="voice_capture_listening">Listening…</string>
     <string name="voice_capture_starting">Getting ready…</string>
     <string name="voice_capture_done">Done</string>
-    <string name="mapvm_asr_ready">Vela voice is ready</string>
+    <string name="mapvm_asr_ready">Vela Voice is ready</string>
     <string name="mapvm_asr_download_failed">Couldn\'t download the voice model. Check your connection and try again.</string>
-    <string name="settings_voice_search_model">Vela voice</string>
-    <string name="settings_voice_search_model_hint">Vela voice turns speech into a search right on your phone: no other app needed and nothing is uploaded. One-time %1$d MB download.</string>  <!-- format -->
+    <string name="settings_voice_search_model">Vela Voice</string>
+    <string name="settings_voice_search_model_hint">Vela Voice turns speech into a search right on your phone: no other app needed and nothing is uploaded. One-time %1$d MB download.</string>  <!-- format -->
     <string name="settings_voice_search_download">Download (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Remove</string>
     <string name="settings_voice_search_downloading">Downloading… %1$d%%</string>  <!-- format -->
     <string name="settings_voice_search_installing">Installing…</string>
     <string name="settings_voice_search_engine_title">When you tap the mic</string>
-    <string name="settings_voice_search_engine_auto">Vela voice</string>
+    <string name="settings_voice_search_engine_auto">Vela Voice</string>
     <string name="settings_voice_search_engine_system">Other voice app</string>
     <string name="map_asr_offer_title">Voice search</string>
-    <string name="map_asr_offer_body">Download Vela voice to speak your searches. It runs entirely on your phone and uploads nothing.</string>
+    <string name="map_asr_offer_body">Download Vela Voice to speak your searches. It runs entirely on your phone and uploads nothing.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,8 +32,7 @@
     <string name="settings_language_hint">Changes the app\'s language and the spoken directions. Grab a matching voice in the Voice library.</string>
     <string name="settings_search">Search</string>
     <string name="settings_voice_search_toggle">Voice search mic</string>
-    <string name="settings_voice_search_hint">Shows a mic in the search bar. Tap it to speak your search, using a voice-input app on your phone.</string>
-    <string name="settings_voice_search_none">Shows a mic in the search bar to speak your search. Needs a voice-input app such as FUTO Voice Input; none is installed yet.</string>
+    <string name="settings_voice_search_hint">Shows a mic in the search bar to speak your search.</string>
     <string name="search_voice_cd">Voice search</string>
     <string name="search_voice_prompt">Speak to search</string>
     <string name="settings_voice">Voice</string>
@@ -514,7 +513,7 @@
     <string name="mapvm_asr_ready">Vela voice is ready</string>
     <string name="mapvm_asr_download_failed">Couldn\'t download the voice model. Check your connection and try again.</string>
     <string name="settings_voice_search_model">Vela voice</string>
-    <string name="settings_voice_search_model_hint">Vela voice turns speech into a search right on your phone: no other app needed and nothing is uploaded. One-time ~%1$d MB download.</string>  <!-- format -->
+    <string name="settings_voice_search_model_hint">Vela voice turns speech into a search right on your phone: no other app needed and nothing is uploaded. One-time %1$d MB download.</string>  <!-- format -->
     <string name="settings_voice_search_download">Download (%1$d MB)</string>  <!-- format -->
     <string name="settings_voice_search_remove">Remove</string>
     <string name="settings_voice_search_downloading">Downloading… %1$d%%</string>  <!-- format -->
@@ -522,4 +521,6 @@
     <string name="settings_voice_search_engine_title">When you tap the mic</string>
     <string name="settings_voice_search_engine_auto">Vela voice</string>
     <string name="settings_voice_search_engine_system">Other voice app</string>
+    <string name="map_asr_offer_title">Voice search</string>
+    <string name="map_asr_offer_body">Download Vela voice to speak your searches. It runs entirely on your phone and uploads nothing.</string>
 </resources>

--- a/tools/build-asr-model.sh
+++ b/tools/build-asr-model.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Builds the lean on-device speech-to-text archive Vela downloads for voice search (tier-1),
+# and uploads it to the `asr-models` GitHub release. Run once (or when bumping the model).
+#
+# The archive is Whisper tiny multilingual (int8) + Silero VAD, taken from the upstream
+# sherpa-onnx pre-trained models and slimmed to the four files the app actually loads:
+#   whisper-tiny/tiny-encoder.int8.onnx
+#   whisper-tiny/tiny-decoder.int8.onnx
+#   whisper-tiny/tiny-tokens.txt
+#   whisper-tiny/silero_vad.onnx
+# The full upstream tarball also ships the fp32 models + test wavs (~116 MB); dropping those
+# takes the download to ~47 MB. sherpa-onnx models are Apache-2.0 / MIT.
+#
+# Usage: tools/build-asr-model.sh            # build the archive into ./out
+#        UPLOAD=1 tools/build-asr-model.sh   # also create/refresh the asr-models release
+set -euo pipefail
+
+WHISPER_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-tiny.tar.bz2"
+VAD_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_vad.onnx"
+REPO="PimpinPumpkin/Vela"
+OUT="${OUT:-out}"
+
+mkdir -p "$OUT" && cd "$OUT"
+echo "==> downloading upstream whisper-tiny + silero_vad"
+[ -f whisper-tiny.tar.bz2 ] || curl -fL "$WHISPER_URL" -o whisper-tiny.tar.bz2
+[ -f silero_vad.onnx ]      || curl -fL "$VAD_URL" -o silero_vad.onnx
+tar xjf whisper-tiny.tar.bz2
+
+echo "==> slimming to int8 + VAD"
+rm -rf whisper-tiny && mkdir whisper-tiny
+cp sherpa-onnx-whisper-tiny/tiny-encoder.int8.onnx \
+   sherpa-onnx-whisper-tiny/tiny-decoder.int8.onnx \
+   sherpa-onnx-whisper-tiny/tiny-tokens.txt \
+   silero_vad.onnx \
+   whisper-tiny/
+tar cjf vela-asr-whisper-tiny.tar.bz2 whisper-tiny
+SIZE_MB=$(( $(stat -f%z vela-asr-whisper-tiny.tar.bz2 2>/dev/null || stat -c%s vela-asr-whisper-tiny.tar.bz2) / 1048576 ))
+echo "==> vela-asr-whisper-tiny.tar.bz2 = ${SIZE_MB} MB"
+
+cat > asr-manifest.json <<JSON
+{
+  "schema": 1,
+  "models": [
+    {
+      "id": "whisper-tiny",
+      "name": "Whisper tiny (multilingual)",
+      "url": "https://github.com/${REPO}/releases/download/asr-models/vela-asr-whisper-tiny.tar.bz2",
+      "sizeMb": ${SIZE_MB},
+      "dir": "whisper-tiny",
+      "encoder": "tiny-encoder.int8.onnx",
+      "decoder": "tiny-decoder.int8.onnx",
+      "tokens": "tiny-tokens.txt",
+      "vad": "silero_vad.onnx",
+      "languages": ["en","fr","de","es","it","pt","nl","ru","pl","sv","uk"]
+    }
+  ]
+}
+JSON
+
+if [ "${UPLOAD:-0}" = "1" ]; then
+  echo "==> publishing to the asr-models release"
+  gh release view asr-models --repo "$REPO" >/dev/null 2>&1 \
+    && gh release upload asr-models --repo "$REPO" --clobber vela-asr-whisper-tiny.tar.bz2 asr-manifest.json \
+    || gh release create asr-models --repo "$REPO" --prerelease \
+         --title "ASR models (on-device voice search)" \
+         --notes "On-device speech-to-text (Whisper tiny int8 + Silero VAD) Vela downloads for voice search. Infrastructure release." \
+         vela-asr-whisper-tiny.tar.bz2 asr-manifest.json
+fi
+echo "==> done"

--- a/tools/build-asr-model.sh
+++ b/tools/build-asr-model.sh
@@ -9,7 +9,7 @@
 #   whisper-tiny/tiny-tokens.txt
 #   whisper-tiny/silero_vad.onnx
 # The full upstream tarball also ships the fp32 models + test wavs (~116 MB); dropping those
-# takes the download to ~47 MB. sherpa-onnx models are Apache-2.0 / MIT.
+# keeps the download small (gzip, not bzip2: a phone unpacks gzip about ten times faster). sherpa-onnx models are Apache-2.0 / MIT.
 #
 # Usage: tools/build-asr-model.sh            # build the archive into ./out
 #        UPLOAD=1 tools/build-asr-model.sh   # also create/refresh the asr-models release
@@ -33,9 +33,9 @@ cp sherpa-onnx-whisper-tiny/tiny-encoder.int8.onnx \
    sherpa-onnx-whisper-tiny/tiny-tokens.txt \
    silero_vad.onnx \
    whisper-tiny/
-tar cjf vela-asr-whisper-tiny.tar.bz2 whisper-tiny
-SIZE_MB=$(( $(stat -f%z vela-asr-whisper-tiny.tar.bz2 2>/dev/null || stat -c%s vela-asr-whisper-tiny.tar.bz2) / 1048576 ))
-echo "==> vela-asr-whisper-tiny.tar.bz2 = ${SIZE_MB} MB"
+tar czf vela-asr-whisper-tiny.tar.gz whisper-tiny
+SIZE_MB=$(( $(stat -f%z vela-asr-whisper-tiny.tar.gz 2>/dev/null || stat -c%s vela-asr-whisper-tiny.tar.gz) / 1048576 ))
+echo "==> vela-asr-whisper-tiny.tar.gz = ${SIZE_MB} MB"
 
 cat > asr-manifest.json <<JSON
 {
@@ -44,7 +44,7 @@ cat > asr-manifest.json <<JSON
     {
       "id": "whisper-tiny",
       "name": "Whisper tiny (multilingual)",
-      "url": "https://github.com/${REPO}/releases/download/asr-models/vela-asr-whisper-tiny.tar.bz2",
+      "url": "https://github.com/${REPO}/releases/download/asr-models/vela-asr-whisper-tiny.tar.gz",
       "sizeMb": ${SIZE_MB},
       "dir": "whisper-tiny",
       "encoder": "tiny-encoder.int8.onnx",
@@ -60,10 +60,10 @@ JSON
 if [ "${UPLOAD:-0}" = "1" ]; then
   echo "==> publishing to the asr-models release"
   gh release view asr-models --repo "$REPO" >/dev/null 2>&1 \
-    && gh release upload asr-models --repo "$REPO" --clobber vela-asr-whisper-tiny.tar.bz2 asr-manifest.json \
+    && gh release upload asr-models --repo "$REPO" --clobber vela-asr-whisper-tiny.tar.gz asr-manifest.json \
     || gh release create asr-models --repo "$REPO" --prerelease \
          --title "ASR models (on-device voice search)" \
          --notes "On-device speech-to-text (Whisper tiny int8 + Silero VAD) Vela downloads for voice search. Infrastructure release." \
-         vela-asr-whisper-tiny.tar.bz2 asr-manifest.json
+         vela-asr-whisper-tiny.tar.gz asr-manifest.json
 fi
 echo "==> done"


### PR DESCRIPTION
Adds a second, on-device path for the search mic: Vela's own speech-to-text, so voice search works with no third-party app and no account, and nothing leaves the phone.

**Stacked on #24** (base branch is `settings-cleanup`). Retarget to `main` after #24 merges.

**How it works**
- Download Vela's ~47 MB speech model (Settings → Search). Tapping the mic then records with `AudioRecord` and transcribes on the phone with **Whisper tiny (int8, multilingual) + Silero VAD** through the already-bundled sherpa-onnx runtime (the same AAR Piper TTS uses, so no new dependency). It covers all 11 of Vela's languages.
- A listening sheet shows the mic pulsing with your voice; the VAD stops it after a beat of silence, or you tap Done. RECORD_AUDIO is asked only the first time you tap the mic, and never for the provider path.
- Which path runs is resolved from what's available (`VoiceSearch.resolvedMode`): on-device when the model is present, otherwise a voice-input app (the existing intent handoff), otherwise the mic is hidden. When both exist, a Settings picker chooses (on-device by default).

**Infrastructure:** the model is hosted on a new `asr-models` release (like `tts-runtime`/`routing-graphs`); `tools/build-asr-model.sh` slims the upstream sherpa whisper-tiny to the int8 files + Silero and publishes it. The download reuses the neural-voice installer and its no-call-timeout client.

**Device-verified scenario matrix** (Pixel 4a 5G):
- Model only, no provider → mic appears (tier-1); download + install, point-of-use permission, listening sheet, VAD auto-stop, transcript into the search box. The whole pipeline runs on-device (confirmed the native runtime + VAD loading in logcat).
- Model + a real provider (FUTO Voice Input) → the "When you tap the mic" picker appears; Auto uses on-device, "Other voice app" launches FUTO (that app records, Vela records nothing).
- Provider detection is reactive (the Settings hint flips once a voice app is installed).

**D-pad:** the capture sheet auto-focuses its Done button (the VelaDialog raw-Dialog pattern); the Settings rows use the standard focusable helpers; static audit clean for the new file.

**Strings** for the capture sheet, the Settings download/picker, and status messages are translated across all 11 languages. PRIVACY.md, FEATURES.md and CLAUDE.md updated.

**Known tradeoff:** tiny-int8 is the smallest Whisper, chosen for size (~47 MB) and speed on budget phones; accuracy on clean, close speech is good but it's not large-model accuracy. A bigger model could be a future catalog entry. Real-world accuracy is worth a listen on your own voice.
