### PR TITLE
Warn when you would arrive close to closing time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,6 +472,18 @@ Defaults that make the safe path the easy one:
   kept (it's still the reusable pre-permission screen the **PR3 voice-search mic** uses at
   point-of-use for RECORD_AUDIO) - it's just no longer used for location. Don't re-request location
   straight from the map.
+- **Closing-time warning at nav start (2026-07-10).** `MapViewModel.maybeWarnClosingSoon` (called
+  in `startNav` before launch/demo): when the drive's arrival (now + in-traffic ETA) lands within
+  an hour of the destination's closing time, or past it, it warns ONCE - `flashStatus` heads-up
+  card + `voice.speak` - "X closes at 9:00 PM and you arrive around 8:40 PM". Closing time is
+  parsed from the place's own localized STATUS TEXT by `:core`'s `data/ClosingTime`
+  (unit-tested): 12h and 24h shapes, last-time-token-wins, and it ONLY parses an OPEN place -
+  a closed status carries opening times ("Closed - Opens 9 AM"), the classic mistake. A "12 AM"/
+  "00:00" closing returns 1440 (tonight's midnight) so plain arithmetic works; a closing that
+  reads earlier than now is treated as past-midnight (+24 h). Guards: the selected place must sit
+  within 200 m of the route end (multi-stop trips whose last stop isn't the selected place skip
+  the warning). NB on a device with NO TTS voice the later "no voice engine" hint overwrites the
+  flash (single status slot) - with any voice installed the warning shows and is spoken.
 - **Location-permission UX gates (2026-07-10).** Turn-by-turn REQUIRES precise location (coarse
   fixes are ~2 km; the nav fix discipline correctly refuses non-GPS and >50 m fixes, so nav on
   coarse sat at "Searching for GPS" forever with no explanation). `onStartNav` in MapScreen now

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -201,6 +201,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   place has an X on its row to remove just that entry (Clear recents still wipes the lot). A real
   place shows its street address in smaller text under the name, and the Home/Work rows show the
   saved address too. The three-dot menus on Home/Work match the row text color now.
+- ✅ **Warns when you'd arrive near closing time (2026-07-10).** Starting navigation to a place
+  that closes within an hour of your arrival (or before you'd get there) shows a heads-up card
+  and speaks it: "closes at 9:00 PM and you arrive around 8:40 PM". Reads the closing time from
+  the place's own status in any app language; says nothing when the place is closed already or
+  has no hours.
 - ✅ **Approximate location explains itself, and the blob actually shows (2026-07-10).** Granting
   approximate (at setup or from the locate button) now gets one plain dialog saying what it means -
   wide circle for a dot, no turn-by-turn - with an Allow-precise shortcut that goes straight into

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -2120,11 +2120,49 @@ class MapViewModel @Inject constructor(
             // route's traffic signals once + fold the clauses into its turns before the session starts.
             val enriched = enrichLightsIfEnabled(named)
             if (enriched !== named) _state.update { it.copy(activeRoute = enriched) }
+            // Google-style courtesy: warn once, card + voice, when this drive lands within an hour
+            // of the destination's closing time (or after it).
+            maybeWarnClosingSoon(enriched)
             // Demo / screenshot / test mode (Settings → Navigation): drive the route as a SYNTHETIC GPS
             // trace instead of using the real fix, so nav can be shown/tested anywhere (a Davis route
             // while the phone is elsewhere). Same replay pipeline as a recorded trip.
             if (settingsPrefs.getBoolean("demo_drive", false)) startDemoDrive(enriched) else launchNav(enriched)
         }
+    }
+
+    /** Warn at nav start when the drive arrives within an hour of the destination closing, or after
+     *  it — a heads-up card plus the nav voice, so nobody drives forty minutes to a place that locks
+     *  its doors on arrival. Closing time comes from the place's own localized status text
+     *  ([app.vela.core.data.ClosingTime]); no parsable status, no warning. */
+    private fun maybeWarnClosingSoon(route: app.vela.core.model.Route) {
+        val sel = _state.value.selected ?: return
+        val end = route.polyline.lastOrNull() ?: return
+        if (sel.location.distanceTo(end) > 200.0) return // the selected place isn't this trip's destination
+        val closing = app.vela.core.data.ClosingTime.closingMinuteOfDay(sel.statusText, sel.openNow) ?: return
+        val cal = java.util.Calendar.getInstance()
+        val nowMin = cal.get(java.util.Calendar.HOUR_OF_DAY) * 60 + cal.get(java.util.Calendar.MINUTE)
+        // A closing that reads EARLIER than now is past midnight ("Closes 1 AM" seen at 11 PM).
+        val closeAbs = if (closing < nowMin) closing + 24 * 60 else closing
+        val etaSec = route.durationInTrafficSeconds ?: route.durationSeconds
+        val arriveMin = nowMin + (etaSec / 60.0).toInt()
+        val gap = closeAbs - arriveMin
+        if (gap >= 60) return
+        val msg = appContext.getString(
+            if (gap < 0) R.string.mapvm_closing_before_arrival else R.string.mapvm_closing_soon,
+            sel.name,
+            formatMinuteOfDay(closeAbs % 1440),
+            formatMinuteOfDay(arriveMin % 1440),
+        )
+        flashStatus(msg, 15_000L)
+        voice.speak(msg)
+    }
+
+    /** A minute-of-day in the user's clock format (locale + the system 12/24-hour setting). */
+    private fun formatMinuteOfDay(min: Int): String {
+        val cal = java.util.Calendar.getInstance()
+        cal.set(java.util.Calendar.HOUR_OF_DAY, min / 60)
+        cal.set(java.util.Calendar.MINUTE, min % 60)
+        return android.text.format.DateFormat.getTimeFormat(appContext).format(cal.time)
     }
 
     /** Drive [route] as a synthetic GPS trace ([DemoTrace] → the recorded-trip [LocationProvider.replay]

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -489,6 +489,8 @@
     <string name="voice_capture_done">Fertig</string>
     <string name="mapvm_asr_ready">Die Vela-Stimme ist bereit</string>
     <string name="mapvm_asr_download_failed">Sprachmodell konnte nicht geladen werden. Prüfe deine Verbindung und versuche es erneut.</string>
+    <string name="mapvm_closing_soon">%1$s schließt um %2$s und du kommst gegen %3$s an</string> <!-- format -->
+    <string name="mapvm_closing_before_arrival">%1$s schließt um %2$s, bevor du gegen %3$s ankommst</string> <!-- format -->
     <string name="settings_voice_search_model">Vela-Stimme</string>
     <string name="settings_voice_search_model_hint">Die Vela-Stimme macht aus Sprache direkt auf deinem Gerät eine Suche: keine andere App nötig, nichts wird hochgeladen. Einmaliger Download von %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Herunterladen (%1$d MB)</string>  <!-- format -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -489,6 +489,8 @@
     <string name="voice_capture_done">Listo</string>
     <string name="mapvm_asr_ready">La voz de Vela está lista</string>
     <string name="mapvm_asr_download_failed">No se pudo descargar el modelo de voz. Revisa tu conexión e inténtalo de nuevo.</string>
+    <string name="mapvm_closing_soon">%1$s cierra a las %2$s y llegas hacia las %3$s</string> <!-- format -->
+    <string name="mapvm_closing_before_arrival">%1$s cierra a las %2$s, antes de que llegues hacia las %3$s</string> <!-- format -->
     <string name="settings_voice_search_model">Voz de Vela</string>
     <string name="settings_voice_search_model_hint">La voz de Vela convierte tu voz en una búsqueda directamente en el teléfono: sin otra app y sin subir nada. Descarga única de %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Descargar (%1$d MB)</string>  <!-- format -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -489,6 +489,8 @@
     <string name="voice_capture_done">Terminé</string>
     <string name="mapvm_asr_ready">La voix Vela est prête</string>
     <string name="mapvm_asr_download_failed">Impossible de télécharger le modèle vocal. Vérifiez votre connexion et réessayez.</string>
+    <string name="mapvm_closing_soon">%1$s ferme à %2$s et vous arrivez vers %3$s</string> <!-- format -->
+    <string name="mapvm_closing_before_arrival">%1$s ferme à %2$s, avant votre arrivée vers %3$s</string> <!-- format -->
     <string name="settings_voice_search_model">Voix Vela</string>
     <string name="settings_voice_search_model_hint">La voix Vela transforme la parole en recherche directement sur votre téléphone : aucune autre appli et rien n\'est envoyé. Téléchargement unique d\'environ %1$d Mo.</string>  <!-- format -->
     <string name="settings_voice_search_download">Télécharger (%1$d Mo)</string>  <!-- format -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -489,6 +489,8 @@
     <string name="voice_capture_done">Fatto</string>
     <string name="mapvm_asr_ready">La voce Vela è pronta</string>
     <string name="mapvm_asr_download_failed">Impossibile scaricare il modello vocale. Controlla la connessione e riprova.</string>
+    <string name="mapvm_closing_soon">%1$s chiude alle %2$s e arrivi verso le %3$s</string> <!-- format -->
+    <string name="mapvm_closing_before_arrival">%1$s chiude alle %2$s, prima del tuo arrivo verso le %3$s</string> <!-- format -->
     <string name="settings_voice_search_model">Voce Vela</string>
     <string name="settings_voice_search_model_hint">La voce Vela trasforma il parlato in una ricerca direttamente sul telefono: nessun\'altra app e nulla viene caricato. Download una tantum di %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Scarica (%1$d MB)</string>  <!-- format -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -489,6 +489,8 @@
     <string name="voice_capture_done">Klaar</string>
     <string name="mapvm_asr_ready">De Vela-stem is klaar</string>
     <string name="mapvm_asr_download_failed">Kan het spraakmodel niet downloaden. Controleer je verbinding en probeer opnieuw.</string>
+    <string name="mapvm_closing_soon">%1$s sluit om %2$s en je komt rond %3$s aan</string> <!-- format -->
+    <string name="mapvm_closing_before_arrival">%1$s sluit om %2$s, voordat je rond %3$s aankomt</string> <!-- format -->
     <string name="settings_voice_search_model">Vela-stem</string>
     <string name="settings_voice_search_model_hint">De Vela-stem zet spraak direct op je telefoon om in een zoekopdracht: geen andere app nodig en er wordt niets geüpload. Eenmalige download van %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Downloaden (%1$d MB)</string>  <!-- format -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -489,6 +489,8 @@
     <string name="voice_capture_done">Gotowe</string>
     <string name="mapvm_asr_ready">Głos Vela jest gotowy</string>
     <string name="mapvm_asr_download_failed">Nie udało się pobrać modelu głosu. Sprawdź połączenie i spróbuj ponownie.</string>
+    <string name="mapvm_closing_soon">%1$s zamyka się o %2$s, a ty dojedziesz około %3$s</string> <!-- format -->
+    <string name="mapvm_closing_before_arrival">%1$s zamyka się o %2$s, zanim dojedziesz (około %3$s)</string> <!-- format -->
     <string name="settings_voice_search_model">Głos Vela</string>
     <string name="settings_voice_search_model_hint">Głos Vela zamienia mowę w wyszukiwanie bezpośrednio na telefonie: bez innej aplikacji i bez wysyłania czegokolwiek. Jednorazowe pobranie %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Pobierz (%1$d MB)</string>  <!-- format -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -489,6 +489,8 @@
     <string name="voice_capture_done">Concluído</string>
     <string name="mapvm_asr_ready">A voz Vela está pronta</string>
     <string name="mapvm_asr_download_failed">Não foi possível transferir o modelo de voz. Verifica a ligação e tenta novamente.</string>
+    <string name="mapvm_closing_soon">%1$s fecha às %2$s e você chega por volta das %3$s</string> <!-- format -->
+    <string name="mapvm_closing_before_arrival">%1$s fecha às %2$s, antes de você chegar por volta das %3$s</string> <!-- format -->
     <string name="settings_voice_search_model">Voz Vela</string>
     <string name="settings_voice_search_model_hint">A voz Vela transforma a fala numa pesquisa diretamente no telemóvel: sem outra app e sem enviar nada. Transferência única de %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Transferir (%1$d MB)</string>  <!-- format -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -489,6 +489,8 @@
     <string name="voice_capture_done">Готово</string>
     <string name="mapvm_asr_ready">Голос Vela готов</string>
     <string name="mapvm_asr_download_failed">Не удалось загрузить голосовую модель. Проверьте подключение и повторите попытку.</string>
+    <string name="mapvm_closing_soon">%1$s закрывается в %2$s, вы приедете около %3$s</string> <!-- format -->
+    <string name="mapvm_closing_before_arrival">%1$s закрывается в %2$s, раньше вашего приезда (около %3$s)</string> <!-- format -->
     <string name="settings_voice_search_model">Голос Vela</string>
     <string name="settings_voice_search_model_hint">Голос Vela превращает речь в поиск прямо на телефоне: без других приложений и без выгрузки данных. Разовая загрузка %1$d МБ.</string>  <!-- format -->
     <string name="settings_voice_search_download">Загрузить (%1$d МБ)</string>  <!-- format -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -489,6 +489,8 @@
     <string name="voice_capture_done">Klar</string>
     <string name="mapvm_asr_ready">Vela-rösten är klar</string>
     <string name="mapvm_asr_download_failed">Det gick inte att ladda ner röstmodellen. Kontrollera anslutningen och försök igen.</string>
+    <string name="mapvm_closing_soon">%1$s stänger %2$s och du är framme runt %3$s</string> <!-- format -->
+    <string name="mapvm_closing_before_arrival">%1$s stänger %2$s, innan du är framme (runt %3$s)</string> <!-- format -->
     <string name="settings_voice_search_model">Vela-röst</string>
     <string name="settings_voice_search_model_hint">Vela-rösten gör tal till en sökning direkt på telefonen: ingen annan app behövs och inget laddas upp. Engångsnedladdning på %1$d MB.</string>  <!-- format -->
     <string name="settings_voice_search_download">Ladda ner (%1$d MB)</string>  <!-- format -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -489,6 +489,8 @@
     <string name="voice_capture_done">Готово</string>
     <string name="mapvm_asr_ready">Голос Vela готовий</string>
     <string name="mapvm_asr_download_failed">Не вдалося завантажити голосову модель. Перевірте з\'єднання та повторіть спробу.</string>
+    <string name="mapvm_closing_soon">%1$s зачиняється о %2$s, ви приїдете близько %3$s</string> <!-- format -->
+    <string name="mapvm_closing_before_arrival">%1$s зачиняється о %2$s, ще до вашого приїзду (близько %3$s)</string> <!-- format -->
     <string name="settings_voice_search_model">Голос Vela</string>
     <string name="settings_voice_search_model_hint">Голос Vela перетворює мовлення на пошук просто на телефоні: без інших застосунків і без надсилання даних. Одноразове завантаження %1$d МБ.</string>  <!-- format -->
     <string name="settings_voice_search_download">Завантажити (%1$d МБ)</string>  <!-- format -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -512,6 +512,8 @@
     <string name="voice_capture_done">Done</string>
     <string name="mapvm_asr_ready">Vela Voice is ready</string>
     <string name="mapvm_asr_download_failed">Couldn\'t download the voice model. Check your connection and try again.</string>
+    <string name="mapvm_closing_soon">%1$s closes at %2$s and you arrive around %3$s</string> <!-- format -->
+    <string name="mapvm_closing_before_arrival">%1$s closes at %2$s, before you arrive around %3$s</string> <!-- format -->
     <string name="settings_voice_search_model">Vela Voice</string>
     <string name="settings_voice_search_model_hint">Vela Voice turns speech into a search right on your phone: no other app needed and nothing is uploaded. One-time %1$d MB download.</string>  <!-- format -->
     <string name="settings_voice_search_download">Download (%1$d MB)</string>  <!-- format -->

--- a/core/src/main/java/app/vela/core/data/ClosingTime.kt
+++ b/core/src/main/java/app/vela/core/data/ClosingTime.kt
@@ -1,0 +1,49 @@
+package app.vela.core.data
+
+/**
+ * Pulls today's CLOSING time out of Google's localized status text ("Open ⋅ Closes 9 PM",
+ * "Ouvert ⋅ Ferme à 19:00", "Open ⋅ Closes soon ⋅ 7:30 PM") so navigation can warn when a
+ * drive lands right at, or after, the destination's closing time. Text-based on purpose:
+ * the status line is the one field that reliably carries the day's closing time in every
+ * language the app scrapes, and holiday hours already flow into it.
+ *
+ * Only an OPEN place parses (the [closingMinuteOfDay] openNow gate): a closed place's status
+ * times are OPENING times ("Closed ⋅ Opens 9 AM") and must not be mistaken for a closing.
+ */
+object ClosingTime {
+    // "9 PM", "7:30 pm", "12 a.m." — the 12-hour shapes Google writes in English-style locales.
+    private val T12 = Regex("""(\d{1,2})(?::(\d{2}))?\s*([ap])\.?\s?m\.?""", RegexOption.IGNORE_CASE)
+
+    // "19:00", "19h00", "19.30" — the 24-hour shapes in the other scraped locales.
+    private val T24 = Regex("""(\d{1,2})[:hH.](\d{2})""")
+
+    /**
+     * Today's closing time as a minute-of-day, or null when there is nothing to parse (place
+     * closed, "Open 24 hours", no status). A midnight closing ("12 AM" / "00:00") returns 1440,
+     * i.e. tonight's midnight, so it stays LATER than any same-day arrival in plain arithmetic.
+     */
+    fun closingMinuteOfDay(statusText: String?, openNow: Boolean?): Int? {
+        if (openNow != true) return null
+        val s = statusText ?: return null
+        // The LAST time token wins: an open status carries the closing time as its final time
+        // ("Open ⋅ Closes 9 PM", "Closes soon ⋅ 9 PM"); "Open 24 hours" carries none.
+        val m12 = T12.findAll(s).lastOrNull()
+        if (m12 != null) {
+            val h = m12.groupValues[1].toInt()
+            val min = m12.groupValues[2].ifEmpty { "0" }.toInt()
+            if (h !in 1..12 || min > 59) return null
+            val pm = m12.groupValues[3].equals("p", ignoreCase = true)
+            val h24 = when {
+                pm && h < 12 -> h + 12
+                !pm && h == 12 -> 24 // "12 AM" as a closing means midnight TONIGHT
+                else -> h
+            }
+            return h24 * 60 + min
+        }
+        val m24 = T24.findAll(s).lastOrNull() ?: return null
+        val h = m24.groupValues[1].toInt()
+        val min = m24.groupValues[2].toInt()
+        if (h > 24 || min > 59) return null
+        return (if (h == 0) 24 else h) * 60 + min // "00:00" closing is midnight tonight too
+    }
+}

--- a/core/src/test/java/app/vela/core/data/ClosingTimeTest.kt
+++ b/core/src/test/java/app/vela/core/data/ClosingTimeTest.kt
@@ -1,0 +1,50 @@
+package app.vela.core.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ClosingTimeTest {
+
+    @Test fun parsesEnglish12h() {
+        assertEquals(21 * 60, ClosingTime.closingMinuteOfDay("Open ⋅ Closes 9 PM", true))
+    }
+
+    @Test fun parsesMinutes() {
+        assertEquals(19 * 60 + 30, ClosingTime.closingMinuteOfDay("Open ⋅ Closes 7:30 PM", true))
+    }
+
+    @Test fun parses24hLocales() {
+        assertEquals(19 * 60, ClosingTime.closingMinuteOfDay("Ouvert ⋅ Ferme à 19:00", true))
+        assertEquals(19 * 60, ClosingTime.closingMinuteOfDay("Geöffnet ⋅ Schließt um 19:00", true))
+    }
+
+    @Test fun closesSoonStillFindsTheTime() {
+        assertEquals(21 * 60, ClosingTime.closingMinuteOfDay("Open ⋅ Closes soon ⋅ 9 PM", true))
+    }
+
+    @Test fun midnightClosingIsTonight() {
+        // 1440, not 0 — must stay later than any same-day arrival in plain arithmetic.
+        assertEquals(24 * 60, ClosingTime.closingMinuteOfDay("Open ⋅ Closes 12 AM", true))
+        assertEquals(24 * 60, ClosingTime.closingMinuteOfDay("Ouvert ⋅ Ferme à 00:00", true))
+    }
+
+    @Test fun noonPmIsNoon() {
+        assertEquals(12 * 60, ClosingTime.closingMinuteOfDay("Open ⋅ Closes 12 PM", true))
+    }
+
+    @Test fun closedPlaceNeverParses() {
+        // A closed status carries an OPENING time; parsing it as a closing is the failure mode.
+        assertNull(ClosingTime.closingMinuteOfDay("Closed ⋅ Opens 9 AM", false))
+        assertNull(ClosingTime.closingMinuteOfDay("Closed ⋅ Opens 9 AM", null))
+    }
+
+    @Test fun open24HoursHasNoClosing() {
+        assertNull(ClosingTime.closingMinuteOfDay("Open 24 hours", true))
+    }
+
+    @Test fun nullAndBlankStatus() {
+        assertNull(ClosingTime.closingMinuteOfDay(null, true))
+        assertNull(ClosingTime.closingMinuteOfDay("Open", true))
+    }
+}


### PR DESCRIPTION
Starting navigation to a place that closes within an hour of your arrival (or before you would get there at all) now warns once, right at the start: a heads-up card plus the spoken nav voice, for example "closes at 9:00 PM and you arrive around 8:40 PM".

How it works:

- The closing time is parsed from the place's own localized status text (core/data/ClosingTime, unit tested). It handles 12 hour and 24 hour forms, takes the last time in the line, and treats a midnight closing as tonight rather than this morning.
- It only parses places that are currently open. A closed status carries opening times, which must never be read as a closing.
- The arrival estimate uses the in-traffic ETA when there is one.
- Multi stop trips whose final stop is not the opened place skip the warning (the destination is matched against the route end).
- Times render in the user's clock format, and the two message strings are translated into all 11 languages.

No new settings, no extra network traffic.