### PR TITLE
Nav voice: stop 'take' becoming 'tyke' on ramp/exit steps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1280,7 +1280,13 @@ HEADLINE feature in What-you-get (the self-healing pitch), not just an architect
   are left alone. Unit-tested. (3) **Feet steps**
  - `formatDistance` (banner) + all 11 `NavStrings.spokenDistance` (voice) round feet Google-style: 50 ft at/above
   100 ft, 10 ft below. (4) **Voice K/C** - `EnNavStrings.expandForSpeech` rewrites `<XX>-<n>` (CA-99, SR-99) →
-  "State Route n" so espeak's G2P doesn't mangle the bare 2-letter code's onset. (6) **Continue/straight lane silence** - a CONTINUE/STRAIGHT speaks its lane preface ONLY for a GENUINE fork (an "off" lane whose OWN indication is an explicit `straight`/`slight*` arrow, e.g. "use the left 2 lanes to stay on I-80"); a plain turn bay at an intersection (off lane marked only `left`/`right`, OR **`none`** = OSRM's "no painted arrow" sentinel, which is NOT "goes straight") while you sail straight through is silenced (`Route.continueHasGenuineFork` gates `NavEngine`'s escape hatch; it matches only `straight`/`slight*` on an off lane - `none`/`through` are excluded) - Google stays silent there and the road-just-renames case had been over-speaking. (5) **Traffic-light landmarks
+  "State Route n" so espeak's G2P doesn't mangle the bare 2-letter code's onset. **(4b) "take" → "tyke"
+  (2026-07-11):** espeak's G2P is context-sensitive - on a full "take the ramp toward Woodland" it
+  mis-voweled "take", but "take the ramp" alone was correct (user A/B). `expandForSpeech` now inserts a
+  comma before " toward " (`", toward "`), which is a `SpeechText.speechFragments` boundary, so the model
+  phonemizes "take the ramp" in isolation and reads the sign destination as its own beat (Google pauses
+  there too). "toward" only appears on ramp/exit/highway-sign steps, so plain "onto" turns are untouched;
+  unit-tested. Verify-by-ear pending (can't hear it here). (6) **Continue/straight lane silence** - a CONTINUE/STRAIGHT speaks its lane preface ONLY for a GENUINE fork (an "off" lane whose OWN indication is an explicit `straight`/`slight*` arrow, e.g. "use the left 2 lanes to stay on I-80"); a plain turn bay at an intersection (off lane marked only `left`/`right`, OR **`none`** = OSRM's "no painted arrow" sentinel, which is NOT "goes straight") while you sail straight through is silenced (`Route.continueHasGenuineFork` gates `NavEngine`'s escape hatch; it matches only `straight`/`slight*` on an off lane - `none`/`through` are excluded) - Google stays silent there and the road-just-renames case had been over-speaking. (5) **Traffic-light landmarks
   ("pass the light, then turn") - BUILT (Settings → Navigation → "Traffic-light guidance", OFF by default,
   English-only):** `RouteGeometry.enrichWithLights` folds a "pass the light, then …" clause into a surface-street
   TURN when 1–2 signals fall on the approach (`NavStrings.passLights`); signals from `OverpassTrafficSignals.fetchAlong`

--- a/core/src/main/java/app/vela/core/i18n/NavStrings.kt
+++ b/core/src/main/java/app/vela/core/i18n/NavStrings.kt
@@ -179,6 +179,14 @@ object EnNavStrings : NavStrings {
         // code (e.g. "CA") makes espeak's G2P mangle the K/C onset — a cause of the "the K/T sounds off
         // sometimes" bug. Runs AFTER I-/US- so those keep their spoken forms (US- is already de-hyphenated).
         s = Regex("\\b[A-Z]{2}-(\\d+)").replace(s) { "State Route ${it.groupValues[1]}" }
+        // Break the maneuver clause off the sign destination with a comma before " toward ":
+        // espeak's G2P is context-sensitive, and on a full "take the ramp toward Woodland" it
+        // mis-voweled "take" to "tyke" — chopping "toward Woodland" made it correct (user
+        // 2026-07-11). The comma is a fragment boundary (see SpeechText.speechFragments), so the
+        // model phonemizes "take the ramp" in isolation, where it's right, and reads the
+        // destination as its own beat (Google pauses there too). "toward" only appears on ramp/
+        // exit/highway-sign steps, so plain turns ("... onto Main St") are untouched.
+        s = Regex(" toward ", RegexOption.IGNORE_CASE).replace(s, ", toward ")
         EN_SPEECH_WORDS.forEach { (re, rep) -> s = re.replace(s, rep) }
         s = SpeechText.spokenNumbers(s) // "128th" → "one twenty eighth" (space, not hyphen — the compound got a mushy -ty), not a mangled "one hundred and 28th"
         return s

--- a/core/src/test/java/app/vela/core/i18n/NavStringsTest.kt
+++ b/core/src/test/java/app/vela/core/i18n/NavStringsTest.kt
@@ -112,6 +112,14 @@ class NavStringsTest {
         assertEquals("Biegen Sie ab auf Hauptstr", DeNavStrings.expandForSpeech("Biegen Sie ab auf Hauptstr"))
     }
 
+    @Test fun `a comma breaks the maneuver off the sign destination so espeak keeps take`() {
+        // "take the ramp toward Woodland" mis-voweled "take" -> the comma isolates the verb clause.
+        assertEquals("Take the ramp, toward Woodland", EnNavStrings.expandForSpeech("Take the ramp toward Woodland"))
+        assertEquals("Take exit 15, toward Sacramento", EnNavStrings.expandForSpeech("Take exit 15 toward Sacramento"))
+        // Plain turns use "onto", not "toward", so they are untouched (no stray comma).
+        assertEquals("Turn right onto Main Street", EnNavStrings.expandForSpeech("Turn right onto Main St"))
+    }
+
     @Test fun `every registered language produces non-blank nav strings and keeps road names`() {
         val langs = listOf("fr", "de", "es", "it", "pt", "nl", "ru", "pl", "sv", "uk")
         for (code in langs) {


### PR DESCRIPTION
You heard "in 500 feet **take** the ramp toward Woodland" mispronounce *take* as *tyke*, but "take the ramp" alone was fine, and it varied run to run.

**Cause:** espeak-ng's grapheme→phoneme is context-sensitive. On the full clause it mis-vowels "take" (/eɪ/ → /aɪ/); in isolation it's correct — exactly what you observed by chopping "toward Woodland".

**Fix:** `EnNavStrings.expandForSpeech` inserts a comma before " toward " (spoken text only, banner unchanged). The comma is a `speechFragments` boundary, so the model phonemizes "take the ramp" on its own — where it's right — and reads the sign destination as its own short beat (Google pauses there too). "toward" only shows up on ramp/exit/highway-sign steps, so ordinary "onto" turns are untouched. Unit-tested.

**Note:** I can't hear the output here, so this needs a verify-by-ear on a drive. "San Francisco not slick" is separate — espeak gets the phonemes right, it's the neural prosody being flat on the proper noun; no clean keyless fix, so I left it.