### PR TITLE
Localization sweep: backfill the newest UI strings into all 14 locales

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -540,4 +540,11 @@
     <string name="settings_map_colors_hint">Modern entspricht der aktuellen Google-Palette. Klassisch ist der frühere Vela-Look: weiße Straßen, gelbe Autobahnen, kräftige Grüntöne.</string>
     <string name="place_avoid_tolls">Mautstraßen vermeiden</string>
     <string name="place_avoid_highways">Autobahnen vermeiden</string>
+    <string name="map_parking_find">Mein Auto finden</string>
+    <string name="map_parking_move_here">Parkplatz hierher verschieben</string>
+    <string name="map_parking_earlier">Frühere Parkplätze</string>
+    <string name="map_parking_clear">Parkplatz entfernen</string>
+    <string name="map_parking_moved">Parkplatz hierher verschoben</string>
+    <string name="mapscreen_system_voices">Systemstimmen</string>
+    <string name="mapvm_voice_lang_system">Ansagen auf %1$s nutzen die Stimme Ihres Telefons. Fügen Sie eine in den System-Sprachausgabe-Einstellungen hinzu.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -540,4 +540,11 @@
     <string name="settings_map_colors_hint">Moderno sigue la paleta actual de Google Maps. Clásico es el aspecto anterior de Vela: carreteras blancas, autopistas amarillas, verdes intensos.</string>
     <string name="place_avoid_tolls">Evitar peajes</string>
     <string name="place_avoid_highways">Evitar autopistas</string>
+    <string name="map_parking_find">Encontrar mi coche</string>
+    <string name="map_parking_move_here">Mover aparcamiento aquí</string>
+    <string name="map_parking_earlier">Sitios anteriores</string>
+    <string name="map_parking_clear">Borrar aparcamiento</string>
+    <string name="map_parking_moved">Aparcamiento movido aquí</string>
+    <string name="mapscreen_system_voices">Voces del sistema</string>
+    <string name="mapvm_voice_lang_system">Las indicaciones en %1$s usan la voz de tu teléfono. Añade una en los ajustes de voz del sistema.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -540,4 +540,11 @@
     <string name="settings_map_colors_hint">Moderne reprend la palette actuelle de Google Maps. Classique est l\'ancien style de Vela : routes blanches, autoroutes jaunes, verts francs.</string>
     <string name="place_avoid_tolls">Éviter les péages</string>
     <string name="place_avoid_highways">Éviter les autoroutes</string>
+    <string name="map_parking_find">Trouver ma voiture</string>
+    <string name="map_parking_move_here">Déplacer le parking ici</string>
+    <string name="map_parking_earlier">Emplacements précédents</string>
+    <string name="map_parking_clear">Effacer le parking</string>
+    <string name="map_parking_moved">Place de parking déplacée ici</string>
+    <string name="mapscreen_system_voices">Voix du système</string>
+    <string name="mapvm_voice_lang_system">Les instructions en %1$s utilisent la voix de votre téléphone. Ajoutez-en une dans les paramètres vocaux du système.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -540,4 +540,11 @@
     <string name="settings_map_colors_hint">Moderno segue la palette attuale di Google Maps. Classico è il vecchio aspetto di Vela: strade bianche, autostrade gialle, verdi pieni.</string>
     <string name="place_avoid_tolls">Evita i pedaggi</string>
     <string name="place_avoid_highways">Evita le autostrade</string>
+    <string name="map_parking_find">Trova la mia auto</string>
+    <string name="map_parking_move_here">Sposta il parcheggio qui</string>
+    <string name="map_parking_earlier">Posti precedenti</string>
+    <string name="map_parking_clear">Rimuovi parcheggio</string>
+    <string name="map_parking_moved">Parcheggio spostato qui</string>
+    <string name="mapscreen_system_voices">Voci di sistema</string>
+    <string name="mapvm_voice_lang_system">Le indicazioni in %1$s usano la voce del telefono. Aggiungine una nelle impostazioni voce di sistema.</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -535,4 +535,15 @@
     <string name="place_avoid_highways">הימנע מכבישים מהירים</string>
     <string name="shortcut_home">בית</string>
     <string name="shortcut_work">עבודה</string>
+    <string name="settings_map_colors">צבעי מפה</string>
+    <string name="settings_map_colors_modern">מודרני</string>
+    <string name="settings_map_colors_classic">קלאסי</string>
+    <string name="settings_map_colors_hint">מודרני תואם את פלטת הצבעים הנוכחית של אפליקציית Google. קלאסי הוא המראה המוקדם של Vela: כבישים לבנים, כבישים מהירים צהובים, ירוקים אמיתיים.</string>
+    <string name="map_parking_find">מצא את הרכב שלי</string>
+    <string name="map_parking_move_here">הזז חניה לכאן</string>
+    <string name="map_parking_earlier">מקומות קודמים</string>
+    <string name="map_parking_clear">נקה חניה</string>
+    <string name="map_parking_moved">מיקום החניה הוזז לכאן</string>
+    <string name="mapscreen_system_voices">קולות מערכת</string>
+    <string name="mapvm_voice_lang_system">הוראות ב%1$s משתמשות בקול של הטלפון שלך. הוסף אחד בהגדרות הקול של המערכת.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -557,4 +557,15 @@
     <string name="settings_ui_scale">表示サイズ</string>
     <string name="place_avoid_tolls">有料道路を回避</string>
     <string name="place_avoid_highways">高速道路を回避</string>
+    <string name="settings_map_colors">地図の色</string>
+    <string name="settings_map_colors_modern">モダン</string>
+    <string name="settings_map_colors_classic">クラシック</string>
+    <string name="settings_map_colors_hint">モダンは Google アプリの現在の配色に合わせています。クラシックは Vela の以前の見た目です：白い道路、黄色い高速道路、本来の緑。</string>
+    <string name="map_parking_find">車を探す</string>
+    <string name="map_parking_move_here">駐車位置をここに移動</string>
+    <string name="map_parking_earlier">以前の駐車位置</string>
+    <string name="map_parking_clear">駐車位置を消去</string>
+    <string name="map_parking_moved">駐車位置をここに移動しました</string>
+    <string name="mapscreen_system_voices">システムの音声</string>
+    <string name="mapvm_voice_lang_system">%1$s のナビは端末の音声を使用します。システムの音声設定で追加できます。</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -540,4 +540,11 @@
     <string name="settings_map_colors_hint">Modern volgt het huidige palet van Google Maps. Klassiek is de eerdere look van Vela: witte wegen, gele snelwegen, echte groentinten.</string>
     <string name="place_avoid_tolls">Tolwegen vermijden</string>
     <string name="place_avoid_highways">Snelwegen vermijden</string>
+    <string name="map_parking_find">Mijn auto zoeken</string>
+    <string name="map_parking_move_here">Parkeerplek hierheen verplaatsen</string>
+    <string name="map_parking_earlier">Eerdere parkeerplekken</string>
+    <string name="map_parking_clear">Parkeerplek wissen</string>
+    <string name="map_parking_moved">Parkeerplek hierheen verplaatst</string>
+    <string name="mapscreen_system_voices">Systeemstemmen</string>
+    <string name="mapvm_voice_lang_system">Aanwijzingen in het %1$s gebruiken de stem van je telefoon. Voeg er een toe in je systeemstem-instellingen.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -542,4 +542,11 @@
     <string name="settings_map_colors_hint">Nowoczesne odpowiadają obecnej palecie Google Maps. Klasyczne to wcześniejszy wygląd Vela: białe drogi, żółte autostrady, wyraziste zielenie.</string>
     <string name="place_avoid_tolls">Unikaj opłat drogowych</string>
     <string name="place_avoid_highways">Unikaj autostrad</string>
+    <string name="map_parking_find">Znajdź mój samochód</string>
+    <string name="map_parking_move_here">Przenieś parking tutaj</string>
+    <string name="map_parking_earlier">Wcześniejsze miejsca</string>
+    <string name="map_parking_clear">Usuń parking</string>
+    <string name="map_parking_moved">Przeniesiono parking tutaj</string>
+    <string name="mapscreen_system_voices">Głosy systemowe</string>
+    <string name="mapvm_voice_lang_system">Wskazówki dla języka %1$s używają głosu telefonu. Dodaj go w systemowych ustawieniach głosu.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -540,4 +540,11 @@
     <string name="settings_map_colors_hint">Moderno segue a paleta atual do Google Maps. Clássico é o visual anterior do Vela: estradas brancas, autoestradas amarelas, verdes fortes.</string>
     <string name="place_avoid_tolls">Evitar pedágios</string>
     <string name="place_avoid_highways">Evitar rodovias</string>
+    <string name="map_parking_find">Encontrar o meu carro</string>
+    <string name="map_parking_move_here">Mover estacionamento para aqui</string>
+    <string name="map_parking_earlier">Locais anteriores</string>
+    <string name="map_parking_clear">Remover estacionamento</string>
+    <string name="map_parking_moved">Estacionamento movido para aqui</string>
+    <string name="mapscreen_system_voices">Vozes do sistema</string>
+    <string name="mapvm_voice_lang_system">As indicações em %1$s usam a voz do telemóvel. Adicione uma nas definições de voz do sistema.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -539,7 +539,14 @@
     <string name="settings_map_colors">Цвета карты</string>
     <string name="settings_map_colors_modern">Современные</string>
     <string name="settings_map_colors_classic">Классические</string>
-    <string name="settings_map_colors_hint">Современные повторяют текущую палитру Google Maps. Классические — прежний вид Vela: белые дороги, жёлтые магистрали, насыщенная зелень.</string>
+    <string name="settings_map_colors_hint">Современные повторяют текущую палитру Google Maps. Классические возвращают прежний вид Vela: белые дороги, жёлтые магистрали, насыщенная зелень.</string>
     <string name="place_avoid_tolls">Избегать платных дорог</string>
     <string name="place_avoid_highways">Избегать шоссе</string>
+    <string name="map_parking_find">Найти мою машину</string>
+    <string name="map_parking_move_here">Переместить парковку сюда</string>
+    <string name="map_parking_earlier">Предыдущие места</string>
+    <string name="map_parking_clear">Убрать парковку</string>
+    <string name="map_parking_moved">Парковка перемещена сюда</string>
+    <string name="mapscreen_system_voices">Системные голоса</string>
+    <string name="mapvm_voice_lang_system">Указания для языка %1$s используют голос телефона. Добавьте его в системных настройках голоса.</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -540,4 +540,11 @@
     <string name="settings_map_colors_hint">Modern följer Google Maps nuvarande palett. Klassisk är Velas tidigare utseende: vita vägar, gula motorvägar, riktiga gröna toner.</string>
     <string name="place_avoid_tolls">Undvik vägtullar</string>
     <string name="place_avoid_highways">Undvik motorvägar</string>
+    <string name="map_parking_find">Hitta min bil</string>
+    <string name="map_parking_move_here">Flytta parkeringen hit</string>
+    <string name="map_parking_earlier">Tidigare parkeringar</string>
+    <string name="map_parking_clear">Rensa parkering</string>
+    <string name="map_parking_moved">Parkeringen flyttad hit</string>
+    <string name="mapscreen_system_voices">Systemröster</string>
+    <string name="mapvm_voice_lang_system">Vägbeskrivningar på %1$s använder telefonens röst. Lägg till en i systemets röstinställningar.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -539,7 +539,14 @@
     <string name="settings_map_colors">Кольори карти</string>
     <string name="settings_map_colors_modern">Сучасні</string>
     <string name="settings_map_colors_classic">Класичні</string>
-    <string name="settings_map_colors_hint">Сучасні повторюють поточну палітру Google Maps. Класичні — попередній вигляд Vela: білі дороги, жовті магістралі, насичена зелень.</string>
+    <string name="settings_map_colors_hint">Сучасні повторюють поточну палітру Google Maps. Класичні повертають попередній вигляд Vela: білі дороги, жовті магістралі, насичена зелень.</string>
     <string name="place_avoid_tolls">Уникати платних доріг</string>
     <string name="place_avoid_highways">Уникати шосе</string>
+    <string name="map_parking_find">Знайти моє авто</string>
+    <string name="map_parking_move_here">Перемістити парковку сюди</string>
+    <string name="map_parking_earlier">Попередні місця</string>
+    <string name="map_parking_clear">Прибрати парковку</string>
+    <string name="map_parking_moved">Парковку переміщено сюди</string>
+    <string name="mapscreen_system_voices">Системні голоси</string>
+    <string name="mapvm_voice_lang_system">Вказівки для мови %1$s використовують голос телефону. Додайте його в системних налаштуваннях голосу.</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -557,4 +557,15 @@
     <string name="settings_ui_scale">介面大小</string>
     <string name="place_avoid_tolls">避開收費路段</string>
     <string name="place_avoid_highways">避開高速公路</string>
+    <string name="settings_map_colors">地圖顏色</string>
+    <string name="settings_map_colors_modern">現代</string>
+    <string name="settings_map_colors_classic">經典</string>
+    <string name="settings_map_colors_hint">現代與 Google 應用程式目前的配色一致。經典是 Vela 早期的樣式：白色道路、黃色高速公路、純正的綠色。</string>
+    <string name="map_parking_find">尋找我的車</string>
+    <string name="map_parking_move_here">將停車位移到這裡</string>
+    <string name="map_parking_earlier">較早的停車位</string>
+    <string name="map_parking_clear">清除停車位</string>
+    <string name="map_parking_moved">停車位已移到這裡</string>
+    <string name="mapscreen_system_voices">系統語音</string>
+    <string name="mapvm_voice_lang_system">%1$s 導航使用手機的語音。可在系統語音設定中新增。</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -557,4 +557,15 @@
     <string name="settings_ui_scale">界面大小</string>
     <string name="place_avoid_tolls">避开收费站</string>
     <string name="place_avoid_highways">避开高速</string>
+    <string name="settings_map_colors">地图颜色</string>
+    <string name="settings_map_colors_modern">现代</string>
+    <string name="settings_map_colors_classic">经典</string>
+    <string name="settings_map_colors_hint">现代与 Google 应用当前的配色一致。经典是 Vela 早期的样式：白色道路、黄色高速公路、纯正的绿色。</string>
+    <string name="map_parking_find">寻找我的车</string>
+    <string name="map_parking_move_here">将停车点移到这里</string>
+    <string name="map_parking_earlier">较早的停车点</string>
+    <string name="map_parking_clear">清除停车点</string>
+    <string name="map_parking_moved">停车点已移到这里</string>
+    <string name="mapscreen_system_voices">系统语音</string>
+    <string name="mapvm_voice_lang_system">%1$s 导航使用手机的语音。可在系统语音设置中添加。</string>
 </resources>


### PR DESCRIPTION
Backfills the strings added since the last sweep so they stop falling back to English:
- **Map color sets** (`settings_map_colors*`) into the CJK + Hebrew files (the 10 base languages already had them from #67).
- **Parking hub** (`map_parking_find/move_here/earlier/clear/moved`) into all 14.
- **System-voices prompt** (`mapscreen_system_voices`, `mapvm_voice_lang_system`) into all 14.

Done by five translation passes grouped by language family (Romance / Germanic / Slavic / CJK / Hebrew), matched to each file's existing register and terminology (e.g. the existing "system voice settings" phrasing, the parking-status pattern). Simplified vs Traditional Chinese genuinely differ (停车点 vs 停車位, 设置 vs 設定, …).

Validated across all 14 files: no duplicate keys, all 11 keys present, `%1$s` placeholder parity, valid XML, **zero em-dashes**, and `:app:mergeReleaseResources` passes (the apostrophe/AAPT trap). Also removed two stray em-dashes that had slipped into the existing ru/uk map-colors hint.