### PR TITLE
Routing graphs: variant input for coexisting graph generations

### DIFF
--- a/.github/workflows/routing-graphs.yml
+++ b/.github/workflows/routing-graphs.yml
@@ -29,6 +29,10 @@ on:
         description: "Skip large (big:true) regions for a quick run"
         type: boolean
         default: false
+      variant:
+        description: "Asset-name suffix for a parallel graph generation (e.g. 'v2' publishes <id>-v2.zip + routing-manifest-v2.json beside the originals; empty = legacy names). Lets a new format coexist with the old for a safe cutover."
+        type: string
+        default: ""
 
 permissions:
   contents: write # create/upload assets on the routing-graphs release
@@ -98,6 +102,7 @@ jobs:
           VELA_REPO: ${{ github.repository }}
           MANIFEST_MODE: emit
           ENTRY_OUT: ${{ matrix.id }}.json
+          VARIANT: ${{ inputs.variant }}
         run: bash scripts/build-routing-region.sh "${{ matrix.id }}" "${{ matrix.name }}" "${{ matrix.pbf_url }}"
       - uses: actions/upload-artifact@v4
         with:
@@ -122,6 +127,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VELA_REPO: ${{ github.repository }}
+          VARIANT: ${{ inputs.variant }}
         run: |
           shopt -s nullglob
           files=(entries/*.json)

--- a/scripts/build-routing-region.sh
+++ b/scripts/build-routing-region.sh
@@ -13,6 +13,10 @@ set -euo pipefail
 ID="${1:?region id}"; NAME="${2:?display name}"; URL="${3:?geofabrik pbf url}"
 REPO="${VELA_REPO:-PimpinPumpkin/Vela}"
 TAG="routing-graphs"
+# VARIANT (e.g. "v2") publishes <id>-v2.zip beside the legacy <id>.zip so a new graph
+# format can coexist with the old on the SAME release - the app cuts over by pointing its
+# manifest URL at routing-manifest-v2.json, and cutting back is just pointing it back.
+SUFFIX="${VARIANT:+-$VARIANT}"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
 
@@ -22,15 +26,15 @@ curl -fsSL "$URL" -o "$WORK/region.osm.pbf"
 echo "→ building CH graph"
 ( cd "$ROOT" && ./gradlew :tools:graphbuilder:run --args="$WORK/region.osm.pbf $WORK/graph" --no-daemon -q )
 
-( cd "$WORK/graph" && zip -qr "$WORK/$ID.zip" . )
-SIZE=$(( ( $(stat -f%z "$WORK/$ID.zip" 2>/dev/null || stat -c%s "$WORK/$ID.zip") + 1048575 ) / 1048576 ))
+( cd "$WORK/graph" && zip -qr "$WORK/$ID$SUFFIX.zip" . )
+SIZE=$(( ( $(stat -f%z "$WORK/$ID$SUFFIX.zip" 2>/dev/null || stat -c%s "$WORK/$ID$SUFFIX.zip") + 1048575 ) / 1048576 ))
 
 # bbox [S,W,N,E] from the extract's HEADER box (the declared region) — NOT data.bbox, whose node
 # extent gets blown up by outlier nodes (a stray ferry/error node sends it to Alaska). osmium prints
 # (minlon,minlat,maxlon,maxlat).
 read -r MINLON MINLAT MAXLON MAXLAT < <(osmium fileinfo -g header.boxes "$WORK/region.osm.pbf" | tr -d '()' | tr ',' ' ')
 BBOX="[$MINLAT,$MINLON,$MAXLAT,$MAXLON]"
-ASSET_URL="https://github.com/$REPO/releases/download/$TAG/$ID.zip"
+ASSET_URL="https://github.com/$REPO/releases/download/$TAG/$ID$SUFFIX.zip"
 echo "→ $ID: ${SIZE} MB, bbox $BBOX"
 
 # ensure the catalog release exists (prerelease so it never becomes the "Latest" the APK tracks)
@@ -38,7 +42,7 @@ gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1 || \
   gh release create "$TAG" --repo "$REPO" --prerelease --title "Offline routing graphs" \
     --notes "Prebuilt GraphHopper CH graphs for Vela offline routing. Data assets, not a code release."
 
-gh release upload "$TAG" "$WORK/$ID.zip" --clobber --repo "$REPO"
+gh release upload "$TAG" "$WORK/$ID$SUFFIX.zip" --clobber --repo "$REPO"
 
 # this region's manifest entry
 ENTRY="$(jq -nc --arg id "$ID" --arg name "$NAME" --arg url "$ASSET_URL" --argjson size "$SIZE" --argjson bbox "$BBOX" \

--- a/scripts/merge-routing-manifest.sh
+++ b/scripts/merge-routing-manifest.sh
@@ -11,10 +11,14 @@ set -euo pipefail
 DIR="${1:?dir of *.json entry files}"
 REPO="${VELA_REPO:-PimpinPumpkin/Vela}"
 TAG="routing-graphs"
+# VARIANT (e.g. "v2") reads/writes routing-manifest-v2.json so a new graph generation keeps
+# its own catalog beside the legacy one (see build-routing-region.sh).
+SUFFIX="${VARIANT:+-$VARIANT}"
+MANIFEST_NAME="routing-manifest$SUFFIX.json"
 WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
 
 # start from the live manifest (preserve regions not in this batch); empty catalog if none yet
-gh release download "$TAG" --repo "$REPO" -p routing-manifest.json -O "$WORK/manifest.json" 2>/dev/null \
+gh release download "$TAG" --repo "$REPO" -p "$MANIFEST_NAME" -O "$WORK/manifest.json" 2>/dev/null \
   || echo '{"regions":[]}' > "$WORK/manifest.json"
 
 # collect this batch's entries into one array, then upsert each by id
@@ -26,8 +30,8 @@ jq --slurpfile batch "$WORK/batch.json" '
   ($batch[0] | map(.id)) as $ids
   | .regions = ([.regions[] | select(.id as $i | $ids | index($i) | not)] + $batch[0])
   | .regions |= sort_by(.name)
-' "$WORK/manifest.json" > "$WORK/routing-manifest.json"
+' "$WORK/manifest.json" > "$WORK/$MANIFEST_NAME"
 
-jq -r '.regions[] | "   \(.name)  \(.sizeMb) MB  \(.bbox)"' "$WORK/routing-manifest.json"
-gh release upload "$TAG" "$WORK/routing-manifest.json" --clobber --repo "$REPO"
-echo "✓ manifest now lists $(jq '.regions | length' "$WORK/routing-manifest.json") regions"
+jq -r '.regions[] | "   \(.name)  \(.sizeMb) MB  \(.bbox)"' "$WORK/$MANIFEST_NAME"
+gh release upload "$TAG" "$WORK/$MANIFEST_NAME" --clobber --repo "$REPO"
+echo "✓ $MANIFEST_NAME now lists $(jq '.regions | length' "$WORK/$MANIFEST_NAME") regions"


### PR DESCRIPTION
The machinery behind the v2 avoid-profile rebake, lifted from the rebake-v2 working branch now that the bake is done.

- `routing-graphs.yml` gains a `variant` dispatch input; `build-routing-region.sh` publishes `<id>-<variant>.zip` and `merge-routing-manifest.sh` maintains `routing-manifest-<variant>.json` — same release tag hosts both generations, old assets untouched.
- Already proven end to end: all 135 regions baked as v2 with the avoid CH profiles (`car_avoid_toll`/`car_avoid_motorway` + `toll`/`road_class` encoded values), verified in a graph's properties file and by an on-device avoid-tolls route in Delaware that swung off the toll road.

The app-side cutover (pointing `ROUTING_MANIFEST_URL` at the v2 manifest) is a separate one-line PR so rollback stays a single revert.