### PR TITLE
Speed B (data): reversible bake pipeline for a posted-speed-limit overlay

### DIFF
--- a/.github/workflows/maxspeed-overlays.yml
+++ b/.github/workflows/maxspeed-overlays.yml
@@ -1,0 +1,117 @@
+# Build POSTED-SPEED-LIMIT overlays (OSM `maxspeed` road ways, ODbL) as PMTiles for many regions in
+# parallel and publish them to the `maxspeed-overlays` release - the app can show a speed-limit sign
+# WITHOUT the (much larger) offline routing graph. Sibling of building-overlays.yml; SOURCE is the same
+# Geofabrik OSM PBFs the routing graphs use, so the catalog is tools/routing-regions.json (id/name/pbf_url).
+#
+# Run from Actions → "Build maxspeed overlays" → pick a `group` (us | world | ...) or pass `ids`.
+# ADDITIVE + reversible: its own release + manifest; delete the `maxspeed-overlays` release to revert.
+name: Build maxspeed overlays
+
+on:
+  workflow_dispatch:
+    inputs:
+      group:
+        description: "Build a whole catalog group from routing-regions.json (e.g. us). Blank → use ids/all."
+        type: string
+        default: ""
+      ids:
+        description: "Space/comma-separated region ids (e.g. 'oregon washington'). Blank + all=true builds everything."
+        type: string
+        default: "oregon"
+      all:
+        description: "Build every region in tools/routing-regions.json (ignores 'ids'). Prefer `group` (256-job cap)."
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.sel.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: sel
+        env:
+          GRP: ${{ inputs.group }}
+          IDS: ${{ inputs.ids }}
+          ALL: ${{ inputs.all }}
+        run: |
+          ids_json=$(jq -cn --arg s "$IDS" '$s | gsub(",";" ") | split(" ") | map(select(length > 0))')
+          sel=$(jq -c --argjson ids "$ids_json" --argjson all "${ALL:-false}" --arg grp "$GRP" '
+            [ .regions[]
+              | select( if $grp != "" then (.group // "") == $grp
+                        else ($all or (($ids|length) > 0 and ((.id as $rid | $ids | index($rid)) != null))) end )
+              | {id, name, pbf_url} ]
+          ' tools/routing-regions.json)
+          n=$(printf '%s' "$sel" | jq 'length')
+          echo "selected $n region(s):"; printf '%s' "$sel" | jq -r '.[].id' | paste -sd' ' -
+          if [ "$n" -eq 0 ]; then echo "::error::no regions matched group='$GRP' ids='$IDS' all='$ALL'"; exit 1; fi
+          if [ "$n" -gt 256 ]; then echo "::error::$n regions exceeds the 256-job matrix cap - dispatch by group"; exit 1; fi
+          echo "matrix={\"include\":$sel}" >> "$GITHUB_OUTPUT"
+      - name: Ensure the catalog release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view maxspeed-overlays --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
+            gh release create maxspeed-overlays --repo "$GITHUB_REPOSITORY" --prerelease \
+              --title "Posted speed-limit overlays" \
+              --notes "OSM maxspeed road ways as PMTiles for Vela's keyless posted speed-limit source. Data assets, not a code release. Speed limits © OpenStreetMap contributors, ODbL."
+
+  build:
+    needs: prep
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix: ${{ fromJSON(needs.prep.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install osmium + tippecanoe
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y osmium-tool build-essential libsqlite3-dev zlib1g-dev jq
+          git clone --depth 1 https://github.com/felt/tippecanoe.git /tmp/tippecanoe
+          make -C /tmp/tippecanoe -j"$(nproc)"
+          sudo make -C /tmp/tippecanoe install
+      - name: Build ${{ matrix.id }} maxspeed PMTiles + upload + emit entry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VELA_REPO: ${{ github.repository }}
+          MANIFEST_MODE: emit
+          ENTRY_OUT: ${{ matrix.id }}.json
+        run: bash scripts/build-maxspeed-region.sh "${{ matrix.id }}" "${{ matrix.name }}" "${{ matrix.pbf_url }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: entry-${{ matrix.id }}
+          path: ${{ matrix.id }}.json
+          retention-days: 1
+
+  merge:
+    needs: build
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: maxspeed-overlays-manifest-merge
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - uses: actions/download-artifact@v4
+        with:
+          path: entries
+          pattern: entry-*
+          merge-multiple: true
+      - name: Merge entries into maxspeed-overlay-manifest.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VELA_REPO: ${{ github.repository }}
+        run: |
+          shopt -s nullglob
+          files=(entries/*.json)
+          if [ ${#files[@]} -eq 0 ]; then echo "no region entries were built - nothing to merge"; exit 0; fi
+          echo "merging ${#files[@]} entr(y/ies)"
+          bash scripts/merge-maxspeed-manifest.sh entries

--- a/scripts/build-maxspeed-region.sh
+++ b/scripts/build-maxspeed-region.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Build + publish ONE region's POSTED-SPEED-LIMIT overlay as a PMTiles archive to the `maxspeed-overlays`
+# GitHub release, merged into maxspeed-overlay-manifest.json. It carries OSM `maxspeed` on the road ways,
+# so the app can show a posted speed-limit sign WITHOUT the (much larger) offline routing graph downloaded
+# - the keyless "Speed B" source that GraphHopperRouteEngine.currentRoadLimit falls back to. Sibling of
+# build-routing-region.sh (same Geofabrik OSM PBF source) and build-overlay-region.sh (same tippecanoe →
+# PMTiles → release + manifest publish). ADDITIVE + reversible: its own release tag + manifest, nothing
+# the routing/building/address artifacts touch; delete the tag to revert.
+#
+#   scripts/build-maxspeed-region.sh <id> "<Display name>" <geofabrik .osm.pbf URL>
+#     scripts/build-maxspeed-region.sh oregon "Oregon" \
+#       https://download.geofabrik.de/north-america/us/oregon-latest.osm.pbf
+#
+# Needs: gh (authenticated), osmium-tool, tippecanoe, jq, curl. LICENSE: OSM data, ODbL (same as the tiles).
+set -euo pipefail
+
+ID="${1:?region id}"; NAME="${2:?display name}"; URL="${3:?geofabrik pbf url}"
+REPO="${VELA_REPO:-PimpinPumpkin/Vela}"
+TAG="maxspeed-overlays"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+echo "→ downloading $URL"
+curl -fsSL "$URL" -o "$WORK/region.osm.pbf"
+
+# Keep ONLY the ways that carry a posted maxspeed (nearly always highways) - a tiny slice of the PBF, so the
+# overlay is small. maxspeed on a non-highway is negligibly rare; filtering by the tag itself is enough.
+echo "→ osmium: keeping ways with a maxspeed tag"
+osmium tags-filter --overwrite -o "$WORK/ms.osm.pbf" "$WORK/region.osm.pbf" w/maxspeed
+
+# Export the road LINES to GeoJSONSeq (one Feature per line, streams into tippecanoe).
+echo "→ osmium export → GeoJSONSeq"
+osmium export "$WORK/ms.osm.pbf" -f geojsonseq --geometry-types=linestring -o "$WORK/ms.geojsonseq" --overwrite
+
+# Bbox from the PBF header (not the geometry extent - a stray node sends it to Alaska; same guard as routing).
+read -r MINLON MINLAT MAXLON MAXLAT < <(osmium fileinfo -g header.boxes "$WORK/region.osm.pbf" | tr -d '()' | tr ',' ' ')
+BBOX="[$MINLAT,$MINLON,$MAXLAT,$MAXLON]" # [S,W,N,E], the shape the routing manifest + picker use
+
+# Tile z11→z16: roads must be present + queryable at nav/free-drive zoom (~14-17), and z11 keeps the file
+# small while covering a snap. Keep ONLY the maxspeed attributes (-y) so the tiles carry no other tags.
+echo "→ tiling with tippecanoe"
+tippecanoe -o "$WORK/$ID.pmtiles" -l maxspeed -n "Vela speed-limit overlay: $NAME" \
+  -Z11 -z16 --drop-densest-as-needed --extend-zooms-if-still-dropping -P \
+  -y maxspeed -y maxspeed:forward -y maxspeed:backward \
+  --attribution "Speed limits © OpenStreetMap contributors (ODbL)" --force "$WORK/ms.geojsonseq"
+
+SIZE=$(( ( $(stat -f%z "$WORK/$ID.pmtiles" 2>/dev/null || stat -c%s "$WORK/$ID.pmtiles") + 1048575 ) / 1048576 ))
+ASSET_URL="https://github.com/$REPO/releases/download/$TAG/$ID.pmtiles"
+echo "→ $ID: ${SIZE} MB, bbox $BBOX"
+
+# The overlay catalog release - prerelease so it never becomes the "Latest" the APK auto-tracks.
+gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1 || \
+  gh release create "$TAG" --repo "$REPO" --prerelease --title "Posted speed-limit overlays" \
+    --notes "OSM \`maxspeed\` road ways as PMTiles, so Vela can show posted speed limits without the offline routing graph. Data assets, not a code release. Speed limits © OpenStreetMap contributors, ODbL."
+
+gh release upload "$TAG" "$WORK/$ID.pmtiles" --clobber --repo "$REPO"
+
+ENTRY="$(jq -nc --arg id "$ID" --arg name "$NAME" --arg url "$ASSET_URL" --argjson size "$SIZE" --argjson bbox "$BBOX" \
+  '{id:$id,name:$name,url:$url,sizeMb:$size,bbox:$bbox}')"
+
+# MANIFEST_MODE=emit (CI matrix): drop the entry to $ENTRY_OUT; the merge is centralised in one job so
+# parallel region builds can't clobber the manifest. Default (local single-region): read-modify-write here.
+if [ "${MANIFEST_MODE:-merge}" = "emit" ]; then
+  printf '%s\n' "$ENTRY" > "${ENTRY_OUT:?set ENTRY_OUT in emit mode}"
+  echo "✓ built $ID, pmtiles uploaded, entry → $ENTRY_OUT (manifest merged separately)"
+else
+  gh release download "$TAG" --repo "$REPO" -p maxspeed-overlay-manifest.json -O "$WORK/m.json" 2>/dev/null \
+    || echo '{"regions":[]}' > "$WORK/m.json"
+  jq --argjson entry "$ENTRY" \
+    '.regions = ([.regions[] | select(.id != ($entry.id))] + [$entry])' \
+    "$WORK/m.json" > "$WORK/maxspeed-overlay-manifest.json"
+  gh release upload "$TAG" "$WORK/maxspeed-overlay-manifest.json" --clobber --repo "$REPO"
+  echo "✓ published $ID"
+fi

--- a/scripts/merge-maxspeed-manifest.sh
+++ b/scripts/merge-maxspeed-manifest.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Merge many region entries into maxspeed-overlay-manifest.json in ONE upload - the race-safe half of the
+# CI matrix (build-maxspeed-region.sh MANIFEST_MODE=emit drops one entry file per region; this folds them
+# all in). Replace-by-id; regions not in this batch are preserved. Sibling of merge-overlay-manifest.sh.
+#
+#   scripts/merge-maxspeed-manifest.sh <dir-of-entry-json-files>
+#
+# Each file in <dir> is one {id,name,url,sizeMb,bbox} object. Needs: gh (auth), jq.
+set -euo pipefail
+
+DIR="${1:?dir of *.json entry files}"
+REPO="${VELA_REPO:-PimpinPumpkin/Vela}"
+TAG="maxspeed-overlays"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+gh release download "$TAG" --repo "$REPO" -p maxspeed-overlay-manifest.json -O "$WORK/manifest.json" 2>/dev/null \
+  || echo '{"regions":[]}' > "$WORK/manifest.json"
+
+jq -s '.' "$DIR"/*.json > "$WORK/batch.json"
+COUNT=$(jq 'length' "$WORK/batch.json")
+echo "→ merging $COUNT region entr$( [ "$COUNT" = 1 ] && echo y || echo ies ) into the maxspeed manifest"
+
+jq --slurpfile batch "$WORK/batch.json" '
+  ($batch[0] | map(.id)) as $ids
+  | .regions = ([.regions[] | select(.id as $i | $ids | index($i) | not)] + $batch[0])
+  | .regions |= sort_by(.name)
+' "$WORK/manifest.json" > "$WORK/maxspeed-overlay-manifest.json"
+
+jq -r '.regions[] | "   \(.name)  \(.sizeMb) MB  \(.bbox)"' "$WORK/maxspeed-overlay-manifest.json"
+gh release upload "$TAG" "$WORK/maxspeed-overlay-manifest.json" --clobber --repo "$REPO"
+echo "✓ maxspeed manifest now lists $(jq '.regions | length' "$WORK/maxspeed-overlay-manifest.json") regions"


### PR DESCRIPTION
The **data half of Speed B** - the keyless maxspeed source that removes the "download the routing graph" requirement. Additive + fully reversible, mirroring the building-overlay + routing bakes:

- **`scripts/build-maxspeed-region.sh`** - Geofabrik OSM PBF → `osmium tags-filter w/maxspeed` → `osmium export` linestrings → tippecanoe (`-y maxspeed*`, z11-16) → PMTiles → uploads to a **new `maxspeed-overlays` release** + emits a manifest entry.
- **`scripts/merge-maxspeed-manifest.sh`** - race-safe merge into `maxspeed-overlay-manifest.json` (replace-by-id).
- **`.github/workflows/maxspeed-overlays.yml`** - matrix from `tools/routing-regions.json` (same Geofabrik sources as the routing graphs), `max-parallel: 8`, its own manifest-merge concurrency group.

**Nothing existing is touched** - new release tag, new manifest, catalog reused read-only. Delete the `maxspeed-overlays` release to revert. **You dispatch it** (Actions → "Build maxspeed overlays" → pick a `group`), same as the poi-packs/routing bakes.

No app change in this PR (so no canary effect yet). The **on-device consumer** - stream the overlay for the in-view region, snap the fix to the nearest maxspeed way, and feed it as `currentRoadLimit`'s fallback (your "A falls back to B") - lands next, once tiles exist to test the snap against. Docs updated in FEATURES.