### PR TITLE
Choose which voice app the mic uses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,7 +449,12 @@ Defaults that make the safe path the easy one:
   `startActivityForResult(ACTION_RECOGNIZE_SPEECH)` and reads `EXTRA_RESULTS` into the query -
   **the provider records, so Vela needs NO RECORD_AUDIO for this tier.** KEY DISTINCTION verified
   2026-07-10: only apps that register the RECOGNIZE_SPEECH **activity** count (FUTO Voice Input
-  does - confirmed in its manifest). Keyboard/IME voice (Sayboard, FUTO Keyboard) provides a
+  does - confirmed in its manifest). **With several voice apps installed the intent pins the
+  user's pick** (2026-07-10): `VoiceSearch.providers()` enumerates them, the Settings picker lists
+  each BY NAME beside Vela Voice, the choice persists as a flattened ComponentName
+  (`voice_search_provider`), and the tier-2 intent sets that component - the old bare implicit
+  intent let ANDROID choose (default-app or a system chooser). An uninstalled pick degrades to the
+  first available provider, never a dead mic. Keyboard/IME voice (Sayboard, FUTO Keyboard) provides a
   RecognitionService or in-IME mic, NOT the activity, so `queryIntentActivities` returns empty and
   the mic correctly hides - Vela can't `startActivityForResult` to them. That's intended: those
   users use the keyboard mic, and tier-1 (on-device Whisper) serves everyone regardless.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,12 +449,14 @@ Defaults that make the safe path the easy one:
   `startActivityForResult(ACTION_RECOGNIZE_SPEECH)` and reads `EXTRA_RESULTS` into the query -
   **the provider records, so Vela needs NO RECORD_AUDIO for this tier.** KEY DISTINCTION verified
   2026-07-10: only apps that register the RECOGNIZE_SPEECH **activity** count (FUTO Voice Input
-  does - confirmed in its manifest). **With several voice apps installed the intent pins the
-  user's pick** (2026-07-10): `VoiceSearch.providers()` enumerates them, the Settings picker lists
-  each BY NAME beside Vela Voice, the choice persists as a flattened ComponentName
-  (`voice_search_provider`), and the tier-2 intent sets that component - the old bare implicit
-  intent let ANDROID choose (default-app or a system chooser). An uninstalled pick degrades to the
-  first available provider, never a dead mic. Keyboard/IME voice (Sayboard, FUTO Keyboard) provides a
+  does - confirmed in its manifest). **With several voice apps installed the launch resolution
+  is a LADDER** (2026-07-10): the user's Settings pick (persisted as a flattened ComponentName,
+  `voice_search_provider`) pins the intent; with no pick, the intent stays IMPLICIT so Android's
+  own default-app choice routes it (a default set outside Vela is respected); only when Android
+  has no default either (`resolveActivity` returns the package-"android" resolver) does Vela pin
+  the FIRST installed app, so the system chooser can never interrupt a dictation. The Settings
+  picker lists every app BY NAME beside Vela Voice (`VoiceSearch.providers()`); an uninstalled
+  pick degrades down the same ladder, never a dead mic. Keyboard/IME voice (Sayboard, FUTO Keyboard) provides a
   RecognitionService or in-IME mic, NOT the activity, so `queryIntentActivities` returns empty and
   the mic correctly hides - Vela can't `startActivityForResult` to them. That's intended: those
   users use the keyboard mic, and tier-1 (on-device Whisper) serves everyone regardless.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -198,6 +198,9 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 - ✅ **Transit lines are opt-in now (2026-07-10).** The purple rail highlight is off by default;
   it reads as mystery lines if you don't know what it is. Settings → Map → "Highlight transit
   lines" brings it back, and an earlier choice is kept either way.
+- ✅ **Pick your voice app (2026-07-10).** With more than one voice-input app installed, Settings →
+  Search lists each by name next to Vela Voice, and the mic launches exactly the one you chose
+  instead of whatever Android felt like resolving.
 - ✅ **The place card follows your finger (2026-07-10).** Dragging the place sheet moves it with
   your finger and, on release, it coasts on the fling to whichever size is closest - no more
   stepping between sizes in fixed hops.

--- a/app/src/main/java/app/vela/ui/VoiceSearch.kt
+++ b/app/src/main/java/app/vela/ui/VoiceSearch.kt
@@ -35,6 +35,7 @@ object VoiceSearch {
     fun init(context: Context) {
         enabled.value = prefs(context).getBoolean(KEY, true)
         engine.value = readEngine(prefs(context).getString(ENGINE_KEY, null))
+        provider.value = prefs(context).getString(PROVIDER_KEY, null)
     }
 
     fun set(context: Context, value: Boolean) {
@@ -45,6 +46,42 @@ object VoiceSearch {
     fun setEngine(context: Context, value: Engine) {
         engine.value = value
         prefs(context).edit().putString(ENGINE_KEY, value.name).apply()
+    }
+
+    /** An installed tier-2 voice-input app: display label + the exact activity Vela launches. */
+    data class Provider(val label: String, val component: android.content.ComponentName)
+
+    /** The chosen provider's flattened ComponentName - reactive so the Settings picker updates live.
+     *  Null = no explicit pick yet (the first installed provider is used). */
+    val provider = mutableStateOf<String?>(null)
+
+    /** Every installed voice-input app that can service the RECOGNIZE_SPEECH activity intent, in
+     *  resolution order. With more than one installed, the old implicit intent left the pick to
+     *  ANDROID (its default-app choice or a system disambiguation dialog) - the Settings picker +
+     *  [chosenProvider] give the choice to the user instead (user 2026-07-10). */
+    fun providers(context: Context): List<Provider> = runCatching {
+        val pm = context.packageManager
+        pm.queryIntentActivities(Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH), 0).map {
+            Provider(
+                it.loadLabel(pm).toString(),
+                android.content.ComponentName(it.activityInfo.packageName, it.activityInfo.name),
+            )
+        }
+    }.getOrDefault(emptyList())
+
+    /** The provider the SYSTEM path launches: the saved pick while it's still installed, else the
+     *  first available (an uninstalled favourite degrades gracefully instead of a dead mic). */
+    fun chosenProvider(context: Context): Provider? {
+        val all = providers(context)
+        if (all.isEmpty()) return null
+        val saved = provider.value?.let(android.content.ComponentName::unflattenFromString)
+        return all.firstOrNull { it.component == saved } ?: all.first()
+    }
+
+    fun setProvider(context: Context, component: android.content.ComponentName) {
+        val flat = component.flattenToString()
+        provider.value = flat
+        prefs(context).edit().putString(PROVIDER_KEY, flat).apply()
     }
 
     /** Is a third-party voice-input APP installed (tier-2)? Cheap PackageManager query; only apps that
@@ -80,4 +117,5 @@ object VoiceSearch {
     private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
     private const val KEY = "voice_search_button"
     private const val ENGINE_KEY = "voice_search_engine"
+    private const val PROVIDER_KEY = "voice_search_provider"
 }

--- a/app/src/main/java/app/vela/ui/VoiceSearch.kt
+++ b/app/src/main/java/app/vela/ui/VoiceSearch.kt
@@ -69,13 +69,41 @@ object VoiceSearch {
         }
     }.getOrDefault(emptyList())
 
-    /** The provider the SYSTEM path launches: the saved pick while it's still installed, else the
-     *  first available (an uninstalled favourite degrades gracefully instead of a dead mic). */
+    /** The component to PIN on the launch intent, or null to leave the intent implicit. Pinning
+     *  order: the user's Settings pick wins; otherwise DEFER to Android's own default app for
+     *  speech (null - the system routes it, respecting a choice made outside Vela); only when
+     *  Android has no default either (its chooser would interject mid-dictation) pin the first
+     *  installed app. An uninstalled Settings pick degrades down this same ladder. */
+    fun launchComponent(context: Context): android.content.ComponentName? {
+        val all = providers(context)
+        if (all.isEmpty()) return null
+        val saved = provider.value?.let(android.content.ComponentName::unflattenFromString)
+        all.firstOrNull { it.component == saved }?.let { return it.component }
+        if (androidDefault(context) != null) return null
+        return all.first().component
+    }
+
+    /** Android's own default RECOGNIZE_SPEECH handler, or null when none is set (the resolver
+     *  activity, package "android", answers when the choice is ambiguous). */
+    private fun androidDefault(context: Context): android.content.ComponentName? = runCatching {
+        val ri = context.packageManager.resolveActivity(
+            Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH),
+            android.content.pm.PackageManager.MATCH_DEFAULT_ONLY,
+        ) ?: return null
+        val ai = ri.activityInfo ?: return null
+        if (ai.packageName == "android") null
+        else android.content.ComponentName(ai.packageName, ai.name)
+    }.getOrNull()
+
+    /** What the Settings picker should show as selected: the saved pick, else Android's default,
+     *  else the first installed - the same app [launchComponent] would end up launching. */
     fun chosenProvider(context: Context): Provider? {
         val all = providers(context)
         if (all.isEmpty()) return null
         val saved = provider.value?.let(android.content.ComponentName::unflattenFromString)
-        return all.firstOrNull { it.component == saved } ?: all.first()
+        all.firstOrNull { it.component == saved }?.let { return it }
+        androidDefault(context)?.let { d -> all.firstOrNull { it.component == d }?.let { return it } }
+        return all.first()
     }
 
     fun setProvider(context: Context, component: android.content.ComponentName) {

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -494,6 +494,10 @@ fun MapScreen(
                 app.vela.ui.VoiceSearch.Mode.NONE -> showAsrOffer = true
                 app.vela.ui.VoiceSearch.Mode.SYSTEM -> {
                     val intent = Intent(android.speech.RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                        // Pin the exact voice app the user picked in Settings (falls back to the
+                        // first installed one) - the bare implicit intent left the choice to
+                        // Android when several voice apps were installed.
+                        app.vela.ui.VoiceSearch.chosenProvider(context)?.let { component = it.component }
                         putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE_MODEL, android.speech.RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
                         putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE, app.vela.ui.AppLocale.effective().toLanguageTag())
                         putExtra(android.speech.RecognizerIntent.EXTRA_PROMPT, voicePrompt)

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -494,10 +494,10 @@ fun MapScreen(
                 app.vela.ui.VoiceSearch.Mode.NONE -> showAsrOffer = true
                 app.vela.ui.VoiceSearch.Mode.SYSTEM -> {
                     val intent = Intent(android.speech.RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-                        // Pin the exact voice app the user picked in Settings (falls back to the
-                        // first installed one) - the bare implicit intent left the choice to
-                        // Android when several voice apps were installed.
-                        app.vela.ui.VoiceSearch.chosenProvider(context)?.let { component = it.component }
+                        // Pin the voice app the user picked in Settings; with no pick, defer to
+                        // Android's own default app, and only pin the first installed one when
+                        // Android has no default either (else its chooser interrupts dictation).
+                        app.vela.ui.VoiceSearch.launchComponent(context)?.let { component = it }
                         putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE_MODEL, android.speech.RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
                         putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE, app.vela.ui.AppLocale.effective().toLanguageTag())
                         putExtra(android.speech.RecognizerIntent.EXTRA_PROMPT, voicePrompt)

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -461,12 +461,33 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
             // otherwise the resolver already does the one available thing. TWO options, not three:
             // "Vela voice" maps to AUTO (Vela's model wins, with the provider as a graceful fallback
             // if the model is ever removed) - an explicit local-only third choice read as jargon.
-            if (state.asrInstalled && hasVoiceProvider) {
+            // One row per way to dictate: Vela Voice (when the model is installed) plus every
+            // installed voice app BY NAME - picking an app pins it, so Android never interjects
+            // its own chooser when several are installed. Enumerated off the main thread: it's a
+            // binder query + per-app label load (the same class of call as the TTS engine list).
+            val voiceProviders by produceState(initialValue = emptyList<app.vela.ui.VoiceSearch.Provider>()) {
+                value = withContext(Dispatchers.IO) { app.vela.ui.VoiceSearch.providers(context) }
+            }
+            // Shown whenever there's a real choice: Vela Voice vs any app, or between two apps
+            // even without the model.
+            if ((state.asrInstalled && voiceProviders.isNotEmpty()) || voiceProviders.size > 1) {
                 Spacer(Modifier.height(12.dp))
                 SubHead(stringResource(R.string.settings_voice_search_engine_title))
                 val eng = app.vela.ui.VoiceSearch.engine.value
-                SelectableRow(stringResource(R.string.settings_voice_search_engine_auto), eng != app.vela.ui.VoiceSearch.Engine.SYSTEM, onClick = { app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.AUTO) })
-                SelectableRow(stringResource(R.string.settings_voice_search_engine_system), eng == app.vela.ui.VoiceSearch.Engine.SYSTEM, onClick = { app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.SYSTEM) })
+                val chosen = app.vela.ui.VoiceSearch.chosenProvider(context)
+                if (state.asrInstalled) {
+                    SelectableRow(stringResource(R.string.settings_voice_search_engine_auto), eng != app.vela.ui.VoiceSearch.Engine.SYSTEM, onClick = { app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.AUTO) })
+                }
+                voiceProviders.forEach { p ->
+                    SelectableRow(
+                        p.label,
+                        eng == app.vela.ui.VoiceSearch.Engine.SYSTEM && chosen?.component == p.component,
+                        onClick = {
+                            app.vela.ui.VoiceSearch.setProvider(context, p.component)
+                            app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.SYSTEM)
+                        },
+                    )
+                }
             }
 
             Spacer(Modifier.height(20.dp))


### PR DESCRIPTION
With several voice-input apps installed, the mic fired a bare RECOGNIZE_SPEECH intent and Android decided which app answered. Settings > Search now lists every installed voice app by name alongside Vela Voice; choosing one pins its exact activity on the intent. The pick persists, and an uninstalled favourite degrades to the first available provider instead of a dead mic. Replaces #35.