### PR TITLE
i18n: pluralize the results count (fixes #56 "1 results")

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -910,6 +910,13 @@ Defaults that make the safe path the easy one:
   they localize only once display text is split from the logic key. **Names/addresses/reviews are DATA - never
   translated.** Adding a user-facing string means: add it to `values/strings.xml` AND all `values-<lang>/`,
   and match the `%1$s`/`%2$d` placeholder TYPE to the arg (Int → `%d`, else `%s`; a `%d` fed a String crashes).
+  **Count strings use `<plurals>`, not a bare `%d X` (2026-07-11, issue #56 "1 results"):** the
+  results-count bar is a `<plurals name="mapscreen_results_count">` read via `pluralStringResource(...,
+  n, n)`. Use the CORRECT CLDR categories PER LANGUAGE - en/de/es/it/pt/nl/sv/fr = `one`+`other`
+  (sv "resultat" is invariable); ru/uk/pl need `one`+`few`+`many`+`other` (e.g. ru результат/
+  результата/результатов/результата). Any NEW "N &lt;noun&gt;" that can equal 1 (reviews, stops,
+  places) should become a plural the same way; `place_review_count`/`place_transit_stops` are still
+  bare and are the follow-up.
   **No em dashes in translations** (swept 2026-07-10): the 10 locale files carried 100+ of them as
   clause glue (plus German/Swedish spaced en dashes used the same way) - they read as machine-
   translation tells. Use a comma, a colon, or rephrase; the one legitimate dash is the numeric

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1987,7 +1987,7 @@ private fun SearchResults(
                             )
                         }
                         Text(
-                            stringResource(R.string.mapscreen_results_count, shown.size),
+                            androidx.compose.ui.res.pluralStringResource(R.plurals.mapscreen_results_count, shown.size, shown.size),
                             style = if (barTitle != null) MaterialTheme.typography.bodyMedium else MaterialTheme.typography.bodyLarge,
                             color = SheetPalette.dim(dark),
                             maxLines = 1,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -279,7 +279,10 @@
     <string name="mapscreen_got_it">Verstanden</string>
     <string name="mapscreen_heads_up">Hinweis</string>
     <string name="mapscreen_dismiss">Schließen</string>
-    <string name="mapscreen_results_count">%1$d Ergebnisse</string>
+    <plurals name="mapscreen_results_count"> <!-- format -->
+        <item quantity="one">%1$d Ergebnis</item>
+        <item quantity="other">%1$d Ergebnisse</item>
+    </plurals>
     <string name="mapscreen_shrink_list">Liste verkleinern</string>
     <string name="mapscreen_expand_list">Liste vergrößern</string>
     <string name="mapscreen_close_results">Suchergebnisse schließen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -279,7 +279,10 @@
     <string name="mapscreen_got_it">Entendido</string>
     <string name="mapscreen_heads_up">Atención</string>
     <string name="mapscreen_dismiss">Descartar</string>
-    <string name="mapscreen_results_count">%1$d resultados</string>
+    <plurals name="mapscreen_results_count"> <!-- format -->
+        <item quantity="one">%1$d resultado</item>
+        <item quantity="other">%1$d resultados</item>
+    </plurals>
     <string name="mapscreen_shrink_list">Reducir lista</string>
     <string name="mapscreen_expand_list">Expandir lista</string>
     <string name="mapscreen_close_results">Cerrar los resultados de búsqueda</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -279,7 +279,10 @@
     <string name="mapscreen_got_it">Compris</string>
     <string name="mapscreen_heads_up">À noter</string>
     <string name="mapscreen_dismiss">Ignorer</string>
-    <string name="mapscreen_results_count">%1$d résultats</string>
+    <plurals name="mapscreen_results_count"> <!-- format -->
+        <item quantity="one">%1$d résultat</item>
+        <item quantity="other">%1$d résultats</item>
+    </plurals>
     <string name="mapscreen_shrink_list">Réduire la liste</string>
     <string name="mapscreen_expand_list">Agrandir la liste</string>
     <string name="mapscreen_close_results">Fermer les résultats de recherche</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -279,7 +279,10 @@
     <string name="mapscreen_got_it">Ho capito</string>
     <string name="mapscreen_heads_up">Attenzione</string>
     <string name="mapscreen_dismiss">Ignora</string>
-    <string name="mapscreen_results_count">%1$d risultati</string>
+    <plurals name="mapscreen_results_count"> <!-- format -->
+        <item quantity="one">%1$d risultato</item>
+        <item quantity="other">%1$d risultati</item>
+    </plurals>
     <string name="mapscreen_shrink_list">Riduci elenco</string>
     <string name="mapscreen_expand_list">Espandi elenco</string>
     <string name="mapscreen_close_results">Chiudi i risultati di ricerca</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -279,7 +279,10 @@
     <string name="mapscreen_got_it">Begrepen</string>
     <string name="mapscreen_heads_up">Let op</string>
     <string name="mapscreen_dismiss">Sluiten</string>
-    <string name="mapscreen_results_count">%1$d resultaten</string>
+    <plurals name="mapscreen_results_count"> <!-- format -->
+        <item quantity="one">%1$d resultaat</item>
+        <item quantity="other">%1$d resultaten</item>
+    </plurals>
     <string name="mapscreen_shrink_list">Lijst verkleinen</string>
     <string name="mapscreen_expand_list">Lijst vergroten</string>
     <string name="mapscreen_close_results">Zoekresultaten sluiten</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -279,7 +279,12 @@
     <string name="mapscreen_got_it">OK</string>
     <string name="mapscreen_heads_up">Uwaga</string>
     <string name="mapscreen_dismiss">Odrzuć</string>
-    <string name="mapscreen_results_count">%1$d wyników</string>
+    <plurals name="mapscreen_results_count"> <!-- format -->
+        <item quantity="one">%1$d wynik</item>
+        <item quantity="few">%1$d wyniki</item>
+        <item quantity="many">%1$d wyników</item>
+        <item quantity="other">%1$d wyniku</item>
+    </plurals>
     <string name="mapscreen_shrink_list">Zwiń listę</string>
     <string name="mapscreen_expand_list">Rozwiń listę</string>
     <string name="mapscreen_close_results">Zamknij wyniki wyszukiwania</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -279,7 +279,10 @@
     <string name="mapscreen_got_it">Percebi</string>
     <string name="mapscreen_heads_up">Atenção</string>
     <string name="mapscreen_dismiss">Dispensar</string>
-    <string name="mapscreen_results_count">%1$d resultados</string>
+    <plurals name="mapscreen_results_count"> <!-- format -->
+        <item quantity="one">%1$d resultado</item>
+        <item quantity="other">%1$d resultados</item>
+    </plurals>
     <string name="mapscreen_shrink_list">Encolher lista</string>
     <string name="mapscreen_expand_list">Expandir lista</string>
     <string name="mapscreen_close_results">Fechar os resultados da pesquisa</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -279,7 +279,12 @@
     <string name="mapscreen_got_it">Понятно</string>
     <string name="mapscreen_heads_up">Обратите внимание</string>
     <string name="mapscreen_dismiss">Закрыть</string>
-    <string name="mapscreen_results_count">%1$d результатов</string>
+    <plurals name="mapscreen_results_count"> <!-- format -->
+        <item quantity="one">%1$d результат</item>
+        <item quantity="few">%1$d результата</item>
+        <item quantity="many">%1$d результатов</item>
+        <item quantity="other">%1$d результата</item>
+    </plurals>
     <string name="mapscreen_shrink_list">Свернуть список</string>
     <string name="mapscreen_expand_list">Развернуть список</string>
     <string name="mapscreen_close_results">Закрыть результаты поиска</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -279,7 +279,10 @@
     <string name="mapscreen_got_it">Uppfattat</string>
     <string name="mapscreen_heads_up">Obs</string>
     <string name="mapscreen_dismiss">Stäng</string>
-    <string name="mapscreen_results_count">%1$d resultat</string>
+    <plurals name="mapscreen_results_count"> <!-- format -->
+        <item quantity="one">%1$d resultat</item>
+        <item quantity="other">%1$d resultat</item>
+    </plurals>
     <string name="mapscreen_shrink_list">Krymp listan</string>
     <string name="mapscreen_expand_list">Expandera listan</string>
     <string name="mapscreen_close_results">Stäng sökresultaten</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -279,7 +279,12 @@
     <string name="mapscreen_got_it">Зрозуміло</string>
     <string name="mapscreen_heads_up">Увага</string>
     <string name="mapscreen_dismiss">Відхилити</string>
-    <string name="mapscreen_results_count">%1$d результатів</string>
+    <plurals name="mapscreen_results_count"> <!-- format -->
+        <item quantity="one">%1$d результат</item>
+        <item quantity="few">%1$d результати</item>
+        <item quantity="many">%1$d результатів</item>
+        <item quantity="other">%1$d результату</item>
+    </plurals>
     <string name="mapscreen_shrink_list">Згорнути список</string>
     <string name="mapscreen_expand_list">Розгорнути список</string>
     <string name="mapscreen_close_results">Закрити результати пошуку</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,7 +297,10 @@
     <string name="mapscreen_got_it">Got it</string>
     <string name="mapscreen_heads_up">Heads up</string>
     <string name="mapscreen_dismiss">Dismiss</string>
-    <string name="mapscreen_results_count">%1$d results</string> <!-- format -->
+    <plurals name="mapscreen_results_count"> <!-- format -->
+        <item quantity="one">%1$d result</item>
+        <item quantity="other">%1$d results</item>
+    </plurals>
     <string name="mapscreen_shrink_list">Shrink list</string>
     <string name="mapscreen_expand_list">Expand list</string>
     <string name="mapscreen_close_results">Close search results</string>


### PR DESCRIPTION
Closes #56.

The minimized results bar said "1 results". Converted `mapscreen_results_count` from a bare `%1$d results` string to an Android `<plurals>` across all 11 locales, read via `pluralStringResource`. Uses the correct CLDR categories per language: en/de/es/it/pt/nl/sv/fr get `one`+`other` (Swedish "resultat" is invariable), and ru/uk/pl get `one`+`few`+`many`+`other`.

Debug build passes (resource merge validates the plural blocks).

Follow-up (same i18n epic): `place_review_count` ("N reviews") and `place_transit_stops` ("N stops") are still bare and can hit "1" — noted in CLAUDE.