### PR TITLE
The results list rides its throws, and back exits the search in one press

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,9 +318,13 @@ Defaults that make the safe path the easy one:
   bar while `resultsShown` AND bumps `sheetPanTick` → PlaceSheet's `minimizeTick` effect glides
   an open place card to its minimized detent — Google's behaviour; programmatic framing (a
   different move reason) never triggers it. Both drops use a SOFT spring (stiffness 140f, vs
-  the 350f settle) — at settle stiffness the unprompted drop read as a blink (user 2026-07-10);
-  the place-sheet tick effect animates on VALUE not targetValue so it deliberately replaces the
-  state-flip effect's quicker settle. **Filter
+  the 350f settle) and both GLIDE FIRST, FLIP STATE AFTER — the pan path used to flip
+  `resultsCollapsed`/`minimizedState` immediately, which unmounted/switched the content
+  mid-drop and read as a pop no matter the spring (user 2026-07-10, the "just kinda pops down"
+  report); the tick effects animate to the floor and only then flip, the same order the drag
+  path always used. The minimized results bar leads with the QUERY (or list name) in ink +
+  SemiBold, then "· N results" in dim (`barTitle` annotated string) — the bare dim count was
+  easy to miss. **Filter
   chips are `ElevatedFilterChip` with an explicit filled `chipColors`** (subtle alpha tint off, solid
   `primary` teal + check on, `border = null`). **Chrome:** `resultsShown` (peek/expanded) hides the
   scale bar / locate FAB / "Search this area"; `resultsMinimized` shows them again but LIFTED by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,11 +312,15 @@ Defaults that make the safe path the easy one:
   while the sheet is minimized so expanding re-frames; and the fit CONSUMES `lastCameraTarget` - the
   inset-grow nulls it, and with it null the else-recenter branch re-fired on the STALE VM center one
   recomposition later and yanked the camera back to wherever you were before the search (device-found
-  2026-07-09, the "search framed then snapped home" bug). There is **NO "hide results" button**. **Grabbing the map minimizes the list (2026-07-10):**
+  2026-07-09, the "search framed then snapped home" bug). There is **NO "hide results" button**. **Grabbing the map minimizes the sheets (2026-07-10):**
   `VelaMapView.onUserPan` (fired from the camera-move-started listener on REASON_API_GESTURE,
-  the same signal "Search this area" keys off) → MapScreen collapses the sheet to its bar while
-  `resultsShown` — Google's behaviour; programmatic framing (a different move reason) never
-  triggers it. **Filter
+  the same signal "Search this area" keys off) → MapScreen collapses the results sheet to its
+  bar while `resultsShown` AND bumps `sheetPanTick` → PlaceSheet's `minimizeTick` effect glides
+  an open place card to its minimized detent — Google's behaviour; programmatic framing (a
+  different move reason) never triggers it. Both drops use a SOFT spring (stiffness 140f, vs
+  the 350f settle) — at settle stiffness the unprompted drop read as a blink (user 2026-07-10);
+  the place-sheet tick effect animates on VALUE not targetValue so it deliberately replaces the
+  state-flip effect's quicker settle. **Filter
   chips are `ElevatedFilterChip` with an explicit filled `chipColors`** (subtle alpha tint off, solid
   `primary` teal + check on, `border = null`). **Chrome:** `resultsShown` (peek/expanded) hides the
   scale bar / locate FAB / "Search this area"; `resultsMinimized` shows them again but LIFTED by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,11 @@ Defaults that make the safe path the easy one:
   while the sheet is minimized so expanding re-frames; and the fit CONSUMES `lastCameraTarget` - the
   inset-grow nulls it, and with it null the else-recenter branch re-fired on the STALE VM center one
   recomposition later and yanked the camera back to wherever you were before the search (device-found
-  2026-07-09, the "search framed then snapped home" bug). There is **NO "hide results" button**. **Filter
+  2026-07-09, the "search framed then snapped home" bug). There is **NO "hide results" button**. **Grabbing the map minimizes the list (2026-07-10):**
+  `VelaMapView.onUserPan` (fired from the camera-move-started listener on REASON_API_GESTURE,
+  the same signal "Search this area" keys off) → MapScreen collapses the sheet to its bar while
+  `resultsShown` — Google's behaviour; programmatic framing (a different move reason) never
+  triggers it. **Filter
   chips are `ElevatedFilterChip` with an explicit filled `chipColors`** (subtle alpha tint off, solid
   `primary` teal + check on, `border = null`). **Chrome:** `resultsShown` (peek/expanded) hides the
   scale bar / locate FAB / "Search this area"; `resultsMinimized` shows them again but LIFTED by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,8 +323,12 @@ Defaults that make the safe path the easy one:
   mid-drop and read as a pop no matter the spring (user 2026-07-10, the "just kinda pops down"
   report); the tick effects animate to the floor and only then flip, the same order the drag
   path always used. The minimized results bar leads with the QUERY (or list name) in ink +
-  SemiBold, then "· N results" in dim (`barTitle` annotated string) — the bare dim count was
-  easy to miss. **Filter
+  SemiBold with the dim count on its OWN LINE under it (the inline "title · count" floated
+  awkwardly against the right-side buttons) — the bare dim count was easy to miss. BOTH pan-tick
+  effects carry a **seenTick consume-once guard** (initialized to the tick's mount-time value):
+  a LaunchedEffect fires on FIRST composition too, so a remounted sheet (pick a place from the
+  list, or return from one) used to replay the stale tick and open pre-minimized (user
+  2026-07-10). Any new tick-style signal into a sheet needs the same guard. **Filter
   chips are `ElevatedFilterChip` with an explicit filled `chipColors`** (subtle alpha tint off, solid
   `primary` teal + check on, `border = null`). **Chrome:** `resultsShown` (peek/expanded) hides the
   scale bar / locate FAB / "Search this area"; `resultsMinimized` shows them again but LIFTED by

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -220,7 +220,9 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   follows your finger and rides the throw's inertia to the nearest size, minimizing included, and
   the back gesture exits the search in one press instead of stepping through sizes. Grabbing the
   map GLIDES the list down to its bar so the map is yours to look at, and does the same to an
-  open place card (down to its small state); the bar or a drag brings them back.
+  open place card (down to its small state); the bar or a drag brings them back. The minimized
+  bar now says WHAT it's holding: the search text (or list name) leads in full ink, then the
+  result count, instead of an easy-to-miss dim "20 results".
 - ✅ **One tidy notification area (2026-07-10).** Heads-up messages, download progress, update
   offers and notices now stack below the search bar and chips (or just below the turn card during
   navigation, whatever its height), each dismissed on its own, instead of painting over each other.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -219,7 +219,8 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 - ✅ **The results list moves like the place card (2026-07-11).** Dragging the search results
   follows your finger and rides the throw's inertia to the nearest size, minimizing included, and
   the back gesture exits the search in one press instead of stepping through sizes. Grabbing the
-  map drops the list down to its bar so the map is yours to look at; the bar brings it back.
+  map GLIDES the list down to its bar so the map is yours to look at, and does the same to an
+  open place card (down to its small state); the bar or a drag brings them back.
 - ✅ **One tidy notification area (2026-07-10).** Heads-up messages, download progress, update
   offers and notices now stack below the search bar and chips (or just below the turn card during
   navigation, whatever its height), each dismissed on its own, instead of painting over each other.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -218,7 +218,8 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   stack too, so it can't sit under the turn card.
 - ✅ **The results list moves like the place card (2026-07-11).** Dragging the search results
   follows your finger and rides the throw's inertia to the nearest size, minimizing included, and
-  the back gesture exits the search in one press instead of stepping through sizes.
+  the back gesture exits the search in one press instead of stepping through sizes. Grabbing the
+  map drops the list down to its bar so the map is yours to look at; the bar brings it back.
 - ✅ **One tidy notification area (2026-07-10).** Heads-up messages, download progress, update
   offers and notices now stack below the search bar and chips (or just below the turn card during
   navigation, whatever its height), each dismissed on its own, instead of painting over each other.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -216,6 +216,9 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   is bigger and bolder, and the redundant "current traffic" note under it is gone (the route ETAs
   already show traffic). The faster-route offer during navigation joined the tidy notification
   stack too, so it can't sit under the turn card.
+- ✅ **The results list moves like the place card (2026-07-11).** Dragging the search results
+  follows your finger and rides the throw's inertia to the nearest size, minimizing included, and
+  the back gesture exits the search in one press instead of stepping through sizes.
 - ✅ **One tidy notification area (2026-07-10).** Heads-up messages, download progress, update
   offers and notices now stack below the search bar and chips (or just below the turn card during
   navigation, whatever its height), each dismissed on its own, instead of painting over each other.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -221,8 +221,8 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   the back gesture exits the search in one press instead of stepping through sizes. Grabbing the
   map GLIDES the list down to its bar so the map is yours to look at, and does the same to an
   open place card (down to its small state); the bar or a drag brings them back. The minimized
-  bar now says WHAT it's holding: the search text (or list name) leads in full ink, then the
-  result count, instead of an easy-to-miss dim "20 results".
+  bar now says WHAT it's holding: the search text (or list name) leads in full ink with the
+  result count under it, instead of an easy-to-miss dim "20 results".
 - ✅ **One tidy notification area (2026-07-10).** Heads-up messages, download progress, update
   offers and notices now stack below the search bar and chips (or just below the turn card during
   navigation, whatever its height), each dismissed on its own, instead of painting over each other.

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -132,7 +132,10 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import app.vela.R
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
@@ -297,9 +300,10 @@ fun MapScreen(
     // ANY size, not just full screen. The panel and the chrome are siblings in the same Box and the
     // chrome is declared later, so it stacks above the panel unless gated out (user 2026-07-08).
     val resultsShown = state.results.isNotEmpty() && state.selected == null && !searchOpen && !state.resultsCollapsed
-    // Bumped when the user grabs the map with the place sheet open — PlaceSheet glides down to
-    // its minimized card on each bump (see onUserPan below).
+    // Bumped when the user grabs the map with a sheet open — each sheet glides down to its
+    // minimized form on its bump (see onUserPan below).
     var sheetPanTick by remember { mutableStateOf(0) }
+    var resultsPanTick by remember { mutableStateOf(0) }
     // Expanded detent of the results bottom sheet, hoisted here so the BACK gesture can step it
     // one detent (expanded -> peek) before collapsing to the minimized bar (user 2026-07-09).
     var resultsExpanded by remember { mutableStateOf(false) }
@@ -695,7 +699,10 @@ fun MapScreen(
             // to look at (Google does the same): the results sheet to its bar, the place sheet to
             // its minimized card. The bar / a drag brings them back.
             onUserPan = {
-                if (resultsShown) vm.collapseResults()
+                // Bump ticks, don't flip state here: each sheet GLIDES down first and only then
+                // flips its collapsed state, so the bar/card swap happens invisibly (flipping
+                // straight away unmounted the content mid-drop — the "pops down" report).
+                if (resultsShown) resultsPanTick++
                 if (state.selected != null && !searchOpen) sheetPanTick++
             },
             onScaleChanged = { metersPerPixel = it },
@@ -1332,6 +1339,8 @@ fun MapScreen(
                 onExpand = vm::expandResults,
                 onClose = vm::clearSearch,
                 listName = state.openListId?.let { id -> state.lists.firstOrNull { it.id == id }?.name },
+                query = state.query,
+                minimizeTick = resultsPanTick,
                 modifier = Modifier.align(Alignment.BottomCenter),
               )
             // Imported Google list preview: offer to save (nothing persisted until tapped).
@@ -1694,6 +1703,8 @@ private fun SearchResults(
     onExpand: () -> Unit,
     onClose: () -> Unit,
     listName: String? = null, // set when the results ARE an open list — shown as the sheet title
+    query: String = "", // the search text — leads the minimized bar so it says WHAT the results are
+    minimizeTick: Int = 0, // bumped when the user grabs the map — glide down, THEN flip collapsed
     modifier: Modifier = Modifier,
 ) {
     // A BOTTOM sheet, Google-style, sharing the place sheet's detent grammar:
@@ -1723,6 +1734,13 @@ private fun SearchResults(
     LaunchedEffect(collapsed, expanded) {
         val target = if (collapsed) 0f else if (expanded) expL else peekL
         if (listH.targetValue != target) listH.animateTo(target, if (target == 0f) resultsGlideSpec else resultsSettleSpec)
+    }
+    // Map grabbed: glide the OPEN list down to zero and only then flip collapsed — the same
+    // order the drag path uses. Flipping first unmounts the list mid-drop (the visible "pop").
+    LaunchedEffect(minimizeTick) {
+        if (minimizeTick == 0 || collapsed) return@LaunchedEffect
+        listH.animateTo(0f, resultsGlideSpec)
+        onMinimize()
     }
     val listState = rememberLazyListState()
     val minimize = rememberUpdatedState(onMinimize)
@@ -1868,14 +1886,25 @@ private fun SearchResults(
                         .padding(start = 16.dp, end = 4.dp, top = 2.dp, bottom = if (collapsed) 8.dp else 0.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    // An open list leads with its NAME (the count alone didn't say which
-                    // list you were looking at); plain searches keep the count.
+                    // The bar says WHAT you're looking at, not just how many: the list name or
+                    // the search text leads in full ink, then a dot and the count in dim — the
+                    // bare dim "20 results" was easy to miss (user 2026-07-10).
+                    val barTitle = listName ?: query.trim().ifBlank { null }
                     Text(
-                        listName?.let { "$it · ${shown.size}" }
-                            ?: stringResource(R.string.mapscreen_results_count, shown.size),
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        color = if (listName != null) SheetPalette.ink(dark) else SheetPalette.dim(dark),
+                        buildAnnotatedString {
+                            if (barTitle != null) {
+                                withStyle(
+                                    SpanStyle(color = SheetPalette.ink(dark), fontWeight = FontWeight.SemiBold),
+                                ) { append(barTitle) }
+                                append("  ·  ")
+                            }
+                            append(
+                                if (listName != null) "${shown.size}"
+                                else stringResource(R.string.mapscreen_results_count, shown.size),
+                            )
+                        },
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = SheetPalette.dim(dark),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f),

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1737,8 +1737,12 @@ private fun SearchResults(
     }
     // Map grabbed: glide the OPEN list down to zero and only then flip collapsed — the same
     // order the drag path uses. Flipping first unmounts the list mid-drop (the visible "pop").
+    // seenTick consumes the mount-time value so a REMOUNT (returning from a place sheet) can't
+    // replay a stale pan as a fresh minimize (same guard as the place sheet).
+    var seenTick by remember { mutableStateOf(minimizeTick) }
     LaunchedEffect(minimizeTick) {
-        if (minimizeTick == 0 || collapsed) return@LaunchedEffect
+        if (minimizeTick == seenTick || collapsed) return@LaunchedEffect
+        seenTick = minimizeTick
         listH.animateTo(0f, resultsGlideSpec)
         onMinimize()
     }
@@ -1887,28 +1891,28 @@ private fun SearchResults(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     // The bar says WHAT you're looking at, not just how many: the list name or
-                    // the search text leads in full ink, then a dot and the count in dim — the
-                    // bare dim "20 results" was easy to miss (user 2026-07-10).
+                    // the search text leads in full ink with the count on its own line UNDER it —
+                    // the inline "title · count" floated awkwardly against the right-side buttons
+                    // (user 2026-07-10); stacked left-aligned lines read like a proper header.
                     val barTitle = listName ?: query.trim().ifBlank { null }
-                    Text(
-                        buildAnnotatedString {
-                            if (barTitle != null) {
-                                withStyle(
-                                    SpanStyle(color = SheetPalette.ink(dark), fontWeight = FontWeight.SemiBold),
-                                ) { append(barTitle) }
-                                append("  ·  ")
-                            }
-                            append(
-                                if (listName != null) "${shown.size}"
-                                else stringResource(R.string.mapscreen_results_count, shown.size),
+                    Column(Modifier.weight(1f)) {
+                        if (barTitle != null) {
+                            Text(
+                                barTitle,
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.SemiBold,
+                                color = SheetPalette.ink(dark),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
                             )
-                        },
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = SheetPalette.dim(dark),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
-                    )
+                        }
+                        Text(
+                            stringResource(R.string.mapscreen_results_count, shown.size),
+                            style = if (barTitle != null) MaterialTheme.typography.bodyMedium else MaterialTheme.typography.bodyLarge,
+                            color = SheetPalette.dim(dark),
+                            maxLines = 1,
+                        )
+                    }
                     IconButton(onClick = { if (collapsed) onExpand() else onExpandedChange(!expanded) }) {
                         Icon(
                             if (!collapsed && expanded) Icons.Default.KeyboardArrowDown else Icons.Default.KeyboardArrowUp,

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -688,6 +688,9 @@ fun MapScreen(
             navMode = state.navigating,
             navFollowing = !state.navCameraDetached,
             onNavPanned = vm::onNavPanned,
+            // Grabbing the map with the results sheet up drops the sheet to its minimized bar so
+            // the map is yours to look at (Google does the same); the bar brings it back.
+            onUserPan = { if (resultsShown) vm.collapseResults() },
             onScaleChanged = { metersPerPixel = it },
             darkTheme = darkTheme,
             applyKeylessTheme = !hasMapTiler,

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -297,6 +297,9 @@ fun MapScreen(
     // ANY size, not just full screen. The panel and the chrome are siblings in the same Box and the
     // chrome is declared later, so it stacks above the panel unless gated out (user 2026-07-08).
     val resultsShown = state.results.isNotEmpty() && state.selected == null && !searchOpen && !state.resultsCollapsed
+    // Bumped when the user grabs the map with the place sheet open — PlaceSheet glides down to
+    // its minimized card on each bump (see onUserPan below).
+    var sheetPanTick by remember { mutableStateOf(0) }
     // Expanded detent of the results bottom sheet, hoisted here so the BACK gesture can step it
     // one detent (expanded -> peek) before collapsing to the minimized bar (user 2026-07-09).
     var resultsExpanded by remember { mutableStateOf(false) }
@@ -688,9 +691,13 @@ fun MapScreen(
             navMode = state.navigating,
             navFollowing = !state.navCameraDetached,
             onNavPanned = vm::onNavPanned,
-            // Grabbing the map with the results sheet up drops the sheet to its minimized bar so
-            // the map is yours to look at (Google does the same); the bar brings it back.
-            onUserPan = { if (resultsShown) vm.collapseResults() },
+            // Grabbing the map with a sheet up drops it down out of the way so the map is yours
+            // to look at (Google does the same): the results sheet to its bar, the place sheet to
+            // its minimized card. The bar / a drag brings them back.
+            onUserPan = {
+                if (resultsShown) vm.collapseResults()
+                if (state.selected != null && !searchOpen) sheetPanTick++
+            },
             onScaleChanged = { metersPerPixel = it },
             darkTheme = darkTheme,
             applyKeylessTheme = !hasMapTiler,
@@ -1301,6 +1308,7 @@ fun MapScreen(
                 onRemoveFromList = { listId -> vm.removePlaceFromList(listId, state.selected!!) },
                 onCreateListWith = { name -> val id = vm.createList(name); vm.addPlaceToList(id, state.selected!!) },
                 onSetNote = { note -> vm.setPlaceNote(state.selected!!, note) },
+                minimizeTick = sheetPanTick,
                 // No navigationBarsPadding here: the sheet's background should reach
                 // the screen bottom (no map peeking through under the nav bar); the
                 // sheet pads its own content for the nav bar instead.
@@ -1707,10 +1715,14 @@ private fun SearchResults(
     val expL = screenH * 0.82f
     val listH = remember { Animatable(if (collapsed) 0f else if (expanded) expL else peekL) }
     val resultsSettleSpec = remember { spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = 350f) }
+    // Dropping to the bar GLIDES on a soft spring — at the settle stiffness the pan-triggered
+    // drop read as an abrupt blink (user 2026-07-10). Growing keeps the quicker settle so taps
+    // feel responsive.
+    val resultsGlideSpec = remember { spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = 140f) }
     val resultsDecay = remember { exponentialDecay<Float>(frictionMultiplier = 1.6f) }
     LaunchedEffect(collapsed, expanded) {
         val target = if (collapsed) 0f else if (expanded) expL else peekL
-        if (listH.targetValue != target) listH.animateTo(target, resultsSettleSpec)
+        if (listH.targetValue != target) listH.animateTo(target, if (target == 0f) resultsGlideSpec else resultsSettleSpec)
     }
     val listState = rememberLazyListState()
     val minimize = rememberUpdatedState(onMinimize)

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -120,6 +120,12 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.calculateTargetValue
+import androidx.compose.animation.core.exponentialDecay
+import androidx.compose.animation.core.spring
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
@@ -346,11 +352,10 @@ fun MapScreen(
             state.directionsOpen || state.activeRoute != null || state.routes.isNotEmpty() ||
                 state.transit.isNotEmpty() || state.transitLoading -> vm.clearRoute()
             state.selected != null -> vm.clearSelection()
-            // Results sheet: back steps ONE detent (expanded -> peek -> minimized -> cleared),
-            // never straight out of the app (a back on the minimized bar used to exit Vela).
-            resultsExpanded -> resultsExpanded = false
-            !state.resultsCollapsed -> vm.collapseResults()
-            else -> vm.clearSearch()
+            // Results sheet: BACK exits the search outright - the drag gestures, the handle and
+            // the X already cover stepping between sizes, so back-stepping detents just made
+            // leaving take three presses (user 2026-07-11).
+            else -> { resultsExpanded = false; vm.clearSearch() }
         }
     }
     // The map target is the focus surface ONLY when the map is primary — hidden while any
@@ -1691,44 +1696,80 @@ private fun SearchResults(
     // 0 = off; else the max price level to show (1=$ … 4=$$$$). Tapping the chip cycles.
     var priceMax by remember { mutableStateOf(0) }
     val screenH = LocalConfiguration.current.screenHeightDp
-    val listMaxH by animateDpAsState(
-        if (expanded) (screenH * 0.82f).dp else (screenH * 0.42f).dp,
-        label = "resultsListHeight",
-    )
-    // Bottom-sheet nested scroll, mirroring PlaceSheet.dismissConn: ONE detent step per
-    // gesture (re-armed at the fling boundary), a down-drag at the list top shrinks a
-    // detent (expanded → peek → minimized), an up-drag into the content grows to full.
+    // The list height is a hand-driven Animatable, the place sheet's physics: drags move it 1:1
+    // with the finger, releases ride the throw's own decay to the nearest size (0 = the minimized
+    // bar, peek, expanded), and the detent just stops the coast. Minimizing animates the list to
+    // ZERO first and only then flips the collapsed state, so the bar swap happens invisibly.
+    val peekL = screenH * 0.42f
+    val expL = screenH * 0.82f
+    val listH = remember { Animatable(if (collapsed) 0f else if (expanded) expL else peekL) }
+    val resultsSettleSpec = remember { spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = 350f) }
+    val resultsDecay = remember { exponentialDecay<Float>(frictionMultiplier = 1.6f) }
+    LaunchedEffect(collapsed, expanded) {
+        val target = if (collapsed) 0f else if (expanded) expL else peekL
+        if (listH.targetValue != target) listH.animateTo(target, resultsSettleSpec)
+    }
     val listState = rememberLazyListState()
     val minimize = rememberUpdatedState(onMinimize)
+    val expand = rememberUpdatedState(onExpand)
+    val isCollapsed = rememberUpdatedState(collapsed)
     val isExpanded = rememberUpdatedState(expanded)
     val setExpanded = rememberUpdatedState(onExpandedChange)
-    val dismissConn = remember(collapsed) {
+    val density = LocalDensity.current
+    val sheetScope = rememberCoroutineScope()
+    fun dragListBy(dyPx: Float) {
+        val dyDp = with(density) { dyPx.toDp().value }
+        sheetScope.launch { listH.snapTo((listH.value - dyDp).coerceIn(0f, expL)) }
+    }
+    fun settleList(velocityPxPerSec: Float) {
+        val vDp = with(density) { velocityPxPerSec.toDp().value }
+        val naturalEnd = resultsDecay.calculateTargetValue(listH.value, -vDp)
+        val target = listOf(0f, peekL, expL).minByOrNull { kotlin.math.abs(it - naturalEnd) } ?: peekL
+        sheetScope.launch {
+            // States first for peek/expanded so everything keyed on them stays honest; the
+            // MINIMIZED flip waits until the list has ridden down to zero (see above).
+            if (target != 0f) {
+                if (isCollapsed.value) expand.value()
+                setExpanded.value(target == expL)
+            }
+            val towardTarget = (naturalEnd - listH.value) * (target - listH.value) > 0f
+            if (towardTarget && kotlin.math.abs(naturalEnd - listH.value) >= kotlin.math.abs(target - listH.value)) {
+                try {
+                    listH.updateBounds(lowerBound = minOf(listH.value, target), upperBound = maxOf(listH.value, target))
+                    listH.animateDecay(-vDp, resultsDecay)
+                } finally {
+                    listH.updateBounds(lowerBound = null, upperBound = null)
+                }
+                if (kotlin.math.abs(listH.value - target) > 0.5f) listH.animateTo(target, resultsSettleSpec)
+            } else {
+                listH.animateTo(target, resultsSettleSpec, initialVelocity = -vDp)
+            }
+            if (target == 0f && !isCollapsed.value) minimize.value()
+        }
+    }
+    val dismissConn = remember {
         object : NestedScrollConnection {
-            private var acc = 0f
-            private var steppedThisGesture = false
+            private var draggingSheet = false
             override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
                 val atTop = listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
-                if (available.y > 0f && atTop) {
-                    acc += available.y
-                    if (!steppedThisGesture) {
-                        when {
-                            isExpanded.value && acc > 90f -> { setExpanded.value(false); steppedThisGesture = true; acc = 0f }
-                            !isExpanded.value && !collapsed && acc > 150f -> { steppedThisGesture = true; acc = 0f; minimize.value() }
-                        }
-                    }
+                if (available.y > 0f && atTop && listH.value > 0f) {
+                    draggingSheet = true
+                    dragListBy(available.y)
                     return available
                 }
-                if (available.y < 0f) {
-                    acc = 0f
-                    if (!isExpanded.value) setExpanded.value(true)
+                if (available.y < 0f && listH.value < expL) {
+                    draggingSheet = true
+                    dragListBy(available.y)
+                    return available
                 }
                 return Offset.Zero
             }
-            // Fling phase closes every drag (even at zero velocity) — the gesture boundary
-            // that re-arms stepping for the next swipe, exactly like the place sheet.
             override suspend fun onPreFling(available: Velocity): Velocity {
-                acc = 0f
-                steppedThisGesture = false
+                if (draggingSheet) {
+                    draggingSheet = false
+                    settleList(available.y)
+                    return available
+                }
                 return Velocity.Zero
             }
         }
@@ -1778,19 +1819,20 @@ private fun SearchResults(
                             if (collapsed) onExpand() else onExpandedChange(!expanded)
                         })
                     }
-                    .pointerInput(collapsed, expanded) {
-                        var total = 0f
+                    .pointerInput(Unit) {
+                        // Same physics as the body: the handle drags the list 1:1 and the release
+                        // rides the fling to the nearest size.
+                        val tracker = androidx.compose.ui.input.pointer.util.VelocityTracker()
                         detectVerticalDragGestures(
-                            onDragStart = { total = 0f },
-                            onVerticalDrag = { change, dy -> change.consume(); total += dy },
-                            onDragEnd = {
-                                when {
-                                    total < -40f && collapsed -> onExpand()
-                                    total < -40f -> onExpandedChange(true)
-                                    total > 40f && expanded -> onExpandedChange(false)
-                                    total > 40f && !collapsed -> onMinimize()
-                                }
+                            onDragStart = { tracker.resetTracking() },
+                            onVerticalDrag = { change, dy ->
+                                change.consume()
+                                tracker.addPosition(change.uptimeMillis, change.position)
+                                if (isCollapsed.value && dy < 0f) expand.value() // list mounts at 0 and grows with the finger
+                                dragListBy(dy)
                             },
+                            onDragEnd = { settleList(tracker.calculateVelocity().y) },
+                            onDragCancel = { settleList(0f) },
                         )
                     },
             ) {
@@ -1915,7 +1957,17 @@ private fun SearchResults(
             }
             if (!collapsed) {
             Divider()
-            LazyColumn(Modifier.nestedScroll(dismissConn).heightIn(max = listMaxH), state = listState) {
+            LazyColumn(
+                Modifier
+                    .nestedScroll(dismissConn)
+                    .layout { measurable, constraints ->
+                        // Layout-phase read: animation frames re-layout the list, never recompose it.
+                        val maxHPx = listH.value.dp.roundToPx().coerceAtLeast(0)
+                        val pl = measurable.measure(constraints.copy(maxHeight = minOf(constraints.maxHeight, maxHPx)))
+                        layout(pl.width, pl.height) { pl.place(0, 0) }
+                    },
+                state = listState,
+            ) {
                 items(shown) { place ->
                 Column(
                     Modifier

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -197,6 +197,7 @@ fun VelaMapView(
     navMode: Boolean,
     navFollowing: Boolean = true,
     onNavPanned: () -> Unit = {},
+    onUserPan: () -> Unit = {},
     onScaleChanged: (metersPerPixel: Double) -> Unit = {},
     darkTheme: Boolean,
     applyKeylessTheme: Boolean,
@@ -247,6 +248,7 @@ fun VelaMapView(
     val longPress = rememberUpdatedState(onMapLongPress)
     val addrLabelTap = rememberUpdatedState(onAddressLabelTap)
     val navPanned = rememberUpdatedState(onNavPanned)
+    val userPan = rememberUpdatedState(onUserPan)
     val scaleChanged = rememberUpdatedState(onScaleChanged)
     val selectAlt = rememberUpdatedState(onSelectAlternate)
     val navModeHolder = rememberUpdatedState(navMode)
@@ -752,6 +754,9 @@ fun VelaMapView(
                 map.addOnCameraMoveStartedListener { reason ->
                     gestureMove[0] = reason ==
                         MapLibreMap.OnCameraMoveStartedListener.REASON_API_GESTURE
+                    // The user grabbing the map is a signal in its own right — MapScreen uses it
+                    // to drop the results sheet down out of the way (Google's behaviour).
+                    if (gestureMove[0]) userPan.value()
                 }
                 // Tell a PAN from a PINCH during nav (the move-started reason can't): a pan
                 // detaches the follow-camera so you can look around (the Re-center button

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -301,9 +301,11 @@ fun PlaceSheet(
     val glideSpec = remember { spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = 140f) }
     LaunchedEffect(minimizeTick) {
         if (minimizeTick == 0) return@LaunchedEffect
+        // Glide FIRST, flip the states after: any content keyed on the minimized state then
+        // changes only once the card is already down (flipping first read as a pop, not a glide).
+        if (heightAnim.value > minH + 0.5f) heightAnim.animateTo(minH, glideSpec)
         expandedState.value = false
         minimizedState.value = true
-        if (heightAnim.value > minH + 0.5f) heightAnim.animateTo(minH, glideSpec)
     }
     // NOTE: heightAnim.value is deliberately NOT read here in composition - the height is applied
     // in the layout modifier on the Card below, so an animation frame only re-LAYOUTS the sheet

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -243,6 +243,9 @@ fun PlaceSheet(
     onRemoveFromList: (listId: String) -> Unit = {},
     onCreateListWith: (name: String) -> Unit = {},
     onSetNote: (String?) -> Unit = {},
+    // Bumped by MapScreen when the user grabs the map — the sheet glides down to its minimized
+    // card so the map is unobstructed (Google's behaviour). 0 = never.
+    minimizeTick: Int = 0,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -291,6 +294,16 @@ fun PlaceSheet(
         // Skip when a drag-release settle is already animating to this exact detent - restarting
         // would zero the coast velocity mid-glide.
         if (heightAnim.targetValue != target) heightAnim.animateTo(target, settleSpec)
+    }
+    // The user grabbed the map: glide down to the minimized card on a SOFT spring (the settle
+    // stiffness reads as a blink for this unprompted drop). Runs after the state-flip effect
+    // above, so animating on VALUE (not targetValue) deliberately replaces its quicker settle.
+    val glideSpec = remember { spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = 140f) }
+    LaunchedEffect(minimizeTick) {
+        if (minimizeTick == 0) return@LaunchedEffect
+        expandedState.value = false
+        minimizedState.value = true
+        if (heightAnim.value > minH + 0.5f) heightAnim.animateTo(minH, glideSpec)
     }
     // NOTE: heightAnim.value is deliberately NOT read here in composition - the height is applied
     // in the layout modifier on the Card below, so an animation frame only re-LAYOUTS the sheet

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -299,8 +299,14 @@ fun PlaceSheet(
     // stiffness reads as a blink for this unprompted drop). Runs after the state-flip effect
     // above, so animating on VALUE (not targetValue) deliberately replaces its quicker settle.
     val glideSpec = remember { spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = 140f) }
+    // Consume-once guard: seenTick INITIALIZES to the tick's CURRENT value, so a fresh mount
+    // (picking a place from the results list re-mounts the sheet) never treats a STALE tick as
+    // a new pan - a LaunchedEffect fires on first composition too, and without this the next
+    // place opened pre-minimized (user 2026-07-10). Only a bump AFTER mount glides.
+    var seenTick by remember { mutableStateOf(minimizeTick) }
     LaunchedEffect(minimizeTick) {
-        if (minimizeTick == 0) return@LaunchedEffect
+        if (minimizeTick == seenTick) return@LaunchedEffect
+        seenTick = minimizeTick
         // Glide FIRST, flip the states after: any content keyed on the minimized state then
         // changes only once the card is already down (flipping first read as a pop, not a glide).
         if (heightAnim.value > minH + 0.5f) heightAnim.animateTo(minH, glideSpec)


### PR DESCRIPTION
Ports the place card physics to the search results sheet: the list tracks the finger one to one from the handle or the top of the content, releases ride the fling's own decay to the nearest of its three sizes, and minimizing animates the list to zero before the compact bar swaps in, so the transition is seamless. The list height applies in the layout pass so animation frames never recompose the rows. Back now exits the search outright instead of stepping expanded to peek to minimized; the drag gestures, handle taps and the X already cover stepping. Verified on device: mid-drag intermediate heights, a settle onto the minimized bar, and a single back press to the bare map.