### PR TITLE
The voice picker shows Android default as its own choice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,8 +460,11 @@ Defaults that make the safe path the easy one:
   own default-app choice routes it (a default set outside Vela is respected); only when Android
   has no default either (`resolveActivity` returns the package-"android" resolver) does Vela pin
   the FIRST installed app, so the system chooser can never interrupt a dictation. The Settings
-  picker lists every app BY NAME beside Vela Voice (`VoiceSearch.providers()`); an uninstalled
-  pick degrades down the same ladder, never a dead mic. Keyboard/IME voice (Sayboard, FUTO Keyboard) provides a
+  picker mirrors the ladder EXPLICITLY (2026-07-10): Vela Voice, then an "Android default" row
+  (= the no-pick state, `clearProvider`), then every installed app BY NAME as manual overrides
+  (`VoiceSearch.providers()`); an uninstalled pick degrades down the same ladder, never a dead
+  mic. Legacy `Engine.LOCAL` pins migrate to AUTO at init (a LOCAL pin hid the mic entirely once
+  the model was deleted, and the UI stopped offering LOCAL when the picker shipped). Keyboard/IME voice (Sayboard, FUTO Keyboard) provides a
   RecognitionService or in-IME mic, NOT the activity, so `queryIntentActivities` returns empty and
   the mic correctly hides - Vela can't `startActivityForResult` to them. That's intended: those
   users use the keyboard mic, and tier-1 (on-device Whisper) serves everyone regardless.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -198,9 +198,9 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 - ✅ **Transit lines are opt-in now (2026-07-10).** The purple rail highlight is off by default;
   it reads as mystery lines if you don't know what it is. Settings → Map → "Highlight transit
   lines" brings it back, and an earlier choice is kept either way.
-- ✅ **Pick your voice app (2026-07-10).** With more than one voice-input app installed, Settings →
-  Search lists each by name next to Vela Voice, and the mic launches exactly the one you chose
-  instead of whatever Android felt like resolving.
+- ✅ **Pick your voice app (2026-07-10).** Settings → Search lists Vela Voice, "Android default"
+  (your system-wide choice, untouched), and every installed voice app by name as a manual
+  override. The mic launches exactly what the picker says.
 - ✅ **The place card follows your finger (2026-07-10).** Dragging the place sheet moves it with
   your finger and, on release, it coasts on the fling to whichever size is closest - no more
   stepping between sizes in fixed hops.

--- a/app/src/main/java/app/vela/ui/VoiceSearch.kt
+++ b/app/src/main/java/app/vela/ui/VoiceSearch.kt
@@ -35,6 +35,10 @@ object VoiceSearch {
     fun init(context: Context) {
         enabled.value = prefs(context).getBoolean(KEY, true)
         engine.value = readEngine(prefs(context).getString(ENGINE_KEY, null))
+        // Legacy migration: an old explicit LOCAL pin (pre-picker) hid the mic entirely when the
+        // model was later deleted, even with voice apps installed. AUTO behaves identically while
+        // the model exists and degrades gracefully without it.
+        if (engine.value == Engine.LOCAL) setEngine(context, Engine.AUTO)
         provider.value = prefs(context).getString(PROVIDER_KEY, null)
     }
 
@@ -110,6 +114,13 @@ object VoiceSearch {
         val flat = component.flattenToString()
         provider.value = flat
         prefs(context).edit().putString(PROVIDER_KEY, flat).apply()
+    }
+
+    /** Back to "Android default": drop the explicit pick so the launch intent stays implicit
+     *  (Android's own default app routes it; first-installed only when there is no default). */
+    fun clearProvider(context: Context) {
+        provider.value = null
+        prefs(context).edit().remove(PROVIDER_KEY).apply()
     }
 
     /** Is a third-party voice-input APP installed (tier-2)? Cheap PackageManager query; only apps that

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -474,14 +474,28 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 Spacer(Modifier.height(12.dp))
                 SubHead(stringResource(R.string.settings_voice_search_engine_title))
                 val eng = app.vela.ui.VoiceSearch.engine.value
-                val chosen = app.vela.ui.VoiceSearch.chosenProvider(context)
+                // A row per way to dictate: Vela Voice, then "Android default" (the no-pick state -
+                // the intent stays implicit and Android's own default app routes it), then each
+                // installed app by name as a manual override.
+                val savedPick = app.vela.ui.VoiceSearch.provider.value
+                val savedValid = voiceProviders.any { it.component.flattenToString() == savedPick }
                 if (state.asrInstalled) {
                     SelectableRow(stringResource(R.string.settings_voice_search_engine_auto), eng != app.vela.ui.VoiceSearch.Engine.SYSTEM, onClick = { app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.AUTO) })
+                }
+                if (voiceProviders.isNotEmpty()) {
+                    SelectableRow(
+                        stringResource(R.string.settings_voice_search_engine_default),
+                        eng == app.vela.ui.VoiceSearch.Engine.SYSTEM && !savedValid,
+                        onClick = {
+                            app.vela.ui.VoiceSearch.clearProvider(context)
+                            app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.SYSTEM)
+                        },
+                    )
                 }
                 voiceProviders.forEach { p ->
                     SelectableRow(
                         p.label,
-                        eng == app.vela.ui.VoiceSearch.Engine.SYSTEM && chosen?.component == p.component,
+                        eng == app.vela.ui.VoiceSearch.Engine.SYSTEM && savedValid && p.component.flattenToString() == savedPick,
                         onClick = {
                             app.vela.ui.VoiceSearch.setProvider(context, p.component)
                             app.vela.ui.VoiceSearch.setEngine(context, app.vela.ui.VoiceSearch.Engine.SYSTEM)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -503,6 +503,7 @@
     <string name="settings_voice_search_installing">Wird installiert…</string>
     <string name="settings_voice_search_engine_title">Beim Tippen auf das Mikrofon</string>
     <string name="settings_voice_search_engine_auto">Vela-Stimme</string>
+    <string name="settings_voice_search_engine_default">Android-Standard</string>
     <string name="settings_voice_search_engine_system">Andere Sprach-App</string>
     <string name="map_asr_offer_title">Sprachsuche</string>
     <string name="map_asr_offer_body">Lade die Vela-Stimme herunter, um Suchen zu sprechen. Sie läuft komplett auf deinem Gerät und lädt nichts hoch.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -503,6 +503,7 @@
     <string name="settings_voice_search_installing">Instalando…</string>
     <string name="settings_voice_search_engine_title">Al tocar el micrófono</string>
     <string name="settings_voice_search_engine_auto">Voz de Vela</string>
+    <string name="settings_voice_search_engine_default">Predeterminada de Android</string>
     <string name="settings_voice_search_engine_system">Otra app de voz</string>
     <string name="map_asr_offer_title">Búsqueda por voz</string>
     <string name="map_asr_offer_body">Descarga la voz de Vela para dictar tus búsquedas. Funciona por completo en tu teléfono y no sube nada.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -503,6 +503,7 @@
     <string name="settings_voice_search_installing">Installation…</string>
     <string name="settings_voice_search_engine_title">Quand vous touchez le micro</string>
     <string name="settings_voice_search_engine_auto">Voix Vela</string>
+    <string name="settings_voice_search_engine_default">Défaut Android</string>
     <string name="settings_voice_search_engine_system">Autre appli vocale</string>
     <string name="map_asr_offer_title">Recherche vocale</string>
     <string name="map_asr_offer_body">Téléchargez la voix Vela pour dicter vos recherches. Elle tourne entièrement sur votre téléphone et n\'envoie rien.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -503,6 +503,7 @@
     <string name="settings_voice_search_installing">Installazione…</string>
     <string name="settings_voice_search_engine_title">Quando tocchi il microfono</string>
     <string name="settings_voice_search_engine_auto">Voce Vela</string>
+    <string name="settings_voice_search_engine_default">Predefinita di Android</string>
     <string name="settings_voice_search_engine_system">Altra app vocale</string>
     <string name="map_asr_offer_title">Ricerca vocale</string>
     <string name="map_asr_offer_body">Scarica la voce Vela per dettare le ricerche. Gira interamente sul telefono e non carica nulla.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -503,6 +503,7 @@
     <string name="settings_voice_search_installing">Installeren…</string>
     <string name="settings_voice_search_engine_title">Als je op de microfoon tikt</string>
     <string name="settings_voice_search_engine_auto">Vela-stem</string>
+    <string name="settings_voice_search_engine_default">Android-standaard</string>
     <string name="settings_voice_search_engine_system">Andere spraak-app</string>
     <string name="map_asr_offer_title">Spraakzoeken</string>
     <string name="map_asr_offer_body">Download de Vela-stem om je zoekopdrachten in te spreken. Hij draait volledig op je telefoon en uploadt niets.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -503,6 +503,7 @@
     <string name="settings_voice_search_installing">Instalowanie…</string>
     <string name="settings_voice_search_engine_title">Po dotknięciu mikrofonu</string>
     <string name="settings_voice_search_engine_auto">Głos Vela</string>
+    <string name="settings_voice_search_engine_default">Domyślna w Androidzie</string>
     <string name="settings_voice_search_engine_system">Inna aplikacja głosowa</string>
     <string name="map_asr_offer_title">Wyszukiwanie głosowe</string>
     <string name="map_asr_offer_body">Pobierz głos Vela, aby dyktować wyszukiwania. Działa w całości na telefonie i niczego nie wysyła.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -503,6 +503,7 @@
     <string name="settings_voice_search_installing">A instalar…</string>
     <string name="settings_voice_search_engine_title">Ao tocar no microfone</string>
     <string name="settings_voice_search_engine_auto">Voz Vela</string>
+    <string name="settings_voice_search_engine_default">Padrão do Android</string>
     <string name="settings_voice_search_engine_system">Outra app de voz</string>
     <string name="map_asr_offer_title">Pesquisa por voz</string>
     <string name="map_asr_offer_body">Transfere a voz Vela para ditar as tuas pesquisas. Corre inteiramente no telemóvel e não envia nada.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -503,6 +503,7 @@
     <string name="settings_voice_search_installing">Установка…</string>
     <string name="settings_voice_search_engine_title">При нажатии на микрофон</string>
     <string name="settings_voice_search_engine_auto">Голос Vela</string>
+    <string name="settings_voice_search_engine_default">По умолчанию в Android</string>
     <string name="settings_voice_search_engine_system">Другое голосовое приложение</string>
     <string name="map_asr_offer_title">Голосовой поиск</string>
     <string name="map_asr_offer_body">Загрузите голос Vela, чтобы диктовать запросы. Он работает целиком на телефоне и ничего не выгружает.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -503,6 +503,7 @@
     <string name="settings_voice_search_installing">Installerar…</string>
     <string name="settings_voice_search_engine_title">När du trycker på mikrofonen</string>
     <string name="settings_voice_search_engine_auto">Vela-röst</string>
+    <string name="settings_voice_search_engine_default">Androids standard</string>
     <string name="settings_voice_search_engine_system">Annan röstapp</string>
     <string name="map_asr_offer_title">Röstsökning</string>
     <string name="map_asr_offer_body">Ladda ner Vela-rösten för att tala in dina sökningar. Den körs helt på telefonen och laddar inte upp något.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -503,6 +503,7 @@
     <string name="settings_voice_search_installing">Встановлення…</string>
     <string name="settings_voice_search_engine_title">Коли торкаєтеся мікрофона</string>
     <string name="settings_voice_search_engine_auto">Голос Vela</string>
+    <string name="settings_voice_search_engine_default">Типова в Android</string>
     <string name="settings_voice_search_engine_system">Інший голосовий застосунок</string>
     <string name="map_asr_offer_title">Голосовий пошук</string>
     <string name="map_asr_offer_body">Завантажте голос Vela, щоб диктувати запити. Він працює цілком на телефоні й нічого не надсилає.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -526,6 +526,7 @@
     <string name="settings_voice_search_installing">Installing…</string>
     <string name="settings_voice_search_engine_title">When you tap the mic</string>
     <string name="settings_voice_search_engine_auto">Vela Voice</string>
+    <string name="settings_voice_search_engine_default">Android default</string>
     <string name="settings_voice_search_engine_system">Other voice app</string>
     <string name="map_asr_offer_title">Voice search</string>
     <string name="map_asr_offer_body">Download Vela Voice to speak your searches. It runs entirely on your phone and uploads nothing.</string>


### PR DESCRIPTION
The picker listed Vela Voice and the installed apps by name, but the default behaviour, deferring to the user's Android-wide speech app, had no visible row. It is now an explicit Android default choice between Vela Voice and the named overrides, selected whenever no manual pick is active; choosing it clears the pick so the intent stays implicit. Also migrates the retired local-only engine pin to Auto, which could hide the mic entirely if the model was deleted later. Verified on device: the picker reads Vela Voice / Android default / Voice Input with the model and FUTO installed.