### PR TITLE
Search page polish: removable recents, addresses, menu color fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,6 +524,9 @@ Defaults that make the safe path the easy one:
   primary `CircleShape` pill (onPrimary text); the dismiss stays a plain text button, quieted further
   to `onSurfaceVariant` when `dismissLowEmphasis`. One change in `VelaDialog`, so EVERY dialog (voice,
   location, diagnostics consent, trip consent, …) gets the pill - don't hand-roll per-dialog buttons.
+  The map's UpdateCard uses the same treatment (2026-07-10): its Update action is a filled primary
+  CircleShape `Button` beside a plain "Not now" text button, so the action reads by shape and fill,
+  not text colour alone (colour-blind safe). Give any future card's primary action the same pill.
   The button row is a **`FlowRow`** (not `Row`): when the two labels don't fit on one line (a long
   "Download Vela voice" pill beside "Use system voice", or a small/feature-phone screen) the confirm
   pill wraps to its OWN full-width line instead of being squeezed and breaking mid-word. Both buttons

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,6 +368,12 @@ Defaults that make the safe path the easy one:
   provider is off (degoogled devices often carry a present-but-disabled NETWORK provider) ->
   AbstractMethodError, crash on every launch (user report, Android 10/Adreno 308). Override all
   four callbacks explicitly in any android.location.LocationListener implementation.
+- **SavedPlace carries an optional address (2026-07-10).** `SavedPlace.address` (defaulted null, so
+  pre-existing payloads decode; every store's Json sets ignoreUnknownKeys so downgrades survive too)
+  is filled by `SavedPlace.of(Place)` - recents rows show it as a sublabel and the Home/Work rows
+  show it as their subtext. Recents also support PER-ROW removal (`RecentSearchStore.remove(query)`
+  / `RecentPlaceStore.remove(placeId)` -> the X in `SuggestionRow(onRemove=...)`, its own D-pad
+  focus stop with a ring).
 - **Recents stores are timestamped under NEW pref keys (2026-07-09).** `RecentQuery`/`RecentPlace`
   carry `at` (epoch ms) so the search page can interleave queries and places chronologically.
   They persist under `queries2`/`places2`; the legacy `queries`/`places` payloads are READ ONCE

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -491,13 +491,26 @@ Defaults that make the safe path the easy one:
   MapScreen falls back to 2000 m when the fix hasn't reported accuracy yet (Android hands coarse
   apps a fix only every few minutes), and the recenter tap ZOOM-FITS the circle (at street zoom a
   2 km halo covers the whole screen as an invisible uniform wash; the blob only reads when its edge
-  is on screen) - so an approximate-only
+  is on screen). **The fit works in DENSITY-INDEPENDENT px with the 512-tile constant
+  (78271.517*cos(lat)/2^z m/dp, 2026-07-10)** - the first cut used physical px + the 256-tile
+  constant, landed ~2.5 levels too close on a 2.75x-density phone, and the circle still overflowed
+  the screen as the invisible wash (why "i am not seeing a large blob" persisted through a whole
+  build). Device-verified: locate on coarse-only now frames the disc at ~70% of screen width with
+  its edge line visible - so an approximate-only
   permission or a weak network fix reads as "somewhere in this blob" instead of a falsely precise
   dot, and ordinary GPS (3-30 m) stays a plain dot. Identity-gated like the other applyData uploads.
   Render verified on-device via a temporary forced-1500 m build (a real coarse fix is
   interval-throttled by Android, too slow to wait out in a test loop).
-- **Onboarding is deliberately SHORT - three steps, no more (declutter 2026-07-10).** Welcome →
-  location → voice, then the map. The old **offline-maps** onboarding prompt and the **diagnostics/
+- **Onboarding is deliberately SHORT - four steps, no more (declutter 2026-07-10).** Welcome →
+  location → notifications → voice, then the map. The notification step (2026-07-10, Android 13+
+  only, `Onboarding.showNotifPrompt`) fires the raw POST_NOTIFICATIONS dialog right after the
+  location result so turn-by-turn's next-turn notification works on the first drive; a denial gets
+  ONE plain-words "Skip notifications?" are-you-sure (re-request on Allow, move on on Skip), and
+  the nav-start point-of-use gate stays as the fallback for skippers/existing installs. The
+  location step also grew a COARSE-ONLY branch: granting approximate pops an "Approximate
+  location" dialog (what it means, nav won't work) whose "Allow precise" re-runs the request as
+  Android's upgrade choice - asked ONCE (`approxAsked`), keeping it never nags again. The locate
+  FAB's re-ask does the same via `showApproxNotice` in MapScreen. The old **offline-maps** onboarding prompt and the **diagnostics/
   trip-recording** onboarding prompt were CUT (they made a long wall of asks a first-run user has no
   context for). Both settings still exist, off by default, in Settings → Diagnostics + Offline; the
   diagnostics ask now surfaces **in context** on the crash-report card (Settings → Diagnostics only

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -195,6 +195,8 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   Done), and the microphone permission is asked only the first time you tap the mic. When both Vela voice and a
   voice-input app are present, a Settings picker chooses which to use (Vela voice by default). Device-verified end to end: download, install, the mic appears, the permission prompt,
   the listening sheet, and the model transcribing back into the search box.
+- ✅ **Update button is a filled pill (2026-07-10).** The update card's Update action is a filled
+  pill instead of tinted text, so it stands out by shape and fill rather than colour alone.
 - ✅ **Recents you can prune, with addresses (2026-07-10).** Every recent search and recently-opened
   place has an X on its row to remove just that entry (Clear recents still wipes the lot). A real
   place shows its street address in smaller text under the name, and the Home/Work rows show the

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -199,6 +199,16 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   place has an X on its row to remove just that entry (Clear recents still wipes the lot). A real
   place shows its street address in smaller text under the name, and the Home/Work rows show the
   saved address too. The three-dot menus on Home/Work match the row text color now.
+- ✅ **Approximate location explains itself, and the blob actually shows (2026-07-10).** Granting
+  approximate (at setup or from the locate button) now gets one plain dialog saying what it means -
+  wide circle for a dot, no turn-by-turn - with an Allow-precise shortcut that goes straight into
+  Android's upgrade choice. And the accuracy circle itself is finally visible: the locate zoom-fit
+  had a pixel-density bug that always framed the circle bigger than the screen, so it read as
+  nothing at all.
+- ✅ **Notifications are asked during setup (2026-07-10).** Turn-by-turn keeps your next move in a
+  notification, so onboarding now asks right after location; declining gets one are-you-sure and
+  never blocks anything. Heads-up cards also drop below the turn card during navigation instead of
+  colliding with it, and a mid-drive voice download stays visible instead of silently hiding.
 - ✅ **Navigation asks for precise location instead of failing silently (2026-07-10).** Turn-by-turn
   needs GPS, and with approximate-only permission it used to start and sit at "Searching for GPS"
   forever. Tapping Start now explains it plainly and offers to allow precise location; Android shows

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -195,6 +195,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   Done), and the microphone permission is asked only the first time you tap the mic. When both Vela voice and a
   voice-input app are present, a Settings picker chooses which to use (Vela voice by default). Device-verified end to end: download, install, the mic appears, the permission prompt,
   the listening sheet, and the model transcribing back into the search box.
+- ✅ **Recents you can prune, with addresses (2026-07-10).** Every recent search and recently-opened
+  place has an X on its row to remove just that entry (Clear recents still wipes the lot). A real
+  place shows its street address in smaller text under the name, and the Home/Work rows show the
+  saved address too. The three-dot menus on Home/Work match the row text color now.
 - ✅ **Navigation asks for precise location instead of failing silently (2026-07-10).** Turn-by-turn
   needs GPS, and with approximate-only permission it used to start and sit at "Searching for GPS"
   forever. Tapping Start now explains it plainly and offers to allow precise location; Android shows

--- a/app/src/main/java/app/vela/ui/Onboarding.kt
+++ b/app/src/main/java/app/vela/ui/Onboarding.kt
@@ -3,6 +3,7 @@ package app.vela.ui
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import androidx.compose.runtime.mutableStateOf
 import androidx.core.content.ContextCompat
 import app.vela.core.voice.VelaPiper
@@ -32,9 +33,15 @@ object Onboarding {
      *  search/browse working, and the locate button re-asks later). */
     val showLocationPrompt = mutableStateOf(false)
 
+    /** True for the single session where the one-time notification ask should fire — right after the
+     *  location step, because turn-by-turn keeps your next turn in a notification and asking during
+     *  setup means the first navigation just works. Android 13+ only; suppressed once granted or
+     *  answered. A denial gets one plain-words are-you-sure in VelaRoot, then the app moves on. */
+    val showNotifPrompt = mutableStateOf(false)
+
     /** True for the single session where the one-time "download the Vela neural voice?" prompt should
-     *  show — offered right after the location step so the best voice is one tap away. Suppressed once
-     *  the model is present or the user has answered. */
+     *  show — offered right after the notification step so the best voice is one tap away. Suppressed
+     *  once the model is present or the user has answered. */
     val showVoicePrompt = mutableStateOf(false)
 
     // Replace with your own funding page (Liberapay / Ko-fi / GitHub Sponsors).
@@ -74,12 +81,30 @@ object Onboarding {
             ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
             PackageManager.PERMISSION_GRANTED
 
-    /** Mark the location rationale handled (whatever the user chose) so it never shows again, and arm
-     *  the voice prompt next. Called from both "Allow" and "Not now". */
+    /** Notifications need no runtime grant before Android 13. */
+    private fun hasNotifications(context: Context): Boolean =
+        Build.VERSION.SDK_INT < 33 ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+
+    /** Mark the location step handled (whatever the user chose) so it never shows again, and arm the
+     *  next step: notifications where the OS needs an ask, else straight to the voice offer. */
     fun dismissLocationPrompt(context: Context) {
         showLocationPrompt.value = false
         val p = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
         p.edit().putBoolean("location_prompt_done", true).apply()
+        if (!p.getBoolean("notif_prompt_done", false) && !hasNotifications(context)) {
+            showNotifPrompt.value = true
+        } else {
+            showVoicePrompt.value = !p.getBoolean("voice_prompt_done", false) && !VelaPiper.isReady(context)
+        }
+    }
+
+    /** Mark the notification step handled so it never shows again, and arm the voice offer next. */
+    fun dismissNotifPrompt(context: Context) {
+        showNotifPrompt.value = false
+        val p = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        p.edit().putBoolean("notif_prompt_done", true).apply()
         showVoicePrompt.value = !p.getBoolean("voice_prompt_done", false) && !VelaPiper.isReady(context)
     }
 
@@ -94,10 +119,12 @@ object Onboarding {
         welcomeDone.value = true
         val p = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
         p.edit().putBoolean("welcome_done", true).apply()
-        // First-run order: location rationale → voice. Arm location here; its dismissal arms
-        // voice. If location was somehow already granted, skip straight to the voice offer.
+        // First-run order: location → notifications → voice. Arm location here; each step's
+        // dismissal arms the next. If a step is somehow already granted/answered, skip past it.
         if (!p.getBoolean("location_prompt_done", false) && !hasLocation(context)) {
             showLocationPrompt.value = true
+        } else if (!p.getBoolean("notif_prompt_done", false) && !hasNotifications(context)) {
+            showNotifPrompt.value = true
         } else {
             showVoicePrompt.value = !p.getBoolean("voice_prompt_done", false) && !VelaPiper.isReady(context)
         }

--- a/app/src/main/java/app/vela/ui/VelaRoot.kt
+++ b/app/src/main/java/app/vela/ui/VelaRoot.kt
@@ -43,15 +43,27 @@ fun VelaRoot(vm: MapViewModel = hiltViewModel()) {
     // its own (see MapScreen); this owns the first ask. A grant starts location immediately (coarse-
     // only works too, via the NETWORK provider); a denial just moves on and leaves search/browse
     // working, with the locate FAB re-asking later.
+    // A coarse-only grant is easy to pick without meaning to, and it looks broken later (a wide
+    // circle for a dot, navigation that can't start). Say what it means ONCE, right when it happens;
+    // "Allow precise" re-runs the request, which Android shows as its approximate-to-precise choice.
+    var approxPrompt by rememberSaveable { mutableStateOf(false) }
+    var approxAsked by rememberSaveable { mutableStateOf(false) }
     val locationLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions(),
     ) { result ->
-        if (result.values.any { it }) vm.startLocation()
-        Onboarding.dismissLocationPrompt(context)
+        val fine = result[Manifest.permission.ACCESS_FINE_LOCATION] == true
+        val coarse = result[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+        if (fine || coarse) vm.startLocation()
+        if (!fine && coarse && !approxAsked) {
+            approxAsked = true
+            approxPrompt = true
+        } else {
+            Onboarding.dismissLocationPrompt(context)
+        }
     }
     // Ask for location the moment onboarding reaches this step - no separate rationale screen, since
     // the welcome screen is context enough for a maps app (one less thing to tap through). Fires once
-    // as the block enters composition; the result arms the voice step next.
+    // as the block enters composition; the result arms the notification step next.
     if (Onboarding.showLocationPrompt.value) {
         LaunchedEffect(Unit) {
             locationLauncher.launch(
@@ -61,6 +73,59 @@ fun VelaRoot(vm: MapViewModel = hiltViewModel()) {
                 ),
             )
         }
+    }
+    // Notifications come right after location: turn-by-turn keeps your next move in a notification,
+    // so asking during setup means the first navigation just works. Graceful on a no - a denial gets
+    // one plain-words are-you-sure, and skipping never blocks anything (the nav start re-asks).
+    var notifReasked by rememberSaveable { mutableStateOf(false) }
+    var notifSure by rememberSaveable { mutableStateOf(false) }
+    val notifLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted || notifReasked) Onboarding.dismissNotifPrompt(context) else notifSure = true
+    }
+    var notifRequested by rememberSaveable { mutableStateOf(false) }
+    if (Onboarding.showNotifPrompt.value && !notifRequested) {
+        LaunchedEffect(Unit) {
+            notifRequested = true
+            notifLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+    if (approxPrompt) {
+        VelaDialog(
+            onDismissRequest = { approxPrompt = false; Onboarding.dismissLocationPrompt(context) },
+            title = stringResource(R.string.loc_approx_title),
+            confirmText = stringResource(R.string.loc_approx_allow),
+            onConfirm = {
+                approxPrompt = false
+                locationLauncher.launch(
+                    arrayOf(
+                        Manifest.permission.ACCESS_FINE_LOCATION,
+                        Manifest.permission.ACCESS_COARSE_LOCATION,
+                    ),
+                )
+            },
+            dismissText = stringResource(R.string.loc_approx_keep),
+            onDismiss = { approxPrompt = false; Onboarding.dismissLocationPrompt(context) },
+            dismissLowEmphasis = true,
+            text = { Text(stringResource(R.string.loc_approx_body)) },
+        )
+    }
+    if (notifSure) {
+        VelaDialog(
+            onDismissRequest = { notifSure = false; Onboarding.dismissNotifPrompt(context) },
+            title = stringResource(R.string.notif_ask_title),
+            confirmText = stringResource(R.string.notif_ask_allow),
+            onConfirm = {
+                notifSure = false
+                notifReasked = true
+                notifLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            },
+            dismissText = stringResource(R.string.notif_ask_skip),
+            onDismiss = { notifSure = false; Onboarding.dismissNotifPrompt(context) },
+            dismissLowEmphasis = true,
+            text = { Text(stringResource(R.string.notif_ask_body)) },
+        )
     }
     Box {
         // MapScreen stays composed even while Settings is open, and Settings draws OVER it as an

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -2605,9 +2605,20 @@ private fun UpdateCard(
                     modifier = Modifier.fillMaxWidth().padding(top = 6.dp, bottom = 8.dp),
                 )
             } else {
-                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                Row(
+                    Modifier.fillMaxWidth().padding(bottom = 6.dp),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
                     TextButton(onClick = onDismiss) { Text(stringResource(R.string.update_later)) }
-                    TextButton(onClick = onUpdate) { Text(stringResource(R.string.update_install)) }
+                    Spacer(Modifier.width(4.dp))
+                    // A filled primary pill, same treatment as the dialogs' confirm button: the
+                    // action reads by SHAPE and fill, not by text colour alone (colour-blind safe).
+                    Button(
+                        onClick = onUpdate,
+                        shape = CircleShape,
+                        modifier = Modifier.dpadHighlight(CircleShape),
+                    ) { Text(stringResource(R.string.update_install)) }
                 }
             }
         }

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -935,6 +935,8 @@ fun MapScreen(
                                 focusManager.clearFocus()
                                 vm.selectSaved(it)
                             },
+                            onRemoveRecent = vm::removeRecentQuery,
+                            onRemoveRecentPlace = vm::removeRecentPlace,
                             onClearRecents = vm::clearRecents,
                             onPickShortcut = {
                                 focusManager.clearFocus()
@@ -2110,6 +2112,8 @@ private fun SearchEntryContent(
     onPickSaved: (SavedPlace) -> Unit,
     onPickRecent: (String) -> Unit,
     onPickRecentPlace: (SavedPlace) -> Unit,
+    onRemoveRecent: (String) -> Unit,
+    onRemoveRecentPlace: (String) -> Unit,
     onClearRecents: () -> Unit,
     onPickShortcut: (ShortcutKind) -> Unit,
     onAssignShortcut: (ShortcutKind) -> Unit,
@@ -2199,13 +2203,17 @@ private fun SearchEntryContent(
                         icon = Icons.Default.Place,
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         label = entry.place.name,
+                        // A real place shows its address under the name (Google-style).
+                        sublabel = entry.place.address,
                         onClick = { onPickRecentPlace(entry.place) },
+                        onRemove = { onRemoveRecentPlace(entry.place.id) },
                     )
                     is RecentQuery -> SuggestionRow(
                         icon = Icons.Default.History,
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         label = entry.query,
                         onClick = { onPickRecent(entry.query) },
+                        onRemove = { onRemoveRecent(entry.query) },
                     )
                 }
                 Divider()
@@ -2256,7 +2264,8 @@ private fun ShortcutRow(
         Column(Modifier.weight(1f)) {
             Text(kind.label, style = MaterialTheme.typography.bodyLarge, color = SheetPalette.ink(dark))
             Text(
-                place?.name ?: stringResource(R.string.mapscreen_set_shortcut_address, kind.label.lowercase()),
+                place?.let { it.address ?: it.name }
+                    ?: stringResource(R.string.mapscreen_set_shortcut_address, kind.label.lowercase()),
                 style = MaterialTheme.typography.bodySmall,
                 color = SheetPalette.dim(dark),
                 maxLines = 1,
@@ -2267,7 +2276,13 @@ private fun ShortcutRow(
             var menu by remember { mutableStateOf(false) }
             Box {
                 IconButton(onClick = { menu = true }) {
-                    Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.mapscreen_edit_shortcut, kind.label))
+                    // Same ink as the row's text - the default LocalContentColor went near-black
+                    // on the fixed sheet grey under some themes (user report).
+                    Icon(
+                        Icons.Default.MoreVert,
+                        contentDescription = stringResource(R.string.mapscreen_edit_shortcut, kind.label),
+                        tint = SheetPalette.ink(dark),
+                    )
                 }
                 VelaMenu(expanded = menu, onDismissRequest = { menu = false }) {
                     item(stringResource(R.string.mapscreen_menu_change)) { menu = false; onAssign(kind) }
@@ -2393,6 +2408,7 @@ private fun SuggestionRow(
     label: String,
     onClick: () -> Unit,
     sublabel: String? = null,
+    onRemove: (() -> Unit)? = null,
 ) {
     Row(
         Modifier.fillMaxWidth().dpadHighlight(RoundedCornerShape(6.dp)).clickable(onClick = onClick).padding(horizontal = 16.dp, vertical = 12.dp),
@@ -2400,7 +2416,14 @@ private fun SuggestionRow(
     ) {
         Icon(icon, contentDescription = null, modifier = Modifier.padding(end = 12.dp), tint = tint)
         if (sublabel == null) {
-            Text(label, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurface)
+            Text(
+                label,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = if (onRemove != null) Modifier.weight(1f) else Modifier,
+            )
         } else {
             Column(Modifier.weight(1f)) {
                 Text(
@@ -2416,6 +2439,17 @@ private fun SuggestionRow(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        // Per-row remove (the X on recents). Its own focus stop with a visible ring, so a D-pad
+        // walk can reach it after the row itself.
+        if (onRemove != null) {
+            IconButton(onClick = onRemove, modifier = Modifier.dpadHighlight(androidx.compose.foundation.shape.CircleShape)) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = stringResource(R.string.mapscreen_menu_remove),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -394,10 +394,21 @@ fun MapScreen(
     // When the request comes back fully denied (including Android's instant deny after a permanent
     // "don't ask again"), the locate button used to just do nothing. Explain and point at settings.
     var showLocationOff by remember { mutableStateOf(false) }
+    // A coarse-only grant looks broken later (a wide circle for a dot, navigation that can't start),
+    // so the locate button's re-ask explains it ONCE when it happens; "Allow precise" re-runs the
+    // request, which Android shows as its approximate-to-precise choice.
+    var showApproxNotice by remember { mutableStateOf(false) }
+    var approxNoticed by remember { mutableStateOf(false) }
     val permLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions(),
     ) { result ->
-        if (result.values.any { it }) vm.startLocation() else showLocationOff = true
+        val fineNow = result[Manifest.permission.ACCESS_FINE_LOCATION] == true
+        val coarseNow = result[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+        if (fineNow || coarseNow) vm.startLocation() else showLocationOff = true
+        if (!fineNow && coarseNow && !approxNoticed) {
+            approxNoticed = true
+            showApproxNotice = true
+        }
     }
     // Only START location if it's already granted. The raw system dialog is NOT fired here anymore:
     // the onboarding rationale (VelaRoot) owns the first ask so it comes with an explanation, and the
@@ -608,6 +619,23 @@ fun MapScreen(
             onDismiss = { showLocationOff = false },
             dismissLowEmphasis = true,
             text = { Text(stringResource(R.string.loc_off_body)) },
+        )
+    }
+    if (showApproxNotice) {
+        app.vela.ui.VelaDialog(
+            onDismissRequest = { showApproxNotice = false },
+            title = stringResource(R.string.loc_approx_title),
+            confirmText = stringResource(R.string.loc_approx_allow),
+            onConfirm = {
+                showApproxNotice = false
+                permLauncher.launch(
+                    arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION),
+                )
+            },
+            dismissText = stringResource(R.string.loc_approx_keep),
+            onDismiss = { showApproxNotice = false },
+            dismissLowEmphasis = true,
+            text = { Text(stringResource(R.string.loc_approx_body)) },
         )
     }
 
@@ -1515,7 +1543,8 @@ fun MapScreen(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .statusBarsPadding()
-                    .padding(top = 96.dp, start = 12.dp, end = 12.dp),
+                    // During nav, drop below the turn card (which can grow lane + "then" rows).
+                    .padding(top = if (state.navigating) 260.dp else 96.dp, start = 12.dp, end = 12.dp),
             )
         }
         // Pushed notices (signed calibration channel) + the voice-download progress card — on the
@@ -1524,14 +1553,17 @@ fun MapScreen(
         // the prompt dismissed — progress only existed in Settings; user 2026-07-07).
         val downloadingVoiceId = state.voiceDownloadingId
         val downloadingRegion = state.routingDownloadingId != null || state.poiPackDownloadingId != null
-        if (!state.navigating && state.selected == null && !searchOpen &&
+        if (state.selected == null && !searchOpen &&
             (state.notices.isNotEmpty() || downloadingVoiceId != null || downloadingRegion || state.updateInfo != null)
         ) {
             Column(
                 Modifier
                     .align(Alignment.TopCenter)
                     .statusBarsPadding()
-                    .padding(top = 140.dp, start = 12.dp, end = 12.dp), // below the search bar AND the chips
+                    // Below the search bar AND the chips; during nav, below the turn card instead
+                    // (these used to hide entirely in nav, which made a mid-drive voice download
+                    // look stalled).
+                    .padding(top = if (state.navigating) 260.dp else 140.dp, start = 12.dp, end = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 if (downloadingVoiceId != null) {

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -725,7 +725,7 @@ class MapViewModel @Inject constructor(
             val near = mapCenter ?: _state.value.myLocation // suggestions near the viewport, like search
             val res = runCatching { dataSource.search(term, near).places }.getOrDefault(emptyList())
             if (_state.value.query.trim() == term) { // ignore if the query changed meanwhile
-                _state.update { it.copy(suggestions = res.take(6)) }
+                _state.update { it.copy(suggestions = res.take(8)) }
             }
         }
     }
@@ -762,6 +762,17 @@ class MapViewModel @Inject constructor(
     fun searchRecent(q: String) {
         onQueryChange(q)
         search()
+    }
+
+    /** The X on a single recent row - remove just that entry. */
+    fun removeRecentQuery(query: String) {
+        recentStore.remove(query)
+        _state.update { it.copy(recents = recentStore.recent()) }
+    }
+
+    fun removeRecentPlace(placeId: String) {
+        recentPlaceStore.remove(placeId)
+        _state.update { it.copy(recentPlaces = recentPlaceStore.recent()) }
     }
 
     fun clearRecents() {

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1086,9 +1086,15 @@ fun VelaMapView(
                     val acc = myAccuracyM
                     val zoom = when {
                         acc != null && acc > 100f -> {
-                            val screenPx = mapView.width.coerceAtLeast(1)
-                            val mpp = (acc.toDouble() * 2 / 0.7) / screenPx
-                            (Math.log((156543.03392 * Math.cos(Math.toRadians(t.lat))) / mpp) / Math.log(2.0)).coerceIn(3.0, 15.0)
+                            // MapLibre's zoom scale is DENSITY-INDEPENDENT (m per dp, 512-tile
+                            // constant), not physical pixels. The first cut used physical px +
+                            // the 256-tile constant and landed ~2.5 levels too CLOSE on a 2.75x
+                            // phone - the 2 km circle overflowed the screen as the same invisible
+                            // uniform wash the fit exists to avoid.
+                            val density = mapView.resources.displayMetrics.density
+                            val screenDp = (mapView.width / density).coerceAtLeast(1f)
+                            val mpd = (acc.toDouble() * 2 / 0.7) / screenDp
+                            (Math.log((78271.517 * Math.cos(Math.toRadians(t.lat))) / mpd) / Math.log(2.0)).coerceIn(3.0, 15.0)
                         }
                         cameraBottomInsetPx > 0 -> 16.5
                         else -> 15.0

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -214,7 +214,7 @@
     <string name="place_arriveby_leave">Ankunft bis %1$s  ·  Abfahrt %2$s</string>
     <string name="place_in_typical_traffic">bei üblichem Verkehr</string>
     <string name="place_based_current_traffic">basierend auf aktuellem Verkehr</string>
-    <string name="place_arrive_approx">Ankunft ~%1$s</string>
+    <string name="place_arrive_approx">Ankunft um %1$s</string>
     <string name="place_usually_range">Normalerweise %1$s – %2$s</string>
     <string name="place_current_traffic">aktueller Verkehr</string>
     <string name="place_fastest">Schnellste</string>
@@ -232,7 +232,7 @@
     <string name="place_review_count">%1$d Rezensionen</string>
     <string name="place_all_n_reviews">Alle %1$d Rezensionen · sortieren &amp; suchen</string>
     <string name="place_all_reviews">Alle Rezensionen · sortieren &amp; suchen</string>
-    <string name="place_reviews_progress">Rezensionen · %1$d von ~%2$d</string>
+    <string name="place_reviews_progress">Rezensionen · %1$d von etwa %2$d</string>
     <string name="place_reviews_so_far">Rezensionen · bisher %1$d</string>
     <string name="place_gathering_reviews">Rezensionen werden gesammelt …</string>
     <string name="place_reviews_load_failed">Rezensionen konnten nicht geladen werden. Zum Wiederholen tippen.</string>
@@ -304,7 +304,7 @@
     <string name="mapscreen_pick_stop_hint">Wählen Sie einen Ort, der als Halt hinzugefügt werden soll</string>
     <string name="mapscreen_learn_more">Mehr erfahren</string>
     <string name="mapscreen_faster_route_title">Schnellere Route</string>
-    <string name="mapscreen_faster_route_saves">Spart ~%1$s bei aktuellem Verkehr</string>
+    <string name="mapscreen_faster_route_saves">Spart etwa %1$s bei aktuellem Verkehr</string>
     <string name="mapscreen_no">Nein</string>
     <string name="mapscreen_switch">Wechseln</string>
     <string name="root_not_now">Jetzt nicht</string>
@@ -501,10 +501,18 @@
     <string name="map_asr_offer_title">Sprachsuche</string>
     <string name="map_asr_offer_body">Lade die Vela-Stimme herunter, um Suchen zu sprechen. Sie läuft komplett auf deinem Gerät und lädt nichts hoch.</string>
     <string name="nav_precise_title">Genauer Standort nötig</string>
-    <string name="nav_precise_body">Die Navigation folgt dir per GPS und braucht dafür den genauen Standort. Ungefähr liefert nur ein grobes Gebiet, die Navigation würde dich nie finden.</string>
+    <string name="nav_precise_body">Die Navigation folgt dir per GPS und braucht dafür den genauen Standort. Aktuell kennt Vela nur deine ungefähre Umgebung.</string>
     <string name="nav_precise_allow">Genau erlauben</string>
     <string name="nav_precise_toast">Die Navigation braucht den genauen Standort</string>
     <string name="loc_off_title">Standort ist aus</string>
     <string name="loc_off_body">Vela hat keinen Standortzugriff. Du kannst ihn in den Systemeinstellungen erlauben.</string>
     <string name="loc_off_settings">Einstellungen öffnen</string>
+    <string name="loc_approx_title">Ungefährer Standort</string>
+    <string name="loc_approx_body">Vela kennt nur deine ungefähre Umgebung, nicht deinen genauen Standort. Die Karte zeigt einen großen Kreis statt eines Punkts, und die Navigation funktioniert nicht. Du kannst jederzeit auf den genauen Standort wechseln.</string>
+    <string name="loc_approx_allow">Genauen Standort erlauben</string>
+    <string name="loc_approx_keep">Ungefähr lassen</string>
+    <string name="notif_ask_title">Benachrichtigungen überspringen?</string>
+    <string name="notif_ask_body">Die Navigation zeigt die nächste Abbiegung in einer Benachrichtigung, damit die Hinweise auch bei ausgeschaltetem Bildschirm oder in anderen Apps bei dir bleiben. Ohne sie gibt es Hinweise nur in Vela selbst.</string>
+    <string name="notif_ask_allow">Erlauben</string>
+    <string name="notif_ask_skip">Überspringen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -214,7 +214,7 @@
     <string name="place_arriveby_leave">Llegada a las %1$s  ·  salida %2$s</string>
     <string name="place_in_typical_traffic">con tráfico habitual</string>
     <string name="place_based_current_traffic">según el tráfico actual</string>
-    <string name="place_arrive_approx">Llegada ~%1$s</string>
+    <string name="place_arrive_approx">Llegada a las %1$s</string>
     <string name="place_usually_range">Normalmente %1$s – %2$s</string>
     <string name="place_current_traffic">tráfico actual</string>
     <string name="place_fastest">La más rápida</string>
@@ -232,7 +232,7 @@
     <string name="place_review_count">%1$d reseñas</string>
     <string name="place_all_n_reviews">Las %1$d reseñas · ordenar y buscar</string>
     <string name="place_all_reviews">Todas las reseñas · ordenar y buscar</string>
-    <string name="place_reviews_progress">Reseñas · %1$d de ~%2$d</string>
+    <string name="place_reviews_progress">Reseñas · %1$d de unos %2$d</string>
     <string name="place_reviews_so_far">Reseñas · %1$d hasta ahora</string>
     <string name="place_gathering_reviews">Recopilando reseñas…</string>
     <string name="place_reviews_load_failed">No se pudieron cargar las reseñas. Toca para reintentar.</string>
@@ -304,7 +304,7 @@
     <string name="mapscreen_pick_stop_hint">Elige un lugar para añadirlo como parada</string>
     <string name="mapscreen_learn_more">Más información</string>
     <string name="mapscreen_faster_route_title">Ruta más rápida</string>
-    <string name="mapscreen_faster_route_saves">Ahorra ~%1$s con el tráfico actual</string>
+    <string name="mapscreen_faster_route_saves">Ahorra unos %1$s con el tráfico actual</string>
     <string name="mapscreen_no">No</string>
     <string name="mapscreen_switch">Cambiar</string>
     <string name="root_not_now">Ahora no</string>
@@ -501,10 +501,18 @@
     <string name="map_asr_offer_title">Búsqueda por voz</string>
     <string name="map_asr_offer_body">Descarga la voz de Vela para dictar tus búsquedas. Funciona por completo en tu teléfono y no sube nada.</string>
     <string name="nav_precise_title">Se necesita ubicación precisa</string>
-    <string name="nav_precise_body">La navegación te sigue por GPS, que necesita la ubicación precisa. La aproximada solo da una zona general, así que la navegación nunca te encontraría.</string>
+    <string name="nav_precise_body">La navegación te sigue por GPS, y eso requiere la ubicación precisa. Ahora mismo Vela solo conoce tu zona aproximada.</string>
     <string name="nav_precise_allow">Permitir precisa</string>
     <string name="nav_precise_toast">La navegación necesita la ubicación precisa</string>
     <string name="loc_off_title">La ubicación está desactivada</string>
     <string name="loc_off_body">Vela no tiene acceso a la ubicación. Puedes permitirlo en los ajustes del sistema.</string>
     <string name="loc_off_settings">Abrir ajustes</string>
+    <string name="loc_approx_title">Ubicación aproximada</string>
+    <string name="loc_approx_body">Vela solo conoce tu zona aproximada, no dónde estás. El mapa muestra un círculo amplio en vez de un punto, y la navegación no funcionará. Puedes cambiar a la ubicación precisa cuando quieras.</string>
+    <string name="loc_approx_allow">Permitir precisa</string>
+    <string name="loc_approx_keep">Mantener aproximada</string>
+    <string name="notif_ask_title">¿Omitir las notificaciones?</string>
+    <string name="notif_ask_body">La navegación mantiene tu próximo giro en una notificación, para que las indicaciones te acompañen con la pantalla apagada o en otra app. Sin ella, solo hay indicaciones dentro de Vela.</string>
+    <string name="notif_ask_allow">Permitir</string>
+    <string name="notif_ask_skip">Omitir</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -214,7 +214,7 @@
     <string name="place_arriveby_leave">Arrivée avant %1$s  ·  départ %2$s</string>
     <string name="place_in_typical_traffic">en trafic habituel</string>
     <string name="place_based_current_traffic">selon le trafic actuel</string>
-    <string name="place_arrive_approx">Arrivée ~%1$s</string>
+    <string name="place_arrive_approx">Arrivée à %1$s</string>
     <string name="place_usually_range">Habituellement %1$s – %2$s</string>
     <string name="place_current_traffic">trafic actuel</string>
     <string name="place_fastest">Le plus rapide</string>
@@ -232,7 +232,7 @@
     <string name="place_review_count">%1$d avis</string>
     <string name="place_all_n_reviews">Tous les %1$d avis · trier et rechercher</string>
     <string name="place_all_reviews">Tous les avis · trier et rechercher</string>
-    <string name="place_reviews_progress">Avis · %1$d sur ~%2$d</string>
+    <string name="place_reviews_progress">Avis · %1$d sur environ %2$d</string>
     <string name="place_reviews_so_far">Avis · %1$d jusqu\'ici</string>
     <string name="place_gathering_reviews">Collecte des avis…</string>
     <string name="place_reviews_load_failed">Impossible de charger les avis. Appuyez pour réessayer.</string>
@@ -304,7 +304,7 @@
     <string name="mapscreen_pick_stop_hint">Choisissez un lieu à ajouter comme arrêt</string>
     <string name="mapscreen_learn_more">En savoir plus</string>
     <string name="mapscreen_faster_route_title">Itinéraire plus rapide</string>
-    <string name="mapscreen_faster_route_saves">Économise ~%1$s avec le trafic actuel</string>
+    <string name="mapscreen_faster_route_saves">Économise environ %1$s avec le trafic actuel</string>
     <string name="mapscreen_no">Non</string>
     <string name="mapscreen_switch">Basculer</string>
     <string name="root_not_now">Pas maintenant</string>
@@ -501,10 +501,18 @@
     <string name="map_asr_offer_title">Recherche vocale</string>
     <string name="map_asr_offer_body">Téléchargez la voix Vela pour dicter vos recherches. Elle tourne entièrement sur votre téléphone et n\'envoie rien.</string>
     <string name="nav_precise_title">Position précise requise</string>
-    <string name="nav_precise_body">Le guidage vous suit par GPS, ce qui demande la position précise. L\'approximative ne donne qu\'une zone grossière, la navigation ne vous trouverait jamais.</string>
+    <string name="nav_precise_body">La navigation vous suit par GPS, ce qui demande la position précise. Pour l\'instant, Vela ne connaît que votre zone approximative.</string>
     <string name="nav_precise_allow">Autoriser la précision</string>
     <string name="nav_precise_toast">Le guidage a besoin de la position précise</string>
     <string name="loc_off_title">La localisation est désactivée</string>
     <string name="loc_off_body">Vela n\'a pas accès à la localisation. Vous pouvez l\'autoriser dans les réglages du système.</string>
     <string name="loc_off_settings">Ouvrir les réglages</string>
+    <string name="loc_approx_title">Position approximative</string>
+    <string name="loc_approx_body">Vela ne connaît que votre zone approximative, pas votre position exacte. La carte affiche un large cercle au lieu d\'un point, et la navigation ne fonctionnera pas. Vous pouvez passer à la position précise quand vous voulez.</string>
+    <string name="loc_approx_allow">Autoriser la position précise</string>
+    <string name="loc_approx_keep">Garder l\'approximatif</string>
+    <string name="notif_ask_title">Ignorer les notifications ?</string>
+    <string name="notif_ask_body">La navigation garde votre prochain virage dans une notification, pour que les indications vous suivent quand l\'écran est éteint ou que vous changez d\'appli. Sans elle, les indications ne s\'affichent que dans Vela.</string>
+    <string name="notif_ask_allow">Autoriser</string>
+    <string name="notif_ask_skip">Ignorer</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -214,7 +214,7 @@
     <string name="place_arriveby_leave">Arrivo entro %1$s  ·  parti alle %2$s</string>
     <string name="place_in_typical_traffic">con traffico tipico</string>
     <string name="place_based_current_traffic">in base al traffico attuale</string>
-    <string name="place_arrive_approx">Arrivo ~%1$s</string>
+    <string name="place_arrive_approx">Arrivo alle %1$s</string>
     <string name="place_usually_range">Di solito %1$s – %2$s</string>
     <string name="place_current_traffic">traffico attuale</string>
     <string name="place_fastest">Più veloce</string>
@@ -232,7 +232,7 @@
     <string name="place_review_count">%1$d recensioni</string>
     <string name="place_all_n_reviews">Tutte le %1$d recensioni · ordina e cerca</string>
     <string name="place_all_reviews">Tutte le recensioni · ordina e cerca</string>
-    <string name="place_reviews_progress">Recensioni · %1$d di ~%2$d</string>
+    <string name="place_reviews_progress">Recensioni · %1$d di circa %2$d</string>
     <string name="place_reviews_so_far">Recensioni · %1$d finora</string>
     <string name="place_gathering_reviews">Raccolta recensioni…</string>
     <string name="place_reviews_load_failed">Impossibile caricare le recensioni. Tocca per riprovare.</string>
@@ -304,7 +304,7 @@
     <string name="mapscreen_pick_stop_hint">Scegli un luogo da aggiungere come tappa</string>
     <string name="mapscreen_learn_more">Scopri di più</string>
     <string name="mapscreen_faster_route_title">Percorso più veloce</string>
-    <string name="mapscreen_faster_route_saves">Risparmia ~%1$s con il traffico attuale</string>
+    <string name="mapscreen_faster_route_saves">Risparmia circa %1$s con il traffico attuale</string>
     <string name="mapscreen_no">No</string>
     <string name="mapscreen_switch">Cambia</string>
     <string name="root_not_now">Non ora</string>
@@ -501,10 +501,18 @@
     <string name="map_asr_offer_title">Ricerca vocale</string>
     <string name="map_asr_offer_body">Scarica la voce Vela per dettare le ricerche. Gira interamente sul telefono e non carica nulla.</string>
     <string name="nav_precise_title">Serve la posizione precisa</string>
-    <string name="nav_precise_body">La navigazione ti segue col GPS, che richiede la posizione precisa. Quella approssimativa dà solo un\'area generica, la navigazione non ti troverebbe mai.</string>
+    <string name="nav_precise_body">La navigazione ti segue con il GPS, che richiede la posizione precisa. Al momento Vela conosce solo la tua zona approssimativa.</string>
     <string name="nav_precise_allow">Consenti precisa</string>
     <string name="nav_precise_toast">La navigazione richiede la posizione precisa</string>
     <string name="loc_off_title">La posizione è disattivata</string>
     <string name="loc_off_body">Vela non ha accesso alla posizione. Puoi consentirlo nelle impostazioni di sistema.</string>
     <string name="loc_off_settings">Apri impostazioni</string>
+    <string name="loc_approx_title">Posizione approssimativa</string>
+    <string name="loc_approx_body">Vela conosce solo la tua zona approssimativa, non dove sei. La mappa mostra un cerchio ampio invece di un punto, e la navigazione non funzionerà. Puoi passare alla posizione precisa quando vuoi.</string>
+    <string name="loc_approx_allow">Consenti precisa</string>
+    <string name="loc_approx_keep">Tieni approssimativa</string>
+    <string name="notif_ask_title">Saltare le notifiche?</string>
+    <string name="notif_ask_body">La navigazione tiene la prossima svolta in una notifica, così le indicazioni ti seguono a schermo spento o in un\'altra app. Senza, le indicazioni restano solo dentro Vela.</string>
+    <string name="notif_ask_allow">Consenti</string>
+    <string name="notif_ask_skip">Salta</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -214,7 +214,7 @@
     <string name="place_arriveby_leave">Aankomst %1$s  ·  vertrek %2$s</string>
     <string name="place_in_typical_traffic">bij gebruikelijk verkeer</string>
     <string name="place_based_current_traffic">op basis van huidig verkeer</string>
-    <string name="place_arrive_approx">Aankomst ~%1$s</string>
+    <string name="place_arrive_approx">Aankomst om %1$s</string>
     <string name="place_usually_range">Meestal %1$s – %2$s</string>
     <string name="place_current_traffic">huidig verkeer</string>
     <string name="place_fastest">Snelste</string>
@@ -232,7 +232,7 @@
     <string name="place_review_count">%1$d recensies</string>
     <string name="place_all_n_reviews">Alle %1$d recensies · sorteren en zoeken</string>
     <string name="place_all_reviews">Alle recensies · sorteren en zoeken</string>
-    <string name="place_reviews_progress">Recensies · %1$d van ~%2$d</string>
+    <string name="place_reviews_progress">Recensies · %1$d van ongeveer %2$d</string>
     <string name="place_reviews_so_far">Recensies · %1$d tot nu toe</string>
     <string name="place_gathering_reviews">Recensies verzamelen…</string>
     <string name="place_reviews_load_failed">Kon recensies niet laden. Tik om opnieuw te proberen.</string>
@@ -304,7 +304,7 @@
     <string name="mapscreen_pick_stop_hint">Kies een plaats om als tussenstop toe te voegen</string>
     <string name="mapscreen_learn_more">Meer info</string>
     <string name="mapscreen_faster_route_title">Snellere route</string>
-    <string name="mapscreen_faster_route_saves">Bespaart ~%1$s bij huidig verkeer</string>
+    <string name="mapscreen_faster_route_saves">Bespaart ongeveer %1$s bij huidig verkeer</string>
     <string name="mapscreen_no">Nee</string>
     <string name="mapscreen_switch">Overschakelen</string>
     <string name="root_not_now">Niet nu</string>
@@ -501,10 +501,18 @@
     <string name="map_asr_offer_title">Spraakzoeken</string>
     <string name="map_asr_offer_body">Download de Vela-stem om je zoekopdrachten in te spreken. Hij draait volledig op je telefoon en uploadt niets.</string>
     <string name="nav_precise_title">Precieze locatie nodig</string>
-    <string name="nav_precise_body">Navigatie volgt je met gps en heeft daarvoor je precieze locatie nodig. Bij benadering geeft alleen een ruw gebied, dus navigatie zou je nooit vinden.</string>
+    <string name="nav_precise_body">Navigatie volgt je via gps en heeft daarvoor de precieze locatie nodig. Op dit moment kent Vela alleen je globale omgeving.</string>
     <string name="nav_precise_allow">Precies toestaan</string>
     <string name="nav_precise_toast">Navigatie heeft je precieze locatie nodig</string>
     <string name="loc_off_title">Locatie staat uit</string>
     <string name="loc_off_body">Vela heeft geen locatietoegang. Je kunt dit toestaan in de systeeminstellingen.</string>
     <string name="loc_off_settings">Instellingen openen</string>
+    <string name="loc_approx_title">Locatie bij benadering</string>
+    <string name="loc_approx_body">Vela kent alleen je globale omgeving, niet waar je bent. De kaart toont een grote cirkel in plaats van een punt, en navigatie werkt niet. Je kunt altijd overstappen op de precieze locatie.</string>
+    <string name="loc_approx_allow">Precies toestaan</string>
+    <string name="loc_approx_keep">Bij benadering houden</string>
+    <string name="notif_ask_title">Meldingen overslaan?</string>
+    <string name="notif_ask_body">Navigatie houdt je volgende afslag in een melding, zodat de aanwijzingen bij je blijven met het scherm uit of in een andere app. Zonder melding zie je aanwijzingen alleen in Vela.</string>
+    <string name="notif_ask_allow">Toestaan</string>
+    <string name="notif_ask_skip">Overslaan</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -214,7 +214,7 @@
     <string name="place_arriveby_leave">Przyjazd do %1$s  ·  wyjazd %2$s</string>
     <string name="place_in_typical_traffic">przy typowym ruchu</string>
     <string name="place_based_current_traffic">na podstawie bieżącego ruchu</string>
-    <string name="place_arrive_approx">Przyjazd ~%1$s</string>
+    <string name="place_arrive_approx">Przyjazd o %1$s</string>
     <string name="place_usually_range">Zwykle %1$s – %2$s</string>
     <string name="place_current_traffic">bieżący ruch</string>
     <string name="place_fastest">Najszybsza</string>
@@ -232,7 +232,7 @@
     <string name="place_review_count">%1$d opinii</string>
     <string name="place_all_n_reviews">Wszystkie %1$d opinii · sortuj i szukaj</string>
     <string name="place_all_reviews">Wszystkie opinie · sortuj i szukaj</string>
-    <string name="place_reviews_progress">Opinie · %1$d z ~%2$d</string>
+    <string name="place_reviews_progress">Opinie · %1$d z około %2$d</string>
     <string name="place_reviews_so_far">Opinie · %1$d jak dotąd</string>
     <string name="place_gathering_reviews">Zbieranie opinii…</string>
     <string name="place_reviews_load_failed">Nie udało się wczytać opinii. Dotknij, aby ponowić.</string>
@@ -304,7 +304,7 @@
     <string name="mapscreen_pick_stop_hint">Wybierz miejsce do dodania jako przystanek</string>
     <string name="mapscreen_learn_more">Dowiedz się więcej</string>
     <string name="mapscreen_faster_route_title">Szybsza trasa</string>
-    <string name="mapscreen_faster_route_saves">Oszczędza ~%1$s przy bieżącym ruchu</string>
+    <string name="mapscreen_faster_route_saves">Oszczędza około %1$s przy bieżącym ruchu</string>
     <string name="mapscreen_no">Nie</string>
     <string name="mapscreen_switch">Przełącz</string>
     <string name="root_not_now">Nie teraz</string>
@@ -501,10 +501,18 @@
     <string name="map_asr_offer_title">Wyszukiwanie głosowe</string>
     <string name="map_asr_offer_body">Pobierz głos Vela, aby dyktować wyszukiwania. Działa w całości na telefonie i niczego nie wysyła.</string>
     <string name="nav_precise_title">Potrzebna dokładna lokalizacja</string>
-    <string name="nav_precise_body">Nawigacja śledzi cię przez GPS, co wymaga dokładnej lokalizacji. Przybliżona daje tylko ogólny obszar, więc nawigacja nigdy by cię nie znalazła.</string>
+    <string name="nav_precise_body">Nawigacja śledzi cię przez GPS, a to wymaga dokładnej lokalizacji. Na razie Vela zna tylko twoją przybliżoną okolicę.</string>
     <string name="nav_precise_allow">Zezwól na dokładną</string>
     <string name="nav_precise_toast">Nawigacja wymaga dokładnej lokalizacji</string>
     <string name="loc_off_title">Lokalizacja jest wyłączona</string>
     <string name="loc_off_body">Vela nie ma dostępu do lokalizacji. Możesz go włączyć w ustawieniach systemu.</string>
     <string name="loc_off_settings">Otwórz ustawienia</string>
+    <string name="loc_approx_title">Przybliżona lokalizacja</string>
+    <string name="loc_approx_body">Vela zna tylko twoją przybliżoną okolicę, nie to, gdzie jesteś. Mapa pokazuje szerokie koło zamiast punktu, a nawigacja nie zadziała. Na dokładną lokalizację możesz przejść w każdej chwili.</string>
+    <string name="loc_approx_allow">Zezwól na dokładną</string>
+    <string name="loc_approx_keep">Zostaw przybliżoną</string>
+    <string name="notif_ask_title">Pominąć powiadomienia?</string>
+    <string name="notif_ask_body">Nawigacja trzyma następny zakręt w powiadomieniu, więc wskazówki są z tobą przy zgaszonym ekranie albo w innej aplikacji. Bez niego wskazówki widać tylko w Veli.</string>
+    <string name="notif_ask_allow">Zezwól</string>
+    <string name="notif_ask_skip">Pomiń</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -214,7 +214,7 @@
     <string name="place_arriveby_leave">Chegar até %1$s  ·  partir %2$s</string>
     <string name="place_in_typical_traffic">com trânsito habitual</string>
     <string name="place_based_current_traffic">com base no trânsito atual</string>
-    <string name="place_arrive_approx">Chegada ~%1$s</string>
+    <string name="place_arrive_approx">Chegada às %1$s</string>
     <string name="place_usually_range">Normalmente %1$s – %2$s</string>
     <string name="place_current_traffic">trânsito atual</string>
     <string name="place_fastest">Mais rápido</string>
@@ -232,7 +232,7 @@
     <string name="place_review_count">%1$d avaliações</string>
     <string name="place_all_n_reviews">Todas as %1$d avaliações · ordenar e pesquisar</string>
     <string name="place_all_reviews">Todas as avaliações · ordenar e pesquisar</string>
-    <string name="place_reviews_progress">Avaliações · %1$d de ~%2$d</string>
+    <string name="place_reviews_progress">Avaliações · %1$d de cerca de %2$d</string>
     <string name="place_reviews_so_far">Avaliações · %1$d até agora</string>
     <string name="place_gathering_reviews">A recolher avaliações…</string>
     <string name="place_reviews_load_failed">Não foi possível carregar as avaliações. Toque para tentar novamente.</string>
@@ -304,7 +304,7 @@
     <string name="mapscreen_pick_stop_hint">Escolha um local para adicionar como paragem</string>
     <string name="mapscreen_learn_more">Saber mais</string>
     <string name="mapscreen_faster_route_title">Percurso mais rápido</string>
-    <string name="mapscreen_faster_route_saves">Poupa ~%1$s com o trânsito atual</string>
+    <string name="mapscreen_faster_route_saves">Poupa cerca de %1$s com o trânsito atual</string>
     <string name="mapscreen_no">Não</string>
     <string name="mapscreen_switch">Mudar</string>
     <string name="root_not_now">Agora não</string>
@@ -501,10 +501,18 @@
     <string name="map_asr_offer_title">Pesquisa por voz</string>
     <string name="map_asr_offer_body">Transfere a voz Vela para ditar as tuas pesquisas. Corre inteiramente no telemóvel e não envia nada.</string>
     <string name="nav_precise_title">Localização precisa necessária</string>
-    <string name="nav_precise_body">A navegação segue-te por GPS, o que exige a localização precisa. A aproximada só dá uma zona geral, por isso a navegação nunca te encontraria.</string>
+    <string name="nav_precise_body">A navegação segue você pelo GPS, o que exige a localização precisa. No momento o Vela só conhece a sua área aproximada.</string>
     <string name="nav_precise_allow">Permitir precisa</string>
     <string name="nav_precise_toast">A navegação precisa da localização precisa</string>
     <string name="loc_off_title">A localização está desligada</string>
     <string name="loc_off_body">A Vela não tem acesso à localização. Podes permitir nas definições do sistema.</string>
     <string name="loc_off_settings">Abrir definições</string>
+    <string name="loc_approx_title">Localização aproximada</string>
+    <string name="loc_approx_body">O Vela só conhece a sua área aproximada, não onde você está. O mapa mostra um círculo largo em vez de um ponto, e a navegação não vai funcionar. Você pode mudar para a localização precisa quando quiser.</string>
+    <string name="loc_approx_allow">Permitir precisa</string>
+    <string name="loc_approx_keep">Manter aproximada</string>
+    <string name="notif_ask_title">Pular as notificações?</string>
+    <string name="notif_ask_body">A navegação mantém a próxima curva numa notificação, para as instruções ficarem com você com a tela apagada ou em outro app. Sem ela, as instruções só aparecem dentro do Vela.</string>
+    <string name="notif_ask_allow">Permitir</string>
+    <string name="notif_ask_skip">Pular</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -214,7 +214,7 @@
     <string name="place_arriveby_leave">Прибытие к %1$s  ·  выезд %2$s</string>
     <string name="place_in_typical_traffic">при обычных пробках</string>
     <string name="place_based_current_traffic">с учётом текущих пробок</string>
-    <string name="place_arrive_approx">Прибытие ~%1$s</string>
+    <string name="place_arrive_approx">Прибытие в %1$s</string>
     <string name="place_usually_range">Обычно %1$s – %2$s</string>
     <string name="place_current_traffic">текущие пробки</string>
     <string name="place_fastest">Самый быстрый</string>
@@ -232,7 +232,7 @@
     <string name="place_review_count">%1$d отзывов</string>
     <string name="place_all_n_reviews">Все отзывы (%1$d) · сортировка и поиск</string>
     <string name="place_all_reviews">Все отзывы · сортировка и поиск</string>
-    <string name="place_reviews_progress">Отзывы · %1$d из ~%2$d</string>
+    <string name="place_reviews_progress">Отзывы · %1$d из примерно %2$d</string>
     <string name="place_reviews_so_far">Отзывы · пока %1$d</string>
     <string name="place_gathering_reviews">Сбор отзывов…</string>
     <string name="place_reviews_load_failed">Не удалось загрузить отзывы. Нажмите, чтобы повторить.</string>
@@ -304,7 +304,7 @@
     <string name="mapscreen_pick_stop_hint">Выберите место, чтобы добавить как остановку</string>
     <string name="mapscreen_learn_more">Подробнее</string>
     <string name="mapscreen_faster_route_title">Более быстрый маршрут</string>
-    <string name="mapscreen_faster_route_saves">Экономит ~%1$s с учётом текущих пробок</string>
+    <string name="mapscreen_faster_route_saves">Экономит около %1$s с учётом текущих пробок</string>
     <string name="mapscreen_no">Нет</string>
     <string name="mapscreen_switch">Переключить</string>
     <string name="root_not_now">Не сейчас</string>
@@ -501,10 +501,18 @@
     <string name="map_asr_offer_title">Голосовой поиск</string>
     <string name="map_asr_offer_body">Загрузите голос Vela, чтобы диктовать запросы. Он работает целиком на телефоне и ничего не выгружает.</string>
     <string name="nav_precise_title">Нужна точная геолокация</string>
-    <string name="nav_precise_body">Навигация ведёт вас по GPS, для этого нужна точная геолокация. Приблизительная даёт лишь общий район, и навигация вас не найдёт.</string>
+    <string name="nav_precise_body">Навигация следит за вами по GPS, для этого нужно точное местоположение. Сейчас Vela знает только ваш примерный район.</string>
     <string name="nav_precise_allow">Разрешить точную</string>
     <string name="nav_precise_toast">Навигации нужна точная геолокация</string>
     <string name="loc_off_title">Геолокация выключена</string>
     <string name="loc_off_body">У Vela нет доступа к геолокации. Разрешить его можно в настройках системы.</string>
     <string name="loc_off_settings">Открыть настройки</string>
+    <string name="loc_approx_title">Примерное местоположение</string>
+    <string name="loc_approx_body">Vela знает только ваш примерный район, а не где вы находитесь. Карта показывает широкий круг вместо точки, и навигация работать не будет. Перейти на точное местоположение можно в любой момент.</string>
+    <string name="loc_approx_allow">Разрешить точное</string>
+    <string name="loc_approx_keep">Оставить примерное</string>
+    <string name="notif_ask_title">Пропустить уведомления?</string>
+    <string name="notif_ask_body">Навигация держит следующий поворот в уведомлении, чтобы подсказки оставались с вами при выключенном экране или в другом приложении. Без него подсказки видны только внутри Vela.</string>
+    <string name="notif_ask_allow">Разрешить</string>
+    <string name="notif_ask_skip">Пропустить</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -214,7 +214,7 @@
     <string name="place_arriveby_leave">Framme senast %1$s  ·  åk %2$s</string>
     <string name="place_in_typical_traffic">vid normal trafik</string>
     <string name="place_based_current_traffic">baserat på aktuell trafik</string>
-    <string name="place_arrive_approx">Framme ~%1$s</string>
+    <string name="place_arrive_approx">Framme kl. %1$s</string>
     <string name="place_usually_range">Vanligtvis %1$s – %2$s</string>
     <string name="place_current_traffic">aktuell trafik</string>
     <string name="place_fastest">Snabbast</string>
@@ -232,7 +232,7 @@
     <string name="place_review_count">%1$d recensioner</string>
     <string name="place_all_n_reviews">Alla %1$d recensioner · sortera &amp;amp; sök</string>
     <string name="place_all_reviews">Alla recensioner · sortera &amp;amp; sök</string>
-    <string name="place_reviews_progress">Recensioner · %1$d av ~%2$d</string>
+    <string name="place_reviews_progress">Recensioner · %1$d av cirka %2$d</string>
     <string name="place_reviews_so_far">Recensioner · %1$d hittills</string>
     <string name="place_gathering_reviews">Samlar recensioner…</string>
     <string name="place_reviews_load_failed">Kunde inte läsa in recensioner. Tryck för att försöka igen.</string>
@@ -304,7 +304,7 @@
     <string name="mapscreen_pick_stop_hint">Välj en plats att lägga till som stopp</string>
     <string name="mapscreen_learn_more">Läs mer</string>
     <string name="mapscreen_faster_route_title">Snabbare rutt</string>
-    <string name="mapscreen_faster_route_saves">Sparar ~%1$s i aktuell trafik</string>
+    <string name="mapscreen_faster_route_saves">Sparar cirka %1$s i aktuell trafik</string>
     <string name="mapscreen_no">Nej</string>
     <string name="mapscreen_switch">Byt</string>
     <string name="root_not_now">Inte nu</string>
@@ -501,10 +501,18 @@
     <string name="map_asr_offer_title">Röstsökning</string>
     <string name="map_asr_offer_body">Ladda ner Vela-rösten för att tala in dina sökningar. Den körs helt på telefonen och laddar inte upp något.</string>
     <string name="nav_precise_title">Exakt plats krävs</string>
-    <string name="nav_precise_body">Navigeringen följer dig med GPS, vilket kräver exakt plats. Ungefärlig ger bara ett grovt område, så navigeringen skulle aldrig hitta dig.</string>
+    <string name="nav_precise_body">Navigeringen följer dig via GPS, vilket kräver exakt plats. Just nu känner Vela bara till ditt ungefärliga område.</string>
     <string name="nav_precise_allow">Tillåt exakt</string>
     <string name="nav_precise_toast">Navigering kräver exakt plats</string>
     <string name="loc_off_title">Platsen är av</string>
     <string name="loc_off_body">Vela har inte platsåtkomst. Du kan tillåta det i systeminställningarna.</string>
     <string name="loc_off_settings">Öppna inställningar</string>
+    <string name="loc_approx_title">Ungefärlig plats</string>
+    <string name="loc_approx_body">Vela känner bara till ditt ungefärliga område, inte var du är. Kartan visar en stor cirkel i stället för en punkt, och navigeringen fungerar inte. Du kan byta till exakt plats när du vill.</string>
+    <string name="loc_approx_allow">Tillåt exakt</string>
+    <string name="loc_approx_keep">Behåll ungefärlig</string>
+    <string name="notif_ask_title">Hoppa över aviseringar?</string>
+    <string name="notif_ask_body">Navigeringen håller nästa sväng i en avisering, så att anvisningarna följer med när skärmen är släckt eller du byter app. Utan den syns anvisningar bara inne i Vela.</string>
+    <string name="notif_ask_allow">Tillåt</string>
+    <string name="notif_ask_skip">Hoppa över</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -214,7 +214,7 @@
     <string name="place_arriveby_leave">Прибуття до %1$s  ·  виїзд %2$s</string>
     <string name="place_in_typical_traffic">за звичайного трафіку</string>
     <string name="place_based_current_traffic">за поточним трафіком</string>
-    <string name="place_arrive_approx">Прибуття ~%1$s</string>
+    <string name="place_arrive_approx">Прибуття о %1$s</string>
     <string name="place_usually_range">Зазвичай %1$s – %2$s</string>
     <string name="place_current_traffic">поточний трафік</string>
     <string name="place_fastest">Найшвидший</string>
@@ -232,7 +232,7 @@
     <string name="place_review_count">%1$d відгуків</string>
     <string name="place_all_n_reviews">Усі %1$d відгуків · сортування й пошук</string>
     <string name="place_all_reviews">Усі відгуки · сортування й пошук</string>
-    <string name="place_reviews_progress">Відгуки · %1$d з ~%2$d</string>
+    <string name="place_reviews_progress">Відгуки · %1$d з приблизно %2$d</string>
     <string name="place_reviews_so_far">Відгуки · поки %1$d</string>
     <string name="place_gathering_reviews">Збирання відгуків…</string>
     <string name="place_reviews_load_failed">Не вдалося завантажити відгуки. Натисніть, щоб повторити.</string>
@@ -304,7 +304,7 @@
     <string name="mapscreen_pick_stop_hint">Виберіть місце, щоб додати як зупинку</string>
     <string name="mapscreen_learn_more">Докладніше</string>
     <string name="mapscreen_faster_route_title">Швидший маршрут</string>
-    <string name="mapscreen_faster_route_saves">Заощаджує ~%1$s за поточного трафіку</string>
+    <string name="mapscreen_faster_route_saves">Заощаджує близько %1$s за поточного трафіку</string>
     <string name="mapscreen_no">Ні</string>
     <string name="mapscreen_switch">Перемкнути</string>
     <string name="root_not_now">Не зараз</string>
@@ -501,10 +501,18 @@
     <string name="map_asr_offer_title">Голосовий пошук</string>
     <string name="map_asr_offer_body">Завантажте голос Vela, щоб диктувати запити. Він працює цілком на телефоні й нічого не надсилає.</string>
     <string name="nav_precise_title">Потрібна точна геолокація</string>
-    <string name="nav_precise_body">Навігація веде вас за GPS, для цього потрібна точна геолокація. Приблизна дає лише загальний район, тож навігація вас не знайде.</string>
+    <string name="nav_precise_body">Навігація стежить за вами через GPS, і для цього потрібне точне місцезнаходження. Наразі Vela знає лише ваш приблизний район.</string>
     <string name="nav_precise_allow">Дозволити точну</string>
     <string name="nav_precise_toast">Навігації потрібна точна геолокація</string>
     <string name="loc_off_title">Геолокацію вимкнено</string>
     <string name="loc_off_body">Vela не має доступу до геолокації. Дозволити його можна в налаштуваннях системи.</string>
     <string name="loc_off_settings">Відкрити налаштування</string>
+    <string name="loc_approx_title">Приблизне місцезнаходження</string>
+    <string name="loc_approx_body">Vela знає лише ваш приблизний район, а не де ви є. Карта показує широке коло замість точки, і навігація не працюватиме. Перейти на точне місцезнаходження можна будь-коли.</string>
+    <string name="loc_approx_allow">Дозволити точне</string>
+    <string name="loc_approx_keep">Лишити приблизне</string>
+    <string name="notif_ask_title">Пропустити сповіщення?</string>
+    <string name="notif_ask_body">Навігація тримає наступний поворот у сповіщенні, щоб підказки лишалися з вами з вимкненим екраном чи в іншому застосунку. Без нього підказки видно лише у Vela.</string>
+    <string name="notif_ask_allow">Дозволити</string>
+    <string name="notif_ask_skip">Пропустити</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,7 +230,7 @@
     <string name="place_arriveby_leave">Arrive by %1$s  ·  leave %2$s</string> <!-- format -->
     <string name="place_in_typical_traffic">in typical traffic</string>
     <string name="place_based_current_traffic">based on current traffic</string>
-    <string name="place_arrive_approx">Arrive ~%1$s</string> <!-- format -->
+    <string name="place_arrive_approx">Arrive at %1$s</string> <!-- format -->
     <string name="place_usually_range">Usually %1$s – %2$s</string> <!-- format -->
     <string name="place_current_traffic">current traffic</string>
     <string name="place_fastest">Fastest</string>
@@ -248,7 +248,7 @@
     <string name="place_review_count">%1$d reviews</string> <!-- format -->
     <string name="place_all_n_reviews">All %1$d reviews · sort &amp; search</string> <!-- format -->
     <string name="place_all_reviews">All reviews · sort &amp; search</string>
-    <string name="place_reviews_progress">Reviews · %1$d of ~%2$d</string> <!-- format -->
+    <string name="place_reviews_progress">Reviews · %1$d of about %2$d</string> <!-- format -->
     <string name="place_reviews_so_far">Reviews · %1$d so far</string> <!-- format -->
     <string name="place_gathering_reviews">Gathering reviews…</string>
     <string name="place_reviews_load_failed">Couldn\'t load reviews. Tap to retry.</string>
@@ -322,7 +322,7 @@
     <string name="mapscreen_pick_stop_hint">Choose a place to add as a stop</string>
     <string name="mapscreen_learn_more">Learn more</string>
     <string name="mapscreen_faster_route_title">Faster route</string>
-    <string name="mapscreen_faster_route_saves">Saves ~%1$s in current traffic</string> <!-- format -->
+    <string name="mapscreen_faster_route_saves">Saves about %1$s in current traffic</string> <!-- format -->
     <string name="mapscreen_no">No</string>
     <string name="mapscreen_switch">Switch</string>
     <string name="mapscreen_resume_nav">Resume navigation to %1$s?</string> <!-- format -->
@@ -524,10 +524,18 @@
     <string name="map_asr_offer_title">Voice search</string>
     <string name="map_asr_offer_body">Download Vela Voice to speak your searches. It runs entirely on your phone and uploads nothing.</string>
     <string name="nav_precise_title">Precise location needed</string>
-    <string name="nav_precise_body">Turn-by-turn follows you with GPS, which needs precise location. Approximate only gives a rough area, so navigation would never find you.</string>
+    <string name="nav_precise_body">Turn-by-turn follows you with GPS, which needs precise location. Right now Vela only knows your rough area.</string>
     <string name="nav_precise_allow">Allow precise</string>
     <string name="nav_precise_toast">Turn-by-turn needs precise location</string>
     <string name="loc_off_title">Location is off</string>
     <string name="loc_off_body">Vela doesn\'t have location access. You can allow it in system settings.</string>
     <string name="loc_off_settings">Open settings</string>
+    <string name="loc_approx_title">Approximate location</string>
+    <string name="loc_approx_body">Vela only knows your rough area, not where you are. The map shows a wide circle instead of a dot, and turn-by-turn navigation won\'t work. You can switch to precise location whenever you want.</string>
+    <string name="loc_approx_allow">Allow precise</string>
+    <string name="loc_approx_keep">Keep approximate</string>
+    <string name="notif_ask_title">Skip notifications?</string>
+    <string name="notif_ask_body">Navigation keeps your next turn in a notification, so directions stay with you when the screen is off or you switch apps. Without it, directions only show inside Vela.</string>
+    <string name="notif_ask_allow">Allow</string>
+    <string name="notif_ask_skip">Skip</string>
 </resources>

--- a/core/src/main/java/app/vela/core/data/RecentPlaceStore.kt
+++ b/core/src/main/java/app/vela/core/data/RecentPlaceStore.kt
@@ -45,6 +45,10 @@ class RecentPlaceStore @Inject constructor(
         prefs.edit().putString(KEY2, json.encodeToString(updated)).apply()
     }
 
+    /** Remove one place (the X on its row). */
+    fun remove(placeId: String) =
+        prefs.edit().putString(KEY2, json.encodeToString(recent().filterNot { it.place.id == placeId })).apply()
+
     fun clear() = prefs.edit().remove(KEY).remove(KEY2).apply()
 
     /** Pre-timestamp data was a bare SavedPlace list under [KEY]. Read it once, synthesize

--- a/core/src/main/java/app/vela/core/data/RecentSearchStore.kt
+++ b/core/src/main/java/app/vela/core/data/RecentSearchStore.kt
@@ -43,6 +43,10 @@ class RecentSearchStore @Inject constructor(
         prefs.edit().putString(KEY2, json.encodeToString(updated)).apply()
     }
 
+    /** Remove one query (the X on its row). */
+    fun remove(query: String) =
+        prefs.edit().putString(KEY2, json.encodeToString(recent().filterNot { it.query.equals(query, ignoreCase = true) })).apply()
+
     fun clear() = prefs.edit().remove(KEY).remove(KEY2).apply()
 
     /** Pre-timestamp data was a bare string list under [KEY]. Read it once, synthesize

--- a/core/src/main/java/app/vela/core/model/SavedPlace.kt
+++ b/core/src/main/java/app/vela/core/model/SavedPlace.kt
@@ -9,10 +9,13 @@ data class SavedPlace(
     val name: String,
     val lat: Double,
     val lng: Double,
+    // Defaulted so payloads saved before it existed still decode (every store's Json also sets
+    // ignoreUnknownKeys, so an older build reading a newer payload survives too).
+    val address: String? = null,
 ) {
     val location: LatLng get() = LatLng(lat, lng)
 
     companion object {
-        fun of(p: Place) = SavedPlace(p.id, p.name, p.location.lat, p.location.lng)
+        fun of(p: Place) = SavedPlace(p.id, p.name, p.location.lat, p.location.lng, p.address)
     }
 }


### PR DESCRIPTION
Small quality pass on the search page: recents you can prune, addresses where they help, and a color fix.

**Stacked on #25** (base branch is `voice-search-model`). Retarget to `main` after #25 merges.

**What changed**
- Every recent search and recently-opened place has an **X on its row** to remove just that entry. Clear recents still wipes the lot. The X is its own D-pad focus stop with the standard ring.
- A recently-opened **real place shows its street address** in smaller text under the name, and once Home or Work is set the row shows the **saved address** instead of repeating the place name.
- The **three-dot menus on Home and Work** rendered darker than the row text under some themes (they took the theme's default content color on the fixed sheet grey); they use the same ink as the text now.
- Saved places carry an optional address now (defaulted, so everything saved before this decodes unchanged, and older builds reading newer data survive too since all the stores ignore unknown fields).
- Typed suggestions fetch a couple more results, which helps when picking an address for Home or Work.

**Testing:** compiles; device-verified end to end: searched, opened a place, the recent row showed the name with its address underneath and the X removed exactly that row. Strings reuse existing translated labels, so nothing new to translate.
