### PR TITLE
House numbers stop repeating across apartment complexes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1234,7 +1234,12 @@ Defaults that make the safe path the easy one:
   device-verified in the test suburb).** Microsoft footprints have geometry but **no addresses**, so house numbers
   come from a SECOND overlay: **OpenAddresses** address POINTS → per-state `.pmtiles` (`-l address`, keep the
   `number` prop) → `address-overlays` GitHub release + `address-overlay-manifest.json` (`ADDRESS_MANIFEST_URL`,
-  `-PaddressManifestUrl=`). Data source = OpenAddresses batch API: `/api/data?source=us/<st>/statewide&layer=addresses`
+  `-PaddressManifestUrl=`). **The bake DEDUPES per-unit/parcel repeats (2026-07-10, `scripts/dedup-addresses.py`):**
+  OpenAddresses carries one row per unit/parcel, so a complex repeated its number all over its
+  footprint on the map; the build keeps one point per (number, street, ~150 m cell). Takes
+  effect per region on the next `address-overlays` workflow run (streamed tiles pick it up
+  automatically; a LOCALLY DOWNLOADED overlay keeps the old points until re-downloaded).
+  Data source = OpenAddresses batch API: `/api/data?source=us/<st>/statewide&layer=addresses`
   → its current `job` → `https://v2.openaddresses.io/batch-prod/job/<job>/source.geojson.gz` (GeoJSONL of Points
   with `number`/`street`; **42 US states have a `statewide` source**, the rest are county-only). Render:
   `VelaMapView`'s `LaunchedEffect(addressOverlays, …)` adds a `VectorSource` (the URI) + a **`SymbolLayer`**

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **One house number per address (2026-07-10).** The open-address overlay used to print an
+  apartment complex's number over its whole footprint (OpenAddresses has a row per unit/parcel);
+  the overlay build now collapses those to a single point per address, so each number appears
+  once. Takes effect per state as the overlays rebuild.
 - ✅ **Settings reorganized + navigation UI refresh (2026-07-08, user request).** Settings had grown
   disjointed, so the sections now follow how you actually use the app: Appearance, then Map (traffic,
   transit lines, 3D buildings), then a new **Place pages** section (Show reviews, the "Read all reviews"

--- a/scripts/build-address-region.sh
+++ b/scripts/build-address-region.sh
@@ -54,6 +54,13 @@ LINES=$(wc -l < "$GEOJSON" | tr -d ' ')
 [ "$LINES" -gt 0 ] || { echo "!! empty address data for $SRC" >&2; exit 1; }
 echo "→ $LINES address points"
 
+# OpenAddresses carries one row per UNIT/PARCEL, so an apartment complex repeats the same house
+# number dozens of times across its footprint - rendered as the number printed all over the
+# building. Collapse to one point per (number, street, ~150 m cell) before tiling.
+echo "→ collapsing repeated per-unit/parcel points"
+python3 "$(cd "$(dirname "$0")" && pwd)/dedup-addresses.py" "$GEOJSON" "$WORK/$ID.dedup.geojsonl"
+mv "$WORK/$ID.dedup.geojsonl" "$GEOJSON"
+
 # House numbers render only at z>=17.5 (VelaMapView minZoom — Google street-level parity), so bake
 # -Z16 -z17: the app never requests tiles below 16 (dead pyramid weight), and maxzoom 17 quarters the
 # per-tile point count vs the old -z16 — at maxzoom tippecanoe keeps EVERY point, and overzooming a

--- a/scripts/dedup-addresses.py
+++ b/scripts/dedup-addresses.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Collapse OpenAddresses' repeated address points before tiling.
+
+OpenAddresses statewide data carries one row per UNIT or PARCEL, so an apartment
+complex contributes the same house number dozens of times across its footprint and
+Vela's house-number overlay printed it over the whole building (user 2026-07-10).
+One label per address is what a map wants: keep the FIRST point for each
+(number, street, ~150 m grid cell) and drop the rest. Streaming, one pass, no
+geometry math - the grid cell stands in for "the same building/complex". Points
+with no number render nothing and are dropped outright.
+
+Usage: dedup-addresses.py <in.geojsonl> <out.geojsonl>   (prints stats to stderr)
+"""
+import json
+import sys
+
+CELL = 0.0015  # degrees, ~165 m of latitude - spans a big complex, well under a city block pair
+
+def main() -> None:
+    inp, out = sys.argv[1], sys.argv[2]
+    seen = set()
+    kept = dropped = bad = 0
+    with open(inp, encoding="utf-8", errors="replace") as f, open(out, "w", encoding="utf-8") as o:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                feat = json.loads(line)
+                props = feat.get("properties") or {}
+                num = str(props.get("number") or "").strip()
+                street = str(props.get("street") or "").strip().lower()
+                lng, lat = feat["geometry"]["coordinates"][:2]
+            except Exception:
+                bad += 1
+                continue
+            if not num:
+                dropped += 1
+                continue
+            key = hash((num, street, round(lat / CELL), round(lng / CELL)))
+            if key in seen:
+                dropped += 1
+                continue
+            seen.add(key)
+            o.write(line + "\n")
+            kept += 1
+    print(f"dedup: kept {kept}, dropped {dropped} (dupes + numberless), {bad} unparsable", file=sys.stderr)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
OpenAddresses carries one row per unit or parcel, so the house-number overlay printed a complex's number all over its footprint. The overlay build now collapses the source data to one point per (number, street, ~150 m cell) before tippecanoe, verified with a synthetic fixture (unit duplicates collapse; different streets, numbers, and far-apart same-number points all survive; numberless rows drop since they render nothing).

No app change needed: the overlay streams by range requests, so each state picks the fix up when its overlay rebuilds. After merging, dispatch the Build address overlays workflow to re-bake; locally downloaded overlays keep old points until re-downloaded.