### PR TITLE
Japanese spoken directions: guide to the system voice instead of a dead-end pill

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -349,6 +349,17 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   offers and notices now stack below the search bar and chips (or just below the turn card during
   navigation, whatever its height), each dismissed on its own, instead of painting over each other.
   A missing-voice warning carries a "Get a voice" pill straight into the voice library.
+- ✅ **Right fix for a missing voice, per language (2026-07-11).** The missing-voice pill now forks
+  by cause. A language Vela can train a Piper voice for (French, Russian, …) still gets a "Get a
+  voice" pill into the library. A language Piper **can't** do (Japanese: espeak-ng has no Japanese
+  phonemizer, so there is no Vela ja voice) gets a **"System voices"** pill that opens the phone's
+  own text-to-speech settings instead, because that is where Japanese guidance is spoken from (the
+  system-TTS fallback) and the Vela library would be a dead end. `PiperCatalog.hasVoiceFor(lang)`
+  drives the fork; the pill deep-links `com.android.settings.TTS_SETTINGS` (falling back to the main
+  Settings screen on ROMs that lack it). So Japanese turn-by-turn works today through Google's (or
+  any) system Japanese voice, and the app points you to install one if it's missing, rather than
+  nudging you toward a voice that can't exist. A fully-offline bundled Japanese neural voice (Kokoro)
+  stays a possible follow-up in ROADMAP.
 - ✅ **Spoken directions toggle (2026-07-10).** Settings → Voice has an on/off switch for spoken
   navigation; it remembers your choice, and the mute button during navigation is the same switch.
 - ✅ **Update button is a filled pill (2026-07-10).** The update card's Update action is a filled

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,6 +35,15 @@ Last updated: 2026-07-08.
   validate the arm64 `.so` load on a 16 KB-page GrapheneOS device; revisit on-demand delivery (dynamic
   feature) to shrink the base APK. *(Nav-string localization + per-language voice pairing SHIPPED - see
   the localization entry / `FEATURES.md`.)*
+- **Japanese spoken voice - system-TTS today, Kokoro maybe later.** Piper/espeak-ng has no Japanese
+  phonemizer, so there is no bundled Vela Japanese voice (unlike Chinese, which got the Huayan Piper
+  voice). Japanese turn-by-turn is spoken by the phone's own system TTS (Google's Japanese voice is
+  good), and the missing-voice pill now deep-links system voice settings so users can add one. A
+  fully-**offline** Japanese neural voice would mean bundling **Kokoro** int8 multi-lang (~126 MB, also
+  covers Chinese), which needs the multi-file sherpa Kokoro plumbing restored (it was deleted when
+  Kokoro/Matcha were removed) and an on-device speed re-check first - Kokoro was ~0.4× realtime on a
+  Pixel 9, though short nav lines may be acceptable. Deferred pending appetite for the size + a device
+  speed test.
 - **Voice browser - DONE 2026-07-03, device-verified.** Settings → Voice → **Voice library** downloads and
   switches between ~40 curated Piper voices (Lessac, HFC Female/Male, Ryan, LibriTTS-R, GB voices, a GLaDOS
   novelty…), each in its own `filesDir/piper/<id>/`; per-voice speaker prefs; race-free switch; in-place

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1648,12 +1648,37 @@ fun MapScreen(
                         body = msg,
                         actionLabel = stringResource(R.string.mapscreen_dismiss),
                         onAction = vm::clearStatus,
-                        // A voice problem carries its fix: a pill straight to the voice library.
-                        pillLabel = if (state.statusVoiceAction) stringResource(R.string.mapscreen_get_voice) else null,
-                        onPill = if (state.statusVoiceAction) {
-                            { vm.clearStatus(); onOpenVoiceSettings() }
-                        } else {
-                            null
+                        // A voice problem carries its fix. Normally a pill straight to Vela's voice
+                        // library; for a language with no Vela voice (Japanese) it opens the phone's
+                        // own voice settings instead, where the user can add a system voice.
+                        pillLabel = when {
+                            state.statusOpensTtsSettings -> stringResource(R.string.mapscreen_system_voices)
+                            state.statusVoiceAction -> stringResource(R.string.mapscreen_get_voice)
+                            else -> null
+                        },
+                        onPill = when {
+                            state.statusOpensTtsSettings -> {
+                                {
+                                    vm.clearStatus()
+                                    runCatching {
+                                        context.startActivity(
+                                            Intent("com.android.settings.TTS_SETTINGS")
+                                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                                        )
+                                    }.onFailure {
+                                        runCatching {
+                                            context.startActivity(
+                                                Intent(android.provider.Settings.ACTION_SETTINGS)
+                                                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                            state.statusVoiceAction -> {
+                                { vm.clearStatus(); onOpenVoiceSettings() }
+                            }
+                            else -> null
                         },
                     )
                 }

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -167,6 +167,7 @@ data class MapUiState(
     val arrivedSeconds: Double = 0.0,
     val status: String? = null,
     val statusVoiceAction: Boolean = false, // status is a voice problem -> show the Get-a-voice pill
+    val statusOpensTtsSettings: Boolean = false, // the pill opens the SYSTEM voice settings, not Vela's library
     val installingEngine: String? = null, // pkg of the voice engine currently downloading
     val voiceDownloadPct: Float? = null, // 0f..1f while the neural-voice model downloads; null = idle
     val installedVoiceIds: Set<String> = emptySet(), // Piper voices present on disk (the voice browser)
@@ -329,8 +330,17 @@ class MapViewModel @Inject constructor(
             if (lang != lastVoiceLangHinted) {
                 lastVoiceLangHinted = lang
                 val endonym = app.vela.ui.AppLocale.endonym(lang)
+                // Two fixes for two causes. A language Vela CAN train a voice for (fr, ru, …) →
+                // nudge to the voice library. One it CAN'T (Japanese: no Piper/espeak voice) → the
+                // library is a dead end, so point at the phone's own voice settings to add a system
+                // voice, which is where ja guidance is spoken from.
+                val hasVela = app.vela.core.voice.PiperCatalog.hasVoiceFor(lang)
+                val msg = appContext.getString(
+                    if (hasVela) R.string.mapvm_voice_lang_missing else R.string.mapvm_voice_lang_system,
+                    endonym,
+                )
                 viewModelScope.launch(Dispatchers.Main) {
-                    flashStatus(appContext.getString(R.string.mapvm_voice_lang_missing, endonym), 6000L, voiceAction = true)
+                    flashStatus(msg, 6000L, voiceAction = true, ttsSettings = !hasVela)
                 }
             }
         }
@@ -3063,12 +3073,12 @@ class MapViewModel @Inject constructor(
 
     /** A status banner that **auto-clears** after a few seconds (unlike [showStatus],
      *  which stays until dismissed) — for transient feedback like a finished download. */
-    fun flashStatus(msg: String, millis: Long = 4500L, voiceAction: Boolean = false) {
+    fun flashStatus(msg: String, millis: Long = 4500L, voiceAction: Boolean = false, ttsSettings: Boolean = false) {
         statusJob?.cancel()
-        _state.update { it.copy(status = msg, statusVoiceAction = voiceAction) }
+        _state.update { it.copy(status = msg, statusVoiceAction = voiceAction, statusOpensTtsSettings = ttsSettings) }
         statusJob = viewModelScope.launch {
             delay(millis)
-            _state.update { if (it.status == msg) it.copy(status = null, statusVoiceAction = false) else it }
+            _state.update { if (it.status == msg) it.copy(status = null, statusVoiceAction = false, statusOpensTtsSettings = false) else it }
         }
     }
 
@@ -3102,10 +3112,10 @@ class MapViewModel @Inject constructor(
         startLocation() // resume the live collector (no-ops if already running)
     }
 
-    fun clearStatus() = _state.update { it.copy(status = null, statusVoiceAction = false) }
+    fun clearStatus() = _state.update { it.copy(status = null, statusVoiceAction = false, statusOpensTtsSettings = false) }
 
     fun showStatus(msg: String, voiceAction: Boolean = false) =
-        _state.update { it.copy(status = msg, statusVoiceAction = voiceAction) }
+        _state.update { it.copy(status = msg, statusVoiceAction = voiceAction, statusOpensTtsSettings = false) }
 
     // --- offline download (triggered from Settings, not a map FAB) -------------
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -409,8 +409,12 @@
     <string name="mapvm_trip_default_name">Trip</string>
     <string name="mapvm_no_voice_engine">No voice installed for spoken directions</string>
     <string name="mapscreen_get_voice">Get a voice</string>
+    <string name="mapscreen_system_voices">System voices</string>
     <string name="settings_spoken_directions">Spoken directions</string>
     <string name="mapvm_voice_lang_missing">Spoken directions need a %1$s voice. Get one in Settings → Voice</string>
+    <!-- Shown when the language has no bundled Vela voice (e.g. Japanese) AND the phone has no
+         system voice for it either, so we point at the phone's own voice settings instead. -->
+    <string name="mapvm_voice_lang_system">%1$s directions use your phone\'s voice. Add one in your system voice settings.</string>
     <string name="mapvm_resume_waiting_gps">Waiting for GPS to resume navigation…</string>
     <string name="mapvm_resume_failed">Couldn\'t resume navigation</string>
     <string name="mapvm_no_track_to_replay">That trip has no track to replay</string>

--- a/core/src/main/java/app/vela/core/voice/PiperCatalog.kt
+++ b/core/src/main/java/app/vela/core/voice/PiperCatalog.kt
@@ -118,6 +118,12 @@ object PiperCatalog {
 
     fun byId(id: String): PiperVoice? = ALL.firstOrNull { it.id == id }
 
+    /** True when the catalog ships a downloadable voice for [langCode]. False for languages Piper
+     *  can't train (Japanese: espeak-ng has no Japanese phonemizer), where spoken guidance falls to
+     *  the phone's own system TTS instead of a Vela voice. Drives the "get a Vela voice" vs "add a
+     *  system voice" fork in the no-voice nudge. */
+    fun hasVoiceFor(langCode: String): Boolean = ALL.any { it.langCode == langCode }
+
     /** All language codes present, English first then by endonym, for grouping the browser. */
     fun languageCodes(): List<String> =
         ALL.map { it.langCode }.distinct().sortedWith(compareByDescending<String> { it == "en" }.thenBy { languageLabel(it) })


### PR DESCRIPTION
**How should we do Japanese TTS?** Piper's phonemizer (espeak-ng) has no Japanese, so there's no bundled Vela Japanese voice the way Chinese got Huayan. Japanese turn-by-turn is already spoken by the **phone's own system TTS** (Google's Japanese voice is good) via VoiceGuide's language-mismatch fallback. The only gap was the nudge when a phone lacks a Japanese system voice: it showed "Get a voice" pointing at Vela's library, which has no Japanese voice to install - a dead end.

Now the missing-voice pill **forks by cause**:
- Language Vela **can** train a voice for (fr, ru, …) → "Get a voice" → Vela's voice library (unchanged).
- Language Piper **can't** do (Japanese) → **"System voices"** → opens the phone's TTS settings (`com.android.settings.TTS_SETTINGS`, falling back to the main Settings screen), where the user can add a system Japanese voice.

`PiperCatalog.hasVoiceFor(lang)` drives the fork. So Japanese works today through any installed system Japanese voice, and the app guides users to install one rather than to a voice that can't exist.

A fully-**offline** bundled Japanese neural voice (Kokoro int8 multi-lang, ~126 MB) stays a ROADMAP follow-up pending a device speed re-check (Kokoro was ~0.4x realtime before it was pulled).

Docs: FEATURES + ROADMAP updated. New strings are English-first (i18n backfill with #148).