### PR TITLE
Transit lines start off by default

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -195,6 +195,9 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   Done), and the microphone permission is asked only the first time you tap the mic. When both Vela voice and a
   voice-input app are present, a Settings picker chooses which to use (Vela voice by default). Device-verified end to end: download, install, the mic appears, the permission prompt,
   the listening sheet, and the model transcribing back into the search box.
+- ✅ **Transit lines are opt-in now (2026-07-10).** The purple rail highlight is off by default;
+  it reads as mystery lines if you don't know what it is. Settings → Map → "Highlight transit
+  lines" brings it back, and an earlier choice is kept either way.
 - ✅ **Traffic in words, not just colour (2026-07-10).** Route choices now say "light traffic",
   "moderate traffic" or "heavy traffic" to match the green/amber/red time, so the conditions read
   without relying on colour. And a freshly downloaded voice no longer speaks a sample on its own -

--- a/app/src/main/java/app/vela/ui/TransitLayer.kt
+++ b/app/src/main/java/app/vela/ui/TransitLayer.kt
@@ -5,16 +5,17 @@ import androidx.compose.runtime.mutableStateOf
 
 /**
  * Whether rail lines (train + subway/light rail/tram) are highlighted on the map, Google-style.
- * Process-wide reactive holder like [Traffic] / [Units], flipped from Settings and persisted. ON by
- * default (rail is useful to see and the data is already in the tiles at no cost). The data is already
- * in the keyless basemap tiles (OpenMapTiles `transportation` layer), so this only adds a coloured line
- * layer over it, no network.
+ * Process-wide reactive holder like [Traffic] / [Units], flipped from Settings and persisted. OFF by
+ * default (2026-07-10): unlabeled purple lines over the map read as "what is this?" rather than
+ * useful - the people who ride rail can flip it on in Settings > Map, and anyone who already
+ * toggled it keeps their saved choice. The data is already in the keyless basemap tiles
+ * (OpenMapTiles `transportation` layer), so the toggle only adds a coloured line layer, no network.
  */
 object TransitLayer {
-    val on = mutableStateOf(true)
+    val on = mutableStateOf(false)
 
     fun init(context: Context) {
-        on.value = prefs(context).getBoolean(KEY, true)
+        on.value = prefs(context).getBoolean(KEY, false)
     }
 
     fun set(context: Context, value: Boolean) {


### PR DESCRIPTION
The purple rail highlight reads as mystery lines if you do not know what it is, so it is opt-in now via Settings > Map > Highlight transit lines. Anyone who already flipped the toggle keeps their saved choice, only the default changed.