### PR TITLE
Settings: tap the version number to copy it

### DIFF
--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -1031,10 +1031,21 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
 
             Spacer(Modifier.height(20.dp))
             SectionTitle(stringResource(R.string.settings_version))
+            // Tap to copy - bug reports need the exact version, and typing it from the screen
+            // is error-prone (issue #58's one keeper suggestion).
+            val versionLine = stringResource(R.string.settings_version_line, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE)
+            val versionCopied = stringResource(R.string.settings_version_copied)
+            val clipboard = androidx.compose.ui.platform.LocalClipboardManager.current
             Text(
-                stringResource(R.string.settings_version_line, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE),
+                versionLine,
                 style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.padding(vertical = 4.dp),
+                modifier = Modifier
+                    .dpadHighlight()
+                    .clickable {
+                        clipboard.setText(androidx.compose.ui.text.AnnotatedString(versionLine))
+                        android.widget.Toast.makeText(context, versionCopied, android.widget.Toast.LENGTH_SHORT).show()
+                    }
+                    .padding(vertical = 4.dp),
             )
             // Self-updater: a launch check (throttled to ~daily) plus a manual check here.
             // The system installer does the install either way.

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -134,6 +134,7 @@
     <string name="settings_support_button">Vela unterstützen</string>
     <string name="settings_version">Version</string>
     <string name="settings_version_line">Vela %1$s  (Build %2$d)</string>
+    <string name="settings_version_copied">Version kopiert</string>
     <string name="settings_collapse">Einklappen</string>
     <string name="settings_expand">Ausklappen</string>
     <string name="settings_voice_lib_empty_hint">★ markiert die empfohlenen Stimmen. Jede Stimme läuft offline auf deinem Gerät.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -134,6 +134,7 @@
     <string name="settings_support_button">Apoyar a Vela</string>
     <string name="settings_version">Versión</string>
     <string name="settings_version_line">Vela %1$s  (compilación %2$d)</string>
+    <string name="settings_version_copied">Versión copiada</string>
     <string name="settings_collapse">Contraer</string>
     <string name="settings_expand">Expandir</string>
     <string name="settings_voice_lib_empty_hint">★ marca las voces recomendadas. Todas funcionan sin conexión en tu teléfono.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -134,6 +134,7 @@
     <string name="settings_support_button">Soutenir Vela</string>
     <string name="settings_version">Version</string>
     <string name="settings_version_line">Vela %1$s  (build %2$d)</string>
+    <string name="settings_version_copied">Version copiée</string>
     <string name="settings_collapse">Réduire</string>
     <string name="settings_expand">Développer</string>
     <string name="settings_voice_lib_empty_hint">★ signale les voix recommandées. Chaque voix fonctionne hors ligne sur votre téléphone.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -134,6 +134,7 @@
     <string name="settings_support_button">Sostieni Vela</string>
     <string name="settings_version">Versione</string>
     <string name="settings_version_line">Vela %1$s  (build %2$d)</string>
+    <string name="settings_version_copied">Versione copiata</string>
     <string name="settings_collapse">Comprimi</string>
     <string name="settings_expand">Espandi</string>
     <string name="settings_voice_lib_empty_hint">★ indica le voci consigliate. Ogni voce funziona offline sul telefono.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -134,6 +134,7 @@
     <string name="settings_support_button">Vela steunen</string>
     <string name="settings_version">Versie</string>
     <string name="settings_version_line">Vela %1$s  (build %2$d)</string>
+    <string name="settings_version_copied">Versie gekopieerd</string>
     <string name="settings_collapse">Inklappen</string>
     <string name="settings_expand">Uitklappen</string>
     <string name="settings_voice_lib_empty_hint">★ markeert de aanbevolen stemmen. Elke stem werkt offline op je telefoon.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -134,6 +134,7 @@
     <string name="settings_support_button">Wesprzyj Vela</string>
     <string name="settings_version">Wersja</string>
     <string name="settings_version_line">Vela %1$s  (kompilacja %2$d)</string>
+    <string name="settings_version_copied">Skopiowano wersję</string>
     <string name="settings_collapse">Zwiń</string>
     <string name="settings_expand">Rozwiń</string>
     <string name="settings_voice_lib_empty_hint">★ oznacza polecane głosy. Każdy głos działa offline na telefonie.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -134,6 +134,7 @@
     <string name="settings_support_button">Apoiar o Vela</string>
     <string name="settings_version">Versão</string>
     <string name="settings_version_line">Vela %1$s  (compilação %2$d)</string>
+    <string name="settings_version_copied">Versão copiada</string>
     <string name="settings_collapse">Recolher</string>
     <string name="settings_expand">Expandir</string>
     <string name="settings_voice_lib_empty_hint">★ assinala as vozes recomendadas. Todas funcionam offline no telemóvel.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -134,6 +134,7 @@
     <string name="settings_support_button">Поддержать Vela</string>
     <string name="settings_version">Версия</string>
     <string name="settings_version_line">Vela %1$s  (сборка %2$d)</string>
+    <string name="settings_version_copied">Версия скопирована</string>
     <string name="settings_collapse">Свернуть</string>
     <string name="settings_expand">Развернуть</string>
     <string name="settings_voice_lib_empty_hint">★ отмечает рекомендуемые голоса. Все голоса работают офлайн на телефоне.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -134,6 +134,7 @@
     <string name="settings_support_button">Stöd Vela</string>
     <string name="settings_version">Version</string>
     <string name="settings_version_line">Vela %1$s  (bygge %2$d)</string>
+    <string name="settings_version_copied">Version kopierad</string>
     <string name="settings_collapse">Fäll ihop</string>
     <string name="settings_expand">Expandera</string>
     <string name="settings_voice_lib_empty_hint">★ markerar de rekommenderade rösterna. Varje röst fungerar offline på telefonen.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -134,6 +134,7 @@
     <string name="settings_support_button">Підтримати Vela</string>
     <string name="settings_version">Версія</string>
     <string name="settings_version_line">Vela %1$s  (збірка %2$d)</string>
+    <string name="settings_version_copied">Версію скопійовано</string>
     <string name="settings_collapse">Згорнути</string>
     <string name="settings_expand">Розгорнути</string>
     <string name="settings_voice_lib_empty_hint">★ позначає рекомендовані голоси. Усі голоси працюють офлайн на телефоні.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,7 @@
     <string name="settings_support_button">Support Vela</string>
     <string name="settings_version">Version</string>
     <string name="settings_version_line">Vela %1$s  (build %2$d)</string> <!-- format -->
+    <string name="settings_version_copied">Version copied</string>
     <string name="settings_collapse">Collapse</string>
     <string name="settings_expand">Expand</string>
     <string name="settings_voice_lib_empty_hint">★ marks the recommended voices. Every voice runs offline on your phone.</string>


### PR DESCRIPTION
From issue #58's one keeper suggestion: the Settings version line is now tappable and copies "Vela 0.4.x (build NNNN)" to the clipboard with a confirmation toast, so bug reports carry the exact build. D-pad focusable per the docs/dpad.md rule; toast string added to all 11 locales. Compiles clean.