### PR TITLE
A privacy comparison table joins the README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -856,7 +856,9 @@ Defaults that make the safe path the easy one:
   fails verification is ignored (app keeps the last-good config). An unsigned/older
   cached copy falls back to the compiled `DEFAULT` for one launch.
 - **Notices.** `calibration.json` carries a `notices` array (`id`/`level`/`title`/
-  `body`/`url`) shown as dismissable cards on the bare map (`MapViewModel.refreshNotices`,
+  `body`/`url`) shown as dismissable cards on the bare map; **level "urgent" (2026-07-10)
+  renders as a MODAL VelaDialog instead** (OK dismisses; a `url` adds a Learn-more button) —
+  for pushed announcements that must be seen. Cards for routine notes, urgent sparingly. (`MapViewModel.refreshNotices`,
   dismissed ids in `vela_notices` prefs) - push "search is down, fix coming" with no
   app update. Rides the same signed channel.
 - **Phase 3 (done): remote parse *logic*** via `transformsJs` - a signed JS bundle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,7 +295,14 @@ Defaults that make the safe path the easy one:
   Website pills in a horizontal scroll row with the same gating as the full action row (website
   behind HideExternalLinks). Keep new sheet controls on this language. NB `RatingHistogram` in
   PlaceSheet is ORPHANED (its per-star counts only exist in the live panel DOM) - wire it or
-  delete it, don't duplicate it.
+  delete it, don't duplicate it. **The MENU TAB (2026-07-10)** appears beside Reviews/About when
+  `photoCategories` carries a menu-named category (`MENU_TAB_WORDS`, lowercase contains-match on
+  Google's LOCALIZED gallery-tab name, which is reused as the tab title); content = the tagged
+  photos as a chunked 2-up grid (`MenuTab`) into the shared PhotoGallery. There is NO keyless
+  menu URL (probed 2026-07-10: search payload [38] empty, zero menu links) - don't chase the
+  link; the quality follow-up is making WebPhotoFetcher scrape the menu TAB exhaustively. The
+  inline review search hides behind a circled magnifier beside the All-reviews pill
+  (`reviewSearchOpen`; toggling closed clears the query so a hidden filter can't keep filtering).
 - **Chip style = stadium pills (2026-07-08):** EVERY chip (map CategoryChips, results-panel filter
   chips Open-now/top-rated/price/sort + the collapsed "N results" pill, PlaceSheet travel-mode chips
   now with a leading `Icons.Default.Directions*` glyph, Settings vibrate-on-turns FilterChips) sets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,15 @@ Defaults that make the safe path the easy one:
   Cards with elevation 6dp, 54dp turn glyph, headlineMedium-bold distance, titleMedium-medium road
   name, FilledTonalIconButton for mute/steps. Keep new nav chrome on this treatment (no flat
   default-radius cards, no OutlinedIconButton circles - that was the "dated" look).
+- **Place-sheet surface language (2026-07-10):** header icon buttons (Save/Share/more/close) are
+  40dp icons in `dim.copy(alpha = 0.12f)` CIRCLES with 5dp gaps (Google's treatment); ActionPill
+  and the "All reviews" button are CircleShape stadium pills (the outlined button was the last
+  outlined control on the sheet); the reviews summary block is LEFT-ALIGNED (displaySmall number
+  + stars/count stacked beside it), not centered; the MINIMIZED card carries Directions + Call +
+  Website pills in a horizontal scroll row with the same gating as the full action row (website
+  behind HideExternalLinks). Keep new sheet controls on this language. NB `RatingHistogram` in
+  PlaceSheet is ORPHANED (its per-star counts only exist in the live panel DOM) - wire it or
+  delete it, don't duplicate it.
 - **Chip style = stadium pills (2026-07-08):** EVERY chip (map CategoryChips, results-panel filter
   chips Open-now/top-rated/price/sort + the collapsed "N results" pill, PlaceSheet travel-mode chips
   now with a leading `Icons.Default.Directions*` glyph, Settings vibrate-on-turns FilterChips) sets

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **The photo viewer goes truly full screen (2026-07-10).** Google's treatment: system bars
+  hide while viewing (swipe reveals them), the backdrop is the photo itself blurred and dimmed
+  instead of flat black (Android 12+), and the author/date stamp sits bottom-left in every
+  orientation. The full-screen reviews page also draws edge to edge so rotation can't leak the
+  map through the borders. The photo strip's category chips are gone (the Menu tab replaced
+  them), and the header's circled buttons slimmed to 36dp with wider gaps so they never touch.
 - ✅ **Restaurant menus get their own tab (2026-07-10).** A place with menu photos shows a Menu
   tab beside Reviews and About: a browsable photo grid, titled with Google's own localized
   gallery-tab name, tapping through to the full-screen viewer. Google's keyless data carries no

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **Urgent pushed notices can be a modal (2026-07-10).** A calibration.json notice with
+  level "urgent" renders as a dialog (OK + optional Learn-more link) instead of a map card, for
+  announcements that must be seen — the "servers overloaded, hang tight" class of message. Same
+  signed channel, same one-time dismissal.
 - ✅ **Minimizing the place card fades gracefully (2026-07-10).** The photos and body content
   fade out with the height as the sheet glides down instead of vanishing in one frame at the
   swap, and the compact card (name, stars, action pills) fades in — nothing pops. The header

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,14 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **Restaurant menus get their own tab (2026-07-10).** A place with menu photos shows a Menu
+  tab beside Reviews and About: a browsable photo grid, titled with Google's own localized
+  gallery-tab name, tapping through to the full-screen viewer. Google's keyless data carries no
+  menu LINK (probed: the search payload has none), so photos are the menu surface; making the
+  gallery scrape menu-exhaustive is the known follow-up for places where the tagged set is
+  partial. The inline review search also folds into a magnifier beside the All-reviews pill —
+  the stacked text field read as clutter, and the full-screen panel's server-side search stays
+  the headline way to dig.
 - ✅ **Gallery survives rotation + the save menu (2026-07-10).** The full-screen photo viewer
   draws edge to edge, so rotating to landscape no longer lets the map peek through the system-bar
   strips, and the photo caption's bottom clearance scales with the screen instead of floating to

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **Gallery survives rotation + the save menu (2026-07-10).** The full-screen photo viewer
+  draws edge to edge, so rotating to landscape no longer lets the map peek through the system-bar
+  strips, and the photo caption's bottom clearance scales with the screen instead of floating to
+  the middle in landscape. The place header's star is now the whole save menu (quick save, save
+  to a list, edit note, set as home/work), replacing the separate overflow button that crowded
+  the circled header.
 - ✅ **Place sheet modernization (2026-07-10).** The header's Save/Share/more/close buttons sit in
   Google's subtle grey circles, every pill on the sheet shares the app's stadium shape, the
   reviews summary is Google's block (big number, stars and count stacked beside it, left-aligned)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,13 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **Place sheet modernization (2026-07-10).** The header's Save/Share/more/close buttons sit in
+  Google's subtle grey circles, every pill on the sheet shares the app's stadium shape, the
+  reviews summary is Google's block (big number, stars and count stacked beside it, left-aligned)
+  instead of a centered strip, the "All reviews" button drops the dated outlined look for the
+  sheet's tonal pill language, and the minimized card carries Call and Website beside Directions
+  (same gating as the full sheet) so it's useful without re-expanding.
+
 - ✅ **Settings reorganized + navigation UI refresh (2026-07-08, user request).** Settings had grown
   disjointed, so the sections now follow how you actually use the app: Appearance, then Map (traffic,
   transit lines, 3D buildings), then a new **Place pages** section (Show reviews, the "Read all reviews"

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **Minimizing the place card fades gracefully (2026-07-10).** The photos and body content
+  fade out with the height as the sheet glides down instead of vanishing in one frame at the
+  swap, and the compact card (name, stars, action pills) fades in — nothing pops. The header
+  circles also became fixed-size plain buttons: the Material button's minimum-touch-target
+  machinery kept re-inflating their layout past the visible circle, which is why they overlapped
+  through two rounds of shrinking.
 - ✅ **The photo viewer goes truly full screen (2026-07-10).** Google's treatment: system bars
   hide while viewing (swipe reveals them), the backdrop is the photo itself blurred and dimmed
   instead of flat black (Android 12+), and the author/date stamp sits bottom-left in every

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **Privacy comparison matrix in the README (2026-07-11).** A plain-words table under
+  Privacy comparing the Google Maps app, Google Maps web, and Vela: account linkage, device
+  identifiers, GPS exposure, map-browsing visibility, search anonymity, routing telemetry,
+  saved-place storage, ad profiling, and offline capability. PRIVACY.md stays the per-endpoint
+  deep dive; the table is the ten-second version.
+
 - ✅ **Urgent pushed notices can be a modal (2026-07-10).** A calibration.json notice with
   level "urgent" renders as a dialog (OK + optional Learn-more link) instead of a map card, for
   announcements that must be seen — the "servers overloaded, hang tight" class of message. Same

--- a/README.md
+++ b/README.md
@@ -148,6 +148,25 @@ map area, but **not a Google account or any app key**, much like using
 never leave the device. **[Read the full breakdown of exactly what each service
 receives → `PRIVACY.md`](PRIVACY.md).**
 
+How that compares, honestly:
+
+| What Google gets | Google Maps app | Google Maps web | Vela |
+| --- | --- | --- | --- |
+| Tied to your Google account | Yes, always signed in | Yes unless incognito | Never - there is no login |
+| A persistent device identifier | Yes (device + ad IDs via Play Services) | Browser cookies | No account, no app key; just an IP like any website visitor |
+| Your precise GPS position | Continuously while open, plus Location History if enabled | While the tab is open | Never sent. Position stays on the phone; searches send the map area you are looking at |
+| Every pan and zoom of the map | Yes - their servers render the map | Yes | No - map tiles come from OpenFreeMap, so Google never sees you browse |
+| Your searches | Yes, saved to your account history | Yes | The query text reaches Google anonymously, only when you search |
+| Place pages you open | Yes | Yes | The place lookup reaches Google anonymously |
+| Turn-by-turn routes | Yes, full trip telemetry | Yes | Routing runs on open OSRM/GraphHopper; Google sees one anonymous ETA check, never your live position |
+| Saved places, home, work | Stored on their servers | Stored on their servers | Stored only on your phone |
+| Ad profile building | Feeds your ads profile | Feeds your ads profile | Nothing to attach it to |
+| Works with no Google contact at all | No | No | Yes - downloaded regions search, route, and navigate fully offline |
+
+The short version: Google shrinks from *knowing who you are and everywhere you go* to
+*occasionally answering an anonymous question*. And the parts that matter most while
+driving - your GPS trace, your map browsing - never reach Google at all.
+
 ## Why it's built this way
 
 Two decisions from the planning phase shape everything:

--- a/app/src/main/java/app/vela/ui/VelaRoot.kt
+++ b/app/src/main/java/app/vela/ui/VelaRoot.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import app.vela.R
+import app.vela.ui.place.PlaceOverlays
 import androidx.hilt.navigation.compose.hiltViewModel
 import app.vela.ui.map.MapScreen
 import app.vela.ui.map.MapViewModel
@@ -173,6 +174,10 @@ fun VelaRoot(vm: MapViewModel = hiltViewModel()) {
                 )
             }
         }
+        // Full-screen photo viewer + reviews page render HERE, in the activity's own edge-to-edge
+        // window (not a child Dialog) — genuinely full-screen and rotation-safe. Last child = top
+        // z-order, above the map + sheet + settings.
+        PlaceOverlays()
     }
 }
 

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1345,7 +1345,25 @@ fun MapScreen(
               )
             // Imported Google list preview: offer to save (nothing persisted until tapped).
             // A pill under the search bar, clear of the results sheet at the bottom.
-            state.pendingImport?.let { imp ->
+            // A pushed URGENT notice (calibration.json, level "urgent") is a modal, not a card —
+        // for announcements that must be seen (the "servers overloaded" class of message).
+        // Same signed channel + the same one-time dismissal persistence as the cards.
+        state.notices.firstOrNull { it.level == app.vela.core.config.Notice.LEVEL_URGENT }?.let { n ->
+            app.vela.ui.VelaDialog(
+                onDismissRequest = { vm.dismissNotice(n.id) },
+                title = n.title,
+                confirmText = stringResource(android.R.string.ok),
+                onConfirm = { vm.dismissNotice(n.id) },
+                dismissText = if (n.url != null) stringResource(R.string.mapscreen_learn_more) else stringResource(R.string.place_close),
+                onDismiss = {
+                    n.url?.let { u -> runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(u))) } }
+                    vm.dismissNotice(n.id)
+                },
+            ) {
+                Text(n.body)
+            }
+        }
+        state.pendingImport?.let { imp ->
                 val savedMsg = stringResource(R.string.map_list_saved, imp.title)
                 Surface(
                     shape = RoundedCornerShape(28.dp),
@@ -1634,7 +1652,7 @@ fun MapScreen(
                             onDismiss = { vm.dismissUpdate() },
                         )
                     }
-                    state.notices.forEach { n ->
+                    state.notices.filterNot { it.level == app.vela.core.config.Notice.LEVEL_URGENT }.forEach { n ->
                         NoticeCard(n, onDismiss = { vm.dismissNotice(n.id) })
                     }
                 }

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -155,6 +155,9 @@ import app.vela.ui.item
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -596,28 +599,9 @@ fun PlaceSheet(
             // Hidden entirely when "Load photos" is off (the fetch is skipped too, but the
             // search response can seed a preview photo — don't show it either).
             if (app.vela.ui.LoadPhotos.on.value && (place.photoUrls.isNotEmpty() || photosLoading)) {
-                // Category filter chips (Menu / Food & drink / Vibe / By owner …) — only when Google tagged
-                // photos with categories, mirroring its gallery tabs. "All" clears the filter.
-                val photoCats = remember(place.photoCategories) { place.photoCategories.filterNotNull().distinct() }
-                if (photoCats.isNotEmpty()) {
-                    Row(
-                        Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(bottom = 8.dp),
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    ) {
-                        (listOf<String?>(null) + photoCats).forEach { cat ->
-                            FilterChip(
-                                selected = photoCat == cat,
-                                onClick = { photoCat = cat },
-                                label = { Text(cat ?: stringResource(R.string.place_photo_category_all)) },
-                            )
-                        }
-                    }
-                }
-                // Indices into the FULL photo list that match the selected category (keeps galleryStart
-                // pointing at the right photo in the full-screen viewer).
-                val shown = remember(place.photoUrls, place.photoCategories, photoCat) {
-                    place.photoUrls.indices.filter { photoCat == null || place.photoCategories.getOrNull(it) == photoCat }
-                }
+                // (The All/Menu category chips that used to sit here are gone — the Menu TAB is
+                // the menu surface now, and the other categories read as noise; user 2026-07-10.)
+                val shown = remember(place.photoUrls) { place.photoUrls.indices.toList() }
                 LazyRow(
                     Modifier.fillMaxWidth().padding(bottom = 12.dp),
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -648,7 +632,7 @@ fun PlaceSheet(
             }
             // spacedBy keeps the circled header buttons from touching now that they carry
             // visible backgrounds (Google's circles have the same small gaps).
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 if (isParking) {
                     Icon(
                         Icons.Default.DirectionsCar,
@@ -679,14 +663,14 @@ fun PlaceSheet(
                     IconButton(
                         onClick = { saveMenu = true },
                         modifier = Modifier
-                            .size(40.dp)
+                            .size(36.dp)
                             .background(dim.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
                     ) {
                         Icon(
                             if (isSaved) Icons.Default.Star else Icons.Default.StarBorder,
                             contentDescription = if (isSaved) stringResource(R.string.place_saved) else stringResource(R.string.place_save),
                             tint = if (isSaved) MaterialTheme.colorScheme.primary else dim,
-                            modifier = Modifier.size(20.dp),
+                            modifier = Modifier.size(18.dp),
                         )
                     }
                     VelaMenu(expanded = saveMenu, onDismissRequest = { saveMenu = false }) {
@@ -703,10 +687,10 @@ fun PlaceSheet(
                 IconButton(
                     onClick = onClose,
                     modifier = Modifier
-                        .size(40.dp)
+                        .size(36.dp)
                         .background(dim.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
                 ) {
-                    Icon(Icons.Default.Close, contentDescription = stringResource(R.string.place_close), tint = dim, modifier = Modifier.size(20.dp))
+                    Icon(Icons.Default.Close, contentDescription = stringResource(R.string.place_close), tint = dim, modifier = Modifier.size(18.dp))
                 }
             }
 
@@ -2083,6 +2067,18 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
     // bars / cutout and the map showed through the uncovered strips (user 2026-07-10); drawing
     // edge-to-edge lets the black Box actually cover the screen.
     Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false)) {
+        // TRUE full screen (Google's viewer): hide the status + nav bars for the dialog window,
+        // swipe reveals them transiently. Restored automatically when the dialog window dies.
+        val dialogView = LocalView.current
+        DisposableEffect(Unit) {
+            val win = (dialogView.parent as? androidx.compose.ui.window.DialogWindowProvider)?.window
+            win?.let {
+                val ctl = androidx.core.view.WindowCompat.getInsetsController(it, dialogView)
+                ctl.systemBarsBehavior = androidx.core.view.WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                ctl.hide(androidx.core.view.WindowInsetsCompat.Type.systemBars())
+            }
+            onDispose { }
+        }
         val pager = rememberPagerState(initialPage = start.coerceIn(0, urls.lastIndex)) { urls.size }
         // D-pad (docs/dpad.md): the viewer grabs focus so LEFT/RIGHT page through the
         // photos with no touch; BACK already dismisses (Dialog).
@@ -2109,6 +2105,18 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
                 }
                 .focusable(),
         ) {
+            // Google's diffuse backdrop: the current photo, blurred and dimmed, behind the pager
+            // (Android 12+; older devices keep plain black — Modifier.blur no-ops there and a
+            // sharp copy would read as a glitch, so it's gated).
+            if (android.os.Build.VERSION.SDK_INT >= 31) {
+                AsyncImage(
+                    model = urls[pager.currentPage].atWidth(240),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize().blur(48.dp),
+                )
+                Box(Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.55f)))
+            }
             HorizontalPager(state = pager, modifier = Modifier.fillMaxSize()) { page ->
                 // One gesture loop so pinch-zoom, pan-when-zoomed, swipe-down-to-
                 // dismiss, AND the pager's horizontal swipe between photos all work
@@ -2187,15 +2195,15 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
                 // Pixel 9 — so a normal bottom caption vanished. A FIXED bottom clearance keeps it in the
                 // drawable area regardless (harmlessly a touch higher on phones with no such clip).
                 dates.getOrNull(pager.currentPage)?.let { caption ->
-                    // The clearance is PROPORTIONAL (capped at the old 120dp): a fixed 120dp was
-                    // a third of the screen in landscape and floated the caption to the middle.
-                    val captionClear = (LocalConfiguration.current.screenHeightDp * 0.14f).dp.coerceAtMost(120.dp)
+                    // Bottom-LEFT in every orientation (Google's stamp position). With the system
+                    // bars hidden the window owns the full screen, so a modest fixed clearance
+                    // works in both orientations (the old proportional clearance floated it).
                     Text(
                         caption,
                         style = MaterialTheme.typography.bodyMedium,
                         color = Color.White,
-                        modifier = Modifier.align(Alignment.BottomCenter)
-                            .padding(bottom = captionClear, start = 16.dp, end = 16.dp)
+                        modifier = Modifier.align(Alignment.BottomStart)
+                            .padding(bottom = 28.dp, start = 16.dp, end = 16.dp)
                             .background(Color.Black.copy(alpha = 0.6f), RoundedCornerShape(50))
                             .padding(horizontal = 14.dp, vertical = 7.dp),
                     )
@@ -2456,7 +2464,7 @@ private fun FullScreenReviews(featureId: String, place: Place, ink: Color, dim: 
     // focus on page-finish). The auto-focus loop stops on its first success, so it hands off
     // to the WebView cleanly once the page loads. No-op under touch.
     val reviewsBackFocus = rememberDpadAutoFocus()
-    Dialog(onDismissRequest = onClose, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+    Dialog(onDismissRequest = onClose, properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false)) {
         Surface(Modifier.fillMaxSize(), color = if (dark) SheetDark else SheetLight, contentColor = ink) {
             Column(Modifier.fillMaxSize().statusBarsPadding()) {
                 Row(
@@ -2845,10 +2853,10 @@ private fun ShareIconButton(place: Place, tint: Color) {
         IconButton(
             onClick = { open = true },
             modifier = Modifier
-                .size(40.dp)
+                .size(36.dp)
                 .background(tint.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
         ) {
-            Icon(Icons.Default.Share, contentDescription = stringResource(R.string.place_share), tint = tint, modifier = Modifier.size(20.dp))
+            Icon(Icons.Default.Share, contentDescription = stringResource(R.string.place_share), tint = tint, modifier = Modifier.size(18.dp))
         }
         VelaMenu(expanded = open, onDismissRequest = { open = false }) {
             item(stringResource(R.string.place_share_gmaps_link)) { share("${place.name}\nhttps://www.google.com/maps/search/?api=1&query=$lat%2C$lng") }

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -176,6 +176,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
@@ -183,6 +184,8 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.foundation.layout.offset
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -2074,45 +2077,27 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
     // bars / cutout and the map showed through the uncovered strips (user 2026-07-10); drawing
     // edge-to-edge lets the black Box actually cover the screen.
     Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false)) {
-        // TRUE full screen (Google's viewer): hide the status + nav bars for the dialog window,
-        // swipe reveals them transiently. Restored automatically when the dialog window dies.
+        // Google's viewer treatment: DON'T fight to cover the bars — draw edge-to-edge UNDER
+        // TRANSPARENT, still-visible system bars, with a gradient scrim so the status bar reads
+        // cleanly over the photo (user 2026-07-10). The window lays out past the bars via
+        // NO_LIMITS and the content root demands the true display size, so black fills behind the
+        // (transparent) bars top and bottom — no strips, and the clock stays legible.
         val dialogView = LocalView.current
         DisposableEffect(Unit) {
-            val win = (dialogView.parent as? androidx.compose.ui.window.DialogWindowProvider)?.window
-            win?.let {
-                // The dialog WINDOW itself must claim the whole screen — decorFitsSystemWindows
-                // alone leaves the window sized inside the bars on several API levels (the "still
-                // not completely full screen top or bottom" report).
+            (dialogView.parent as? androidx.compose.ui.window.DialogWindowProvider)?.window?.let {
                 it.setLayout(android.view.WindowManager.LayoutParams.MATCH_PARENT, android.view.WindowManager.LayoutParams.MATCH_PARENT)
                 androidx.core.view.WindowCompat.setDecorFitsSystemWindows(it, false)
-                // The one flag that UNCONDITIONALLY lets the window lay out past the bars — the
-                // fitting flags alone still left top/bottom strips on this device (2026-07-10).
                 it.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
-                // Compose's DialogLayout re-asserts its own window size/fit params, so the window
-                // stubbornly stays inset from the bars (window-dump-proven twice). The strips it
-                // leaves show the ACTIVITY behind — so paint THAT out: a full dim turns anything
-                // outside the window solid black, which reads as true full screen.
-                it.addFlags(android.view.WindowManager.LayoutParams.FLAG_DIM_BEHIND)
-                it.setDimAmount(1f)
-                // API 30+: DIALOG windows fit the bar insets via fitInsetsTypes, which none of
-                // the flags above touch — THIS is what kept the window inset from the screen's
-                // top/bottom through three rounds of "still not full screen" (screenshot-proven).
-                if (android.os.Build.VERSION.SDK_INT >= 30) {
-                    it.attributes = it.attributes.apply { fitInsetsTypes = 0 }
-                }
-                // Paint the WINDOW DECOR black: the compose content is measured to the pre-flag
-                // frame, so the extra NO_LIMITS area showed the sheet ghosting through (the
-                // screenshot-verified "not full screen" strips). The decor background covers the
-                // whole window regardless of content size.
+                it.statusBarColor = android.graphics.Color.TRANSPARENT
+                it.navigationBarColor = android.graphics.Color.TRANSPARENT
                 it.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(android.graphics.Color.BLACK))
                 if (android.os.Build.VERSION.SDK_INT >= 28) {
                     it.attributes = it.attributes.apply {
                         layoutInDisplayCutoutMode = android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
                     }
                 }
-                val ctl = androidx.core.view.WindowCompat.getInsetsController(it, dialogView)
-                ctl.systemBarsBehavior = androidx.core.view.WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-                ctl.hide(androidx.core.view.WindowInsetsCompat.Type.systemBars())
+                // Light icons on the dark viewer.
+                androidx.core.view.WindowCompat.getInsetsController(it, dialogView).isAppearanceLightStatusBars = false
             }
             onDispose { }
         }
@@ -2124,7 +2109,7 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
         LaunchedEffect(Unit) { runCatching { galleryFocus.requestFocus() } }
         Box(
             Modifier
-                .fillMaxSize()
+                .requiredFullScreen()
                 .background(Color.Black)
                 .focusRequester(galleryFocus)
                 .onKeyEvent { ev ->
@@ -2215,6 +2200,11 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
                 }
             }
             Box(Modifier.fillMaxSize()) {
+                // Gradient fade under the (visible) status bar, Google-style.
+                Box(
+                    Modifier.fillMaxWidth().height(140.dp).align(Alignment.TopCenter)
+                        .background(androidx.compose.ui.graphics.Brush.verticalGradient(0f to Color.Black.copy(alpha = 0.55f), 1f to Color.Transparent)),
+                )
                 Text(
                     stringResource(R.string.place_gallery_counter, pager.currentPage + 1, urls.size),
                     style = MaterialTheme.typography.bodyMedium,
@@ -2240,7 +2230,8 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
                         style = MaterialTheme.typography.bodyMedium,
                         color = Color.White,
                         modifier = Modifier.align(Alignment.BottomStart)
-                            .padding(bottom = 28.dp, start = 16.dp, end = 16.dp)
+                            .navigationBarsPadding()
+                            .padding(bottom = 16.dp, start = 16.dp, end = 16.dp)
                             .background(Color.Black.copy(alpha = 0.6f), RoundedCornerShape(50))
                             .padding(horizontal = 14.dp, vertical = 7.dp),
                     )
@@ -2306,6 +2297,21 @@ private fun HeaderCircleButton(
     ) {
         Icon(icon, contentDescription = contentDescription, tint = tint, modifier = Modifier.size(18.dp))
     }
+}
+
+/** Size a full-screen surface's ROOT to the real display bounds so it fills the window even
+ *  under transparent system bars (a Dialog window is measured against INSET bounds, so plain
+ *  fillMaxSize stops a bar short). */
+@Composable
+private fun Modifier.requiredFullScreen(): Modifier {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val bounds = remember {
+        val wm = context.getSystemService(android.content.Context.WINDOW_SERVICE) as android.view.WindowManager
+        if (android.os.Build.VERSION.SDK_INT >= 30) wm.currentWindowMetrics.bounds
+        else android.graphics.Rect(0, 0, context.resources.displayMetrics.widthPixels, context.resources.displayMetrics.heightPixels)
+    }
+    return with(density) { this@requiredFullScreen.requiredSize(bounds.width().toDp(), bounds.height().toDp()) }
 }
 
 /** Re-size a Google FIFE photo URL (…=w500-h350) to a target width for full view. */
@@ -2526,6 +2532,7 @@ private fun FullScreenReviews(featureId: String, place: Place, ink: Color, dim: 
     // focus on page-finish). The auto-focus loop stops on its first success, so it hands off
     // to the WebView cleanly once the page loads. No-op under touch.
     val reviewsBackFocus = rememberDpadAutoFocus()
+    val density = LocalDensity.current
     Dialog(onDismissRequest = onClose, properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false)) {
         val panelView = LocalView.current
         DisposableEffect(Unit) {
@@ -2533,35 +2540,33 @@ private fun FullScreenReviews(featureId: String, place: Place, ink: Color, dim: 
                 it.setLayout(android.view.WindowManager.LayoutParams.MATCH_PARENT, android.view.WindowManager.LayoutParams.MATCH_PARENT)
                 androidx.core.view.WindowCompat.setDecorFitsSystemWindows(it, false)
                 it.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
-                // Compose's DialogLayout re-asserts its own window size/fit params, so the window
-                // stubbornly stays inset from the bars (window-dump-proven twice). The strips it
-                // leaves show the ACTIVITY behind — so paint THAT out: a full dim turns anything
-                // outside the window solid black, which reads as true full screen.
-                it.addFlags(android.view.WindowManager.LayoutParams.FLAG_DIM_BEHIND)
-                it.setDimAmount(1f)
-                // API 30+: DIALOG windows fit the bar insets via fitInsetsTypes, which none of
-                // the flags above touch — THIS is what kept the window inset from the screen's
-                // top/bottom through three rounds of "still not full screen" (screenshot-proven).
-                if (android.os.Build.VERSION.SDK_INT >= 30) {
-                    it.attributes = it.attributes.apply { fitInsetsTypes = 0 }
-                }
+                it.statusBarColor = android.graphics.Color.TRANSPARENT
+                it.navigationBarColor = android.graphics.Color.TRANSPARENT
                 it.setBackgroundDrawable(android.graphics.drawable.ColorDrawable((if (dark) SheetDark else SheetLight).toArgb()))
                 if (android.os.Build.VERSION.SDK_INT >= 28) {
                     it.attributes = it.attributes.apply {
                         layoutInDisplayCutoutMode = android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
                     }
                 }
+                androidx.core.view.WindowCompat.getInsetsController(it, panelView).isAppearanceLightStatusBars = !dark
             }
             onDispose { }
         }
-        Surface(Modifier.fillMaxSize(), color = if (dark) SheetDark else SheetLight, contentColor = ink) {
+        // Swipe DOWN from the top to close (user 2026-07-10): the panel forwards a top-edge
+        // overscroll as `pull`; past the threshold at finger-up it dismisses, like a sheet.
+        var pull by remember { mutableStateOf(0f) }
+        Surface(
+            Modifier.requiredFullScreen().offset { IntOffset(0, pull.roundToInt()) },
+            color = if (dark) SheetDark else SheetLight,
+            contentColor = ink,
+        ) {
             Column(Modifier.fillMaxSize().statusBarsPadding()) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
                 ) {
                     IconButton(onClick = onClose, modifier = Modifier.focusRequester(reviewsBackFocus)) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.place_back), tint = ink)
+                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.place_close), tint = ink)
                     }
                     Column(Modifier.weight(1f)) {
                         Text(place.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = ink, maxLines = 1)
@@ -2577,6 +2582,13 @@ private fun FullScreenReviews(featureId: String, place: Place, ink: Color, dim: 
                     // Tapping a review photo opens Vela's own gallery (Google's photo viewer is a
                     // page-nav the lockdown blocks + the carve can't host).
                     onPhotos = { urls, caps, start -> reviewPhotos = Triple(urls, caps, start) },
+                    // Top-edge pull-down: move the whole panel with the finger; release past the
+                    // threshold closes it (Google's dismiss). Deltas come from the panel's
+                    // boundary scroll-sync (reviews at their top + dragging down).
+                    onOverscroll = { dy -> pull = (pull + dy).coerceAtLeast(0f) },
+                    onOverscrollEnd = {
+                        if (pull > with(density) { 120.dp.toPx() }) onClose() else pull = 0f
+                    },
                 )
             }
         }

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -2070,37 +2070,72 @@ private fun PhotoShimmerTile(base: Color) {
 }
 
 /** Full-screen, swipeable photo viewer (tap a photo in the strip to open). */
+// ---- Activity-window full-screen overlays -------------------------------------------------------
+// A nested compose Dialog window can NOT reach the screen edges (window-dump-proven: it re-asserts
+// inset-fitted params) AND it re-captures stale display bounds on rotation (the "image floats,
+// background gone" report). The MAIN ACTIVITY window is already edge-to-edge, so these surfaces
+// render there instead — genuinely full-screen, and they re-lay-out on rotation for free. Deep call
+// sites push a request to a holder; [PlaceOverlays] (mounted at VelaRoot's root Box) renders it.
+
+object GalleryOverlay {
+    data class Req(val urls: List<String>, val dates: List<String?>, val start: Int, val onDismiss: () -> Unit)
+    var req by mutableStateOf<Req?>(null)
+        private set
+    fun show(urls: List<String>, dates: List<String?>, start: Int, onDismiss: () -> Unit) { req = Req(urls, dates, start, onDismiss) }
+    fun dismiss() { val r = req; req = null; r?.onDismiss?.invoke() }
+    fun clear() { req = null } // caller unmounted its own state — no callback
+}
+
+object FullReviewsOverlay {
+    data class Req(val featureId: String, val place: Place, val onDismiss: () -> Unit)
+    var req by mutableStateOf<Req?>(null)
+        private set
+    fun show(featureId: String, place: Place, onDismiss: () -> Unit) { req = Req(featureId, place, onDismiss) }
+    fun dismiss() { val r = req; req = null; r?.onDismiss?.invoke() }
+    fun clear() { req = null }
+}
+
+/** Rendered LAST in VelaRoot's root Box, so it sits above the map + sheet in the activity's own
+ *  edge-to-edge window. The gallery is drawn after the reviews page so a review-photo tap layers on top. */
+@Composable
+fun PlaceOverlays() {
+    FullReviewsOverlay.req?.let { r ->
+        val dark = isAppInDarkTheme()
+        FullScreenReviewsContent(r.featureId, r.place, if (dark) InkDark else InkLight, if (dark) DimDark else DimLight) { FullReviewsOverlay.dismiss() }
+    }
+    GalleryOverlay.req?.let { r ->
+        PhotoGalleryContent(r.urls, r.dates, r.start) { GalleryOverlay.dismiss() }
+    }
+}
+
 @Composable
 private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, onDismiss: () -> Unit) {
+    // Shim → the activity-window overlay (see GalleryOverlay). The call site keeps its own open/close
+    // state; unmounting clears the overlay without re-firing onDismiss.
+    DisposableEffect(urls, start) {
+        GalleryOverlay.show(urls, dates, start, onDismiss)
+        onDispose { GalleryOverlay.clear() }
+    }
+}
+
+@Composable
+private fun PhotoGalleryContent(urls: List<String>, dates: List<String?>, start: Int, onDismiss: () -> Unit) {
     if (urls.isEmpty()) return
-    // decorFitsSystemWindows=false: in LANDSCAPE the default dialog window stops at the system
-    // bars / cutout and the map showed through the uncovered strips (user 2026-07-10); drawing
-    // edge-to-edge lets the black Box actually cover the screen.
-    Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false)) {
-        // Google's viewer treatment: DON'T fight to cover the bars — draw edge-to-edge UNDER
-        // TRANSPARENT, still-visible system bars, with a gradient scrim so the status bar reads
-        // cleanly over the photo (user 2026-07-10). The window lays out past the bars via
-        // NO_LIMITS and the content root demands the true display size, so black fills behind the
-        // (transparent) bars top and bottom — no strips, and the clock stays legible.
-        val dialogView = LocalView.current
-        DisposableEffect(Unit) {
-            (dialogView.parent as? androidx.compose.ui.window.DialogWindowProvider)?.window?.let {
-                it.setLayout(android.view.WindowManager.LayoutParams.MATCH_PARENT, android.view.WindowManager.LayoutParams.MATCH_PARENT)
-                androidx.core.view.WindowCompat.setDecorFitsSystemWindows(it, false)
-                it.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
-                it.statusBarColor = android.graphics.Color.TRANSPARENT
-                it.navigationBarColor = android.graphics.Color.TRANSPARENT
-                it.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(android.graphics.Color.BLACK))
-                if (android.os.Build.VERSION.SDK_INT >= 28) {
-                    it.attributes = it.attributes.apply {
-                        layoutInDisplayCutoutMode = android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
-                    }
-                }
-                // Light icons on the dark viewer.
-                androidx.core.view.WindowCompat.getInsetsController(it, dialogView).isAppearanceLightStatusBars = false
+    BackHandler(onBack = onDismiss)
+    // The viewer is always black, so force LIGHT status/nav icons while it's up (the map theme
+    // may have set them dark); MainActivity's theme effect restores them when this leaves.
+    val galleryView = LocalView.current
+    DisposableEffect(Unit) {
+        val ctx = galleryView.context
+        val win = (ctx as? android.app.Activity)?.window
+        val prevLight = win?.let { androidx.core.view.WindowCompat.getInsetsController(it, galleryView).isAppearanceLightStatusBars }
+        win?.let { androidx.core.view.WindowCompat.getInsetsController(it, galleryView).isAppearanceLightStatusBars = false }
+        onDispose {
+            if (win != null && prevLight != null) {
+                androidx.core.view.WindowCompat.getInsetsController(win, galleryView).isAppearanceLightStatusBars = prevLight
             }
-            onDispose { }
         }
+    }
         val pager = rememberPagerState(initialPage = start.coerceIn(0, urls.lastIndex)) { urls.size }
         // D-pad (docs/dpad.md): the viewer grabs focus so LEFT/RIGHT page through the
         // photos with no touch; BACK already dismisses (Dialog).
@@ -2109,7 +2144,7 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
         LaunchedEffect(Unit) { runCatching { galleryFocus.requestFocus() } }
         Box(
             Modifier
-                .requiredFullScreen()
+                .fillMaxSize()
                 .background(Color.Black)
                 .focusRequester(galleryFocus)
                 .onKeyEvent { ev ->
@@ -2238,7 +2273,6 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
                 }
             }
         }
-    }
 }
 
 // Google's gallery-tab name for the menu, per app language (the categories arrive localized via
@@ -2523,43 +2557,28 @@ private fun PlaceTabs(
  *  native photo/video viewers all work. Back / the top-bar arrow closes it back to the sheet. */
 @Composable
 private fun FullScreenReviews(featureId: String, place: Place, ink: Color, dim: Color, onClose: () -> Unit) {
+    // Shim → the activity-window overlay (see FullReviewsOverlay).
+    DisposableEffect(featureId) {
+        FullReviewsOverlay.show(featureId, place, onClose)
+        onDispose { FullReviewsOverlay.clear() }
+    }
+}
+
+@Composable
+private fun FullScreenReviewsContent(featureId: String, place: Place, ink: Color, dim: Color, onClose: () -> Unit) {
     val dark = isAppInDarkTheme()
     var reviewPhotos by remember(featureId) { mutableStateOf<Triple<List<String>, List<String?>, Int>?>(null) }
-    // Back closes the photo gallery first (if open), else the whole screen.
     BackHandler(onBack = { if (reviewPhotos != null) reviewPhotos = null else onClose() })
-    // D-pad-first (docs/dpad.md): land focus on the back arrow immediately so the panel isn't
-    // unfocused during the WebView's load window (the WebView itself is alpha-0 + only grabs
-    // focus on page-finish). The auto-focus loop stops on its first success, so it hands off
-    // to the WebView cleanly once the page loads. No-op under touch.
     val reviewsBackFocus = rememberDpadAutoFocus()
     val density = LocalDensity.current
-    Dialog(onDismissRequest = onClose, properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false)) {
-        val panelView = LocalView.current
-        DisposableEffect(Unit) {
-            (panelView.parent as? androidx.compose.ui.window.DialogWindowProvider)?.window?.let {
-                it.setLayout(android.view.WindowManager.LayoutParams.MATCH_PARENT, android.view.WindowManager.LayoutParams.MATCH_PARENT)
-                androidx.core.view.WindowCompat.setDecorFitsSystemWindows(it, false)
-                it.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
-                it.statusBarColor = android.graphics.Color.TRANSPARENT
-                it.navigationBarColor = android.graphics.Color.TRANSPARENT
-                it.setBackgroundDrawable(android.graphics.drawable.ColorDrawable((if (dark) SheetDark else SheetLight).toArgb()))
-                if (android.os.Build.VERSION.SDK_INT >= 28) {
-                    it.attributes = it.attributes.apply {
-                        layoutInDisplayCutoutMode = android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
-                    }
-                }
-                androidx.core.view.WindowCompat.getInsetsController(it, panelView).isAppearanceLightStatusBars = !dark
-            }
-            onDispose { }
-        }
-        // Swipe DOWN from the top to close (user 2026-07-10): the panel forwards a top-edge
-        // overscroll as `pull`; past the threshold at finger-up it dismisses, like a sheet.
-        var pull by remember { mutableStateOf(0f) }
-        Surface(
-            Modifier.requiredFullScreen().offset { IntOffset(0, pull.roundToInt()) },
-            color = if (dark) SheetDark else SheetLight,
-            contentColor = ink,
-        ) {
+    // Swipe DOWN from the top to close (user 2026-07-10): the panel forwards a top-edge overscroll
+    // as `pull`; past the threshold at finger-up it dismisses, like a sheet.
+    var pull by remember { mutableStateOf(0f) }
+    Surface(
+        Modifier.fillMaxSize().offset { IntOffset(0, pull.roundToInt()) },
+        color = if (dark) SheetDark else SheetLight,
+        contentColor = ink,
+    ) {
             Column(Modifier.fillMaxSize().statusBarsPadding()) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
@@ -2591,7 +2610,6 @@ private fun FullScreenReviews(featureId: String, place: Place, ink: Color, dim: 
                     },
                 )
             }
-        }
     }
     reviewPhotos?.let { (urls, caps, start) ->
         PhotoGallery(urls, caps, start) { reviewPhotos = null }

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -286,9 +286,14 @@ fun PlaceSheet(
     // whole detent the moment a drag crossed a pixel threshold, which read as staccato steps
     // (user 2026-07-10). State flips from taps / the reviews panel / auto-expand still animate,
     // via the LaunchedEffect below.
-    val minH = screenH * 0.26f
-    val peekH = screenH * 0.56f
-    val expH = screenH * 0.92f
+    // A parked-car (or any minimal-content) sheet has nothing to minimize INTO — one compact
+    // fixed height, so a drag can't shrink it and hide the actions (user 2026-07-10). All three
+    // detents equal that height, so every detent computation resolves to it and the drag can't
+    // resize the sheet.
+    val singleDetent = isParking
+    val minH = if (singleDetent) screenH * 0.30f else screenH * 0.26f
+    val peekH = if (singleDetent) screenH * 0.30f else screenH * 0.56f
+    val expH = if (singleDetent) screenH * 0.30f else screenH * 0.92f
     fun detentFor(expanded: Boolean, minimized: Boolean) = when {
         expanded -> expH
         minimized -> minH
@@ -336,6 +341,7 @@ fun PlaceSheet(
     // linear projection factor of 0.15 - it's the one knob for "how hard must I throw it".
     val flingDecay = remember { exponentialDecay<Float>(frictionMultiplier = 1.6f) }
     fun settleFromVelocity(velocityPxPerSec: Float) {
+        if (singleDetent) { settleScope.launch { heightAnim.animateTo(peekH, settleSpec) }; return }
         val vDp = with(density) { velocityPxPerSec.toDp().value }
         // Where the throw would naturally coast to, then the nearest detent to THAT point.
         val naturalEnd = flingDecay.calculateTargetValue(heightAnim.value, -vDp)
@@ -508,8 +514,11 @@ fun PlaceSheet(
                     .dpadHighlight(RoundedCornerShape(3.dp))
                     .clickable {
                         // Tap grows one detent: minimized→peek, peek→expanded, expanded→peek.
-                        if (minimizedState.value) minimizedState.value = false
-                        else expandedState.value = !expandedState.value
+                        // (No-op on a single-detent sheet — a parked car has nowhere to step.)
+                        if (!singleDetent) {
+                            if (minimizedState.value) minimizedState.value = false
+                            else expandedState.value = !expandedState.value
+                        }
                     }
                     .pointerInput(Unit) {
                         // The handle drags the sheet 1:1 and the release coasts to the nearest
@@ -546,7 +555,7 @@ fun PlaceSheet(
                     // recomposition), and the minimized card below fades in at the swap - the
                     // content no longer vanishes in one frame at the flip.
                     .graphicsLayer {
-                        if (minimizedState.value) { alpha = 1f; translationY = 0f } else {
+                        if (minimizedState.value || singleDetent) { alpha = 1f; translationY = 0f } else {
                             val f = ((heightAnim.value - minH) / 110f).coerceIn(0f, 1f)
                             alpha = f
                             // The content SLIDES DOWN as it fades (user 2026-07-10) — the exit
@@ -559,7 +568,7 @@ fun PlaceSheet(
             // Minimized detent: a compact card (name, rating, Directions) instead of the full body,
             // like Google's collapsed sheet. At this small height leading with the photo hero showed
             // only photos AND let the horizontal gallery swallow dismiss drags, so short-circuit here.
-            if (minimizedState.value) {
+            if (minimizedState.value && !singleDetent) {
                 val miniIn = remember { androidx.compose.animation.core.Animatable(0f) }
                 LaunchedEffect(Unit) { miniIn.animateTo(1f, tween(220)) }
                 // A single tap ANYWHERE on the minimized card pops it back to peek (Google) —

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -2599,8 +2599,9 @@ private fun FullScreenReviewsContent(featureId: String, place: Place, ink: Color
                     // threshold closes it (Google's dismiss). Deltas come from the panel's
                     // boundary scroll-sync (reviews at their top + dragging down).
                     onOverscroll = { dy -> pull = (pull + dy).coerceAtLeast(0f) },
-                    onOverscrollEnd = {
-                        if (pull > with(density) { 120.dp.toPx() }) onClose() else pull = 0f
+                    onOverscrollEnd = { vel ->
+                        // Close on a real pull OR a hard downward flick, like the photo viewer.
+                        if (pull > with(density) { 120.dp.toPx() } || vel > 2500f) onClose() else pull = 0f
                     },
                 )
             }

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -2088,6 +2088,12 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
                 // The one flag that UNCONDITIONALLY lets the window lay out past the bars — the
                 // fitting flags alone still left top/bottom strips on this device (2026-07-10).
                 it.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
+                // Compose's DialogLayout re-asserts its own window size/fit params, so the window
+                // stubbornly stays inset from the bars (window-dump-proven twice). The strips it
+                // leaves show the ACTIVITY behind — so paint THAT out: a full dim turns anything
+                // outside the window solid black, which reads as true full screen.
+                it.addFlags(android.view.WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+                it.setDimAmount(1f)
                 // API 30+: DIALOG windows fit the bar insets via fitInsetsTypes, which none of
                 // the flags above touch — THIS is what kept the window inset from the screen's
                 // top/bottom through three rounds of "still not full screen" (screenshot-proven).
@@ -2527,6 +2533,12 @@ private fun FullScreenReviews(featureId: String, place: Place, ink: Color, dim: 
                 it.setLayout(android.view.WindowManager.LayoutParams.MATCH_PARENT, android.view.WindowManager.LayoutParams.MATCH_PARENT)
                 androidx.core.view.WindowCompat.setDecorFitsSystemWindows(it, false)
                 it.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
+                // Compose's DialogLayout re-asserts its own window size/fit params, so the window
+                // stubbornly stays inset from the bars (window-dump-proven twice). The strips it
+                // leaves show the ACTIVITY behind — so paint THAT out: a full dim turns anything
+                // outside the window solid black, which reads as true full screen.
+                it.addFlags(android.view.WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+                it.setDimAmount(1f)
                 // API 30+: DIALOG windows fit the bar insets via fitInsetsTypes, which none of
                 // the flags above touch — THIS is what kept the window inset from the screen's
                 // top/bottom through three rounds of "still not full screen" (screenshot-proven).

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -671,43 +671,35 @@ fun PlaceSheet(
                 )
                 // Save + Share as compact header actions (preferred look). The name has weight(1f) and
                 // wraps to 2 lines if long, so these stay put without shoving it off.
-                IconButton(
-                    onClick = onToggleSave,
-                    modifier = Modifier
-                        .size(40.dp)
-                        .background(dim.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
-                ) {
-                    Icon(
-                        if (isSaved) Icons.Default.Star else Icons.Default.StarBorder,
-                        contentDescription = if (isSaved) stringResource(R.string.place_saved) else stringResource(R.string.place_save),
-                        tint = if (isSaved) MaterialTheme.colorScheme.primary else dim,
-                        modifier = Modifier.size(20.dp),
-                    )
-                }
-                ShareIconButton(place, dim)
-                // Overflow: pin this place straight to Home/Work (Google-style).
-                var headerMenu by remember { mutableStateOf(false) }
+                // The STAR is the whole save/pin menu now (quick save, lists, note, home/work) —
+                // four circled buttons crowded the header, and the overflow's items were all
+                // save-family anyway (user 2026-07-10). D-pad-first via VelaMenu (docs/dpad.md).
+                var saveMenu by remember { mutableStateOf(false) }
                 Box {
                     IconButton(
-                        onClick = { headerMenu = true },
+                        onClick = { saveMenu = true },
                         modifier = Modifier
                             .size(40.dp)
                             .background(dim.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
                     ) {
-                        Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.place_more_options), tint = dim, modifier = Modifier.size(20.dp))
+                        Icon(
+                            if (isSaved) Icons.Default.Star else Icons.Default.StarBorder,
+                            contentDescription = if (isSaved) stringResource(R.string.place_saved) else stringResource(R.string.place_save),
+                            tint = if (isSaved) MaterialTheme.colorScheme.primary else dim,
+                            modifier = Modifier.size(20.dp),
+                        )
                     }
-                    // D-pad-first (docs/dpad.md): VelaMenu renders the normal anchored DropdownMenu
-                    // under touch, but a raw-Dialog chooser that AUTO-FOCUSES its first item under
-                    // D-pad (a DropdownMenu Popup can't be pre-focused; a raw Dialog can).
-                    VelaMenu(expanded = headerMenu, onDismissRequest = { headerMenu = false }) {
+                    VelaMenu(expanded = saveMenu, onDismissRequest = { saveMenu = false }) {
+                        item(stringResource(if (isSaved) R.string.place_saved else R.string.place_save)) { saveMenu = false; onToggleSave() }
                         if (!isParking) {
-                            item(stringResource(R.string.place_save_to_list)) { headerMenu = false; showListChooser = true }
-                            if (inAnyList) item(stringResource(R.string.place_edit_note)) { headerMenu = false; showNoteEditor = true }
+                            item(stringResource(R.string.place_save_to_list)) { saveMenu = false; showListChooser = true }
+                            if (inAnyList) item(stringResource(R.string.place_edit_note)) { saveMenu = false; showNoteEditor = true }
                         }
-                        item(stringResource(R.string.place_set_as_home)) { headerMenu = false; onSetShortcut(ShortcutKind.HOME) }
-                        item(stringResource(R.string.place_set_as_work)) { headerMenu = false; onSetShortcut(ShortcutKind.WORK) }
+                        item(stringResource(R.string.place_set_as_home)) { saveMenu = false; onSetShortcut(ShortcutKind.HOME) }
+                        item(stringResource(R.string.place_set_as_work)) { saveMenu = false; onSetShortcut(ShortcutKind.WORK) }
                     }
                 }
+                ShareIconButton(place, dim)
                 IconButton(
                     onClick = onClose,
                     modifier = Modifier
@@ -1008,7 +1000,7 @@ fun PlaceSheet(
             val highlights = remember(place.about) { attributeHighlights(place.about) }
             if (highlights.isNotEmpty()) {
                 Row(
-                    Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(top = 16.dp),
+                    Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(top = 20.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     highlights.forEach { h ->
@@ -1028,7 +1020,10 @@ fun PlaceSheet(
 
             // Popular times sit BELOW the action buttons (Google's order). Lazily
             // filled by the WebView detail fetch, so it pops in a beat after open.
-            place.popularTimes?.let { PopularTimesSection(it, ink, dim) }
+            place.popularTimes?.let {
+                Spacer(Modifier.height(10.dp)) // clear air between the attribute chips and the chart
+                PopularTimesSection(it, ink, dim)
+            }
             // While the (slow, ~10–20 s) detail fetch is in flight and popular times
             // haven't landed yet, show a subtle indicator so it reads as "loading", not
             // "missing" — it clears to the chart, or to nothing if this place has none.
@@ -2084,7 +2079,10 @@ private fun PhotoShimmerTile(base: Color) {
 @Composable
 private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, onDismiss: () -> Unit) {
     if (urls.isEmpty()) return
-    Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+    // decorFitsSystemWindows=false: in LANDSCAPE the default dialog window stops at the system
+    // bars / cutout and the map showed through the uncovered strips (user 2026-07-10); drawing
+    // edge-to-edge lets the black Box actually cover the screen.
+    Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false)) {
         val pager = rememberPagerState(initialPage = start.coerceIn(0, urls.lastIndex)) { urls.size }
         // D-pad (docs/dpad.md): the viewer grabs focus so LEFT/RIGHT page through the
         // photos with no touch; BACK already dismisses (Dialog).
@@ -2189,12 +2187,15 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
                 // Pixel 9 — so a normal bottom caption vanished. A FIXED bottom clearance keeps it in the
                 // drawable area regardless (harmlessly a touch higher on phones with no such clip).
                 dates.getOrNull(pager.currentPage)?.let { caption ->
+                    // The clearance is PROPORTIONAL (capped at the old 120dp): a fixed 120dp was
+                    // a third of the screen in landscape and floated the caption to the middle.
+                    val captionClear = (LocalConfiguration.current.screenHeightDp * 0.14f).dp.coerceAtMost(120.dp)
                     Text(
                         caption,
                         style = MaterialTheme.typography.bodyMedium,
                         color = Color.White,
                         modifier = Modifier.align(Alignment.BottomCenter)
-                            .padding(bottom = 120.dp, start = 16.dp, end = 16.dp)
+                            .padding(bottom = captionClear, start = 16.dp, end = 16.dp)
                             .background(Color.Black.copy(alpha = 0.6f), RoundedCornerShape(50))
                             .padding(horizontal = 14.dp, vertical = 7.dp),
                     )

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -176,6 +176,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -2087,6 +2088,11 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
                 // The one flag that UNCONDITIONALLY lets the window lay out past the bars — the
                 // fitting flags alone still left top/bottom strips on this device (2026-07-10).
                 it.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
+                // Paint the WINDOW DECOR black: the compose content is measured to the pre-flag
+                // frame, so the extra NO_LIMITS area showed the sheet ghosting through (the
+                // screenshot-verified "not full screen" strips). The decor background covers the
+                // whole window regardless of content size.
+                it.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(android.graphics.Color.BLACK))
                 if (android.os.Build.VERSION.SDK_INT >= 28) {
                     it.attributes = it.attributes.apply {
                         layoutInDisplayCutoutMode = android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
@@ -2515,6 +2521,7 @@ private fun FullScreenReviews(featureId: String, place: Place, ink: Color, dim: 
                 it.setLayout(android.view.WindowManager.LayoutParams.MATCH_PARENT, android.view.WindowManager.LayoutParams.MATCH_PARENT)
                 androidx.core.view.WindowCompat.setDecorFitsSystemWindows(it, false)
                 it.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
+                it.setBackgroundDrawable(android.graphics.drawable.ColorDrawable((if (dark) SheetDark else SheetLight).toArgb()))
                 if (android.os.Build.VERSION.SDK_INT >= 28) {
                     it.attributes = it.attributes.apply {
                         layoutInDisplayCutoutMode = android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -2333,21 +2333,6 @@ private fun HeaderCircleButton(
     }
 }
 
-/** Size a full-screen surface's ROOT to the real display bounds so it fills the window even
- *  under transparent system bars (a Dialog window is measured against INSET bounds, so plain
- *  fillMaxSize stops a bar short). */
-@Composable
-private fun Modifier.requiredFullScreen(): Modifier {
-    val context = LocalContext.current
-    val density = LocalDensity.current
-    val bounds = remember {
-        val wm = context.getSystemService(android.content.Context.WINDOW_SERVICE) as android.view.WindowManager
-        if (android.os.Build.VERSION.SDK_INT >= 30) wm.currentWindowMetrics.bounds
-        else android.graphics.Rect(0, 0, context.resources.displayMetrics.widthPixels, context.resources.displayMetrics.heightPixels)
-    }
-    return with(density) { this@requiredFullScreen.requiredSize(bounds.width().toDp(), bounds.height().toDp()) }
-}
-
 /** Re-size a Google FIFE photo URL (…=w500-h350) to a target width for full view. */
 private fun String.atWidth(w: Int): String = replace(Regex("=w\\d+(-h\\d+)?.*$"), "=w$w")
 

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -537,15 +537,30 @@ fun PlaceSheet(
                 Modifier
                     .nestedScroll(dismissConn)
                     .verticalScroll(bodyScroll)
+                    // GRACEFUL EXIT (user 2026-07-10): while the sheet glides toward the minimized
+                    // floor the full body FADES OUT with the height (render-phase read, no
+                    // recomposition), and the minimized card below fades in at the swap - the
+                    // content no longer vanishes in one frame at the flip.
+                    .graphicsLayer {
+                        alpha = if (minimizedState.value) 1f
+                        else ((heightAnim.value - minH) / 110f).coerceIn(0f, 1f)
+                    }
                     .padding(start = 20.dp, end = 20.dp, bottom = 20.dp),
             ) {
             // Minimized detent: a compact card (name, rating, Directions) instead of the full body,
             // like Google's collapsed sheet. At this small height leading with the photo hero showed
             // only photos AND let the horizontal gallery swallow dismiss drags, so short-circuit here.
             if (minimizedState.value) {
+                val miniIn = remember { androidx.compose.animation.core.Animatable(0f) }
+                LaunchedEffect(Unit) { miniIn.animateTo(1f, tween(220)) }
                 // A single tap ANYWHERE on the minimized card pops it back to peek (Google) —
                 // the Directions pill keeps its own tap since inner clickables win their bounds.
-                Column(Modifier.fillMaxWidth().clickable { minimizedState.value = false }) {
+                Column(
+                    Modifier
+                        .fillMaxWidth()
+                        .graphicsLayer { alpha = miniIn.value }
+                        .clickable { minimizedState.value = false },
+                ) {
                 Text(
                     place.name,
                     style = MaterialTheme.typography.titleLarge,
@@ -660,19 +675,12 @@ fun PlaceSheet(
                 // save-family anyway (user 2026-07-10). D-pad-first via VelaMenu (docs/dpad.md).
                 var saveMenu by remember { mutableStateOf(false) }
                 Box {
-                    IconButton(
-                        onClick = { saveMenu = true },
-                        modifier = Modifier
-                            .size(36.dp)
-                            .background(dim.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
-                    ) {
-                        Icon(
-                            if (isSaved) Icons.Default.Star else Icons.Default.StarBorder,
-                            contentDescription = if (isSaved) stringResource(R.string.place_saved) else stringResource(R.string.place_save),
-                            tint = if (isSaved) MaterialTheme.colorScheme.primary else dim,
-                            modifier = Modifier.size(18.dp),
-                        )
-                    }
+                    HeaderCircleButton(
+                        icon = if (isSaved) Icons.Default.Star else Icons.Default.StarBorder,
+                        contentDescription = if (isSaved) stringResource(R.string.place_saved) else stringResource(R.string.place_save),
+                        tint = if (isSaved) MaterialTheme.colorScheme.primary else dim,
+                        bg = dim,
+                    ) { saveMenu = true }
                     VelaMenu(expanded = saveMenu, onDismissRequest = { saveMenu = false }) {
                         item(stringResource(if (isSaved) R.string.place_saved else R.string.place_save)) { saveMenu = false; onToggleSave() }
                         if (!isParking) {
@@ -684,14 +692,7 @@ fun PlaceSheet(
                     }
                 }
                 ShareIconButton(place, dim)
-                IconButton(
-                    onClick = onClose,
-                    modifier = Modifier
-                        .size(36.dp)
-                        .background(dim.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
-                ) {
-                    Icon(Icons.Default.Close, contentDescription = stringResource(R.string.place_close), tint = dim, modifier = Modifier.size(18.dp))
-                }
+                HeaderCircleButton(Icons.Default.Close, stringResource(R.string.place_close), dim, dim, onClick = onClose)
             }
 
             if (place.rating != null) {
@@ -2073,6 +2074,16 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
         DisposableEffect(Unit) {
             val win = (dialogView.parent as? androidx.compose.ui.window.DialogWindowProvider)?.window
             win?.let {
+                // The dialog WINDOW itself must claim the whole screen — decorFitsSystemWindows
+                // alone leaves the window sized inside the bars on several API levels (the "still
+                // not completely full screen top or bottom" report).
+                it.setLayout(android.view.WindowManager.LayoutParams.MATCH_PARENT, android.view.WindowManager.LayoutParams.MATCH_PARENT)
+                androidx.core.view.WindowCompat.setDecorFitsSystemWindows(it, false)
+                if (android.os.Build.VERSION.SDK_INT >= 28) {
+                    it.attributes = it.attributes.apply {
+                        layoutInDisplayCutoutMode = android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+                    }
+                }
                 val ctl = androidx.core.view.WindowCompat.getInsetsController(it, dialogView)
                 ctl.systemBarsBehavior = androidx.core.view.WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
                 ctl.hide(androidx.core.view.WindowInsetsCompat.Type.systemBars())
@@ -2243,6 +2254,31 @@ private fun MenuTab(place: Place, menuIndices: List<Int>, dim: Color, onOpen: (I
                 if (rowIdx.size == 1) Spacer(Modifier.weight(1f))
             }
         }
+    }
+}
+
+/** A header action: an 18dp icon in a fixed 36dp grey circle. A plain clickable Box, NOT an M3
+ *  IconButton — the IconButton's minimum-touch-target machinery kept re-inflating the layout
+ *  box past the visible circle, which is why the header circles overlapped through two rounds
+ *  of "make them smaller" (user 2026-07-10). Here the layout size IS the circle, full stop. */
+@Composable
+private fun HeaderCircleButton(
+    icon: ImageVector,
+    contentDescription: String?,
+    tint: Color,
+    bg: Color,
+    onClick: () -> Unit,
+) {
+    Box(
+        Modifier
+            .size(36.dp)
+            .clip(androidx.compose.foundation.shape.CircleShape)
+            .background(bg.copy(alpha = 0.12f))
+            .dpadHighlight(androidx.compose.foundation.shape.CircleShape)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(icon, contentDescription = contentDescription, tint = tint, modifier = Modifier.size(18.dp))
     }
 }
 
@@ -2465,6 +2501,19 @@ private fun FullScreenReviews(featureId: String, place: Place, ink: Color, dim: 
     // to the WebView cleanly once the page loads. No-op under touch.
     val reviewsBackFocus = rememberDpadAutoFocus()
     Dialog(onDismissRequest = onClose, properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false)) {
+        val panelView = LocalView.current
+        DisposableEffect(Unit) {
+            (panelView.parent as? androidx.compose.ui.window.DialogWindowProvider)?.window?.let {
+                it.setLayout(android.view.WindowManager.LayoutParams.MATCH_PARENT, android.view.WindowManager.LayoutParams.MATCH_PARENT)
+                androidx.core.view.WindowCompat.setDecorFitsSystemWindows(it, false)
+                if (android.os.Build.VERSION.SDK_INT >= 28) {
+                    it.attributes = it.attributes.apply {
+                        layoutInDisplayCutoutMode = android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+                    }
+                }
+            }
+            onDispose { }
+        }
         Surface(Modifier.fillMaxSize(), color = if (dark) SheetDark else SheetLight, contentColor = ink) {
             Column(Modifier.fillMaxSize().statusBarsPadding()) {
                 Row(
@@ -2850,14 +2899,7 @@ private fun ShareIconButton(place: Place, tint: Color) {
     }
 
     Box {
-        IconButton(
-            onClick = { open = true },
-            modifier = Modifier
-                .size(36.dp)
-                .background(tint.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
-        ) {
-            Icon(Icons.Default.Share, contentDescription = stringResource(R.string.place_share), tint = tint, modifier = Modifier.size(18.dp))
-        }
+        HeaderCircleButton(Icons.Default.Share, stringResource(R.string.place_share), tint, tint) { open = true }
         VelaMenu(expanded = open, onDismissRequest = { open = false }) {
             item(stringResource(R.string.place_share_gmaps_link)) { share("${place.name}\nhttps://www.google.com/maps/search/?api=1&query=$lat%2C$lng") }
             // A geo: URI opens in ANY maps app (incl. Vela) — no google.com, the

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -2205,6 +2205,39 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
     }
 }
 
+// Google's gallery-tab name for the menu, per app language (the categories arrive localized via
+// hl=). Lowercase contains-match, so "Menu", "Menú", "Speisekarte & Getränke" all hit.
+private val MENU_TAB_WORDS = listOf("menu", "menú", "menù", "speisekarte", "cardápio", "menukaart", "меню", "meny")
+
+/** The Menu tab: the menu-tagged gallery photos as a browsable 2-up grid (tap → full-screen).
+ *  Only mounted when the place HAS menu photos, so no empty state is needed. Plain Column of
+ *  chunked rows, not a lazy grid — the sheet body already scrolls, and menu sets are tens of
+ *  photos at most. */
+@Composable
+private fun MenuTab(place: Place, menuIndices: List<Int>, dim: Color, onOpen: (Int) -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        menuIndices.chunked(2).forEach { rowIdx ->
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.fillMaxWidth()) {
+                rowIdx.forEach { i ->
+                    AsyncImage(
+                        model = place.photoUrls.getOrNull(i),
+                        contentDescription = stringResource(R.string.place_photo_number, i + 1),
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(150.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(dim.copy(alpha = 0.2f))
+                            .dpadHighlight(RoundedCornerShape(12.dp))
+                            .clickable { onOpen(i) },
+                    )
+                }
+                if (rowIdx.size == 1) Spacer(Modifier.weight(1f))
+            }
+        }
+    }
+}
+
 /** Re-size a Google FIFE photo URL (…=w500-h350) to a target width for full view. */
 private fun String.atWidth(w: Int): String = replace(Regex("=w\\d+(-h\\d+)?.*$"), "=w$w")
 
@@ -2329,8 +2362,21 @@ private fun PlaceTabs(
             (app.vela.ui.LiveReviews.on.value && place.featureId?.contains(":") == true)
         )
     val hasAbout = place.about.isNotEmpty() || place.editorialSummary != null || place.ownerDescription != null
+    // Menu photos get their OWN TAB beside Reviews/About (user 2026-07-10) — the gallery's
+    // category chip buried them. Detection is by Google's own gallery-tab name (it arrives
+    // localized, so match a per-language keyword set; the matched name is reused as the tab
+    // title so it's localized for free). Indices are photoCategories↔photoUrls aligned.
+    val menuIndices = remember(place.photoCategories) {
+        place.photoCategories.withIndex()
+            .filter { (_, cat) -> cat != null && MENU_TAB_WORDS.any { cat.lowercase().contains(it) } }
+            .map { it.index }
+    }
+    val menuTabName = remember(place.photoCategories) {
+        place.photoCategories.firstOrNull { cat -> cat != null && MENU_TAB_WORDS.any { cat.lowercase().contains(it) } }
+    }
     val tabs = buildList {
         if (hasReviews) add("Reviews")
+        if (menuIndices.isNotEmpty() && app.vela.ui.LoadPhotos.on.value) add("Menu")
         if (hasAbout) add("About")
     }
     if (tabs.isEmpty()) return
@@ -2347,7 +2393,9 @@ private fun PlaceTabs(
                 contentColor = ink,
             ) {
                 tabs.forEachIndexed { i, title ->
-                    Tab(selected = i == selected, onClick = { sel = i }, text = { Text(title) })
+                    // The Menu tab shows Google's own (localized) gallery-tab name.
+                    val display = if (title == "Menu") (menuTabName ?: title) else title
+                    Tab(selected = i == selected, onClick = { sel = i }, text = { Text(display) })
                 }
             }
         }
@@ -2375,6 +2423,17 @@ private fun PlaceTabs(
                     }
                     if (showFullPanel && fid != null) {
                         FullScreenReviews(fid, place, ink, dim) { showFullPanel = false }
+                    }
+                }
+                "Menu" -> {
+                    var menuStart by remember(place.id) { mutableStateOf<Int?>(null) }
+                    MenuTab(place, menuIndices, dim) { i -> menuStart = i }
+                    menuStart?.let { start ->
+                        PhotoGallery(
+                            place.photoUrls,
+                            place.photoDates.map { d -> d?.let { stringResource(R.string.place_photo_caption, it) } },
+                            start,
+                        ) { menuStart = null }
                     }
                 }
                 "About" -> AboutTab(place.about, place.editorialSummary, place.ownerDescription, ink, dim)
@@ -2444,6 +2503,10 @@ private fun ReviewsTab(
 ) {
     // Search within the loaded reviews (author or text, case-insensitive). Resets per place.
     var reviewQuery by remember(place.id) { mutableStateOf("") }
+    // The local search hides behind a magnifier beside the All-reviews pill — a full text field
+    // stacked right under the pill read as clutter (user 2026-07-10); the panel's server-side
+    // search stays the headline way to get granular.
+    var reviewSearchOpen by remember(place.id) { mutableStateOf(false) }
     Column {
         place.rating?.let { r ->
             // Google's summary block: the big number leads, stars + count stack beside it,
@@ -2476,28 +2539,48 @@ private fun ReviewsTab(
         // Entry to the full-screen live Google reviews — all of them, plus Google's own SORT and
         // server-side search. The label says so (the button used to just say "Read all").
         onReadAll?.let { open ->
-            // Tonal pill, matching the sheet's action language — the outlined button was the
-            // one outlined control left on the sheet and read as dated beside the pills.
-            Row(
-                Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 10.dp)
-                    .clip(androidx.compose.foundation.shape.CircleShape)
-                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.13f))
-                    .dpadHighlight(androidx.compose.foundation.shape.CircleShape)
-                    .clickable(onClick = open)
-                    .padding(vertical = 12.dp),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(8.dp))
-                Text(
-                    place.reviewCount?.let { stringResource(R.string.place_all_n_reviews, it) } ?: stringResource(R.string.place_all_reviews),
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.primary,
-                    fontWeight = FontWeight.Medium,
-                )
+            // Tonal pill, matching the sheet's action language, with the LOCAL search folded
+            // into a circled magnifier beside it (progressive disclosure — see reviewSearchOpen).
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth().padding(bottom = 10.dp)) {
+                Row(
+                    Modifier
+                        .weight(1f)
+                        .clip(androidx.compose.foundation.shape.CircleShape)
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.13f))
+                        .dpadHighlight(androidx.compose.foundation.shape.CircleShape)
+                        .clickable(onClick = open)
+                        .padding(vertical = 12.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        place.reviewCount?.let { stringResource(R.string.place_all_n_reviews, it) } ?: stringResource(R.string.place_all_reviews),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+                if (!loading && reviews.size >= 5) {
+                    Spacer(Modifier.width(8.dp))
+                    IconButton(
+                        onClick = {
+                            reviewSearchOpen = !reviewSearchOpen
+                            if (!reviewSearchOpen) reviewQuery = "" // a hidden filter must not keep filtering
+                        },
+                        modifier = Modifier
+                            .size(44.dp)
+                            .background(dim.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
+                    ) {
+                        Icon(
+                            if (reviewSearchOpen) Icons.Default.Close else Icons.Default.Search,
+                            contentDescription = stringResource(R.string.place_search_reviews),
+                            tint = dim,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                }
             }
         }
         // Featured-review quote is only a TEASER while the real reviews are still streaming in —
@@ -2562,7 +2645,7 @@ private fun ReviewsTab(
                 // author. Held back until the scrape COMPLETES: popping a text field in above rows
                 // the user is reading mid-stream shifts everything under their finger; appearing at
                 // completion it takes the space the progress header just vacated (a near-swap).
-                if (!loading && reviews.size >= 5) {
+                if (!loading && reviews.size >= 5 && (reviewSearchOpen || onReadAll == null)) {
                     OutlinedTextField(
                         value = reviewQuery,
                         onValueChange = { reviewQuery = it },

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -565,7 +565,29 @@ fun PlaceSheet(
                     }
                 }
                 Spacer(Modifier.height(10.dp))
-                ActionPill(Icons.Default.Directions, stringResource(R.string.place_directions), emphasized = true, onClick = onDirections)
+                // The full sheet's key actions, not just Directions — a minimized card you can
+                // call or open the website from saves a pointless re-expand (user 2026-07-10).
+                // Same gating as the full action row (website behind the external-links toggle).
+                Row(
+                    Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    ActionPill(Icons.Default.Directions, stringResource(R.string.place_directions), emphasized = true, onClick = onDirections)
+                    place.phone?.let { ph ->
+                        ActionPill(Icons.Default.Call, stringResource(R.string.place_call)) {
+                            val dialable = "tel:" + ph.filter { it.isDigit() || it == '+' }
+                            runCatching { context.startActivity(Intent(Intent.ACTION_DIAL, Uri.parse(dialable))) }
+                        }
+                    }
+                    if (!app.vela.ui.HideExternalLinks.on.value) {
+                        place.website?.let { site ->
+                            ActionPill(Icons.Default.Language, stringResource(R.string.place_website)) {
+                                runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(site))) }
+                            }
+                        }
+                    }
+                }
                 }
                 return@Column
             }
@@ -624,7 +646,9 @@ fun PlaceSheet(
                     }
                 }
             }
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            // spacedBy keeps the circled header buttons from touching now that they carry
+            // visible backgrounds (Google's circles have the same small gaps).
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
                 if (isParking) {
                     Icon(
                         Icons.Default.DirectionsCar,
@@ -647,7 +671,12 @@ fun PlaceSheet(
                 )
                 // Save + Share as compact header actions (preferred look). The name has weight(1f) and
                 // wraps to 2 lines if long, so these stay put without shoving it off.
-                IconButton(onClick = onToggleSave, modifier = Modifier.size(40.dp)) {
+                IconButton(
+                    onClick = onToggleSave,
+                    modifier = Modifier
+                        .size(40.dp)
+                        .background(dim.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
+                ) {
                     Icon(
                         if (isSaved) Icons.Default.Star else Icons.Default.StarBorder,
                         contentDescription = if (isSaved) stringResource(R.string.place_saved) else stringResource(R.string.place_save),
@@ -659,7 +688,12 @@ fun PlaceSheet(
                 // Overflow: pin this place straight to Home/Work (Google-style).
                 var headerMenu by remember { mutableStateOf(false) }
                 Box {
-                    IconButton(onClick = { headerMenu = true }, modifier = Modifier.size(40.dp)) {
+                    IconButton(
+                        onClick = { headerMenu = true },
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(dim.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
+                    ) {
                         Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.place_more_options), tint = dim, modifier = Modifier.size(20.dp))
                     }
                     // D-pad-first (docs/dpad.md): VelaMenu renders the normal anchored DropdownMenu
@@ -674,7 +708,12 @@ fun PlaceSheet(
                         item(stringResource(R.string.place_set_as_work)) { headerMenu = false; onSetShortcut(ShortcutKind.WORK) }
                     }
                 }
-                IconButton(onClick = onClose, modifier = Modifier.size(40.dp)) {
+                IconButton(
+                    onClick = onClose,
+                    modifier = Modifier
+                        .size(40.dp)
+                        .background(dim.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
+                ) {
                     Icon(Icons.Default.Close, contentDescription = stringResource(R.string.place_close), tint = dim, modifier = Modifier.size(20.dp))
                 }
             }
@@ -969,8 +1008,8 @@ fun PlaceSheet(
             val highlights = remember(place.about) { attributeHighlights(place.about) }
             if (highlights.isNotEmpty()) {
                 Row(
-                    Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(top = 12.dp),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(top = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     highlights.forEach { h ->
                         Text(
@@ -2406,27 +2445,58 @@ private fun ReviewsTab(
     var reviewQuery by remember(place.id) { mutableStateOf("") }
     Column {
         place.rating?.let { r ->
+            // Google's summary block: the big number leads, stars + count stack beside it,
+            // left-aligned with the reviews below — the old centered strip floated oddly
+            // between the tabs and the button (user 2026-07-10).
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center,
-                modifier = Modifier.fillMaxWidth().padding(bottom = 6.dp),
+                modifier = Modifier.fillMaxWidth().padding(top = 2.dp, bottom = 10.dp),
             ) {
-                Text(String.format(Locale.US, "%.1f", r), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold, color = ink)
-                Spacer(Modifier.width(8.dp))
-                RatingStars(r)
-                place.reviewCount?.let {
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(R.string.place_review_count, it), style = MaterialTheme.typography.bodyMedium, color = dim)
+                Text(
+                    String.format(Locale.US, "%.1f", r),
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.Bold,
+                    color = ink,
+                )
+                Spacer(Modifier.width(14.dp))
+                Column {
+                    RatingStars(r)
+                    place.reviewCount?.let {
+                        Text(
+                            stringResource(R.string.place_review_count, it),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = dim,
+                            modifier = Modifier.padding(top = 3.dp),
+                        )
+                    }
                 }
             }
         }
         // Entry to the full-screen live Google reviews — all of them, plus Google's own SORT and
         // server-side search. The label says so (the button used to just say "Read all").
         onReadAll?.let { open ->
-            OutlinedButton(onClick = open, modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)) {
-                Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = null, modifier = Modifier.size(18.dp))
+            // Tonal pill, matching the sheet's action language — the outlined button was the
+            // one outlined control left on the sheet and read as dated beside the pills.
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 10.dp)
+                    .clip(androidx.compose.foundation.shape.CircleShape)
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.13f))
+                    .dpadHighlight(androidx.compose.foundation.shape.CircleShape)
+                    .clickable(onClick = open)
+                    .padding(vertical = 12.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(18.dp))
                 Spacer(Modifier.width(8.dp))
-                Text(place.reviewCount?.let { stringResource(R.string.place_all_n_reviews, it) } ?: stringResource(R.string.place_all_reviews))
+                Text(
+                    place.reviewCount?.let { stringResource(R.string.place_all_n_reviews, it) } ?: stringResource(R.string.place_all_reviews),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Medium,
+                )
             }
         }
         // Featured-review quote is only a TEASER while the real reviews are still streaming in —
@@ -2650,9 +2720,9 @@ private fun ActionPill(icon: ImageVector, label: String, emphasized: Boolean = f
     val fg = if (emphasized) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary
     Row(
         Modifier
-            .clip(RoundedCornerShape(20.dp))
+            .clip(androidx.compose.foundation.shape.CircleShape)
             .background(bg)
-            .dpadHighlight(RoundedCornerShape(20.dp))
+            .dpadHighlight(androidx.compose.foundation.shape.CircleShape)
             .clickable(onClick = onClick)
             .padding(horizontal = 14.dp, vertical = 9.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -2688,7 +2758,12 @@ private fun ShareIconButton(place: Place, tint: Color) {
     }
 
     Box {
-        IconButton(onClick = { open = true }, modifier = Modifier.size(40.dp)) {
+        IconButton(
+            onClick = { open = true },
+            modifier = Modifier
+                .size(40.dp)
+                .background(tint.copy(alpha = 0.12f), androidx.compose.foundation.shape.CircleShape),
+        ) {
             Icon(Icons.Default.Share, contentDescription = stringResource(R.string.place_share), tint = tint, modifier = Modifier.size(20.dp))
         }
         VelaMenu(expanded = open, onDismissRequest = { open = false }) {

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -542,8 +542,13 @@ fun PlaceSheet(
                     // recomposition), and the minimized card below fades in at the swap - the
                     // content no longer vanishes in one frame at the flip.
                     .graphicsLayer {
-                        alpha = if (minimizedState.value) 1f
-                        else ((heightAnim.value - minH) / 110f).coerceIn(0f, 1f)
+                        if (minimizedState.value) { alpha = 1f; translationY = 0f } else {
+                            val f = ((heightAnim.value - minH) / 110f).coerceIn(0f, 1f)
+                            alpha = f
+                            // The content SLIDES DOWN as it fades (user 2026-07-10) — the exit
+                            // reads as the extras dropping away rather than a plain dissolve.
+                            translationY = (1f - f) * 48.dp.toPx()
+                        }
                     }
                     .padding(start = 20.dp, end = 20.dp, bottom = 20.dp),
             ) {
@@ -2079,6 +2084,9 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
                 // not completely full screen top or bottom" report).
                 it.setLayout(android.view.WindowManager.LayoutParams.MATCH_PARENT, android.view.WindowManager.LayoutParams.MATCH_PARENT)
                 androidx.core.view.WindowCompat.setDecorFitsSystemWindows(it, false)
+                // The one flag that UNCONDITIONALLY lets the window lay out past the bars — the
+                // fitting flags alone still left top/bottom strips on this device (2026-07-10).
+                it.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
                 if (android.os.Build.VERSION.SDK_INT >= 28) {
                     it.attributes = it.attributes.apply {
                         layoutInDisplayCutoutMode = android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
@@ -2506,6 +2514,7 @@ private fun FullScreenReviews(featureId: String, place: Place, ink: Color, dim: 
             (panelView.parent as? androidx.compose.ui.window.DialogWindowProvider)?.window?.let {
                 it.setLayout(android.view.WindowManager.LayoutParams.MATCH_PARENT, android.view.WindowManager.LayoutParams.MATCH_PARENT)
                 androidx.core.view.WindowCompat.setDecorFitsSystemWindows(it, false)
+                it.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
                 if (android.os.Build.VERSION.SDK_INT >= 28) {
                     it.attributes = it.attributes.apply {
                         layoutInDisplayCutoutMode = android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -2088,6 +2088,12 @@ private fun PhotoGallery(urls: List<String>, dates: List<String?>, start: Int, o
                 // The one flag that UNCONDITIONALLY lets the window lay out past the bars — the
                 // fitting flags alone still left top/bottom strips on this device (2026-07-10).
                 it.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
+                // API 30+: DIALOG windows fit the bar insets via fitInsetsTypes, which none of
+                // the flags above touch — THIS is what kept the window inset from the screen's
+                // top/bottom through three rounds of "still not full screen" (screenshot-proven).
+                if (android.os.Build.VERSION.SDK_INT >= 30) {
+                    it.attributes = it.attributes.apply { fitInsetsTypes = 0 }
+                }
                 // Paint the WINDOW DECOR black: the compose content is measured to the pre-flag
                 // frame, so the extra NO_LIMITS area showed the sheet ghosting through (the
                 // screenshot-verified "not full screen" strips). The decor background covers the
@@ -2521,6 +2527,12 @@ private fun FullScreenReviews(featureId: String, place: Place, ink: Color, dim: 
                 it.setLayout(android.view.WindowManager.LayoutParams.MATCH_PARENT, android.view.WindowManager.LayoutParams.MATCH_PARENT)
                 androidx.core.view.WindowCompat.setDecorFitsSystemWindows(it, false)
                 it.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
+                // API 30+: DIALOG windows fit the bar insets via fitInsetsTypes, which none of
+                // the flags above touch — THIS is what kept the window inset from the screen's
+                // top/bottom through three rounds of "still not full screen" (screenshot-proven).
+                if (android.os.Build.VERSION.SDK_INT >= 30) {
+                    it.attributes = it.attributes.apply { fitInsetsTypes = 0 }
+                }
                 it.setBackgroundDrawable(android.graphics.drawable.ColorDrawable((if (dark) SheetDark else SheetLight).toArgb()))
                 if (android.os.Build.VERSION.SDK_INT >= 28) {
                     it.attributes = it.attributes.apply {

--- a/app/src/main/java/app/vela/web/ReviewsPanel.kt
+++ b/app/src/main/java/app/vela/web/ReviewsPanel.kt
@@ -256,10 +256,12 @@ private fun buildPanelWebView(
             }
         }
     }
-    // FULL-SCREEN: the WebView owns the whole screen, no scrolling parent — skip all the scroll-sync
-    // machinery and let it scroll natively (this is what makes full-screen jitter-free by design).
-    if (!fullScreen) wv.setOnTouchListener { v, ev ->
-        if (ev.actionMasked != MotionEvent.ACTION_UP && ev.actionMasked != MotionEvent.ACTION_CANCEL) {
+    // FULL-SCREEN: the WebView owns the whole screen and scrolls natively (that's what makes it
+    // jitter-free) — but it still forwards TOP-EDGE down-drags, so the page can be pulled down to
+    // close like the photo viewer (user 2026-07-11). The bottom/up forwarding stays inline-only
+    // (full-screen has no sheet to grow), and there's no parent to disallow-intercept against.
+    wv.setOnTouchListener { v, ev ->
+        if (!fullScreen && ev.actionMasked != MotionEvent.ACTION_UP && ev.actionMasked != MotionEvent.ACTION_CANCEL) {
             v.parent?.requestDisallowInterceptTouchEvent(true)
         }
         v.getLocationInWindow(winLoc)
@@ -294,7 +296,7 @@ private fun buildPanelWebView(
                     // Forward only clearly-vertical boundary drags (a horizontal chip swipe with
                     // a slight slope must not jiggle the sheet).
                     if (kotlin.math.abs(dy) > kotlin.math.abs(dx) &&
-                        ((panelAtTop.get() && dy > 0f) || (panelAtBottom.get() && dy < 0f))
+                        ((panelAtTop.get() && dy > 0f) || (!fullScreen && panelAtBottom.get() && dy < 0f))
                     ) {
                         forwarded = true
                         forwardDist += kotlin.math.abs(dy)

--- a/core/src/main/java/app/vela/core/config/Notice.kt
+++ b/core/src/main/java/app/vela/core/config/Notice.kt
@@ -7,13 +7,16 @@ package app.vela.core.config
  */
 data class Notice(
     val id: String,
-    val level: String = LEVEL_INFO, // info | warn | error  → UI tone
+    val level: String = LEVEL_INFO, // info | warn | error | urgent  → UI tone (urgent = modal dialog)
     val title: String,
     val body: String,
     val url: String? = null, // optional "Learn more" link
 ) {
     companion object {
         const val LEVEL_INFO = "info"
+        /** Renders as a MODAL DIALOG instead of a map card — for pushed announcements that must
+         *  be seen (a "servers are overloaded" or "Google broke X, fix incoming" note). */
+        const val LEVEL_URGENT = "urgent"
         const val LEVEL_WARN = "warn"
         const val LEVEL_ERROR = "error"
     }


### PR DESCRIPTION
A plain-words matrix under the Privacy section comparing the Google Maps app, the Google Maps website, and Vela across the dimensions that actually differ: account linkage, device identifiers, GPS exposure, map-browsing visibility, search anonymity, routing telemetry, saved-place storage, ad profiling, and offline capability. Each Vela cell reflects how the app actually works (open tiles for browsing, OSRM/GraphHopper for routing, anonymous one-shot Google queries for search and place data, everything personal on-device). PRIVACY.md stays the per-endpoint deep dive; this is the ten-second version.