### PR TITLE
The parked car sheet no longer loads the last place's reviews and photos

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1827,11 +1827,20 @@ class MapViewModel @Inject constructor(
     fun showParkedCar(label: String) {
         val spot = _state.value.parkingSpot ?: return
         val p = Place(id = "parking:${spot.lat},${spot.lng}", name = label, location = spot)
+        // A parked car never fetches reviews/photos/details — but the PREVIOUS place's in-flight
+        // scrape (and its reviews/shimmer flags) would otherwise bleed onto the parking sheet
+        // ("loading reviews on the parked car" bug). Cancel + clear them, like the pin/POI paths.
+        reviewsJob?.cancel()
+        routeJob?.cancel()
         // Frame the spot too — opened from the P button while browsing another city, the
         // sheet alone doesn't tell you WHERE the car is.
         _state.update {
             it.copy(
                 selected = p, results = emptyList(), query = "", directionsOpen = false,
+                placesHere = emptyList(), reviews = emptyList(), reviewsLoading = false,
+                reviewsFound = 0, photosLoading = false, loadingDetails = false,
+                routes = emptyList(), activeRoute = null, showSteps = false, previewStepIndex = null,
+                transit = emptyList(), transitLoading = false,
                 center = spot, recenterTick = it.recenterTick + 1,
             )
         }


### PR DESCRIPTION
Tapping the parked car pin swapped the selected place to the car but left the previously selected place's reviews list, photo shimmer flag, and detail fetch job intact, so the parking sheet showed a real business's reviews and tried to load its photos. showParkedCar now cancels the in-flight review scrape and clears the reviews/photos/details/route state the same way selectPlace and the dropped-pin path already do. A parked car carries no rating, reviews, or feature id, so with the state cleaned the sheet correctly shows only the car with its Directions and Clear actions.