### PR TITLE
Vela Voice warms up before the first dictation

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -2777,7 +2777,17 @@ class MapViewModel @Inject constructor(
     // ---- On-device voice search (tier-1 Whisper ASR) ----
 
     /** Reflect whether the on-device speech model is present (Settings shows Download vs Remove). */
-    fun refreshAsr() { _state.update { it.copy(asrInstalled = whisperRecognizer.isInstalled()) } }
+    fun refreshAsr() {
+        _state.update { it.copy(asrInstalled = whisperRecognizer.isInstalled()) }
+        // Pre-build the Whisper recognizer when the mic would actually use it, so the first
+        // dictation listens immediately instead of showing a "Getting ready" beat while the
+        // ONNX model loads. refreshAsr runs at VM init and the engine pref rarely changes.
+        if (app.vela.ui.VoiceSearch.enabled.value &&
+            app.vela.ui.VoiceSearch.engine.value != app.vela.ui.VoiceSearch.Engine.SYSTEM
+        ) {
+            whisperRecognizer.warmUp()
+        }
+    }
 
     /** Download the ~47 MB on-device speech-to-text model, reusing the neural-voice installer + its
      *  no-call-timeout client (the shared 12 s cap would abort a download this size). */
@@ -2795,7 +2805,10 @@ class MapViewModel @Inject constructor(
                 onExtracting = { _state.update { it.copy(asrInstalling = true) } },
             ) { p -> _state.update { it.copy(asrDownloadPct = p) } }
             _state.update { it.copy(asrDownloadPct = null, asrInstalling = false, asrInstalled = whisperRecognizer.isInstalled()) }
-            if (ok && whisperRecognizer.isInstalled()) flashStatus(appContext.getString(R.string.mapvm_asr_ready))
+            if (ok && whisperRecognizer.isInstalled()) {
+                whisperRecognizer.warmUp() // a fresh install should listen immediately on first tap
+                flashStatus(appContext.getString(R.string.mapvm_asr_ready))
+            }
             else showStatus(appContext.getString(R.string.mapvm_asr_download_failed))
         }
     }

--- a/app/src/main/java/app/vela/voice/WhisperRecognizer.kt
+++ b/app/src/main/java/app/vela/voice/WhisperRecognizer.kt
@@ -61,6 +61,17 @@ class WhisperRecognizer @Inject constructor(
     private fun whisperLang(): String =
         app.vela.ui.AppLocale.effective().language.takeIf { it in app.vela.ui.AppLocale.SUPPORTED } ?: ""
 
+    /** Build the recognizer ahead of the first mic tap, off the main thread. The ONNX load takes a
+     *  second or two on a phone, which used to show as a "Getting ready" beat on the FIRST dictation
+     *  of a session (user 2026-07-10); warmed, the mic listens immediately. Cheap to call when the
+     *  model isn't installed (no-op), and safe to call repeatedly - the synchronized loader keeps a
+     *  built recognizer for the current language. A mid-session app-language switch still rebuilds
+     *  lazily on the next listen (rare enough not to chase). */
+    fun warmUp() {
+        if (!AsrModel.isInstalled(context)) return
+        Thread({ runCatching { ensureRecognizer() } }, "asr-warmup").start()
+    }
+
     /** Load the Whisper recognizer once per language (rebuilt if the app language changes). Returns
      *  null if the model isn't installed or the native load fails - callers then fall back to the
      *  provider intent or hide the mic. */


### PR DESCRIPTION
The first mic tap of a session sat on Getting ready for a second or two while the Whisper model loaded; later dictations were instant. The recognizer now builds in the background at app start whenever Vela Voice is in play, and right after the model installs, so the first tap listens immediately.