### PR TITLE
F-Droid setup leads with the one-line repo address

### DIFF
--- a/FDROID.md
+++ b/FDROID.md
@@ -5,26 +5,29 @@ any F-Droid client (F-Droid, Droid-ify, Neo Store) without sideloading.
 
 ## Add the repo
 
-1. In your F-Droid client, open **Settings → Repositories → Add repository**.
-2. Enter the repo address:
-
-   ```
-   https://pimpinpumpkin.github.io/Vela/repo
-   ```
-
-3. When asked for the fingerprint (or to confirm it), check it matches:
-
-   ```
-   F374920F2F5F38D7508D0B042125B8EAF23CF0F06FA7490280FB77115BB091DE
-   ```
-
-4. Refresh, search for **Vela Maps**, install.
-
-Or use the one-line form some clients accept directly:
+Paste this one line as the repository address — the official F-Droid client,
+Droid-ify and Neo Store all accept it and pick up the fingerprint automatically:
 
 ```
 https://pimpinpumpkin.github.io/Vela/repo?fingerprint=F374920F2F5F38D7508D0B042125B8EAF23CF0F06FA7490280FB77115BB091DE
 ```
+
+(In your client: **Settings → Repositories → Add repository**, paste, refresh,
+search for **Vela Maps**, install.)
+
+If your client wants the address and fingerprint separately, use:
+
+- Address:
+
+  ```
+  https://pimpinpumpkin.github.io/Vela/repo
+  ```
+
+- Fingerprint:
+
+  ```
+  F374920F2F5F38D7508D0B042125B8EAF23CF0F06FA7490280FB77115BB091DE
+  ```
 
 ## What the repo serves
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Fingerprint and full instructions in [FDROID.md](FDROID.md).
   driving somewhere, with a warning if it would be closed when you arrive.
 - **Traffic you can read.** Route choices say light, moderate or heavy traffic in
   words next to their green/amber/red times, and the fastest route leads the list.
+- **Material You theming, if you want it.** An optional toggle tints Vela's chrome
+  with your wallpaper colors (Android 12+); off by default, and the map itself
+  stays clean either way.
 - **Public transit.** Itineraries with line pills, station-by-station stops, and
   step-by-step guidance to the platform.
 - **No account, no tracking.** No Google account, no GMS, no telemetry. What


### PR DESCRIPTION
The combined address-plus-fingerprint line is accepted by the official F-Droid client, Droid-ify and Neo Store, so the setup section leads with it and keeps the split address and fingerprint below for clients that ask for them separately. Also adds the optional Material You theming to the README's feature list; it shipped earlier but never made the user-facing list.