### PR TITLE
One notification area, a Get-a-voice shortcut, and a spoken directions toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,6 +472,23 @@ Defaults that make the safe path the easy one:
   kept (it's still the reusable pre-permission screen the **PR3 voice-search mic** uses at
   point-of-use for RECORD_AUDIO) - it's just no longer used for location. Don't re-request location
   straight from the map.
+- **ONE stacked notification area on the map (2026-07-10).** The heads-up flash, download
+  progress cards, the update card and pushed notices all render in the SAME TopCenter Column in
+  MapScreen (each with its own dismiss) - the old separate status card sat on the category chips
+  and painted over the update card. Position: browse = statusBar + 132dp (just under search bar +
+  chips); during nav it hangs off the turn card's MEASURED bottom edge (`navBannerBottomPx`, the
+  same onGloballyPositioned report the compass uses) + 10dp, so it slides with lane rows / the
+  "then" row instead of a guessed fixed offset. The flash (`MapUiState.status`) shows in ANY map
+  state; the other cards stay gated to the bare map. `statusVoiceAction` on the state marks a
+  voice-problem flash: `InfoCard` then adds a filled **"Get a voice" pill** (UpdateCard layout)
+  that deep-links Settings -> voice library (`MapScreen.onOpenVoiceSettings` -> VelaRoot ->
+  `SettingsScreen(openVoiceLibrary = true)`). Both the no-engine warning and the
+  missing-language hint carry it.
+- **Spoken directions are a persistent toggle (2026-07-10).** Settings -> Voice top row
+  ("Spoken directions", pref `spoken_directions` in vela_settings, default on) and the in-nav
+  speaker button share ONE state: `MapViewModel.setSpokenDirections` writes the pref + `voice.muted`;
+  `toggleVoice` routes through it; init applies the pref at startup. When it's OFF the no-voice-
+  engine warning is suppressed (silence is chosen, don't nag).
 - **Closing-time warning at nav start (2026-07-10).** `MapViewModel.maybeWarnClosingSoon` (called
   in `startNav` before launch/demo): when the drive's arrival (now + in-traffic ETA) lands within
   an hour of the destination's closing time, or past it, it warns ONCE - `flashStatus` heads-up

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,10 @@ Defaults that make the safe path the easy one:
   Voice section) not an inline accordion - `SettingsScreen` early-returns to it when
   `showVoiceLibrary`; its own Back returns to Settings. Put a new setting in the section it serves;
   niche/experimental → Advanced, demo/test tools → Developer, place-content → Place pages not Map.
+- **Directions "Leave now" ETA line (2026-07-10):** "Arrive at 5:30 PM" renders titleMedium
+  SemiBold in ink - the small dim line with a "current traffic" note under it was clutter (the
+  traffic-coloured per-route ETAs already carry that signal); the "Usually X-Y min" typical-range
+  note stays. `place_current_traffic` was deleted from all 11 locales.
 - **Nav UI style (2026-07-08):** ManeuverBanner + NavControls are RoundedCornerShape(24/28dp)
   Cards with elevation 6dp, 54dp turn glyph, headlineMedium-bold distance, titleMedium-medium road
   name, FilledTonalIconButton for mute/steps. Keep new nav chrome on this treatment (no flat
@@ -478,8 +482,13 @@ Defaults that make the safe path the easy one:
   and painted over the update card. Position: browse = statusBar + 132dp (just under search bar +
   chips); during nav it hangs off the turn card's MEASURED bottom edge (`navBannerBottomPx`, the
   same onGloballyPositioned report the compass uses) + 10dp, so it slides with lane rows / the
-  "then" row instead of a guessed fixed offset. The flash (`MapUiState.status`) shows in ANY map
-  state; the other cards stay gated to the bare map. `statusVoiceAction` on the state marks a
+  "then" row instead of a guessed fixed offset. AUDITED COMPLETE 2026-07-10: the FASTER-ROUTE
+  offer during nav renders IN the column too (it used to sit at a fixed 96dp under the turn card),
+  and the bottom PSDS tip is gated to the bare map + yields to the resume-nav card - every
+  top-of-map card is in the one column; bottom cards (PSDS tip, resume-nav) are bare-map-only.
+  The flash (`MapUiState.status`) shows in ANY map state; the other cards stay gated to the bare
+  map, which INCLUDES during nav - a mid-drive voice/region download or update offer stacks under
+  the faster-route/status cards instead of hiding. `statusVoiceAction` on the state marks a
   voice-problem flash: `InfoCard` then adds a filled **"Get a voice" pill** (UpdateCard layout)
   that deep-links Settings -> voice library (`MapScreen.onOpenVoiceSettings` -> VelaRoot ->
   `SettingsScreen(openVoiceLibrary = true)`). Both the no-engine warning and the

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -195,6 +195,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   Done), and the microphone permission is asked only the first time you tap the mic. When both Vela voice and a
   voice-input app are present, a Settings picker chooses which to use (Vela voice by default). Device-verified end to end: download, install, the mic appears, the permission prompt,
   the listening sheet, and the model transcribing back into the search box.
+- ✅ **Arrival time front and center (2026-07-10).** The directions panel's "Arrive at 5:30 PM"
+  is bigger and bolder, and the redundant "current traffic" note under it is gone (the route ETAs
+  already show traffic). The faster-route offer during navigation joined the tidy notification
+  stack too, so it can't sit under the turn card.
 - ✅ **One tidy notification area (2026-07-10).** Heads-up messages, download progress, update
   offers and notices now stack below the search bar and chips (or just below the turn card during
   navigation, whatever its height), each dismissed on its own, instead of painting over each other.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -195,6 +195,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   Done), and the microphone permission is asked only the first time you tap the mic. When both Vela voice and a
   voice-input app are present, a Settings picker chooses which to use (Vela voice by default). Device-verified end to end: download, install, the mic appears, the permission prompt,
   the listening sheet, and the model transcribing back into the search box.
+- ✅ **One tidy notification area (2026-07-10).** Heads-up messages, download progress, update
+  offers and notices now stack below the search bar and chips (or just below the turn card during
+  navigation, whatever its height), each dismissed on its own, instead of painting over each other.
+  A missing-voice warning carries a "Get a voice" pill straight into the voice library.
+- ✅ **Spoken directions toggle (2026-07-10).** Settings → Voice has an on/off switch for spoken
+  navigation; it remembers your choice, and the mute button during navigation is the same switch.
 - ✅ **Update button is a filled pill (2026-07-10).** The update card's Update action is a filled
   pill instead of tinted text, so it stands out by shape and fill rather than colour alone.
 - ✅ **Recents you can prune, with addresses (2026-07-10).** Every recent search and recently-opened

--- a/README.md
+++ b/README.md
@@ -428,6 +428,10 @@ decodes Google's geometry exactly and is covered by a reference-vector test.
   (Settings → Voice) lets you browse, download and switch between ~40 Piper voices (Lessac, HFC, Ryan,
   the HFC Female default, British voices, …) to find the read you like. Plus AOSP
   `TextToSpeech`: we enumerate the phone's installed engines so you can override to any system voice.
+  Spoken directions have an on/off switch that the in-nav mute button shares. **Voice search** is
+  on-device too: the search-bar mic records and transcribes with Vela's own downloadable Whisper
+  model (same bundled runtime, mic permission asked at first use), or hands off to a voice-input
+  app you already have; with neither installed the mic offers the download.
 - **No GMS anywhere:** no Fused location, no FCM, no Firebase, no Play Integrity.
   Everything (MapLibre, OkHttp, Compose, Hilt) is pure AOSP. OrganicMaps is the
   existence proof; Vela's stack is a superset.
@@ -486,6 +490,8 @@ without an app release.
 - [x] Settings toggles to **hide reviews** and **skip photo loading** (place pages stay lean, nothing is fetched)
 - [x] **In-app updater** - checks the newest GitHub release about once a day (Settings toggle), downloads the APK and installs through Android's normal installer; Obtainium still works as before
 - [x] **11 languages** - UI, spoken turn-by-turn, and Google place content localized (English + de es fr it nl pl pt ru sv uk)
+- [x] **On-device voice search** - "Vela Voice" (Whisper tiny through the bundled sherpa-onnx runtime, ~58 MB download) transcribes on the phone; an installed voice-input app works as the alternative path
+- [x] **Honest location UX** - approximate-only permission draws a true accuracy circle and explains itself once; navigation asks for precise location instead of failing silently; nav warns when you'd arrive within an hour of closing
 - [x] **Foreground navigation service** - screen-off guidance, notification, faster-route re-checks
 - [x] **Offline routing on-device (GraphHopper)** - a downloadable **135-region world catalog** (all US states, Canada, Europe, +) hosted on GitHub; saving an offline map area grabs its routing graph too
 - [x] **In-app light/dark**, one consistent Google-grey UI, custom POI markers, hillshade relief

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,11 @@ Last updated: 2026-07-08.
 - **In-app updater + content toggles (2026-07-08).** A PipePipe-style updater checks the newest GitHub
   release (about daily, Settings toggle), downloads the APK and hands it to Android's installer. Plus
   Settings switches to hide reviews and skip photo loading, and a 3D-buildings toggle for weaker GPUs.
+- **On-device voice search (Vela Voice STT) - DONE 2026-07-10, device-verified.** The search-bar mic
+  transcribes IN-PROCESS with a downloadable Whisper tiny model (same bundled sherpa-onnx runtime as
+  TTS, `asr-models` release hosting, ~58 MB), with an installed voice-input app as the intent-handoff
+  alternative and a download offer when neither exists. Possible follow-up: bigger model tiers in the
+  same catalog (tiny is the speed/size tradeoff).
 - **In-process neural voice (Piper) - DONE, device-verified.** Vela bundles the sherpa-onnx VITS
   runtime and downloads a **Piper** voice itself (progress bar), running it in-process as the default nav
   voice - near-Siri quality, no standalone TTS app. Default = **HFC Female** (`en_US-hfc_female-medium`,

--- a/SPEC.md
+++ b/SPEC.md
@@ -572,6 +572,18 @@ handed - no filesystem, network, or device access.
   `filesDir/overlays/<id>.pmtiles`, rendered by `VelaMapView` as a `pmtiles://file://…` `VectorSource` +
   `FillLayer` **beneath** the OSM `building` layer (themed identically), filling only the gaps OSM never mapped.
   Pulled alongside the area's tiles+routing on the same smallest-covering-box rule. Data, not code (GPLv3-orthogonal).
+- **Voice search is two-tier and keyless.** Tier 1: in-process ASR - Whisper tiny int8 +
+  Silero VAD through the SAME bundled sherpa-onnx runtime the TTS uses (`WhisperRecognizer`,
+  `AsrModel`), model downloaded on demand from the `asr-models` GitHub release (tar.GZIP - bzip2
+  unpacked ~15 MB/s on-device), RECORD_AUDIO asked at point of use only, Whisper pinned to the app
+  language (auto-detect hallucinated scripts on noisy audio). Tier 2: `ACTION_RECOGNIZE_SPEECH`
+  handoff to an installed voice-input app (that app records - no mic permission for Vela). Never a
+  cloud STT API.
+- **Permissions are asked with context, never silently broken.** Onboarding = welcome → location →
+  notifications → voice offer; coarse-only location gets a one-time explainer (wide-circle dot +
+  an Android precise-upgrade shortcut) and draws a REAL accuracy circle; navigation start gates on
+  FINE (coarse fixes never feed the nav engine) with the upgrade dialog; a permanently-denied
+  locate tap explains and deep-links system settings.
 - No GMS: no FCM/Firebase/Play Integrity/Fused. Push (if ever) = UnifiedPush; crash
   reporting = ACRA/self-hosted.
 - EU consent: pre-seed `SOCS`/`CONSENT` cookies; never let `Set-Cookie` downgrade

--- a/app/src/main/java/app/vela/ui/VelaRoot.kt
+++ b/app/src/main/java/app/vela/ui/VelaRoot.kt
@@ -39,6 +39,7 @@ fun VelaRoot(vm: MapViewModel = hiltViewModel()) {
 
     var showSettings by rememberSaveable { mutableStateOf(false) }
     var settingsOpenOffline by rememberSaveable { mutableStateOf(false) }
+    var settingsOpenVoice by rememberSaveable { mutableStateOf(false) }
     // Location permission launcher for onboarding. The map no longer fires the raw system dialog on
     // its own (see MapScreen); this owns the first ask. A grant starts location immediately (coarse-
     // only works too, via the NETWORK provider); a denial just moves on and leaves search/browse
@@ -132,12 +133,18 @@ fun VelaRoot(vm: MapViewModel = hiltViewModel()) {
         // opaque overlay. Swapping the two out instead disposed the remembered MapLibre MapView, so
         // returning from Settings rebuilt the map from scratch and it snapped back to the stale
         // center at the default zoom, losing the user's pan/zoom (a reported bug).
-        MapScreen(vm = vm, onOpenSettings = { showSettings = true })
+        MapScreen(
+            vm = vm,
+            onOpenSettings = { showSettings = true },
+            // The no-voice heads-up's pill: straight into the voice library.
+            onOpenVoiceSettings = { settingsOpenVoice = true; showSettings = true },
+        )
         if (showSettings) {
             SettingsScreen(
                 vm = vm,
-                onBack = { showSettings = false; settingsOpenOffline = false },
+                onBack = { showSettings = false; settingsOpenOffline = false; settingsOpenVoice = false },
                 openOffline = settingsOpenOffline,
+                openVoiceLibrary = settingsOpenVoice,
             )
         } else {
             // Location is asked via the system dialog fired above (no rationale screen). The voice

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1011,17 +1011,8 @@ fun MapScreen(
             }
         }
 
-        if (state.navigating && state.fasterRoute != null) {
-            FasterRouteCard(
-                savingSeconds = state.fasterSavingSeconds,
-                onSwitch = vm::acceptFasterRoute,
-                onDismiss = vm::dismissFasterRoute,
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .statusBarsPadding()
-                    .padding(top = 96.dp, start = 12.dp, end = 12.dp),
-            )
-        }
+        // (The faster-route offer renders in the stacked notification column below, so it can
+        // never sit under the turn card or on top of another card.)
 
         // After panning away during nav — or swiping the banner ahead to preview a
         // later step — a Re-center button reattaches the follow-camera AND snaps the
@@ -1523,7 +1514,9 @@ fun MapScreen(
         }
 
         // --- transient surfaces --------------------------------------------
-        if (state.showPsdsTip) {
+        if (state.showPsdsTip && state.selected == null && !searchOpen && !state.navigating &&
+            state.resumeNavLabel == null
+        ) {
             InfoCard(
                 title = stringResource(R.string.mapscreen_psds_tip_title),
                 body = stringResource(R.string.mapscreen_psds_tip_body),
@@ -1544,7 +1537,8 @@ fun MapScreen(
         val downloadingVoiceId = state.voiceDownloadingId
         val downloadingRegion = state.routingDownloadingId != null || state.poiPackDownloadingId != null
         val bareMap = state.selected == null && !searchOpen
-        if (state.status != null ||
+        val fasterOffer = state.navigating && state.fasterRoute != null
+        if (state.status != null || fasterOffer ||
             (bareMap && (state.notices.isNotEmpty() || downloadingVoiceId != null || downloadingRegion || state.updateInfo != null))
         ) {
             val bannerBottom = with(LocalDensity.current) { navBannerBottomPx.toDp() }
@@ -1561,6 +1555,13 @@ fun MapScreen(
                     ),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
+                if (fasterOffer) {
+                    FasterRouteCard(
+                        savingSeconds = state.fasterSavingSeconds,
+                        onSwitch = vm::acceptFasterRoute,
+                        onDismiss = vm::dismissFasterRoute,
+                    )
+                }
                 state.status?.let { msg ->
                     InfoCard(
                         title = stringResource(R.string.mapscreen_heads_up),

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -193,6 +193,7 @@ private const val USE_MAPTILER = false
 fun MapScreen(
     vm: MapViewModel,
     onOpenSettings: () -> Unit,
+    onOpenVoiceSettings: () -> Unit = {},
 ) {
     val state by vm.state.collectAsStateWithLifecycle()
     val darkTheme = isAppInDarkTheme()
@@ -1534,67 +1535,78 @@ fun MapScreen(
                     .padding(16.dp),
             )
         }
-        state.status?.let { msg ->
-            InfoCard(
-                title = stringResource(R.string.mapscreen_heads_up),
-                body = msg,
-                actionLabel = stringResource(R.string.mapscreen_dismiss),
-                onAction = vm::clearStatus,
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .statusBarsPadding()
-                    // During nav, drop below the turn card (which can grow lane + "then" rows).
-                    .padding(top = if (state.navigating) 260.dp else 96.dp, start = 12.dp, end = 12.dp),
-            )
-        }
-        // Pushed notices (signed calibration channel) + the voice-download progress card — on the
-        // bare map only, so they don't cover the nav banner / search / a place sheet. The download
-        // card makes the ONBOARDING one-tap voice install visible (it used to run invisibly after
-        // the prompt dismissed — progress only existed in Settings; user 2026-07-07).
+        // ONE notification area: the heads-up flash, downloads, the update card and pushed notices
+        // all STACK here (each with its own dismiss) instead of painting over each other — the old
+        // separate status card sat on the chips and could cover the update card. Position: just
+        // below the search bar + chips on the browse map; during nav just below the turn card,
+        // whose height VARIES (lanes, "then" row) — so it hangs off the banner's MEASURED bottom
+        // edge, the same navBannerBottomPx the compass uses, and slides with it.
         val downloadingVoiceId = state.voiceDownloadingId
         val downloadingRegion = state.routingDownloadingId != null || state.poiPackDownloadingId != null
-        if (state.selected == null && !searchOpen &&
-            (state.notices.isNotEmpty() || downloadingVoiceId != null || downloadingRegion || state.updateInfo != null)
+        val bareMap = state.selected == null && !searchOpen
+        if (state.status != null ||
+            (bareMap && (state.notices.isNotEmpty() || downloadingVoiceId != null || downloadingRegion || state.updateInfo != null))
         ) {
+            val bannerBottom = with(LocalDensity.current) { navBannerBottomPx.toDp() }
             Column(
                 Modifier
                     .align(Alignment.TopCenter)
-                    .statusBarsPadding()
-                    // Below the search bar AND the chips; during nav, below the turn card instead
-                    // (these used to hide entirely in nav, which made a mid-drive voice download
-                    // look stalled).
-                    .padding(top = if (state.navigating) 260.dp else 140.dp, start = 12.dp, end = 12.dp),
+                    .then(
+                        if (state.navigating && navBannerBottomPx > 0) {
+                            // positionInRoot already spans the status bar — no statusBarsPadding here.
+                            Modifier.padding(top = bannerBottom + 10.dp, start = 12.dp, end = 12.dp)
+                        } else {
+                            Modifier.statusBarsPadding().padding(top = 132.dp, start = 12.dp, end = 12.dp)
+                        },
+                    ),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                if (downloadingVoiceId != null) {
-                    VoiceDownloadCard(installing = state.voiceInstalling, pct = state.voiceDownloadPct ?: 0f)
-                }
-                // The speech model download (started from the mic offer or Settings) gets the same
-                // card - it's also called Vela voice, so the one label fits both.
-                if (state.asrDownloadPct != null) {
-                    VoiceDownloadCard(installing = state.asrInstalling, pct = state.asrDownloadPct ?: 0f)
-                }
-                // A region (state/country) download: the routing graph first, then its place pack —
-                // same progress card treatment as the voice download, so a Settings-started state
-                // download stays visible after backing out to the map.
-                if (downloadingRegion) {
-                    RegionDownloadCard(
-                        name = state.regionDownloadName ?: "",
-                        places = state.poiPackDownloadingId != null,
-                        pct = if (state.poiPackDownloadingId != null) state.poiPackDownloadPct else state.routingDownloadPct,
+                state.status?.let { msg ->
+                    InfoCard(
+                        title = stringResource(R.string.mapscreen_heads_up),
+                        body = msg,
+                        actionLabel = stringResource(R.string.mapscreen_dismiss),
+                        onAction = vm::clearStatus,
+                        // A voice problem carries its fix: a pill straight to the voice library.
+                        pillLabel = if (state.statusVoiceAction) stringResource(R.string.mapscreen_get_voice) else null,
+                        onPill = if (state.statusVoiceAction) {
+                            { vm.clearStatus(); onOpenVoiceSettings() }
+                        } else {
+                            null
+                        },
                     )
                 }
-                // A newer release on GitHub (self-updater; the check is a Settings toggle).
-                state.updateInfo?.let { u ->
-                    UpdateCard(
-                        versionName = u.versionName,
-                        downloadPct = state.updateDownloadPct,
-                        onUpdate = { vm.downloadUpdate() },
-                        onDismiss = { vm.dismissUpdate() },
-                    )
-                }
-                state.notices.forEach { n ->
-                    NoticeCard(n, onDismiss = { vm.dismissNotice(n.id) })
+                if (bareMap) {
+                    if (downloadingVoiceId != null) {
+                        VoiceDownloadCard(installing = state.voiceInstalling, pct = state.voiceDownloadPct ?: 0f)
+                    }
+                    // The speech model download (started from the mic offer or Settings) gets the
+                    // same card - it's also called Vela voice, so the one label fits both.
+                    if (state.asrDownloadPct != null) {
+                        VoiceDownloadCard(installing = state.asrInstalling, pct = state.asrDownloadPct ?: 0f)
+                    }
+                    // A region (state/country) download: the routing graph first, then its place
+                    // pack — same progress card treatment as the voice download, so a Settings-
+                    // started state download stays visible after backing out to the map.
+                    if (downloadingRegion) {
+                        RegionDownloadCard(
+                            name = state.regionDownloadName ?: "",
+                            places = state.poiPackDownloadingId != null,
+                            pct = if (state.poiPackDownloadingId != null) state.poiPackDownloadPct else state.routingDownloadPct,
+                        )
+                    }
+                    // A newer release on GitHub (self-updater; the check is a Settings toggle).
+                    state.updateInfo?.let { u ->
+                        UpdateCard(
+                            versionName = u.versionName,
+                            downloadPct = state.updateDownloadPct,
+                            onUpdate = { vm.downloadUpdate() },
+                            onDismiss = { vm.dismissUpdate() },
+                        )
+                    }
+                    state.notices.forEach { n ->
+                        NoticeCard(n, onDismiss = { vm.dismissNotice(n.id) })
+                    }
                 }
             }
         }
@@ -2495,6 +2507,8 @@ private fun InfoCard(
     actionLabel: String,
     onAction: () -> Unit,
     modifier: Modifier = Modifier,
+    pillLabel: String? = null,
+    onPill: (() -> Unit)? = null,
 ) {
     // Fixed sheet palette so this banner reads as the same grey as the place sheet
     // and results list, not a wallpaper-tinted Material card.
@@ -2503,16 +2517,38 @@ private fun InfoCard(
         modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = SheetPalette.bg(dark)),
     ) {
-        Row(
-            Modifier.fillMaxWidth().padding(16.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(Modifier.weight(1f)) {
+        if (pillLabel != null && onPill != null) {
+            // With a primary action the card takes the UpdateCard layout: text block, then a
+            // trailing row of quiet-dismiss + filled pill (reads by shape/fill, colour-blind safe).
+            Column(Modifier.fillMaxWidth().padding(start = 16.dp, end = 12.dp, top = 12.dp, bottom = 10.dp)) {
                 Text(title, fontWeight = FontWeight.SemiBold, color = SheetPalette.ink(dark))
                 Text(body, style = MaterialTheme.typography.bodySmall, color = SheetPalette.dim(dark))
+                Row(
+                    Modifier.fillMaxWidth().padding(top = 6.dp),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    TextButton(onClick = onAction) { Text(actionLabel) }
+                    Spacer(Modifier.width(4.dp))
+                    Button(
+                        onClick = onPill,
+                        shape = CircleShape,
+                        modifier = Modifier.dpadHighlight(CircleShape),
+                    ) { Text(pillLabel) }
+                }
             }
-            TextButton(onClick = onAction) { Text(actionLabel) }
+        } else {
+            Row(
+                Modifier.fillMaxWidth().padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(Modifier.weight(1f)) {
+                    Text(title, fontWeight = FontWeight.SemiBold, color = SheetPalette.ink(dark))
+                    Text(body, style = MaterialTheme.typography.bodySmall, color = SheetPalette.dim(dark))
+                }
+                TextButton(onClick = onAction) { Text(actionLabel) }
+            }
         }
     }
 }

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -162,6 +162,7 @@ data class MapUiState(
     val arrivedDistanceMeters: Double = 0.0,
     val arrivedSeconds: Double = 0.0,
     val status: String? = null,
+    val statusVoiceAction: Boolean = false, // status is a voice problem -> show the Get-a-voice pill
     val installingEngine: String? = null, // pkg of the voice engine currently downloading
     val voiceDownloadPct: Float? = null, // 0f..1f while the neural-voice model downloads; null = idle
     val installedVoiceIds: Set<String> = emptySet(), // Piper voices present on disk (the voice browser)
@@ -320,7 +321,7 @@ class MapViewModel @Inject constructor(
                 lastVoiceLangHinted = lang
                 val endonym = app.vela.ui.AppLocale.endonym(lang)
                 viewModelScope.launch(Dispatchers.Main) {
-                    flashStatus(appContext.getString(R.string.mapvm_voice_lang_missing, endonym), 6000L)
+                    flashStatus(appContext.getString(R.string.mapvm_voice_lang_missing, endonym), 6000L, voiceAction = true)
                 }
             }
         }
@@ -334,6 +335,12 @@ class MapViewModel @Inject constructor(
         val voicePrefs = appContext.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
         val savedSpeed = voicePrefs.getFloat("voice_speed", calibration.current().defaultVoiceSpeed)
         voice.setRate(savedSpeed) // relay the saved rate to the AOSP TTS engine at startup
+        // Spoken directions on/off is PERSISTENT: the Settings toggle and the in-nav mute
+        // button share the one pref, so a muted choice survives restarts.
+        if (!voicePrefs.getBoolean("spoken_directions", true)) {
+            voice.muted = true
+            _state.update { it.copy(voiceMuted = true) }
+        }
         val installedVoices = VelaPiper.installedVoiceIds(appContext)
         val activeVoice = VelaPiper.effectiveVoiceId(appContext)
         _state.update {
@@ -2257,9 +2264,10 @@ class MapViewModel @Inject constructor(
             tripStore.startTrip(_state.value.selected?.name ?: appContext.getString(R.string.mapvm_trip_default_name), dest, System.currentTimeMillis())
             tripStore.saveRoute(route) // save the blue line + maneuvers so a replay drives THIS route
         }
-        // If the phone has no voice engine, say so once instead of going silent.
-        if (voice.availableEngines().isEmpty()) {
-            showStatus(appContext.getString(R.string.mapvm_no_voice_engine))
+        // If the phone has no voice engine, say so once instead of going silent - with a pill
+        // straight to the voice library. Not when spoken directions are OFF: silence is chosen.
+        if (voice.availableEngines().isEmpty() && !voice.muted) {
+            showStatus(appContext.getString(R.string.mapvm_no_voice_engine), voiceAction = true)
         }
     }
 
@@ -2302,11 +2310,14 @@ class MapViewModel @Inject constructor(
      *  step — so recenter undoes both a manual pan and a swipe-ahead step preview. */
     fun recenterNav() = _state.update { it.copy(navCameraDetached = false, previewStepIndex = null) }
 
-    /** Mute / unmute spoken guidance (the in-nav speaker button). */
-    fun toggleVoice() {
-        val muted = !voice.muted
-        voice.muted = muted
-        _state.update { it.copy(voiceMuted = muted) }
+    /** Mute / unmute spoken guidance (the in-nav speaker button). Persisted. */
+    fun toggleVoice() = setSpokenDirections(voice.muted)
+
+    /** Turn spoken directions on/off (Settings toggle; the nav mute button shares this state). */
+    fun setSpokenDirections(on: Boolean) {
+        voice.muted = !on
+        settingsPrefs.edit().putBoolean("spoken_directions", on).apply()
+        _state.update { it.copy(voiceMuted = !on) }
     }
 
     /** Reflect the persisted opt-in diagnostics flag into UI state (Settings reads it). */
@@ -2892,12 +2903,12 @@ class MapViewModel @Inject constructor(
 
     /** A status banner that **auto-clears** after a few seconds (unlike [showStatus],
      *  which stays until dismissed) — for transient feedback like a finished download. */
-    fun flashStatus(msg: String, millis: Long = 4500L) {
+    fun flashStatus(msg: String, millis: Long = 4500L, voiceAction: Boolean = false) {
         statusJob?.cancel()
-        _state.update { it.copy(status = msg) }
+        _state.update { it.copy(status = msg, statusVoiceAction = voiceAction) }
         statusJob = viewModelScope.launch {
             delay(millis)
-            _state.update { if (it.status == msg) it.copy(status = null) else it }
+            _state.update { if (it.status == msg) it.copy(status = null, statusVoiceAction = false) else it }
         }
     }
 
@@ -2931,9 +2942,10 @@ class MapViewModel @Inject constructor(
         startLocation() // resume the live collector (no-ops if already running)
     }
 
-    fun clearStatus() = _state.update { it.copy(status = null) }
+    fun clearStatus() = _state.update { it.copy(status = null, statusVoiceAction = false) }
 
-    fun showStatus(msg: String) = _state.update { it.copy(status = msg) }
+    fun showStatus(msg: String, voiceAction: Boolean = false) =
+        _state.update { it.copy(status = msg, statusVoiceAction = voiceAction) }
 
     // --- offline download (triggered from Settings, not a map FAB) -------------
 

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -1430,6 +1430,7 @@ private fun DepartTimeChooser(
     onTimeSelected: (Int, Long?) -> Unit = { _, _ -> },
 ) {
     val context = LocalContext.current
+    val ink = if (isAppInDarkTheme()) InkDark else InkLight
     // Keyed to the destination so switching places resets the picked time. mode: 0 now, 1 depart at,
     // 2 arrive by, 3 last available (transit only). date + time compose the chosen wall-clock.
     var mode by remember(route?.summary) { mutableStateOf(0) }
@@ -1485,17 +1486,17 @@ private fun DepartTimeChooser(
             val hasLive = route.hasLiveTraffic
             val typicalNote = stringResource(R.string.place_in_typical_traffic)
             val liveNoteDepart = stringResource(R.string.place_based_current_traffic)
-            val liveNoteNow = stringResource(R.string.place_current_traffic)
             val departNote = when { range != null -> typicalNote; hasLive -> liveNoteDepart; else -> null }
+            // Leave-now shows just the arrival time, prominently - the "current traffic" note under
+            // it was clutter (the traffic-coloured ETA already says it) and kept the time small.
             val (summary, note) = when (mode) {
                 1 -> stringResource(R.string.place_depart_arrive, time.format(fmt), window(time, lo, hi, +1)) to departNote
                 2 -> stringResource(R.string.place_arriveby_leave, time.format(fmt), window(time, hi, lo, -1)) to departNote
                 else -> stringResource(R.string.place_arrive_approx, java.time.LocalTime.now().plusSeconds(nowDur.toLong()).format(fmt)) to
-                    (range?.let { stringResource(R.string.place_usually_range, formatDuration(it.first), formatDuration(it.second)) }
-                        ?: if (hasLive) liveNoteNow else null)
+                    range?.let { stringResource(R.string.place_usually_range, formatDuration(it.first), formatDuration(it.second)) }
             }
             Column {
-                Text(summary, style = MaterialTheme.typography.bodyMedium, color = dim)
+                Text(summary, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = ink)
                 note?.let { Text(it, style = MaterialTheme.typography.bodySmall, color = dim) }
             }
         }

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -101,12 +101,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape as DpadShape
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = false) {
+fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = false, openVoiceLibrary: Boolean = false) {
     val state by vm.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
     // The voice library (browse / download / switch / delete voices) is a DEDICATED screen now, not an
     // inline accordion on this long list. When open it fully replaces Settings; its own Back returns here.
-    var showVoiceLibrary by remember { mutableStateOf(false) }
+    var showVoiceLibrary by remember { mutableStateOf(openVoiceLibrary) }
     if (showVoiceLibrary) {
         VoiceBrowseScreen(vm = vm, onClose = { showVoiceLibrary = false })
         return
@@ -606,6 +606,12 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
 
             Spacer(Modifier.height(20.dp))
             SectionTitle(stringResource(R.string.settings_voice))
+            // The master switch: persisted, and the in-nav speaker button toggles the SAME state.
+            ToggleRow(
+                stringResource(R.string.settings_spoken_directions),
+                checked = !state.voiceMuted,
+                onToggle = { vm.setSpokenDirections(it) },
+            )
             // Vela's own on-device neural voices (the Piper catalog) — download in the Voice
             // library below; once downloaded each shows in the engine list (selectable). No
             // standalone TTS app needed.

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -362,7 +362,9 @@
     <string name="mapvm_routing_failed_reason">Routenberechnung fehlgeschlagen: %1$s</string>
     <string name="mapvm_no_transit_routes">Keine ÖPNV-Verbindungen gefunden</string>
     <string name="mapvm_trip_default_name">Fahrt</string>
-    <string name="mapvm_no_voice_engine">Keine Sprach-Engine installiert – fügen Sie unter Einstellungen → Stimme eine für gesprochene Ansagen hinzu</string>
+    <string name="mapvm_no_voice_engine">Keine Stimme für Sprachansagen installiert</string>
+    <string name="mapscreen_get_voice">Stimme holen</string>
+    <string name="settings_spoken_directions">Sprachansagen</string>
     <string name="mapvm_voice_lang_missing">Sprachansagen brauchen eine Stimme für %1$s — im Menü Einstellungen → Stimme hinzufügen</string>
     <string name="mapvm_no_track_to_replay">Diese Fahrt hat keine Spur zur Wiedergabe</string>
     <string name="mapvm_replaying">%1$s wird wiedergegeben (3×) …</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -216,7 +216,6 @@
     <string name="place_based_current_traffic">basierend auf aktuellem Verkehr</string>
     <string name="place_arrive_approx">Ankunft um %1$s</string>
     <string name="place_usually_range">Normalerweise %1$s – %2$s</string>
-    <string name="place_current_traffic">aktueller Verkehr</string>
     <string name="place_fastest">Schnellste</string>
     <string name="place_delta_min">+%1$d Min.</string>
     <string name="place_via">über %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -216,7 +216,6 @@
     <string name="place_based_current_traffic">según el tráfico actual</string>
     <string name="place_arrive_approx">Llegada a las %1$s</string>
     <string name="place_usually_range">Normalmente %1$s – %2$s</string>
-    <string name="place_current_traffic">tráfico actual</string>
     <string name="place_fastest">La más rápida</string>
     <string name="place_delta_min">+%1$d min</string>
     <string name="place_via">por %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -362,7 +362,9 @@
     <string name="mapvm_routing_failed_reason">Error al calcular la ruta: %1$s</string>
     <string name="mapvm_no_transit_routes">No se encontraron rutas de transporte</string>
     <string name="mapvm_trip_default_name">Trayecto</string>
-    <string name="mapvm_no_voice_engine">No hay ningún motor de voz instalado; añade uno en Ajustes → Voz para las indicaciones habladas</string>
+    <string name="mapvm_no_voice_engine">No hay ninguna voz instalada para las indicaciones por voz</string>
+    <string name="mapscreen_get_voice">Añadir una voz</string>
+    <string name="settings_spoken_directions">Indicaciones por voz</string>
     <string name="mapvm_voice_lang_missing">Las indicaciones por voz necesitan una voz en %1$s — añádela en Ajustes → Voz</string>
     <string name="mapvm_no_track_to_replay">Ese trayecto no tiene rastro para reproducir</string>
     <string name="mapvm_replaying">Reproduciendo %1$s (3×)…</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -216,7 +216,6 @@
     <string name="place_based_current_traffic">selon le trafic actuel</string>
     <string name="place_arrive_approx">Arrivée à %1$s</string>
     <string name="place_usually_range">Habituellement %1$s – %2$s</string>
-    <string name="place_current_traffic">trafic actuel</string>
     <string name="place_fastest">Le plus rapide</string>
     <string name="place_delta_min">+%1$d min</string>
     <string name="place_via">par %1$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -362,7 +362,9 @@
     <string name="mapvm_routing_failed_reason">Échec du calcul d\'itinéraire : %1$s</string>
     <string name="mapvm_no_transit_routes">Aucun itinéraire en transports trouvé</string>
     <string name="mapvm_trip_default_name">Trajet</string>
-    <string name="mapvm_no_voice_engine">Aucun moteur vocal installé — ajoutez-en un dans Paramètres → Voix pour les instructions vocales</string>
+    <string name="mapvm_no_voice_engine">Aucune voix installée pour les instructions vocales</string>
+    <string name="mapscreen_get_voice">Ajouter une voix</string>
+    <string name="settings_spoken_directions">Instructions vocales</string>
     <string name="mapvm_voice_lang_missing">Les instructions vocales nécessitent une voix %1$s — ajoutez-en une dans Réglages → Voix</string>
     <string name="mapvm_no_track_to_replay">Ce trajet n\'a aucune trace à rejouer</string>
     <string name="mapvm_replaying">Relecture de %1$s (3×)…</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -216,7 +216,6 @@
     <string name="place_based_current_traffic">in base al traffico attuale</string>
     <string name="place_arrive_approx">Arrivo alle %1$s</string>
     <string name="place_usually_range">Di solito %1$s – %2$s</string>
-    <string name="place_current_traffic">traffico attuale</string>
     <string name="place_fastest">Più veloce</string>
     <string name="place_delta_min">+%1$d min</string>
     <string name="place_via">via %1$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -362,7 +362,9 @@
     <string name="mapvm_routing_failed_reason">Calcolo del percorso non riuscito: %1$s</string>
     <string name="mapvm_no_transit_routes">Nessun percorso con i mezzi trovato</string>
     <string name="mapvm_trip_default_name">Viaggio</string>
-    <string name="mapvm_no_voice_engine">Nessun motore vocale installato: aggiungine uno in Impostazioni → Voce per le indicazioni vocali</string>
+    <string name="mapvm_no_voice_engine">Nessuna voce installata per le indicazioni vocali</string>
+    <string name="mapscreen_get_voice">Aggiungi una voce</string>
+    <string name="settings_spoken_directions">Indicazioni vocali</string>
     <string name="mapvm_voice_lang_missing">Le indicazioni vocali richiedono una voce %1$s — aggiungila in Impostazioni → Voce</string>
     <string name="mapvm_no_track_to_replay">Quel viaggio non ha una traccia da riprodurre</string>
     <string name="mapvm_replaying">Riproduzione di %1$s (3×)…</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -216,7 +216,6 @@
     <string name="place_based_current_traffic">op basis van huidig verkeer</string>
     <string name="place_arrive_approx">Aankomst om %1$s</string>
     <string name="place_usually_range">Meestal %1$s – %2$s</string>
-    <string name="place_current_traffic">huidig verkeer</string>
     <string name="place_fastest">Snelste</string>
     <string name="place_delta_min">+%1$d min</string>
     <string name="place_via">via %1$s</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -362,7 +362,9 @@
     <string name="mapvm_routing_failed_reason">Routering mislukt: %1$s</string>
     <string name="mapvm_no_transit_routes">Geen OV-routes gevonden</string>
     <string name="mapvm_trip_default_name">Rit</string>
-    <string name="mapvm_no_voice_engine">Geen spraakengine geïnstalleerd — voeg er een toe bij Instellingen → Stem voor gesproken instructies</string>
+    <string name="mapvm_no_voice_engine">Geen stem geïnstalleerd voor gesproken aanwijzingen</string>
+    <string name="mapscreen_get_voice">Stem toevoegen</string>
+    <string name="settings_spoken_directions">Gesproken aanwijzingen</string>
     <string name="mapvm_voice_lang_missing">Gesproken instructies vereisen een %1$s-stem — voeg er een toe via Instellingen → Stem</string>
     <string name="mapvm_no_track_to_replay">Die rit heeft geen spoor om te herhalen</string>
     <string name="mapvm_replaying">%1$s herhalen (3×)…</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -216,7 +216,6 @@
     <string name="place_based_current_traffic">na podstawie bieżącego ruchu</string>
     <string name="place_arrive_approx">Przyjazd o %1$s</string>
     <string name="place_usually_range">Zwykle %1$s – %2$s</string>
-    <string name="place_current_traffic">bieżący ruch</string>
     <string name="place_fastest">Najszybsza</string>
     <string name="place_delta_min">+%1$d min</string>
     <string name="place_via">przez %1$s</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -362,7 +362,9 @@
     <string name="mapvm_routing_failed_reason">Wyznaczanie trasy nie powiodło się: %1$s</string>
     <string name="mapvm_no_transit_routes">Nie znaleziono połączeń komunikacji miejskiej</string>
     <string name="mapvm_trip_default_name">Podróż</string>
-    <string name="mapvm_no_voice_engine">Nie zainstalowano silnika głosowego — dodaj go w Ustawienia → Głos, aby korzystać ze wskazówek głosowych</string>
+    <string name="mapvm_no_voice_engine">Brak głosu do wskazówek głosowych</string>
+    <string name="mapscreen_get_voice">Dodaj głos</string>
+    <string name="settings_spoken_directions">Wskazówki głosowe</string>
     <string name="mapvm_voice_lang_missing">Wskazówki głosowe wymagają głosu %1$s — dodaj go w Ustawienia → Głos</string>
     <string name="mapvm_no_track_to_replay">Ta podróż nie ma zapisu do odtworzenia</string>
     <string name="mapvm_replaying">Odtwarzanie %1$s (3×)…</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -362,7 +362,9 @@
     <string name="mapvm_routing_failed_reason">Falha ao traçar o percurso: %1$s</string>
     <string name="mapvm_no_transit_routes">Nenhum percurso de transportes encontrado</string>
     <string name="mapvm_trip_default_name">Viagem</string>
-    <string name="mapvm_no_voice_engine">Nenhum motor de voz instalado — adicione um em Definições → Voz para indicações faladas</string>
+    <string name="mapvm_no_voice_engine">Nenhuma voz instalada para as instruções por voz</string>
+    <string name="mapscreen_get_voice">Adicionar uma voz</string>
+    <string name="settings_spoken_directions">Instruções por voz</string>
     <string name="mapvm_voice_lang_missing">As indicações por voz precisam de uma voz em %1$s — adicione uma em Definições → Voz</string>
     <string name="mapvm_no_track_to_replay">Essa viagem não tem traço para reproduzir</string>
     <string name="mapvm_replaying">A reproduzir %1$s (3×)…</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -216,7 +216,6 @@
     <string name="place_based_current_traffic">com base no trânsito atual</string>
     <string name="place_arrive_approx">Chegada às %1$s</string>
     <string name="place_usually_range">Normalmente %1$s – %2$s</string>
-    <string name="place_current_traffic">trânsito atual</string>
     <string name="place_fastest">Mais rápido</string>
     <string name="place_delta_min">+%1$d min</string>
     <string name="place_via">via %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -362,7 +362,9 @@
     <string name="mapvm_routing_failed_reason">Не удалось построить маршрут: %1$s</string>
     <string name="mapvm_no_transit_routes">Маршруты транспорта не найдены</string>
     <string name="mapvm_trip_default_name">Поездка</string>
-    <string name="mapvm_no_voice_engine">Голосовой движок не установлен — добавьте его в «Настройки → Голос» для голосовых подсказок</string>
+    <string name="mapvm_no_voice_engine">Нет голоса для голосовых подсказок</string>
+    <string name="mapscreen_get_voice">Добавить голос</string>
+    <string name="settings_spoken_directions">Голосовые подсказки</string>
     <string name="mapvm_voice_lang_missing">Для голосовых подсказок нужен голос «%1$s» — добавьте его в Настройки → Голос</string>
     <string name="mapvm_no_track_to_replay">У этой поездки нет трека для воспроизведения</string>
     <string name="mapvm_replaying">Воспроизведение %1$s (3×)…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -216,7 +216,6 @@
     <string name="place_based_current_traffic">с учётом текущих пробок</string>
     <string name="place_arrive_approx">Прибытие в %1$s</string>
     <string name="place_usually_range">Обычно %1$s – %2$s</string>
-    <string name="place_current_traffic">текущие пробки</string>
     <string name="place_fastest">Самый быстрый</string>
     <string name="place_delta_min">+%1$d мин</string>
     <string name="place_via">через %1$s</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -216,7 +216,6 @@
     <string name="place_based_current_traffic">baserat på aktuell trafik</string>
     <string name="place_arrive_approx">Framme kl. %1$s</string>
     <string name="place_usually_range">Vanligtvis %1$s – %2$s</string>
-    <string name="place_current_traffic">aktuell trafik</string>
     <string name="place_fastest">Snabbast</string>
     <string name="place_delta_min">+%1$d min</string>
     <string name="place_via">via %1$s</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -362,7 +362,9 @@
     <string name="mapvm_routing_failed_reason">Ruttberäkning misslyckades: %1$s</string>
     <string name="mapvm_no_transit_routes">Inga kollektivrutter hittades</string>
     <string name="mapvm_trip_default_name">Resa</string>
-    <string name="mapvm_no_voice_engine">Ingen röstmotor installerad – lägg till en i Inställningar → Röst för talade vägbeskrivningar</string>
+    <string name="mapvm_no_voice_engine">Ingen röst installerad för röstanvisningar</string>
+    <string name="mapscreen_get_voice">Hämta en röst</string>
+    <string name="settings_spoken_directions">Röstanvisningar</string>
     <string name="mapvm_voice_lang_missing">Talade vägbeskrivningar kräver en %1$s-röst — lägg till en i Inställningar → Röst</string>
     <string name="mapvm_no_track_to_replay">Den resan har inget spår att spela upp</string>
     <string name="mapvm_replaying">Spelar upp %1$s (3×)…</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -216,7 +216,6 @@
     <string name="place_based_current_traffic">за поточним трафіком</string>
     <string name="place_arrive_approx">Прибуття о %1$s</string>
     <string name="place_usually_range">Зазвичай %1$s – %2$s</string>
-    <string name="place_current_traffic">поточний трафік</string>
     <string name="place_fastest">Найшвидший</string>
     <string name="place_delta_min">+%1$d хв</string>
     <string name="place_via">через %1$s</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -362,7 +362,9 @@
     <string name="mapvm_routing_failed_reason">Помилка маршрутизації: %1$s</string>
     <string name="mapvm_no_transit_routes">Маршрутів транспорту не знайдено</string>
     <string name="mapvm_trip_default_name">Поїздка</string>
-    <string name="mapvm_no_voice_engine">Не встановлено голосового рушія — додайте один у Налаштування → Голос для голосових вказівок</string>
+    <string name="mapvm_no_voice_engine">Немає голосу для голосових підказок</string>
+    <string name="mapscreen_get_voice">Додати голос</string>
+    <string name="settings_spoken_directions">Голосові підказки</string>
     <string name="mapvm_voice_lang_missing">Для голосових підказок потрібен голос «%1$s» — додайте його в Налаштування → Голос</string>
     <string name="mapvm_no_track_to_replay">Ця поїздка не має треку для відтворення</string>
     <string name="mapvm_replaying">Відтворення %1$s (3×)…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -395,7 +395,9 @@
     <string name="mapvm_routing_failed_reason">Routing failed: %1$s</string> <!-- format -->
     <string name="mapvm_no_transit_routes">No transit routes found</string>
     <string name="mapvm_trip_default_name">Trip</string>
-    <string name="mapvm_no_voice_engine">No voice engine installed. Add one in Settings → Voice for spoken directions</string>
+    <string name="mapvm_no_voice_engine">No voice installed for spoken directions</string>
+    <string name="mapscreen_get_voice">Get a voice</string>
+    <string name="settings_spoken_directions">Spoken directions</string>
     <string name="mapvm_voice_lang_missing">Spoken directions need a %1$s voice. Get one in Settings → Voice</string>
     <string name="mapvm_resume_waiting_gps">Waiting for GPS to resume navigation…</string>
     <string name="mapvm_resume_failed">Couldn\'t resume navigation</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,7 +232,6 @@
     <string name="place_based_current_traffic">based on current traffic</string>
     <string name="place_arrive_approx">Arrive at %1$s</string> <!-- format -->
     <string name="place_usually_range">Usually %1$s – %2$s</string> <!-- format -->
-    <string name="place_current_traffic">current traffic</string>
     <string name="place_fastest">Fastest</string>
     <string name="place_delta_min">+%1$d min</string> <!-- format -->
     <string name="place_via">via %1$s</string> <!-- format -->


### PR DESCRIPTION
Three follow-ups from testing the last batch:

- Heads-up messages, download progress, update offers and pushed notices now stack in one notification area, each dismissed on its own, instead of painting over each other. On the browse map it sits just under the search bar and chips; during navigation it hangs off the turn card's measured bottom edge, so lane rows and the "then" line push it down instead of overlapping it.
- The no-voice warning is shorter and carries a filled "Get a voice" pill that opens the voice library directly. The missing-language hint gets the same shortcut. Filled pill next to quiet text, so it reads by shape, not colour.
- Spoken directions are a real setting now: an on/off switch at the top of Settings > Voice, remembered across restarts, and the mute button during navigation flips the same switch. With it off the no-voice warning stays quiet.

Also a docs pass: README/SPEC/ROADMAP now cover voice search, the permission gates and the notification behaviour.