### PR TITLE
Speed A: show the posted speed-limit sign while free-driving (not just nav)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1110,7 +1110,7 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   derestricted road as 150). Verified: a Monaco graph rebuilds cleanly with `max_speed` + CH. **Coverage =
   OSM `maxspeed` (partial)** - strong on highways/EU/urban, sparse on US residential. **Remaining to light it
   up for everyone: re-bake + re-host the region graphs with `max_speed` (CI), then a fresh region download
-  shows it** (a version-discriminator so *existing* offline graphs auto-re-download is a small follow-up).
+  shows it** (a version-discriminator so *existing* offline graphs auto-re-download is a small follow-up). **Now shown in FREE-DRIVE too (2026-07-12, user request):** the same `updateSpeedLimit` already ran on every live browse fix, it was only *rendered* during nav; the sign now also appears while you're simply driving with no route open (moving, on the clean map), dropped to the nav-bar line since there's no speedometer there. **Speed A** of the plan; **Speed B** (a keyless maxspeed PMTiles overlay) will remove the download-a-graph requirement so limits show anywhere, and the same badge lookup will fall back to it when no graph covers the road.
 - ⬜ Speed-camera + hazard alerts (lane guidance ✅ done above)
 - ✅ **Android Auto - first cut shipped 2026-07-08** (see the entry at the top of this section). The old
   "needs GMS, out of scope" call was wrong: the car app library is plain androidx, and a sideload runs fine

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1149,9 +1149,15 @@ fun MapScreen(
             }
         }
 
-        // Posted speed-limit sign — sits just above the speedometer during nav, when the on-device
-        // graph knows the current road's OSM maxspeed (hidden otherwise; sparse OSM coverage = often blank).
-        if (state.navigating && state.speedLimitKmh != null) {
+        // Posted speed-limit sign, from the on-device graph's OSM maxspeed (hidden when the road's
+        // untagged or no covering graph is downloaded - sparse OSM coverage = often blank). Shown
+        // during nav AND during a FREE-DRIVE (moving with no route open, on the clean map) - the same
+        // `updateSpeedLimit` already runs on every live browse fix, it was only ever *rendered* in nav
+        // (user 2026-07-12: show it while just driving too). In free-drive there's no speedometer, so
+        // it drops to the nav-bar line; during nav it stays above the speedo.
+        val freeDriveSpeed = !state.navigating && (state.mySpeed ?: 0f) > 3f &&
+            !searchOpen && state.selected == null && !state.directionsOpen && !state.showSteps && !resultsShown
+        if ((state.navigating || freeDriveSpeed) && state.speedLimitKmh != null) {
             SpeedLimitSign(
                 limitKmh = state.speedLimitKmh!!,
                 speedMps = state.mySpeed,
@@ -1159,7 +1165,12 @@ fun MapScreen(
                 modifier = Modifier
                     .align(Alignment.BottomStart)
                     .navigationBarsPadding()
-                    .padding(start = 16.dp, bottom = navBarClearance + 68.dp), // above the 60dp speedo + 8dp gap
+                    .padding(
+                        start = 16.dp,
+                        // above the 60dp speedo + 8dp gap during nav; in free-drive lift it above the
+                        // bottom-left scale bar so the two don't overlap.
+                        bottom = navBarClearance + if (state.navigating) 68.dp else 46.dp,
+                    ),
             )
         }
 


### PR DESCRIPTION
Speed limits were already fully built - `GraphBuilder` bakes OSM `maxspeed` into the graph's `max_speed` EV, `currentRoadLimit` reads it, and the MUTCD **SpeedLimitSign** rendered **during nav**. `updateSpeedLimit` already runs on **every live browse fix**, so the data's there off-route too; it was only ever *drawn* in nav.

This shows the sign in **free-drive**: moving (>3 m/s) with no route open, on the clean map (no search/place/directions up). During nav it stays above the speedometer; in free-drive it drops to the nav-bar line (no speedo there) and lifts clear of the scale bar.

Still needs the region's offline routing graph downloaded (the v2 graphs bake `max_speed`). **Speed B** (the keyless maxspeed PMTiles overlay) will remove that dependency and become the fallback source when no graph covers the road - per your "A falls back to B" call.

Open for 4a testing; batched with the rest.