### PR TITLE
The route chooser swipes down to a slim bar so the route is visible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,13 @@ Defaults that make the safe path the easy one:
   SemiBold in ink - the small dim line with a "current traffic" note under it was clutter (the
   traffic-coloured per-route ETAs already carry that signal); the "Usually X-Y min" typical-range
   note stays. `place_current_traffic` was deleted from all 11 locales.
+- **The sheet physics recipe is SHARED (2026-07-11):** the place sheet, the search-results sheet
+  and the DirectionsPanel body all use the same grammar - a hand-driven `Animatable` (height for
+  the sheets, a 0..1 body FRACTION for the chooser) dragged 1:1 (handle + content-at-top nested
+  scroll), settled by `exponentialDecay(1.6)` picking the nearest detent from the natural coast
+  endpoint with a bounds-clamped `animateDecay` ride (spring only when the throw doesn't carry),
+  and the animated value read in a LAYOUT modifier so frames never recompose content. Port this
+  recipe to any new sheet; don't invent a fourth gesture system.
 - **Place-sheet drag physics are CONTINUOUS (2026-07-10):** the sheet height is a hand-driven
   `Animatable` - drags (handle or body-at-top) move it 1:1 with the finger, release projects the
   fling and RIDES THE THROW'S OWN INERTIA to the nearest detent: the landing point comes from

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -212,6 +212,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   "moderate traffic" or "heavy traffic" to match the green/amber/red time, so the conditions read
   without relying on colour. And a freshly downloaded voice no longer speaks a sample on its own -
   only picking a voice in the library (or the Test button) plays one.
+- ✅ **The route chooser swipes out of the way (2026-07-11).** Swipe the chooser down, from its
+  body or its handle, to shrink it to a slim bar with a Start button and see the whole route on
+  the map; it follows your finger and rides the throw, like the place card. Swipe or tap to bring
+  it back.
 - ✅ **Arrival time front and center (2026-07-10).** The directions panel's "Arrive at 5:30 PM"
   is bigger and bolder, and the redundant "current traffic" note under it is gone (the route ETAs
   already show traffic). The faster-route offer during navigation joined the tidy notification

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -42,6 +42,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
@@ -1197,21 +1198,97 @@ fun DirectionsPanel(
     // Keyed to the destination so opening directions for a different place starts
     // expanded again instead of inheriting the previous session's collapsed state.
     val collapsed = remember(destinationName) { mutableStateOf(false) }
+    // The chooser body collapses CONTINUOUSLY, the place card's physics: `frac` (1 = full body,
+    // 0 = minimized to the header + Start) tracks the finger 1:1 from the handle or a body drag
+    // at its top, and releases ride the fling's own decay to whichever end the momentum points
+    // at - the old handle-only threshold flip read as no gesture at all (user 2026-07-11).
+    val frac = remember(destinationName) { Animatable(1f) }
+    var bodyHPx by remember(destinationName) { mutableStateOf(0) }
+    val panelSettle = remember { spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = 350f) }
+    val panelDecay = remember { exponentialDecay<Float>(frictionMultiplier = 1.6f) }
+    val panelScope = rememberCoroutineScope()
+    val panelScroll = rememberScrollState()
+    LaunchedEffect(destinationName, collapsed.value) {
+        val target = if (collapsed.value) 0f else 1f
+        if (frac.targetValue != target) frac.animateTo(target, panelSettle)
+    }
+    fun dragPanelBy(dyPx: Float) {
+        if (bodyHPx <= 0) return
+        panelScope.launch { frac.snapTo((frac.value - dyPx / bodyHPx).coerceIn(0f, 1f)) }
+    }
+    fun settlePanel(velocityPxPerSec: Float) {
+        if (bodyHPx <= 0) return
+        val vFrac = velocityPxPerSec / bodyHPx
+        val naturalEnd = panelDecay.calculateTargetValue(frac.value, -vFrac)
+        val target = if (kotlin.math.abs(naturalEnd - 0f) < kotlin.math.abs(naturalEnd - 1f)) 0f else 1f
+        panelScope.launch {
+            if (target == 1f) collapsed.value = false // body must be composed while it grows
+            val towardTarget = (naturalEnd - frac.value) * (target - frac.value) > 0f
+            if (towardTarget && kotlin.math.abs(naturalEnd - frac.value) >= kotlin.math.abs(target - frac.value)) {
+                try {
+                    frac.updateBounds(lowerBound = minOf(frac.value, target), upperBound = maxOf(frac.value, target))
+                    frac.animateDecay(-vFrac, panelDecay)
+                } finally {
+                    frac.updateBounds(lowerBound = null, upperBound = null)
+                }
+                if (kotlin.math.abs(frac.value - target) > 0.005f) frac.animateTo(target, panelSettle)
+            } else {
+                frac.animateTo(target, panelSettle, initialVelocity = -vFrac)
+            }
+            if (target == 0f) collapsed.value = true
+        }
+    }
+    // Body drags at the scroll top move the chooser 1:1 (the natural "swipe the sheet down"
+    // lands on the body, not the thin handle); content scrolls once the body is fully open.
+    val panelConn = remember(destinationName) {
+        object : NestedScrollConnection {
+            private var dragging = false
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                if (available.y > 0f && panelScroll.value == 0 && frac.value > 0f) {
+                    dragging = true
+                    dragPanelBy(available.y)
+                    return available
+                }
+                if (available.y < 0f && frac.value < 1f) {
+                    dragging = true
+                    dragPanelBy(available.y)
+                    return available
+                }
+                return Offset.Zero
+            }
+            override suspend fun onPreFling(available: Velocity): Velocity {
+                if (dragging) {
+                    dragging = false
+                    settlePanel(available.y)
+                    return available
+                }
+                return Velocity.Zero
+            }
+        }
+    }
     Card(
         modifier.fillMaxWidth(),
         shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
         colors = CardDefaults.cardColors(containerColor = if (dark) SheetDark else SheetLight),
     ) {
         Column(Modifier.navigationBarsPadding().padding(start = 20.dp, end = 8.dp, top = 8.dp, bottom = 16.dp)) {
-            // Drag handle — swipe down to minimise the chooser (peek the route on the
-            // map before you Start), swipe up or tap to bring it back.
+            // Drag handle — the chooser follows the finger; tap still toggles.
             Box(
                 Modifier
                     .fillMaxWidth()
                     .pointerInput(Unit) {
-                        detectVerticalDragGestures { _, dy ->
-                            if (dy > 6f) collapsed.value = true else if (dy < -6f) collapsed.value = false
-                        }
+                        val tracker = androidx.compose.ui.input.pointer.util.VelocityTracker()
+                        detectVerticalDragGestures(
+                            onDragStart = { tracker.resetTracking() },
+                            onVerticalDrag = { change, dy ->
+                                change.consume()
+                                tracker.addPosition(change.uptimeMillis, change.position)
+                                if (collapsed.value && dy < 0f) collapsed.value = false
+                                dragPanelBy(dy)
+                            },
+                            onDragEnd = { settlePanel(tracker.calculateVelocity().y) },
+                            onDragCancel = { settlePanel(0f) },
+                        )
                     }
                     .dpadHighlight(RoundedCornerShape(3.dp)) // D-pad: OK toggles (docs/dpad.md)
                     .clickable { collapsed.value = !collapsed.value }
@@ -1350,15 +1427,24 @@ fun DirectionsPanel(
                 }
                 IconButton(onClick = onClose) { Icon(Icons.Default.Close, contentDescription = stringResource(R.string.place_close_directions), tint = dim) }
             }
-            AnimatedVisibility(visible = !collapsed.value) {
+            if (!collapsed.value || frac.value > 0.005f) {
               // Cap the expandable body to ~58% of the screen and let it scroll — on short screens the
               // mode chips + route/transit list + Start button are taller than the bottom-anchored card,
               // so without this the Start button (drive) and the lower transit trips fall off the bottom,
               // unreachable. verticalScroll keeps the whole chooser usable; the map stays visible above.
+              // The frac read lives in the LAYOUT modifier so animation frames never recompose the body.
               Column(
                   Modifier
+                      .layout { measurable, constraints ->
+                          val pl = measurable.measure(constraints)
+                          bodyHPx = maxOf(bodyHPx, pl.height)
+                          val h = (pl.height * frac.value).toInt().coerceAtLeast(0)
+                          layout(pl.width, h) { pl.place(0, 0) }
+                      }
+                      .clipToBounds()
                       .heightIn(max = (LocalConfiguration.current.screenHeightDp * 0.58f).dp)
-                      .verticalScroll(rememberScrollState()),
+                      .nestedScroll(panelConn)
+                      .verticalScroll(panelScroll),
               ) {
             Spacer(Modifier.height(10.dp))
             // D-pad-first (docs/dpad.md): land focus on the first travel-mode tab when the
@@ -1465,7 +1551,7 @@ fun DirectionsPanel(
               }
             }
             // Minimised: keep a Start button reachable without expanding.
-            if (collapsed.value) {
+            if (collapsed.value && frac.value < 0.05f) {
                 Button(
                     onClick = onStartNav,
                     modifier = Modifier.fillMaxWidth().padding(top = 8.dp, end = 12.dp),


### PR DESCRIPTION
The chooser technically had a collapse, but it was an instant threshold flip on the thin handle only, so it read as not existing. The body now collapses continuously with the finger, from the handle or a downward drag on the content at its scroll top, and releases ride the fling's decay to open or minimized, the same physics as the place card and results list. Minimized keeps the destination header plus a full-width Start button while the whole route shows on the map. The collapse fraction applies in the layout pass so animation frames never recompose the chooser. Verified on device: mid-drag partial heights and a clean settle to the slim bar with the route visible.