### PR TITLE
A new place closes the route chooser, and the map buttons stay under it

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -228,6 +228,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   place has an X on its row to remove just that entry (Clear recents still wipes the lot). A real
   place shows its street address in smaller text under the name, and the Home/Work rows show the
   saved address too. The three-dot menus on Home/Work match the row text color now.
+- ✅ **Route chooser and search stay coherent (2026-07-11).** Opening any new place, from search,
+  a suggestion, a pin, or Home/Work, closes an open route chooser instead of leaving it covering
+  the fresh place with a stale route. The locate and parking buttons also stay hidden under the
+  chooser and step list instead of drawing on top of them.
 - ✅ **Warns when you'd arrive near closing time (2026-07-10).** Starting navigation to a place
   that closes within an hour of your arrival (or before you'd get there) shows a heads-up card
   and speaks it: "closes at 9:00 PM and you arrive around 8:40 PM". Reads the closing time from

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1420,7 +1420,12 @@ fun MapScreen(
             }
         }
 
-        if (!state.navigating && state.selected == null && !searchOpen && state.resumeNavLabel == null && !resultsShown) {
+        // The locate + parking buttons yield to EVERY bottom surface, the route chooser and the
+        // step list included - a search from an open chooser could null the selection while
+        // directionsOpen stayed true, and both buttons drew on top of the panel.
+        if (!state.navigating && state.selected == null && !searchOpen && state.resumeNavLabel == null &&
+            !resultsShown && !state.directionsOpen && !state.showSteps
+        ) {
             // Stock M3 FAB, deliberately: a Google-style flat circle was tried (2026-07-08)
             // and reverted — every surface tone melted into the dark tiles.
             FloatingActionButton(

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -934,7 +934,16 @@ class MapViewModel @Inject constructor(
         val base = Place(id = sp.id, name = sp.name, location = sp.location)
         if (_state.value.pickingStop) { addStop(base); return }
         if (_state.value.pickingOrigin) { setDirectionsOrigin(base); return }
-        _state.update { it.copy(selected = base, center = base.location, placesHere = emptyList(), reviews = emptyList(), reviewsLoading = false, reviewsFound = 0, photosLoading = false, loadingDetails = false) }
+        routeJob?.cancel()
+        _state.update {
+            it.copy(
+                selected = base, center = base.location, placesHere = emptyList(), reviews = emptyList(),
+                reviewsLoading = false, reviewsFound = 0, photosLoading = false, loadingDetails = false,
+                // Same cohesion rule as selectPlace: a new destination closes the old chooser.
+                directionsOpen = false, routes = emptyList(), activeRoute = null,
+                transit = emptyList(), transitLoading = false, showSteps = false,
+            )
+        }
         rememberRecentPlace(sp)
         // A saved place has no feature id, so it used to open with no photos/reviews.
         // Enrich it via a search (like a POI tap) to pull them; keep the saved id so
@@ -1191,10 +1200,16 @@ class MapViewModel @Inject constructor(
         if (_state.value.pickingStop) { addStop(p); return }
         if (_state.value.pickingOrigin) { setDirectionsOrigin(p); return }
         suggestJob?.cancel()
+        routeJob?.cancel() // a directions fetch in flight must not resurrect the stale panel
         _state.update {
             it.copy(
                 selected = withListNote(p), center = p.location, reviews = emptyList(), suggestions = emptyList(),
                 placesHere = othersAt(p, it.results), loadingDetails = false, photosLoading = false,
+                // Picking a NEW place while a route chooser is open closes it: the chooser
+                // belonged to the previous destination and kept covering the fresh place
+                // (the along-route / pick-origin / pick-stop flows early-return above).
+                directionsOpen = false, routes = emptyList(), activeRoute = null,
+                transit = emptyList(), transitLoading = false, showSteps = false,
             )
         }
         fetchReviews(p)


### PR DESCRIPTION
Two coherence fixes. Picking any new place while a route chooser was open, from search results, a suggestion, a result pin, or Home and Work, left the stale chooser covering the fresh place; every selection path now closes the chooser and clears its routes (the along-route stop and pick-origin flows keep their existing behaviour). And the locate plus parking buttons gated only on the place sheet, so the edge state where a search cleared the selection under an open chooser drew both buttons on top of the panel; they now yield to the chooser and the step list too.