### PR TITLE
Classic colors: recolor the overlay houses + note it's dark-mode for now

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -34,7 +34,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   blue-grey dark reading almost identical (user: "classic looks bluish like modern, houses too").
   Classic dark is now a NEUTRAL charcoal-slate identity - slate land, GREY buildings (no blue
   houses), muted-amber motorways echoing the classic-light yellow, its true greens and steel-blue
-  water kept - so the two dark sets are clearly distinct.
+  water kept - so the two dark sets are clearly distinct. **Follow-up (2026-07-12):** the Microsoft
+  building-footprint OVERLAY (the layer that fills OSM's gaps) had its colour hardcoded to Modern, so
+  in Classic those houses stayed Google-navy while the OSM ones went grey; it now honours the palette
+  too. Also, since the two sets currently diverge mostly in dark mode, the Settings hint says so.
 - ✅ **Google-style nav puck (2026-07-11).** The navigation arrow is a white chevron inside a
   filled bright-navy circle with a soft drop shadow (no white ring, per user feedback); it rotates
   about the exact GPS point. Replaces the bare blue chevron. **Enlarged twice from feedback

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -396,12 +396,25 @@ fun VelaMapView(
         // (theme flip mid-effect), and a dead style throws on ANY access, not just mutation.
         runCatching { style.layers.filter { it.id.startsWith("vela-ovl-") }.forEach { style.removeLayer(it) } }
         runCatching { style.sources.filter { it.id.startsWith("vela-ovl-src-") }.forEach { style.removeSource(it) } }
-        // MUST equal the OSM `building` fill/outline in applyDark/applyLight, or the
-        // Microsoft-only footprints read as a second building colour beside the OSM
-        // ones (the "some buildings are still grey" report after the pixel-sampled
-        // palette landed - this pair was left on the old greys, user 2026-07-11).
-        val fill = if (darkTheme) "#1c3b69" else "#e2e3e9"
-        val line = if (darkTheme) "#2e3d6d" else "#c4c9d1"
+        // MUST equal the OSM `building` fill/outline in applyDark/applyLight AND
+        // applyClassicDark/applyClassicLight, or the Microsoft-only footprints read as a second
+        // building colour beside the OSM ones. This pair is keyed on darkTheme but ALSO has to honour
+        // the Modern/Classic palette: it was hardcoded to Modern, so switching to Classic left the
+        // overlay houses Google-navy while the OSM ones went grey ("houses still bluish in classic",
+        // user 2026-07-12). MapColors.current() feeds the styleKey, so a palette switch reloads the
+        // style and re-runs this effect; reading classic() here picks up the new palette.
+        val classic = app.vela.ui.MapColors.classic()
+        val fill = when {
+            classic && darkTheme -> "#383d45" // == applyClassicDark building
+            classic -> "#dde1e7"              // == applyClassicLight building
+            darkTheme -> "#1c3b69"            // == applyDark building
+            else -> "#e2e3e9"                 // == applyLight building
+        }
+        val line = when {
+            classic && darkTheme -> "#464c56"
+            darkTheme -> "#2e3d6d"
+            else -> "#c4c9d1" // classic-light + modern-light share this outline
+        }
         val below = runCatching { style.getLayer("building")?.id }.getOrNull() // beneath OSM buildings so they win wherever OSM has them
         buildingOverlays.forEachIndexed { i, uri ->
             runCatching {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -569,7 +569,7 @@
     <string name="settings_map_colors">Map colors</string>
     <string name="settings_map_colors_modern">Modern</string>
     <string name="settings_map_colors_classic">Classic</string>
-    <string name="settings_map_colors_hint">Modern matches the Google app\'s current palette. Classic is Vela\'s earlier look: white roads, yellow motorways, true greens.</string>
+    <string name="settings_map_colors_hint">Modern matches the Google app\'s current palette. Classic is Vela\'s earlier look: white roads, yellow motorways, true greens. The two differ most in dark mode right now.</string>
     <string name="place_avoid_tolls">Avoid tolls</string>
     <string name="place_avoid_highways">Avoid highways</string>
     <string name="shortcut_home">Home</string>


### PR DESCRIPTION
Follow-up to the Classic-palette fix, from the 4a.

**The blue houses were the Microsoft footprint overlay.** The `vela-ovl-*` layer that fills OSM's building gaps had its color hardcoded to the Modern palette (`#1c3b69` navy in dark), so switching to Classic left those footprints Google-navy while the OSM `building` layer went grey. It now reads `MapColors.classic()` and uses the Classic building colors (`#383d45` dark / `#dde1e7` light), matching the OSM buildings. (A palette switch already reloads the style, which re-runs this effect, so no re-keying needed.)

**Not a remote-config thing:** only *which set is default* (`defaultMapPalette`) rides calibration; the actual colors are compiled, so this needed a build.

**Dark-mode note:** the two sets currently differ most in dark mode, so the Settings → Map colors hint now says so (English updated; the 14 translations keep their prior hint until the next sweep).

Left open for on-device testing on the 4a before merge, per the new flow.