### PR TITLE
The sheet rides out the throw instead of springing to the detent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,8 +271,13 @@ Defaults that make the safe path the easy one:
   note stays. `place_current_traffic` was deleted from all 11 locales.
 - **Place-sheet drag physics are CONTINUOUS (2026-07-10):** the sheet height is a hand-driven
   `Animatable` - drags (handle or body-at-top) move it 1:1 with the finger, release projects the
-  fling (`projected = height - vDp*0.15`; 0.25 minimized too eagerly) and coasts to the NEAREST of the
-  three detents with the finger's velocity (`spring` NoBouncy/350f). The animated height is read
+  fling and RIDES THE THROW'S OWN INERTIA to the nearest detent: the landing point comes from
+  `exponentialDecay(friction 1.6).calculateTargetValue` (friction 1.6 = the same eagerness as the
+  earlier linear 0.15 factor, coast = v/(4.2*friction) - it's the one tuning knob), and when the
+  natural coast reaches the detent the settle IS `animateDecay` clamped by Animatable bounds at
+  the detent - no spring snap, the detent just stops the coast (Google's feel, user 2026-07-10).
+  Only throws that don't carry (gentle drops, releases against the velocity) glide on the spring
+  (NoBouncy/350f). The animated height is read
   in the LAYOUT modifier on the Card, NEVER in composition - a composition read recomposed the
   entire sheet every animation frame (the tap-to-expand dropped-frames report). The old grammar flipped a whole detent at a pixel
   threshold and hopped there - the "staccato" feel. State flips from taps / the reviews panel /

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -11,6 +11,8 @@ import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.calculateTargetValue
+import androidx.compose.animation.core.exponentialDecay
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -300,17 +302,41 @@ fun PlaceSheet(
     // everything keyed on them stays honest), and glide there carrying the finger's velocity. A
     // hard fling projects past the middle detent and lands on MINIMIZED from anywhere; a gentle
     // drop settles back where it came from. A swipe still never CLOSES the sheet (X / back do).
+    //
+    // Friction 1.6 keeps the tuned eagerness: an exponential decay's total coast is
+    // v / (4.2 * friction), so 1.6 reproduces the same landing points as the earlier
+    // linear projection factor of 0.15 - it's the one knob for "how hard must I throw it".
+    val flingDecay = remember { exponentialDecay<Float>(frictionMultiplier = 1.6f) }
     fun settleFromVelocity(velocityPxPerSec: Float) {
         val vDp = with(density) { velocityPxPerSec.toDp().value }
-        // 0.15, down from 0.25: the first cut made a middling downward flick from peek project
-        // past the midpoint and land MINIMIZED - too eager (user 2026-07-10). At 0.15 a gentle
-        // flick settles back and minimizing takes a deliberate throw; position still wins when
-        // the finger actually dragged most of the way.
-        val projected = heightAnim.value - vDp * 0.15f
-        val target = listOf(minH, peekH, expH).minByOrNull { kotlin.math.abs(it - projected) } ?: peekH
+        // Where the throw would naturally coast to, then the nearest detent to THAT point.
+        val naturalEnd = flingDecay.calculateTargetValue(heightAnim.value, -vDp)
+        val target = listOf(minH, peekH, expH).minByOrNull { kotlin.math.abs(it - naturalEnd) } ?: peekH
         expandedState.value = target == expH
         minimizedState.value = target == minH
-        settleScope.launch { heightAnim.animateTo(target, settleSpec, initialVelocity = -vDp) }
+        settleScope.launch {
+            val towardTarget = (naturalEnd - heightAnim.value) * (target - heightAnim.value) > 0f
+            if (towardTarget && kotlin.math.abs(naturalEnd - heightAnim.value) >= kotlin.math.abs(target - heightAnim.value)) {
+                // Google's feel: no spring snap - the sheet RIDES THE THROW'S OWN INERTIA and the
+                // detent simply stops it (Animatable bounds clamp the decay exactly there). Only
+                // a throw whose natural coast reaches the detent qualifies, so the stop never
+                // looks magnetic.
+                try {
+                    heightAnim.updateBounds(
+                        lowerBound = minOf(heightAnim.value, target),
+                        upperBound = maxOf(heightAnim.value, target),
+                    )
+                    heightAnim.animateDecay(-vDp, flingDecay)
+                } finally {
+                    heightAnim.updateBounds(lowerBound = null, upperBound = null)
+                }
+                if (kotlin.math.abs(heightAnim.value - target) > 0.5f) heightAnim.animateTo(target, settleSpec)
+            } else {
+                // The throw doesn't carry to the detent (gentle drop, or released between
+                // detents against the velocity): glide there with a soft spring instead.
+                heightAnim.animateTo(target, settleSpec, initialVelocity = -vDp)
+            }
+        }
     }
     fun dragSheetBy(dyPx: Float) {
         val dyDp = with(density) { dyPx.toDp().value }


### PR DESCRIPTION
Releases used a spring with initial velocity, which decelerates like a magnet pulling into the detent. The settle is now a real decay animation clamped at the landing detent, so the sheet rides the throw's own inertia to a stop. The landing choice comes from the decay's natural endpoint (friction 1.6 keeps the current eagerness exactly); only throws too gentle to carry still glide on the soft spring. Replaces #36.