### PR TITLE
Search results draw as named POI icons instead of red pins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,13 @@ Defaults that make the safe path the easy one:
   neighbour's dot - Google doesn't category-tint result labels,
   only ambient POI labels take the tint. resultPin's GEOMETRY is marker()'s exact proportions at
   0.86 scale (a taller-tailed variant read as a different species of pin, user 2026-07-10) -
-  keep the two in lockstep. While a result SET is on the map (markers.size > 1) the basemap
+  keep the two in lockstep. **OSM POIs hide by COVERAGE, not ambient non-emptiness (2026-07-10):**
+  `MapUiState.ambientCoversView` (computed each onViewport settle: ambient non-empty AND centre
+  within 0.35x of `lastAmbientSpan` of the fetch centre AND viewRadius ≤ 0.55x span; forced true
+  when a fresh fetch lands, false under z14) drives the poi_r* visibility - blanket-hiding left
+  the outskirts iconless because one fetch only covers ~3.5-9 km (user 2026-07-10). Controls
+  (signs/lights) render from z17.5 on the browse map but z16 during nav (set in the nav
+  declutter effect). While a result SET is on the map (markers.size > 1) the basemap
   poi_r1/r7/r20 icons hide too, AND the traffic-control layers (stop signs + lights,
   `lastControlsVis` - controls stay up beside the ambient dots on the browse map, so their
   predicate is the result set alone). Own identity gates, NOT inside the ambient gate -

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,8 +338,10 @@ Defaults that make the safe path the easy one:
   only ambient POI labels take the tint. resultPin's GEOMETRY is marker()'s exact proportions at
   0.86 scale (a taller-tailed variant read as a different species of pin, user 2026-07-10) -
   keep the two in lockstep. While a result SET is on the map (markers.size > 1) the basemap
-  poi_r1/r7/r20 icons hide too (own identity gate `lastOsmPoiVis`, NOT inside the ambient gate -
-  results can appear/clear while ambient stays empty); a single selected place keeps them. Dots carry the same MARKER_INDEX_PROP feature prop, so
+  poi_r1/r7/r20 icons hide too, AND the traffic-control layers (stop signs + lights,
+  `lastControlsVis` - controls stay up beside the ambient dots on the browse map, so their
+  predicate is the result set alone). Own identity gates, NOT inside the ambient gate -
+  results can appear/clear while ambient stays empty; a single selected place keeps both. Dots carry the same MARKER_INDEX_PROP feature prop, so
   a collapsed result is still tappable.
 - **Map tap resolution order (`VelaMapView` click listener, 2026-07-08).** A single tap (24dp hit box)
   resolves, in priority: (1) our search-result pin → `onMarkerTap`; (2) an ambient Google POI dot →

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,11 @@ Defaults that make the safe path the easy one:
   source, below, allowOverlap+ignorePlacement true), expanding back into pins on zoom - never a
   pile of overlapping icons. Pins anchor BOTTOM (tip = the place), labels try UNDER the pin,
   then its right, then its left (variableAnchor TOP/LEFT/RIGHT, radialOffset 0.7 - below-only
-  dropped labels in crowded views, user 2026-07-10) in NEUTRAL ink both themes - Google doesn't category-tint result labels,
+  dropped labels in crowded views, user 2026-07-10) in NEUTRAL ink both themes. The AMBIENT and
+  OSM poi layers got the same treatment (2026-07-10): four anchor slots (RIGHT/LEFT/TOP/BOTTOM,
+  = left of icon / right of it / below / above) instead of the old two - icons still collide by
+  design, but a rendered icon's label now finds a clear side instead of dropping or sitting on a
+  neighbour's dot - Google doesn't category-tint result labels,
   only ambient POI labels take the tint. resultPin's GEOMETRY is marker()'s exact proportions at
   0.86 scale (a taller-tailed variant read as a different species of pin, user 2026-07-10) -
   keep the two in lockstep. While a result SET is on the map (markers.size > 1) the basemap

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,6 +321,19 @@ Defaults that make the safe path the easy one:
   rotated/tilted or during heading-up nav - never removed, just north-hidden on the browse map.
   Its browse-mode top margin is statusBar + 122dp so it sits BELOW the floating search bar and the
   category chips (8dp under the status bar put it exactly behind the bar - a half-hidden circle, 2026-07-09).
+- **Search-result markers are Google's result treatment (2026-07-10, `PoiIcons` result section +
+  the `vela-markers`/`vela-markers-dots` layers in `VelaMapView`).** Every result is RED and keeps
+  its category glyph (`resultPin`); rated FOOD results get the wide rating "speech bubble"
+  (`ratingBubble`, theme-surfaced, regenerated per style load because bitmaps can't theme).
+  Bitmaps are generated ON DEMAND in applyData's marker loop (`ensureResultIcon` - bubble keys
+  carry the rating tenths, so only the ratings actually on screen get bitmaps). The pin layer
+  COLLIDES by rank (`symbolSortKey` = result order, allowOverlap false): in a dense downtown the
+  best results keep pins and the rest draw as the small red dots of `vela-markers-dots` (same
+  source, below, allowOverlap+ignorePlacement true), expanding back into pins on zoom - never a
+  pile of overlapping icons. Pins anchor BOTTOM (tip = the place), labels sit UNDER the pin
+  (variableAnchor TOP) in NEUTRAL ink both themes - Google doesn't category-tint result labels,
+  only ambient POI labels take the tint. Dots carry the same MARKER_INDEX_PROP feature prop, so
+  a collapsed result is still tappable.
 - **Map tap resolution order (`VelaMapView` click listener, 2026-07-08).** A single tap (24dp hit box)
   resolves, in priority: (1) our search-result pin → `onMarkerTap`; (2) an ambient Google POI dot →
   `onAmbientTap`; (3) a greyed alternate route line → `onSelectAlternate`; (4) a NAMED basemap POI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,9 +322,12 @@ Defaults that make the safe path the easy one:
   Its browse-mode top margin is statusBar + 122dp so it sits BELOW the floating search bar and the
   category chips (8dp under the status bar put it exactly behind the bar - a half-hidden circle, 2026-07-09).
 - **Search-result markers are Google's result treatment (2026-07-10, `PoiIcons` result section +
-  the `vela-markers`/`vela-markers-dots` layers in `VelaMapView`).** Every result is RED and keeps
-  its category glyph (`resultPin`); rated FOOD results get the wide rating "speech bubble"
-  (`ratingBubble`, theme-surfaced, regenerated per style load because bitmaps can't theme).
+  the `vela-markers`/`vela-markers-dots` layers in `VelaMapView`).** Every result keeps the app's own
+  marker language - grey teardrop, circle, white glyph - with the circle RED (`resultPin`,
+  drawn a step smaller than the ambient icons' backing); rated FOOD results get the wide rating
+  "speech bubble": the same red circle + white glyph beside the rating in plain ink, NO star
+  glyph (`ratingBubble`, label passed as a string so non-rating labels can ride the same bubble;
+  theme-surfaced, regenerated per style load because bitmaps can't theme).
   Bitmaps are generated ON DEMAND in applyData's marker loop (`ensureResultIcon` - bubble keys
   carry the rating tenths, so only the ratings actually on screen get bitmaps). The pin layer
   COLLIDES by rank (`symbolSortKey` = result order, allowOverlap false): in a dense downtown the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,8 +333,9 @@ Defaults that make the safe path the easy one:
   COLLIDES by rank (`symbolSortKey` = result order, allowOverlap false): in a dense downtown the
   best results keep pins and the rest draw as the small red dots of `vela-markers-dots` (same
   source, below, allowOverlap+ignorePlacement true), expanding back into pins on zoom - never a
-  pile of overlapping icons. Pins anchor BOTTOM (tip = the place), labels sit UNDER the pin
-  (variableAnchor TOP) in NEUTRAL ink both themes - Google doesn't category-tint result labels,
+  pile of overlapping icons. Pins anchor BOTTOM (tip = the place), labels try UNDER the pin,
+  then its right, then its left (variableAnchor TOP/LEFT/RIGHT, radialOffset 0.7 - below-only
+  dropped labels in crowded views, user 2026-07-10) in NEUTRAL ink both themes - Google doesn't category-tint result labels,
   only ambient POI labels take the tint. resultPin's GEOMETRY is marker()'s exact proportions at
   0.86 scale (a taller-tailed variant read as a different species of pin, user 2026-07-10) -
   keep the two in lockstep. While a result SET is on the map (markers.size > 1) the basemap

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,11 @@ Defaults that make the safe path the easy one:
   source, below, allowOverlap+ignorePlacement true), expanding back into pins on zoom - never a
   pile of overlapping icons. Pins anchor BOTTOM (tip = the place), labels sit UNDER the pin
   (variableAnchor TOP) in NEUTRAL ink both themes - Google doesn't category-tint result labels,
-  only ambient POI labels take the tint. Dots carry the same MARKER_INDEX_PROP feature prop, so
+  only ambient POI labels take the tint. resultPin's GEOMETRY is marker()'s exact proportions at
+  0.86 scale (a taller-tailed variant read as a different species of pin, user 2026-07-10) -
+  keep the two in lockstep. While a result SET is on the map (markers.size > 1) the basemap
+  poi_r1/r7/r20 icons hide too (own identity gate `lastOsmPoiVis`, NOT inside the ambient gate -
+  results can appear/clear while ambient stays empty); a single selected place keeps them. Dots carry the same MARKER_INDEX_PROP feature prop, so
   a collapsed result is still tappable.
 - **Map tap resolution order (`VelaMapView` click listener, 2026-07-08).** A single tap (24dp hit box)
   resolves, in priority: (1) our search-result pin → `onMarkerTap`; (2) an ambient Google POI dot →

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -213,7 +213,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   its grey teardrop and category glyph with the circle turned red, rated restaurants get a wide
   speech-bubble marker with the rating beside the circled glyph, and in a dense downtown the lesser results collapse into little red dots that
   expand back into pins as you zoom, so the view never turns into a pile of overlapping icons.
-  Result labels stay plain ink (only ambient POI labels take the category tint, like Google),
+  Result labels stay plain ink (only ambient POI labels take the category tint, like Google);
+  every POI label on the map (results, ambient dots, base-map icons) can now sit left, right,
+  below or above its icon, whichever side is clear, instead of vanishing when its usual spot
+  was taken;
   and while a result set is up the base map's own POI icons, stop signs and traffic lights all
   step aside so the results are the only things on the map.
 - ✅ **Traffic in words, not just colour (2026-07-10).** Route choices now say "light traffic",

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -208,9 +208,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 - ✅ **The place card follows your finger (2026-07-10).** Dragging the place sheet moves it with
   your finger and, on release, it coasts on the fling to whichever size is closest - no more
   stepping between sizes in fixed hops.
-- ✅ **Search results are real POI icons with names (2026-07-11).** Searching "restaurants" pins
-  the map with named restaurant icons, the same category icons the base map uses, instead of a
-  field of anonymous red pins. Labels step aside when crowded; the icons always show.
+- ✅ **Search results are Google-style red markers with real glyphs (2026-07-11).** Searching
+  "restaurants" pins the map with named results instead of anonymous pins: every result is red
+  but keeps its category glyph, rated restaurants get a wide speech-bubble marker with the star
+  rating baked in, and in a dense downtown the lesser results collapse into little red dots that
+  expand back into pins as you zoom, so the view never turns into a pile of overlapping icons.
+  Result labels stay plain ink (only ambient POI labels take the category tint, like Google).
 - ✅ **Traffic in words, not just colour (2026-07-10).** Route choices now say "light traffic",
   "moderate traffic" or "heavy traffic" to match the green/amber/red time, so the conditions read
   without relying on colour. And a freshly downloaded voice no longer speaks a sample on its own -

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -213,6 +213,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   its grey teardrop and category glyph with the circle turned red, rated restaurants get a wide
   speech-bubble marker with the rating beside the circled glyph, and in a dense downtown the lesser results collapse into little red dots that
   expand back into pins as you zoom, so the view never turns into a pile of overlapping icons.
+  The base map's OSM icons now BLEND with the Google dots instead of hiding wholesale: they
+  yield only while the viewport truly sits inside the area the Google fetch covered, so panning
+  or zooming past it keeps icons everywhere and fresh fetches merge in as they land. Stop signs
+  and traffic lights also hold back on the browse map until true street zoom (they stay at nav
+  zoom during turn-by-turn, where they're an aid rather than clutter).
   Result labels stay plain ink (only ambient POI labels take the category tint, like Google);
   every POI label on the map (results, ambient dots, base-map icons) can now sit left, right,
   below or above its icon, whichever side is clear, instead of vanishing when its usual spot

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -214,8 +214,8 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   speech-bubble marker with the rating beside the circled glyph, and in a dense downtown the lesser results collapse into little red dots that
   expand back into pins as you zoom, so the view never turns into a pile of overlapping icons.
   Result labels stay plain ink (only ambient POI labels take the category tint, like Google),
-  and while a result set is up the base map's own POI icons step aside so the results are the
-  only places on the map.
+  and while a result set is up the base map's own POI icons, stop signs and traffic lights all
+  step aside so the results are the only things on the map.
 - ✅ **Traffic in words, not just colour (2026-07-10).** Route choices now say "light traffic",
   "moderate traffic" or "heavy traffic" to match the green/amber/red time, so the conditions read
   without relying on colour. And a freshly downloaded voice no longer speaks a sample on its own -

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -209,9 +209,9 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   your finger and, on release, it coasts on the fling to whichever size is closest - no more
   stepping between sizes in fixed hops.
 - ✅ **Search results are Google-style red markers with real glyphs (2026-07-11).** Searching
-  "restaurants" pins the map with named results instead of anonymous pins: every result is red
-  but keeps its category glyph, rated restaurants get a wide speech-bubble marker with the star
-  rating baked in, and in a dense downtown the lesser results collapse into little red dots that
+  "restaurants" pins the map with named results instead of anonymous pins: every result keeps
+  its grey teardrop and category glyph with the circle turned red, rated restaurants get a wide
+  speech-bubble marker with the rating beside the circled glyph, and in a dense downtown the lesser results collapse into little red dots that
   expand back into pins as you zoom, so the view never turns into a pile of overlapping icons.
   Result labels stay plain ink (only ambient POI labels take the category tint, like Google).
 - ✅ **Traffic in words, not just colour (2026-07-10).** Route choices now say "light traffic",

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -208,6 +208,9 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 - ✅ **The place card follows your finger (2026-07-10).** Dragging the place sheet moves it with
   your finger and, on release, it coasts on the fling to whichever size is closest - no more
   stepping between sizes in fixed hops.
+- ✅ **Search results are real POI icons with names (2026-07-11).** Searching "restaurants" pins
+  the map with named restaurant icons, the same category icons the base map uses, instead of a
+  field of anonymous red pins. Labels step aside when crowded; the icons always show.
 - ✅ **Traffic in words, not just colour (2026-07-10).** Route choices now say "light traffic",
   "moderate traffic" or "heavy traffic" to match the green/amber/red time, so the conditions read
   without relying on colour. And a freshly downloaded voice no longer speaks a sample on its own -

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -213,7 +213,9 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   its grey teardrop and category glyph with the circle turned red, rated restaurants get a wide
   speech-bubble marker with the rating beside the circled glyph, and in a dense downtown the lesser results collapse into little red dots that
   expand back into pins as you zoom, so the view never turns into a pile of overlapping icons.
-  Result labels stay plain ink (only ambient POI labels take the category tint, like Google).
+  Result labels stay plain ink (only ambient POI labels take the category tint, like Google),
+  and while a result set is up the base map's own POI icons step aside so the results are the
+  only places on the map.
 - ✅ **Traffic in words, not just colour (2026-07-10).** Route choices now say "light traffic",
   "moderate traffic" or "heavy traffic" to match the green/amber/red time, so the conditions read
   without relying on colour. And a freshly downloaded voice no longer speaks a sample on its own -

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -683,6 +683,7 @@ fun MapScreen(
             navMode = state.navigating,
             navFollowing = !state.navCameraDetached,
             onNavPanned = vm::onNavPanned,
+            ambientCoversView = state.ambientCoversView,
             onScaleChanged = { metersPerPixel = it },
             darkTheme = darkTheme,
             applyKeylessTheme = !hasMapTiler,

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1665,7 +1665,7 @@ private fun ambientMarkersOf(state: MapUiState): List<MapMarker> =
     }
 
 private fun markersOf(state: MapUiState): List<MapMarker> =
-    displayedPlaces(state).map { MapMarker(it.name, it.location, it.category) }
+    displayedPlaces(state).map { MapMarker(it.name, it.location, it.category, rating = it.rating) }
 
 @Composable
 private fun SearchResults(

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1665,7 +1665,7 @@ private fun ambientMarkersOf(state: MapUiState): List<MapMarker> =
     }
 
 private fun markersOf(state: MapUiState): List<MapMarker> =
-    displayedPlaces(state).map { MapMarker(it.name, it.location) }
+    displayedPlaces(state).map { MapMarker(it.name, it.location, it.category) }
 
 @Composable
 private fun SearchResults(

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -106,6 +106,10 @@ data class MapUiState(
     val query: String = "",
     val results: List<Place> = emptyList(),
     val ambientPois: List<Place> = emptyList(), // Google places for the visible area, shown on the bare browse map
+    // True while the CURRENT viewport sits inside the area the ambient Google fetch covered —
+    // the basemap OSM POIs hide only then, so panning/zooming past the fetched area blends the
+    // OSM icons back in instead of leaving the outskirts iconless (user 2026-07-10).
+    val ambientCoversView: Boolean = false,
     val suggestions: List<Place> = emptyList(),
     val selected: Place? = null,
     val placesHere: List<Place> = emptyList(), // other Google listings at the selected spot
@@ -2991,6 +2995,7 @@ class MapViewModel @Inject constructor(
 
     private var ambientJob: Job? = null
     private var lastAmbientCenter: LatLng? = null
+    private var lastAmbientSpan = 9000.0 // span of the last completed ambient fetch (m)
     private var lastAmbientZoom = 0.0
     // LRU (most-recent last, cap 16) of recent ambient fetches — revisiting ANY of the last ~16 areas
     // repaints POIs INSTANTLY (the ~2 s Google floor only hits genuinely-new areas), with no empty-map
@@ -3031,8 +3036,19 @@ class MapViewModel @Inject constructor(
         if (zoom < 14.0) {
             ambientJob?.cancel()
             lastAmbientCenter = null
-            if (s.ambientPois.isNotEmpty()) _state.update { it.copy(ambientPois = emptyList()) }
+            if (s.ambientPois.isNotEmpty() || s.ambientCoversView) {
+                _state.update { it.copy(ambientPois = emptyList(), ambientCoversView = false) }
+            }
             return
+        }
+        // Coverage check EVERY settle (cheap): the OSM basemap POIs hide only while the view is
+        // truly inside the fetched ambient area — outside it they stay, so the map is never
+        // iconless past the fetch's ~3.5-9 km span. Fresh fetches below re-tighten this.
+        run {
+            val covers = s.ambientPois.isNotEmpty() &&
+                (lastAmbientCenter?.let { it.distanceTo(center) < lastAmbientSpan * 0.35 } == true) &&
+                viewRadiusMeters <= lastAmbientSpan * 0.55
+            if (covers != s.ambientCoversView) _state.update { it.copy(ambientCoversView = covers) }
         }
         // Re-query only on a real pan or a real zoom change (not every settle).
         val moved = lastAmbientCenter?.let { it.distanceTo(center) >= 180.0 } ?: true
@@ -3055,11 +3071,12 @@ class MapViewModel @Inject constructor(
             val res = runCatching { dataSource.nearbyPlaces(center, span) }.getOrNull() ?: return@launch
             lastAmbientCenter = center
             lastAmbientZoom = zoom
+            lastAmbientSpan = span
             cacheAmbient(center, res)
             // Re-check we're still on the bare map — the user may have searched/opened a place while we fetched.
             val cur = _state.value
             if (cur.navigating || cur.replaying || cur.results.isNotEmpty() || cur.selected != null) return@launch
-            _state.update { it.copy(ambientPois = keepAmbientForView(res, viewRadiusMeters)) }
+            _state.update { it.copy(ambientPois = keepAmbientForView(res, viewRadiusMeters), ambientCoversView = true) }
         }
     }
 

--- a/app/src/main/java/app/vela/ui/map/PoiIcons.kt
+++ b/app/src/main/java/app/vela/ui/map/PoiIcons.kt
@@ -44,14 +44,199 @@ object PoiIcons {
     )
 
     fun addTo(context: Context, style: Style) {
-        val tf = runCatching {
-            Typeface.createFromAsset(context.assets, "fonts/MaterialIcons-Regular.ttf")
-        }.getOrNull() ?: return
+        val tf = typeface(context) ?: return
         GROUPS.forEach { (key, codepoint, color) ->
             if (style.getImage("vela-poi-$key") == null) {
                 style.addImage("vela-poi-$key", marker(tf, codepoint, color))
             }
         }
+    }
+
+    private var cachedTf: Typeface? = null
+    private fun typeface(context: Context): Typeface? {
+        cachedTf?.let { return it }
+        return runCatching {
+            Typeface.createFromAsset(context.assets, "fonts/MaterialIcons-Regular.ttf")
+        }.getOrNull()?.also { cachedTf = it }
+    }
+
+    // ── Search-result markers (Google's result treatment) ─────────────────────────────────────
+    // Every result is RED but KEEPS its category glyph (a red pin with the fork/mug/bed on it);
+    // food results with a rating instead get a wide "speech bubble" with the rating baked into
+    // the bitmap, like Google does for restaurants. Results that lose the collision fight render
+    // as a small red dot (their own layer in VelaMapView) that expands into the pin on zoom-in.
+    private const val RESULT_RED = "#DB4437"
+    const val RESULT_DOT_IMG = "vela-res-dot"
+
+    /** The style-image key for a search result: a rating bubble for rated FOOD places
+     *  ("vela-resb-food-45"), a red category pin for everything else ("vela-res-shop"). */
+    fun resultIconKey(name: String?, category: String?, rating: Double?): String {
+        val group = groupFor(name, category)
+        return if (group == "food" && rating != null) {
+            "vela-resb-$group-${(rating * 10).toInt().coerceIn(10, 50)}"
+        } else "vela-res-$group"
+    }
+
+    /** Generate + register the bitmap behind [key] (from [resultIconKey]) if this style doesn't
+     *  have it yet. Rating bubbles are theme-dependent, so a theme flip (= a style reload) simply
+     *  regenerates them for the new [dark]. */
+    fun ensureResultIcon(context: Context, style: Style, key: String, dark: Boolean) {
+        if (style.getImage(key) != null) return
+        val tf = typeface(context) ?: return
+        val bubble = key.startsWith("vela-resb-")
+        val rest = key.removePrefix(if (bubble) "vela-resb-" else "vela-res-")
+        val group = if (bubble) rest.substringBeforeLast('-') else rest
+        val codepoint = (GROUPS.firstOrNull { it.first == group } ?: GROUPS.last()).second
+        val bmp = if (bubble) {
+            val tenths = rest.substringAfterLast('-').toIntOrNull() ?: 40
+            ratingBubble(tf, codepoint, tenths / 10.0, dark)
+        } else resultPin(tf, codepoint)
+        style.addImage(key, bmp)
+    }
+
+    /** Register the collapsed-result dot (theme-independent, one image). */
+    fun addResultDot(style: Style) {
+        if (style.getImage(RESULT_DOT_IMG) != null) return
+        val s = 34
+        val bmp = Bitmap.createBitmap(s, s, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bmp)
+        val c = s / 2f
+        canvas.drawCircle(c, c + 1f, s * 0.30f, Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0x38000000
+            maskFilter = BlurMaskFilter(s * 0.09f, BlurMaskFilter.Blur.NORMAL)
+        })
+        canvas.drawCircle(c, c, s * 0.30f, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.WHITE })
+        canvas.drawCircle(c, c, s * 0.24f, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.parseColor(RESULT_RED) })
+        return style.addImage(RESULT_DOT_IMG, bmp)
+    }
+
+    /** A red teardrop pin with the white category glyph — the pin TIP is at bottom-centre, for a
+     *  bottom-anchored layer (the tip marks the place, Google-style). */
+    private fun resultPin(tf: Typeface, codepoint: Int): Bitmap {
+        val w = 100
+        val h = 108
+        val bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bmp)
+        val cx = w / 2f
+        val bodyCy = h * 0.36f
+        val bodyR = w * 0.335f
+        val tipY = h - 5f
+        val d = tipY - bodyCy
+        val sin = (bodyR / d).coerceAtMost(0.985f)
+        val cos = kotlin.math.sqrt(1f - sin * sin)
+        val teardrop = Path().apply {
+            addCircle(cx, bodyCy, bodyR, Path.Direction.CW)
+            op(
+                Path().apply {
+                    moveTo(cx - bodyR * sin, bodyCy + bodyR * cos)
+                    lineTo(cx, tipY)
+                    lineTo(cx + bodyR * sin, bodyCy + bodyR * cos)
+                    close()
+                },
+                Path.Op.UNION,
+            )
+        }
+        canvas.save()
+        canvas.translate(0f, w * 0.02f)
+        canvas.drawPath(teardrop, Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0x40000000
+            maskFilter = BlurMaskFilter(w * 0.05f, BlurMaskFilter.Blur.NORMAL)
+        })
+        canvas.restore()
+        canvas.drawPath(teardrop, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.parseColor(RESULT_RED) })
+        // A slightly darker inner disc behind the glyph gives the flat red pin its depth cue.
+        canvas.drawCircle(cx, bodyCy, bodyR * 0.80f, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.parseColor("#C5221F") })
+        val text = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            typeface = tf
+            color = Color.WHITE
+            textSize = w * 0.34f
+            textAlign = Paint.Align.CENTER
+        }
+        val glyph = String(Character.toChars(codepoint))
+        val fm = text.fontMetrics
+        canvas.drawText(glyph, cx, bodyCy - (fm.ascent + fm.descent) / 2f, text)
+        return bmp
+    }
+
+    /** Google's restaurant-result marker: a wide speech-bubble with a bottom tail, holding the
+     *  red category glyph, the rating, and a gold star. Theme-surfaced (white in light, grey in
+     *  dark) with the rating in plain ink. Tail tip at bottom-centre for a bottom-anchored layer. */
+    private fun ratingBubble(tf: Typeface, codepoint: Int, rating: Double, dark: Boolean): Bitmap {
+        val fill = Color.parseColor(if (dark) "#3C4043" else "#FFFFFF")
+        val edge = Color.parseColor(if (dark) "#5F6368" else "#DADCE0")
+        val ink = Color.parseColor(if (dark) "#E8EAED" else "#3C4043")
+        val glyphColor = Color.parseColor(if (dark) "#F28B82" else RESULT_RED)
+        val star = Color.parseColor("#FBBC04")
+        val bodyH = 62f
+        val tailH = 16f
+        val pad = 20f
+        val gap = 9f
+        val glyphSize = 34f
+        val starSize = 30f
+        val label = String.format(java.util.Locale.getDefault(), "%.1f", rating)
+        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = ink
+            textSize = 32f
+            typeface = Typeface.create(Typeface.SANS_SERIF, Typeface.BOLD)
+        }
+        val textW = textPaint.measureText(label)
+        val w = (pad + glyphSize + gap + textW + gap * 0.6f + starSize + pad).toInt() + 8
+        val h = (bodyH + tailH).toInt() + 10
+        val bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bmp)
+        val cx = w / 2f
+        val left = 4f
+        val right = w - 4f
+        val top = 3f
+        val bottom = top + bodyH
+        val r = bodyH / 2f
+        val bubble = Path().apply {
+            addRoundRect(left, top, right, bottom, r, r, Path.Direction.CW)
+            // The comic-bubble tail: a small triangle to the tip at bottom-centre.
+            op(
+                Path().apply {
+                    moveTo(cx - 13f, bottom - 6f)
+                    lineTo(cx, top + bodyH + tailH)
+                    lineTo(cx + 13f, bottom - 6f)
+                    close()
+                },
+                Path.Op.UNION,
+            )
+        }
+        canvas.save()
+        canvas.translate(0f, 3f)
+        canvas.drawPath(bubble, Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0x40000000
+            maskFilter = BlurMaskFilter(5f, BlurMaskFilter.Blur.NORMAL)
+        })
+        canvas.restore()
+        canvas.drawPath(bubble, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = fill })
+        canvas.drawPath(bubble, Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = edge
+            style = Paint.Style.STROKE
+            strokeWidth = 1.6f
+        })
+        val cyText = (top + bottom) / 2f
+        var x = left + pad - 4f
+        val glyphPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            typeface = tf
+            color = glyphColor
+            textSize = glyphSize
+        }
+        var fm = glyphPaint.fontMetrics
+        canvas.drawText(String(Character.toChars(codepoint)), x, cyText - (fm.ascent + fm.descent) / 2f, glyphPaint)
+        x += glyphSize + gap
+        fm = textPaint.fontMetrics
+        canvas.drawText(label, x, cyText - (fm.ascent + fm.descent) / 2f, textPaint)
+        x += textW + gap * 0.6f
+        val starPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            typeface = tf
+            color = star
+            textSize = starSize
+        }
+        fm = starPaint.fontMetrics
+        canvas.drawText(String(Character.toChars(0xe838)), x, cyText - (fm.ascent + fm.descent) / 2f, starPaint)
+        return bmp
     }
 
     // class -> group, for OpenFreeMap Liberty's rank-tiered poi layers

--- a/app/src/main/java/app/vela/ui/map/PoiIcons.kt
+++ b/app/src/main/java/app/vela/ui/map/PoiIcons.kt
@@ -345,7 +345,12 @@ object PoiIcons {
                     // search) — the old fixed -2.6 offset here was the "state where labels are too far
                     // from the icon until they re-render" (the re-render = ambient taking over).
                     PropertyFactory.textVariableAnchor(
-                        arrayOf(Property.TEXT_ANCHOR_RIGHT, Property.TEXT_ANCHOR_TOP),
+                        // Four slots like the ambient layer: left/right/below/above the icon, so a
+                        // crowded block keeps its labels instead of dropping them (see VelaMapView).
+                        arrayOf(
+                            Property.TEXT_ANCHOR_RIGHT, Property.TEXT_ANCHOR_LEFT,
+                            Property.TEXT_ANCHOR_TOP, Property.TEXT_ANCHOR_BOTTOM,
+                        ),
                     ),
                     PropertyFactory.textRadialOffset(1.4f),
                     PropertyFactory.textJustify(Property.TEXT_JUSTIFY_AUTO),
@@ -377,7 +382,12 @@ object PoiIcons {
                     PropertyFactory.symbolSortKey(Expression.get("rank")),
                     // Same tight variable-anchor placement as the poi_r* layers above / the ambient layer.
                     PropertyFactory.textVariableAnchor(
-                        arrayOf(Property.TEXT_ANCHOR_RIGHT, Property.TEXT_ANCHOR_TOP),
+                        // Four slots like the ambient layer: left/right/below/above the icon, so a
+                        // crowded block keeps its labels instead of dropping them (see VelaMapView).
+                        arrayOf(
+                            Property.TEXT_ANCHOR_RIGHT, Property.TEXT_ANCHOR_LEFT,
+                            Property.TEXT_ANCHOR_TOP, Property.TEXT_ANCHOR_BOTTOM,
+                        ),
                     ),
                     PropertyFactory.textRadialOffset(1.4f),
                     PropertyFactory.textJustify(Property.TEXT_JUSTIFY_AUTO),

--- a/app/src/main/java/app/vela/ui/map/PoiIcons.kt
+++ b/app/src/main/java/app/vela/ui/map/PoiIcons.kt
@@ -80,7 +80,7 @@ object PoiIcons {
     /** Generate + register the bitmap behind [key] (from [resultIconKey]) if this style doesn't
      *  have it yet. Rating bubbles are theme-dependent, so a theme flip (= a style reload) simply
      *  regenerates them for the new [dark]. */
-    fun ensureResultIcon(context: Context, style: Style, key: String, dark: Boolean) {
+    fun ensureResultIcon(context: Context, style: Style, key: String, dark: Boolean, bubbleLabel: String? = null) {
         if (style.getImage(key) != null) return
         val tf = typeface(context) ?: return
         val bubble = key.startsWith("vela-resb-")
@@ -88,8 +88,10 @@ object PoiIcons {
         val group = if (bubble) rest.substringBeforeLast('-') else rest
         val codepoint = (GROUPS.firstOrNull { it.first == group } ?: GROUPS.last()).second
         val bmp = if (bubble) {
-            val tenths = rest.substringAfterLast('-').toIntOrNull() ?: 40
-            ratingBubble(tf, codepoint, tenths / 10.0, dark)
+            val label = bubbleLabel ?: (rest.substringAfterLast('-').toIntOrNull() ?: 40).let {
+                String.format(java.util.Locale.getDefault(), "%.1f", it / 10.0)
+            }
+            ratingBubble(tf, codepoint, label, dark)
         } else resultPin(tf, codepoint)
         style.addImage(key, bmp)
     }
@@ -110,17 +112,19 @@ object PoiIcons {
         return style.addImage(RESULT_DOT_IMG, bmp)
     }
 
-    /** A red teardrop pin with the white category glyph — the pin TIP is at bottom-centre, for a
+    /** A GREY teardrop pin with a RED circle holding the white category glyph — the app's own
+     *  marker language (grey backing, coloured dot) with red standing in for the category colour,
+     *  which is how a result reads as a result (user 2026-07-10). Pin TIP at bottom-centre, for a
      *  bottom-anchored layer (the tip marks the place, Google-style). */
     private fun resultPin(tf: Typeface, codepoint: Int): Bitmap {
-        val w = 100
-        val h = 108
+        val w = 86
+        val h = 94
         val bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bmp)
         val cx = w / 2f
         val bodyCy = h * 0.36f
         val bodyR = w * 0.335f
-        val tipY = h - 5f
+        val tipY = h - 4f
         val d = tipY - bodyCy
         val sin = (bodyR / d).coerceAtMost(0.985f)
         val cos = kotlin.math.sqrt(1f - sin * sin)
@@ -143,13 +147,12 @@ object PoiIcons {
             maskFilter = BlurMaskFilter(w * 0.05f, BlurMaskFilter.Blur.NORMAL)
         })
         canvas.restore()
-        canvas.drawPath(teardrop, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.parseColor(RESULT_RED) })
-        // A slightly darker inner disc behind the glyph gives the flat red pin its depth cue.
-        canvas.drawCircle(cx, bodyCy, bodyR * 0.80f, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.parseColor("#C5221F") })
+        canvas.drawPath(teardrop, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.parseColor("#9AA0A6") })
+        canvas.drawCircle(cx, bodyCy, bodyR * 0.82f, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.parseColor(RESULT_RED) })
         val text = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             typeface = tf
             color = Color.WHITE
-            textSize = w * 0.34f
+            textSize = w * 0.33f
             textAlign = Paint.Align.CENTER
         }
         val glyph = String(Character.toChars(codepoint))
@@ -159,28 +162,26 @@ object PoiIcons {
     }
 
     /** Google's restaurant-result marker: a wide speech-bubble with a bottom tail, holding the
-     *  red category glyph, the rating, and a gold star. Theme-surfaced (white in light, grey in
-     *  dark) with the rating in plain ink. Tail tip at bottom-centre for a bottom-anchored layer. */
-    private fun ratingBubble(tf: Typeface, codepoint: Int, rating: Double, dark: Boolean): Bitmap {
+     *  white category glyph in a RED CIRCLE (the same circle language as the pins) beside the
+     *  rating in plain ink - no star glyph, the number in a place bubble reads as a rating on its
+     *  own (user 2026-07-10). Theme-surfaced (white in light, grey in dark); tail tip at
+     *  bottom-centre for a bottom-anchored layer. */
+    private fun ratingBubble(tf: Typeface, codepoint: Int, label: String, dark: Boolean): Bitmap {
         val fill = Color.parseColor(if (dark) "#3C4043" else "#FFFFFF")
         val edge = Color.parseColor(if (dark) "#5F6368" else "#DADCE0")
         val ink = Color.parseColor(if (dark) "#E8EAED" else "#3C4043")
-        val glyphColor = Color.parseColor(if (dark) "#F28B82" else RESULT_RED)
-        val star = Color.parseColor("#FBBC04")
         val bodyH = 62f
         val tailH = 16f
-        val pad = 20f
+        val pad = 13f
         val gap = 9f
-        val glyphSize = 34f
-        val starSize = 30f
-        val label = String.format(java.util.Locale.getDefault(), "%.1f", rating)
+        val circleR = 21f
         val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             color = ink
             textSize = 32f
             typeface = Typeface.create(Typeface.SANS_SERIF, Typeface.BOLD)
         }
         val textW = textPaint.measureText(label)
-        val w = (pad + glyphSize + gap + textW + gap * 0.6f + starSize + pad).toInt() + 8
+        val w = (pad + circleR * 2 + gap + textW + pad + 4f).toInt() + 8
         val h = (bodyH + tailH).toInt() + 10
         val bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bmp)
@@ -217,25 +218,19 @@ object PoiIcons {
             strokeWidth = 1.6f
         })
         val cyText = (top + bottom) / 2f
-        var x = left + pad - 4f
+        // Red circle + white glyph, matching the pins.
+        val circleCx = left + pad + circleR
+        canvas.drawCircle(circleCx, cyText, circleR, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.parseColor(RESULT_RED) })
         val glyphPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             typeface = tf
-            color = glyphColor
-            textSize = glyphSize
+            color = Color.WHITE
+            textSize = circleR * 1.3f
+            textAlign = Paint.Align.CENTER
         }
         var fm = glyphPaint.fontMetrics
-        canvas.drawText(String(Character.toChars(codepoint)), x, cyText - (fm.ascent + fm.descent) / 2f, glyphPaint)
-        x += glyphSize + gap
+        canvas.drawText(String(Character.toChars(codepoint)), circleCx, cyText - (fm.ascent + fm.descent) / 2f, glyphPaint)
         fm = textPaint.fontMetrics
-        canvas.drawText(label, x, cyText - (fm.ascent + fm.descent) / 2f, textPaint)
-        x += textW + gap * 0.6f
-        val starPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            typeface = tf
-            color = star
-            textSize = starSize
-        }
-        fm = starPaint.fontMetrics
-        canvas.drawText(String(Character.toChars(0xe838)), x, cyText - (fm.ascent + fm.descent) / 2f, starPaint)
+        canvas.drawText(label, circleCx + circleR + gap, cyText - (fm.ascent + fm.descent) / 2f, textPaint)
         return bmp
     }
 

--- a/app/src/main/java/app/vela/ui/map/PoiIcons.kt
+++ b/app/src/main/java/app/vela/ui/map/PoiIcons.kt
@@ -115,15 +115,17 @@ object PoiIcons {
     /** A GREY teardrop pin with a RED circle holding the white category glyph — the app's own
      *  marker language (grey backing, coloured dot) with red standing in for the category colour,
      *  which is how a result reads as a result (user 2026-07-10). Pin TIP at bottom-centre, for a
-     *  bottom-anchored layer (the tip marks the place, Google-style). */
+     *  bottom-anchored layer (the tip marks the place, Google-style). The GEOMETRY is [marker]'s
+     *  exact proportions scaled to 0.86 — an earlier taller-tailed variant read as a different
+     *  species of pin next to the ambient icons (user 2026-07-10); keep the two in lockstep. */
     private fun resultPin(tf: Typeface, codepoint: Int): Bitmap {
         val w = 86
-        val h = 94
+        val h = 79
         val bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bmp)
         val cx = w / 2f
-        val bodyCy = h * 0.36f
-        val bodyR = w * 0.335f
+        val bodyCy = h / 2f
+        val bodyR = w * 0.32f
         val tipY = h - 4f
         val d = tipY - bodyCy
         val sin = (bodyR / d).coerceAtMost(0.985f)
@@ -148,11 +150,11 @@ object PoiIcons {
         })
         canvas.restore()
         canvas.drawPath(teardrop, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.parseColor("#9AA0A6") })
-        canvas.drawCircle(cx, bodyCy, bodyR * 0.82f, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.parseColor(RESULT_RED) })
+        canvas.drawCircle(cx, bodyCy, w * 0.27f, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.parseColor(RESULT_RED) })
         val text = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             typeface = tf
             color = Color.WHITE
-            textSize = w * 0.33f
+            textSize = w * 0.32f
             textAlign = Paint.Align.CENTER
         }
         val glyph = String(Character.toChars(codepoint))

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -203,6 +203,7 @@ fun VelaMapView(
     navMode: Boolean,
     navFollowing: Boolean = true,
     onNavPanned: () -> Unit = {},
+    ambientCoversView: Boolean = false, // viewport inside the ambient-Google fetch area → OSM POIs yield
     onScaleChanged: (metersPerPixel: Double) -> Unit = {},
     darkTheme: Boolean,
     applyKeylessTheme: Boolean,
@@ -360,6 +361,13 @@ fun VelaMapView(
         // VISIBLE on nav end while its gate still says NONE left doubled icons until the next
         // state flip. Nulling the gate makes the next applyData frame re-assert the right value.
         lastOsmPoiVis = null
+        // Stop signs + lights stay a NAV aid at z16; on the browse map they hold back until true
+        // street zoom (user 2026-07-10: too busy mid-zoom without a route on screen).
+        runCatching {
+            val minZ = if (navMode) 16f else 17.5f
+            (style.getLayer(CONTROLS_LAYER))?.minZoom = minZ
+            (style.getLayer(CONTROLS_CLAIM_LAYER))?.minZoom = minZ
+        }
     }
 
     // Open building-footprint overlays (Microsoft, ODbL — PMTiles): render each region's footprints in a fill
@@ -1069,13 +1077,13 @@ fun VelaMapView(
                 lastGradM[0] = -1e9 // force the nav split to re-render on the fresh style
                 PoiIcons.addTo(context, style)
                 if (applyKeylessTheme) applyMapTheme(style, darkTheme) else tuneMapTiler(style, darkTheme)
-                applyData(map, style, context, darkTheme, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, displayLoc, displayBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
+                applyData(map, style, context, darkTheme, ambientCoversView, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, displayLoc, displayBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
                 ensureTraffic(style, trafficOn)
                 ensureTransit(style, transitOn)
             }
         } else {
             styleRef?.let {
-                applyData(map, it, context, darkTheme, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, displayLoc, displayBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
+                applyData(map, it, context, darkTheme, ambientCoversView, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, displayLoc, displayBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
                 ensureTraffic(it, trafficOn)
                 ensureTransit(it, transitOn)
             }
@@ -2184,6 +2192,7 @@ private fun applyData(
     style: Style,
     context: android.content.Context,
     dark: Boolean,
+    ambientCoversView: Boolean,
     route: List<LatLng>,
     routeColor: String,
     routeDashed: Boolean,
@@ -2361,7 +2370,11 @@ private fun applyData(
     // clutter. Its OWN identity gate (not the ambient one): results can appear/clear while the
     // ambient list stays empty, and the old placement inside the ambient gate would strand the
     // visibility stale. OSM transit + the rest of the basemap always stay.
-    val osmPoiVis = if (ambientPois.isNotEmpty() || markers.size > 1) Property.NONE else Property.VISIBLE
+    // BLEND, don't blanket-hide (user 2026-07-10): the OSM basemap POIs hide only while the
+    // viewport truly sits inside the ambient fetch's covered area — pan or zoom past it and the
+    // OSM icons return immediately (the ambient dots still draw where they exist, so the covered
+    // core keeps Google's data and the outskirts keep OSM's, merging as fresh fetches land).
+    val osmPoiVis = if (ambientCoversView || markers.size > 1) Property.NONE else Property.VISIBLE
     if (osmPoiVis != lastOsmPoiVis) {
         listOf("poi_r1", "poi_r7", "poi_r20").forEach { id ->
             style.getLayer(id)?.setProperties(PropertyFactory.visibility(osmPoiVis))

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1423,8 +1423,16 @@ private fun ensureLayers(style: Style) {
                 // centre→text-edge gap in ems; 1.4 sits the label right up against the dot (was 2.7 → 2.0 →
                 // 1.4 across "too far" reports) while still clearing it. justify=auto so the left form
                 // right-justifies and the under form centres. (Tune from a device glance if it crowds the dot.)
+                // Four anchor slots (left of the icon, right of it, below, above) instead of the
+                // old two — with only left/below to try, a crowded block DROPPED labels (or let
+                // one sit on a neighbour's dot) when both slots were taken; a third/fourth side
+                // usually still fits. Icons still collide by design; this only helps the labels
+                // of the icons that DO render find a clear side (user 2026-07-10).
                 PropertyFactory.textVariableAnchor(
-                    arrayOf(Property.TEXT_ANCHOR_RIGHT, Property.TEXT_ANCHOR_TOP),
+                    arrayOf(
+                        Property.TEXT_ANCHOR_RIGHT, Property.TEXT_ANCHOR_LEFT,
+                        Property.TEXT_ANCHOR_TOP, Property.TEXT_ANCHOR_BOTTOM,
+                    ),
                 ),
                 PropertyFactory.textRadialOffset(1.4f),
                 PropertyFactory.textJustify(Property.TEXT_JUSTIFY_AUTO),

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -155,6 +155,7 @@ private var lastAccuracyM: Float? = null
 private var parkingApplied = false // distinguishes "never applied" from "applied null"
 private var lastAppliedControls: List<app.vela.core.data.TrafficControl>? = null
 private var lastOsmPoiVis: String? = null // identity-gate the basemap-POI visibility flips
+private var lastControlsVis: String? = null // identity-gate the traffic-control visibility flips
 private var lastAppliedRouteLine: List<LatLng>? = null // identity-gate the route upload — applyData runs
                                                        // every recomposition and re-tessellating a
                                                        // thousands-of-vertices linestring per fix burned
@@ -1040,6 +1041,7 @@ fun VelaMapView(
                 ensureLayers(style)
                 lastAppliedMarkers = null // fresh style = empty sources; force applyData to repopulate
                 lastOsmPoiVis = null
+                lastControlsVis = null
                 parkingApplied = false
                 lastAppliedAmbient = null
                 lastAppliedControls = null
@@ -2331,6 +2333,16 @@ private fun applyData(
             style.getLayer(id)?.setProperties(PropertyFactory.visibility(osmPoiVis))
         }
         lastOsmPoiVis = osmPoiVis
+    }
+    // Stop signs + traffic lights step aside during a search too (results are the subject; the
+    // junction furniture reads as clutter behind them) — but UNLIKE the basemap POIs they stay
+    // up alongside the ambient dots on the browse map, so this keys on the result set alone.
+    val controlsVis = if (markers.size > 1) Property.NONE else Property.VISIBLE
+    if (controlsVis != lastControlsVis) {
+        listOf(CONTROLS_LAYER, CONTROLS_CLAIM_LAYER).forEach { id ->
+            style.getLayer(id)?.setProperties(PropertyFactory.visibility(controlsVis))
+        }
+        lastControlsVis = controlsVis
     }
 
     // Traffic controls (lights + stop signs) → icon features. Identity-gated like markers/ambient so a

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -279,7 +279,24 @@ fun VelaMapView(
     // when you PAN (in the move listener, so a pan→Re-center returns to auto-zoom) and when nav
     // ends. Keyed on navMode, NOT navFollowing — navFollowing flips while panning and would
     // otherwise nuke a just-set pinch zoom, snapping it back to auto a beat later.
-    LaunchedEffect(navMode) { if (!navMode) navUserZoom[0] = Double.NaN }
+    LaunchedEffect(navMode) {
+        if (navMode) return@LaunchedEffect
+        navUserZoom[0] = Double.NaN
+        // Ending nav returns the camera to Google's flat north-up browse view — the follow
+        // camera's last bearing/tilt used to linger, which also left the compass pinned on the
+        // map (it only hides facing north; user 2026-07-10).
+        mapRef?.let { m ->
+            val cam = m.cameraPosition
+            if (kotlin.math.abs(cam.bearing) > 0.5 || cam.tilt > 0.5) {
+                m.animateCamera(
+                    org.maplibre.android.camera.CameraUpdateFactory.newCameraPosition(
+                        org.maplibre.android.camera.CameraPosition.Builder(cam).bearing(0.0).tilt(0.0).build(),
+                    ),
+                    600,
+                )
+            }
+        }
+    }
     remember { MapLibre.getInstance(context) }
     // D-pad-only operation (docs/dpad.md): MapLibre's MapView calls requestFocus() on
     // itself and overrides onKeyDown to handle hardware D-pad keys (DPAD_CENTER = zoom in,
@@ -340,6 +357,10 @@ fun VelaMapView(
                 style.getLayer(id)?.setProperties(PropertyFactory.visibility(vis))
             }
         }
+        // This write races applyData's ambient/search suppression of the same layers: forcing
+        // VISIBLE on nav end while its gate still says NONE left doubled icons until the next
+        // state flip. Nulling the gate makes the next applyData frame re-assert the right value.
+        lastOsmPoiVis = null
     }
 
     // Open building-footprint overlays (Microsoft, ODbL — PMTiles): render each region's footprints in a fill

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -87,6 +87,10 @@ private const val ALT_ROUTE_LAYER = "vela-alt-route"
 private const val ALT_INDEX_PROP = "vela-alt-index"
 private const val MARKERS_SRC = "vela-markers-src"
 private const val MARKERS_LAYER = "vela-markers"
+// Collapsed search results: the same source drawn as small red dots UNDER the pins. The pin layer
+// collides (best rank wins the slot); a result whose pin is culled still shows as its dot, which
+// "expands" into the pin as you zoom in - Google's dense-results behaviour.
+private const val MARKERS_DOTS_LAYER = "vela-markers-dots"
 private const val PIN_IMG = "vela-pin"
 // The saved parking spot: one teal "P" pin, tappable (opens the parked-car sheet).
 private const val PARKING_SRC = "vela-parking-src"
@@ -138,7 +142,7 @@ private const val TRAFFIC_TILES =
 
 /** A tappable search-result pin on the map. [prominence] (0 = unknown/low) drives the ambient dot's
  *  size + keep-distance so anchor stores read bigger and show from farther, Google-style. */
-data class MapMarker(val name: String, val location: LatLng, val category: String? = null, val prominence: Double = 0.0)
+data class MapMarker(val name: String, val location: LatLng, val category: String? = null, val prominence: Double = 0.0, val rating: Double? = null)
 
 // Last marker/ambient lists actually pushed to the GeoJSON sources, so applyData can skip a redundant
 // setGeoJson (a full symbol re-tessellation) when they're unchanged. Nulled on style reload (the fresh
@@ -1041,13 +1045,13 @@ fun VelaMapView(
                 lastGradM[0] = -1e9 // force the nav split to re-render on the fresh style
                 PoiIcons.addTo(context, style)
                 if (applyKeylessTheme) applyMapTheme(style, darkTheme) else tuneMapTiler(style, darkTheme)
-                applyData(map, style, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, displayLoc, displayBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
+                applyData(map, style, context, darkTheme, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, displayLoc, displayBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
                 ensureTraffic(style, trafficOn)
                 ensureTransit(style, transitOn)
             }
         } else {
             styleRef?.let {
-                applyData(map, it, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, displayLoc, displayBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
+                applyData(map, it, context, darkTheme, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, displayLoc, displayBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
                 ensureTraffic(it, trafficOn)
                 ensureTransit(it, transitOn)
             }
@@ -1320,23 +1324,33 @@ private fun ensureLayers(style: Style) {
     if (style.getImage(PIN_IMG) == null) style.addImage(PIN_IMG, pinBitmap())
     if (style.getSource(MARKERS_SRC) == null) {
         style.addSource(GeoJsonSource(MARKERS_SRC))
-        // Search results draw as REAL POI icons with their names (the same vela-poi-<group>
-        // images the ambient dots use, sized up so results pop), not anonymous red pins -
-        // "restaurants" reads as a map of named restaurants, Google-style. Icons always show
-        // (results must all be visible at the fitted zoom); labels yield when crowded.
+        // Search results, Google's treatment: every result is a RED marker that keeps its
+        // category glyph (rated food places get the wide rating bubble instead - see PoiIcons),
+        // and the pins COLLIDE by rank instead of stacking - in a dense downtown the best
+        // results keep their pins and the rest collapse to the little red dots below, expanding
+        // back into pins as you zoom in. Labels sit under the pin and yield when crowded.
+        PoiIcons.addResultDot(style)
+        style.addLayer(
+            SymbolLayer(MARKERS_DOTS_LAYER, MARKERS_SRC).withProperties(
+                PropertyFactory.iconImage(PoiIcons.RESULT_DOT_IMG),
+                PropertyFactory.iconAllowOverlap(true),
+                PropertyFactory.iconIgnorePlacement(true),
+            ),
+        )
         style.addLayer(
             SymbolLayer(MARKERS_LAYER, MARKERS_SRC).withProperties(
                 PropertyFactory.iconImage(Expression.get("icon")),
-                PropertyFactory.iconSize(1.3f),
-                PropertyFactory.iconAllowOverlap(true),
-                PropertyFactory.iconIgnorePlacement(true),
+                PropertyFactory.iconSize(1.15f),
+                PropertyFactory.iconAnchor(Property.ICON_ANCHOR_BOTTOM),
+                PropertyFactory.iconAllowOverlap(false),
+                PropertyFactory.iconIgnorePlacement(false),
+                PropertyFactory.iconPadding(2f),
+                PropertyFactory.symbolSortKey(Expression.get("rank")),
                 PropertyFactory.textField(Expression.get("name")),
                 PropertyFactory.textFont(arrayOf("Noto Sans Regular")),
                 PropertyFactory.textSize(13f),
-                PropertyFactory.textVariableAnchor(
-                    arrayOf(Property.TEXT_ANCHOR_RIGHT, Property.TEXT_ANCHOR_TOP),
-                ),
-                PropertyFactory.textRadialOffset(1.4f),
+                PropertyFactory.textVariableAnchor(arrayOf(Property.TEXT_ANCHOR_TOP)),
+                PropertyFactory.textRadialOffset(0.5f),
                 PropertyFactory.textJustify(Property.TEXT_JUSTIFY_AUTO),
                 PropertyFactory.textMaxWidth(7f),
                 PropertyFactory.textOptional(true),
@@ -1638,9 +1652,10 @@ private fun applyMapTheme(style: Style, dark: Boolean) {
         PropertyFactory.textColor(PoiIcons.ambientLabelColor(dark)),
         PropertyFactory.textHaloColor(if (dark) "#11161C" else "#FFFFFF"),
     )
-    // Search-result labels take the same themed treatment (results are category icons now).
+    // Search-result labels stay NEUTRAL ink - Google doesn't category-tint result labels the
+    // way it tints ambient POI labels (the red pin is the result signal, not the text colour).
     (style.getLayer(MARKERS_LAYER) as? SymbolLayer)?.setProperties(
-        PropertyFactory.textColor(PoiIcons.ambientLabelColor(dark)),
+        PropertyFactory.textColor(if (dark) "#E8EAED" else "#3C4043"),
         PropertyFactory.textHaloColor(if (dark) "#11161C" else "#FFFFFF"),
     )
     // Hide Liberty's dashed clutter that Google doesn't draw: footpaths/sidewalks,
@@ -2129,6 +2144,8 @@ private fun routeGradient(
 private fun applyData(
     map: org.maplibre.android.maps.MapLibreMap,
     style: Style,
+    context: android.content.Context,
+    dark: Boolean,
     route: List<LatLng>,
     routeColor: String,
     routeDashed: Boolean,
@@ -2261,9 +2278,16 @@ private fun applyData(
     if (markers != lastAppliedMarkers) {
         val markersFc = FeatureCollection.fromFeatures(
             markers.mapIndexed { i, m ->
+                // Results arrive in relevance order, so the index IS the collision rank (lower
+                // sort key places first = wins the slot). Rated food places get the rating
+                // bubble, everything else the red category pin; bitmaps are generated on demand
+                // per style (they're theme-dependent), see PoiIcons.ensureResultIcon.
+                val iconKey = PoiIcons.resultIconKey(m.name, m.category, m.rating)
+                PoiIcons.ensureResultIcon(context, style, iconKey, dark)
                 Feature.fromGeometry(Point.fromLngLat(m.location.lng, m.location.lat)).apply {
                     addStringProperty("name", m.name)
-                    addStringProperty("icon", "vela-poi-${PoiIcons.groupFor(m.name, m.category)}")
+                    addStringProperty("icon", iconKey)
+                    addNumberProperty("rank", i)
                     addNumberProperty(MARKER_INDEX_PROP, i)
                 }
             },

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -279,24 +279,7 @@ fun VelaMapView(
     // when you PAN (in the move listener, so a pan→Re-center returns to auto-zoom) and when nav
     // ends. Keyed on navMode, NOT navFollowing — navFollowing flips while panning and would
     // otherwise nuke a just-set pinch zoom, snapping it back to auto a beat later.
-    LaunchedEffect(navMode) {
-        if (navMode) return@LaunchedEffect
-        navUserZoom[0] = Double.NaN
-        // Ending nav returns the camera to Google's flat north-up browse view — the follow
-        // camera's last bearing/tilt used to linger, which also left the compass pinned on the
-        // map (it only hides facing north; user 2026-07-10).
-        mapRef?.let { m ->
-            val cam = m.cameraPosition
-            if (kotlin.math.abs(cam.bearing) > 0.5 || cam.tilt > 0.5) {
-                m.animateCamera(
-                    org.maplibre.android.camera.CameraUpdateFactory.newCameraPosition(
-                        org.maplibre.android.camera.CameraPosition.Builder(cam).bearing(0.0).tilt(0.0).build(),
-                    ),
-                    600,
-                )
-            }
-        }
-    }
+    LaunchedEffect(navMode) { if (!navMode) navUserZoom[0] = Double.NaN }
     remember { MapLibre.getInstance(context) }
     // D-pad-only operation (docs/dpad.md): MapLibre's MapView calls requestFocus() on
     // itself and overrides onKeyDown to handle hardware D-pad keys (DPAD_CENTER = zoom in,
@@ -315,6 +298,22 @@ fun VelaMapView(
     }
 
     var mapRef by remember { mutableStateOf<MapLibreMap?>(null) }
+    // Ending nav returns the camera to Google's flat north-up browse view — the follow camera's
+    // last bearing/tilt used to linger, which also left the compass pinned on the map (it only
+    // hides facing north; user 2026-07-10). Below mapRef so the handle is in scope.
+    LaunchedEffect(navMode, mapRef) {
+        if (navMode) return@LaunchedEffect
+        val m = mapRef ?: return@LaunchedEffect
+        val cam = m.cameraPosition
+        if (kotlin.math.abs(cam.bearing) > 0.5 || cam.tilt > 0.5) {
+            m.animateCamera(
+                org.maplibre.android.camera.CameraUpdateFactory.newCameraPosition(
+                    org.maplibre.android.camera.CameraPosition.Builder(cam).bearing(0.0).tilt(0.0).build(),
+                ),
+                600,
+            )
+        }
+    }
     var styleRef by remember { mutableStateOf<Style?>(null) }
     var appliedStyleKey by remember { mutableStateOf<String?>(null) }
     var lastCameraTarget by remember { mutableStateOf<LatLng?>(null) }

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1320,12 +1320,30 @@ private fun ensureLayers(style: Style) {
     if (style.getImage(PIN_IMG) == null) style.addImage(PIN_IMG, pinBitmap())
     if (style.getSource(MARKERS_SRC) == null) {
         style.addSource(GeoJsonSource(MARKERS_SRC))
+        // Search results draw as REAL POI icons with their names (the same vela-poi-<group>
+        // images the ambient dots use, sized up so results pop), not anonymous red pins -
+        // "restaurants" reads as a map of named restaurants, Google-style. Icons always show
+        // (results must all be visible at the fitted zoom); labels yield when crowded.
         style.addLayer(
             SymbolLayer(MARKERS_LAYER, MARKERS_SRC).withProperties(
-                PropertyFactory.iconImage(PIN_IMG),
-                PropertyFactory.iconAnchor(Property.ICON_ANCHOR_BOTTOM),
+                PropertyFactory.iconImage(Expression.get("icon")),
+                PropertyFactory.iconSize(1.3f),
                 PropertyFactory.iconAllowOverlap(true),
                 PropertyFactory.iconIgnorePlacement(true),
+                PropertyFactory.textField(Expression.get("name")),
+                PropertyFactory.textFont(arrayOf("Noto Sans Regular")),
+                PropertyFactory.textSize(13f),
+                PropertyFactory.textVariableAnchor(
+                    arrayOf(Property.TEXT_ANCHOR_RIGHT, Property.TEXT_ANCHOR_TOP),
+                ),
+                PropertyFactory.textRadialOffset(1.4f),
+                PropertyFactory.textJustify(Property.TEXT_JUSTIFY_AUTO),
+                PropertyFactory.textMaxWidth(7f),
+                PropertyFactory.textOptional(true),
+                PropertyFactory.textAllowOverlap(false),
+                PropertyFactory.textColor("#3C4043"),
+                PropertyFactory.textHaloColor("#FFFFFF"),
+                PropertyFactory.textHaloWidth(0.9f),
             ),
         )
     }
@@ -1617,6 +1635,11 @@ private fun applyMapTheme(style: Style, dark: Boolean) {
     // Ambient Google-POI labels match the ICON's category colour, Google-style — saturated in light,
     // pastel tints in dark (see PoiIcons.labelColor). Search-result pins stay plain (Google does too).
     (style.getLayer(AMBIENT_LAYER) as? SymbolLayer)?.setProperties(
+        PropertyFactory.textColor(PoiIcons.ambientLabelColor(dark)),
+        PropertyFactory.textHaloColor(if (dark) "#11161C" else "#FFFFFF"),
+    )
+    // Search-result labels take the same themed treatment (results are category icons now).
+    (style.getLayer(MARKERS_LAYER) as? SymbolLayer)?.setProperties(
         PropertyFactory.textColor(PoiIcons.ambientLabelColor(dark)),
         PropertyFactory.textHaloColor(if (dark) "#11161C" else "#FFFFFF"),
     )
@@ -2240,6 +2263,7 @@ private fun applyData(
             markers.mapIndexed { i, m ->
                 Feature.fromGeometry(Point.fromLngLat(m.location.lng, m.location.lat)).apply {
                     addStringProperty("name", m.name)
+                    addStringProperty("icon", "vela-poi-${PoiIcons.groupFor(m.name, m.category)}")
                     addNumberProperty(MARKER_INDEX_PROP, i)
                 }
             },

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1353,8 +1353,14 @@ private fun ensureLayers(style: Style) {
                 PropertyFactory.textField(Expression.get("name")),
                 PropertyFactory.textFont(arrayOf("Noto Sans Regular")),
                 PropertyFactory.textSize(13f),
-                PropertyFactory.textVariableAnchor(arrayOf(Property.TEXT_ANCHOR_TOP)),
-                PropertyFactory.textRadialOffset(0.5f),
+                // Labels try BELOW the pin first, then the pin's right side, then its left —
+                // a below-only anchor made crowded results drop labels (or sit on a neighbour's
+                // dot) when the space under the pin was taken; a side slot usually still fits.
+                // (Anchor semantics: TOP = text below the point, LEFT = text right of it.)
+                PropertyFactory.textVariableAnchor(
+                    arrayOf(Property.TEXT_ANCHOR_TOP, Property.TEXT_ANCHOR_LEFT, Property.TEXT_ANCHOR_RIGHT),
+                ),
+                PropertyFactory.textRadialOffset(0.7f),
                 PropertyFactory.textJustify(Property.TEXT_JUSTIFY_AUTO),
                 PropertyFactory.textMaxWidth(7f),
                 PropertyFactory.textOptional(true),

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -154,6 +154,7 @@ private var lastAccuracyLoc: LatLng? = null
 private var lastAccuracyM: Float? = null
 private var parkingApplied = false // distinguishes "never applied" from "applied null"
 private var lastAppliedControls: List<app.vela.core.data.TrafficControl>? = null
+private var lastOsmPoiVis: String? = null // identity-gate the basemap-POI visibility flips
 private var lastAppliedRouteLine: List<LatLng>? = null // identity-gate the route upload — applyData runs
                                                        // every recomposition and re-tessellating a
                                                        // thousands-of-vertices linestring per fix burned
@@ -1038,6 +1039,7 @@ fun VelaMapView(
                 styleRef = style
                 ensureLayers(style)
                 lastAppliedMarkers = null // fresh style = empty sources; force applyData to repopulate
+                lastOsmPoiVis = null
                 parkingApplied = false
                 lastAppliedAmbient = null
                 lastAppliedControls = null
@@ -2313,14 +2315,22 @@ private fun applyData(
             },
         )
         style.getSourceAs<GeoJsonSource>(AMBIENT_SRC)?.setGeoJson(ambientFc)
-        // Google-first: while ambient Google POIs are showing, hide the OSM *business* POIs
-        // (poi_r1/r7/r20) so the layers don't duplicate. OSM transit + the whole OSM basemap stay; when
-        // there are no ambient POIs (zoomed out / offline / nav / search) the OSM POIs come back.
-        val osmPoiVis = if (ambientPois.isNotEmpty()) Property.NONE else Property.VISIBLE
+        lastAppliedAmbient = ambientPois
+    }
+
+    // Google-first: hide the OSM *business* POIs (poi_r1/r7/r20) while EITHER the ambient Google
+    // dots are up (the layers would duplicate) OR a search's result set is on the map — during
+    // search only the results should read as places (Google declutters the same way). A single
+    // selected place (markers.size == 1) keeps the basemap POIs: its neighbours are context, not
+    // clutter. Its OWN identity gate (not the ambient one): results can appear/clear while the
+    // ambient list stays empty, and the old placement inside the ambient gate would strand the
+    // visibility stale. OSM transit + the rest of the basemap always stay.
+    val osmPoiVis = if (ambientPois.isNotEmpty() || markers.size > 1) Property.NONE else Property.VISIBLE
+    if (osmPoiVis != lastOsmPoiVis) {
         listOf("poi_r1", "poi_r7", "poi_r20").forEach { id ->
             style.getLayer(id)?.setProperties(PropertyFactory.visibility(osmPoiVis))
         }
-        lastAppliedAmbient = ambientPois
+        lastOsmPoiVis = osmPoiVis
     }
 
     // Traffic controls (lights + stop signs) → icon features. Identity-gated like markers/ambient so a


### PR DESCRIPTION
Searching a category filled the map with anonymous red pins. Results now render with the same vela-poi category icons the basemap uses, sized up to stand out, each with its name beside it; labels use the ambient POI label treatment in both themes and yield when crowded while the icons always show. Tap targeting and the result-cluster camera framing are unchanged. Verified on device: a restaurants search shows named restaurant icons across downtown.