### PR TITLE
Parking: a re-park hub on the P button instead of clear-then-tap-again

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -260,6 +260,14 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   parking pill. The camera frames the spot when opened from afar. All strings in 11 locales.
   *(v1 was a long-press on the locate FAB + a chip - reverted: undiscoverable, and Compose's
   FloatingActionButton consumes the down so outer long-press detectors never fire.)*
+  **Re-parking hub (2026-07-11, user - "setting parking again when you already have a spot is a
+  little clunky").** With no spot set, a tap still saves where you stand in one go. With a spot
+  already set, a tap now opens a small **menu on the P button** instead of jumping straight to the
+  parked-car sheet: **Find my car**, **Move parking here** (overwrites the spot with your current
+  fix; the old one is not lost - it drops into history), **Earlier spots** (shown only when history
+  holds a prior one), and **Clear parking**. So re-parking is one obvious choice rather than the old
+  clear-then-tap-again dance. Long-press still jumps straight to the history sheet. New menu strings
+  are English-first (localization backfill tracked with the other i18n leftovers).
 - ✅ **Local place lists (issue #1, 2026-07-08, device-verified).** Google-Maps-style saved lists:
   a **Your lists** section on the search page, each list a coloured icon + name + count that opens as
   results. Create/edit via a dialog with a **name, a 10-icon picker and an 8-colour picker** (the

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -85,6 +85,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Divider
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedAssistChip
 import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.ExtendedFloatingActionButton
@@ -1507,16 +1509,21 @@ fun MapScreen(
             ) {
                 Icon(Icons.Default.MyLocation, contentDescription = stringResource(R.string.mapscreen_center_on_my_location))
             }
-            // Parking button, its OWN control above the locate FAB. TAP: no spot → save here;
-            // spot set (teal) → open the parked-car sheet (Clear lives there). LONG-PRESS opens
-            // the history menu — accidental-overwrite insurance. A Surface, not SmallFAB: the
-            // FAB's clickable eats the down so an outer long-press never fires; the inner Box
-            // detector owns both gestures (same seam the locate FAB needed, 2026-07-08).
+            // Parking button, its OWN control above the locate FAB. TAP with NO spot → save here
+            // (the one-tap "I parked" path). TAP with a spot set (teal) → a small hub menu (Find my
+            // car / Move parking here / Earlier spots / Clear) so re-parking is one obvious choice
+            // instead of the old clear-then-tap-again dance (user 2026-07-11: "setting parking again
+            // when you already have a spot is clunky"). LONG-PRESS still jumps straight to history.
+            // A Surface, not SmallFAB: the FAB's clickable eats the down so an outer long-press never
+            // fires; the inner Box detector owns both gestures (same seam the locate FAB needed).
             val parkingSavedMsg = stringResource(R.string.map_parking_saved)
             val parkingNoFixMsg = stringResource(R.string.map_parking_no_fix)
+            val parkingMovedMsg = stringResource(R.string.map_parking_moved)
+            val parkingClearedMsg = stringResource(R.string.map_parking_cleared)
             val parkedCarLabel = stringResource(R.string.map_parked_car)
             val parkingSet = state.parkingSpot != null
             var showParkingHistory by remember { mutableStateOf(false) }
+            var showParkingMenu by remember { mutableStateOf(false) }
             Surface(
                 shape = RoundedCornerShape(12.dp),
                 color = if (parkingSet) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondaryContainer,
@@ -1538,7 +1545,7 @@ fun MapScreen(
                             detectTapGestures(
                                 onTap = {
                                     if (parkingSet) {
-                                        vm.showParkedCar(parkedCarLabel)
+                                        showParkingMenu = true
                                     } else {
                                         val msg = if (vm.saveParkingSpot()) parkingSavedMsg else parkingNoFixMsg
                                         Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
@@ -1557,6 +1564,44 @@ fun MapScreen(
                             if (parkingSet) R.string.map_parked_car else R.string.map_parking_save,
                         ),
                     )
+                    // The parking hub, anchored to the button. Only reachable when a spot is set.
+                    DropdownMenu(expanded = showParkingMenu, onDismissRequest = { showParkingMenu = false }) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.map_parking_find)) },
+                            leadingIcon = { Icon(Icons.Default.DirectionsCar, contentDescription = null) },
+                            onClick = { showParkingMenu = false; vm.showParkedCar(parkedCarLabel) },
+                        )
+                        // "Move parking here" overwrites the current spot with your live fix; the old
+                        // one is not lost - saveParkingSpot archives it to history. Hidden with no fix.
+                        if (state.myLocation != null) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.map_parking_move_here)) },
+                                leadingIcon = { Icon(Icons.Default.MyLocation, contentDescription = null) },
+                                onClick = {
+                                    showParkingMenu = false
+                                    val msg = if (vm.saveParkingSpot()) parkingMovedMsg else parkingNoFixMsg
+                                    Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                                },
+                            )
+                        }
+                        if (state.parkingHistory.size > 1) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.map_parking_earlier)) },
+                                leadingIcon = { Icon(Icons.Default.History, contentDescription = null) },
+                                onClick = { showParkingMenu = false; showParkingHistory = true },
+                            )
+                        }
+                        Divider()
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.map_parking_clear)) },
+                            leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                            onClick = {
+                                showParkingMenu = false
+                                vm.clearParkingSpot()
+                                Toast.makeText(context, parkingClearedMsg, Toast.LENGTH_SHORT).show()
+                            },
+                        )
+                    }
                 }
             }
             if (showParkingHistory) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -478,6 +478,11 @@
     <string name="map_parking_cleared">Parking spot cleared</string>
     <string name="map_parked_car">Parked car</string>
     <string name="map_parking_save">Save parking spot</string>
+    <string name="map_parking_find">Find my car</string>
+    <string name="map_parking_move_here">Move parking here</string>
+    <string name="map_parking_earlier">Earlier spots</string>
+    <string name="map_parking_clear">Clear parking</string>
+    <string name="map_parking_moved">Parking moved here</string>
     <string name="map_import_failed">Couldn\'t import that list. Check the link and try again.</string>
     <string name="place_clear_parking">Clear parking</string>
     <string name="parking_history_title">Parking history</string>


### PR DESCRIPTION
"Setting parking again when you already have a spot is a little clunky." It was: with a spot set, tapping the P button opened the parked-car sheet, so re-parking meant clearing first and tapping again (or digging through the long-press history).

Now, with a spot already set, a tap opens a small **menu anchored to the P button**:
- **Find my car** - the old parked-car sheet.
- **Move parking here** - overwrites the spot with your current fix. The old one is **not lost**; `saveParkingSpot` already archives it to history.
- **Earlier spots** - opens the history sheet (shown only when a prior spot exists).
- **Clear parking**.

With **no** spot set the button still saves where you stand in one tap (the fast "I parked" path), and a **long-press** still jumps straight to history.

Menu strings are English-first; the localization backfill rides with the other i18n leftovers (#148). FEATURES updated.