### PR TITLE
Transit: "departs in X min" countdown + live badge on each option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1809,6 +1809,14 @@ architecture note.
   end. The auto-advance is **latched** (`maybeAdvanceTransitNav`, `TRANSIT_ARM_M=90`/`TRANSIT_ARRIVE_M=40`):
   a leg only advances once it's been ARMED by being >ARM_M from its end, so a transfer hub can't cascade
   through legs and a short final walk can't fire a premature arrival.
+  **Departs-in countdown (2026-07-12):** `TransitBoard` runs ONE shared `produceState` clock (30 s
+  tick) and each `TransitRow` shows a leading "Departing"/"in N min" from `departureEpochSec`
+  (`departsInLabel`, hidden when >90 min out or already gone); the countdown reads GREEN with a
+  "Live" dot when any leg carries real-time (`delayText` or a `boardStop.scheduledText` differing
+  from the timetable), and the boarding leg's "N min late/early" is surfaced in the header. Pure
+  render off already-parsed fields, no extra fetch. `delayText` is English-computed in `:core` (as
+  in the drill-down); the countdown wrapper strings ARE localized (`place_transit_now`/`_in_min`/
+  `_live`, invariable "min" abbreviation per locale like `place_delta_min`).
 
 ## Name
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -904,6 +904,15 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   and reads the itinerary set out of `APP_INITIALIZATION_STATE` (the longest
   `)]}'` payload at slot [3]); `TransitParser` (keyless) parses it. **Verified
   on-device** Davis→Sacramento (6 options: Amtrak Thruway, Yolobus 42B/43/44, …).
+- ✅ Transit **"departs in X min" countdown + live badge (2026-07-12).** Each board option
+  leads with a Google-style countdown ("Departing" / "in 7 min") computed from the parsed
+  departure epoch against a shared clock that ticks every 30 s; options departing more than
+  90 minutes out (where the printed time carries it) or already gone are left unmarked. When
+  the itinerary carries **real-time** data (a leg with a live delay, or a real-time time that
+  differs from the timetable) the countdown reads **green** with a **Live** dot, and the
+  boarding leg's **"N min late/early"** is surfaced right in the header (it was only in the
+  drill-down before). Pure render off already-parsed fields (`TransitItinerary.departureEpochSec`,
+  `TransitStep.delayText`), no extra fetch; localized in all 11 languages.
 - ✅ Transit **leg drill-down with full stop detail** - tap an itinerary to expand
   its ordered legs. A ride leg shows Google's whole layout: the **line pill + "towards …"
   headsign**, the **board stop** (name + agency **Stop ID** + real-time board time, with

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -135,6 +135,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
+import kotlinx.coroutines.delay
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
@@ -2004,8 +2005,18 @@ private fun TransitBoard(
             Text(stringResource(R.string.place_finding_transit), style = MaterialTheme.typography.bodyMedium, color = dim)
         }
         trips.isEmpty() -> Text(stringResource(R.string.place_no_transit), style = MaterialTheme.typography.bodyMedium, color = dim)
-        else -> Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            trips.take(6).forEach { TransitRow(it, ink, dim, dark, onWalkDirections, onStartTransit) }
+        else -> {
+            // One shared clock so every row's "departs in X min" countdown ticks together
+            // (recomputed each minute against the parsed departure epochs).
+            val nowSec by produceState(initialValue = System.currentTimeMillis() / 1000L) {
+                while (true) {
+                    delay(30_000L)
+                    value = System.currentTimeMillis() / 1000L
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                trips.take(6).forEach { TransitRow(it, nowSec, ink, dim, dark, onWalkDirections, onStartTransit) }
+            }
         }
     }
 }
@@ -2068,10 +2079,27 @@ fun TransitNavSheet(
     }
 }
 
+/** "Departing" / "in 7 min" from a departure epoch, or null when there's nothing useful to
+ *  show - no epoch, already gone (>1 min past), or too far out (>90 min, where the printed
+ *  departure time carries it). Mirrors Google's leading countdown on the transit board. */
 @Composable
-private fun TransitRow(t: TransitItinerary, ink: Color, dim: Color, dark: Boolean, onWalkDirections: suspend (LatLng, LatLng) -> List<String> = { _, _ -> emptyList() }, onStartTransit: (TransitItinerary) -> Unit = {}) {
+private fun departsInLabel(depEpochSec: Long?, nowSec: Long): String? {
+    val dep = depEpochSec ?: return null
+    val diff = dep - nowSec
+    if (diff < -60L || diff > 90L * 60L) return null
+    if (diff <= 60L) return stringResource(R.string.place_transit_now)
+    return stringResource(R.string.place_transit_in_min, ((diff + 30L) / 60L).toInt())
+}
+
+@Composable
+private fun TransitRow(t: TransitItinerary, nowSec: Long, ink: Color, dim: Color, dark: Boolean, onWalkDirections: suspend (LatLng, LatLng) -> List<String> = { _, _ -> emptyList() }, onStartTransit: (TransitItinerary) -> Unit = {}) {
     var expanded by remember { mutableStateOf(false) }
     val canExpand = t.steps.isNotEmpty()
+    // "Departs in X min" from the parsed departure epoch, and the real-time signal (a leg
+    // carrying a live delay or a real-time-vs-timetable time) so the countdown can read green.
+    val countdown = departsInLabel(t.departureEpochSec, nowSec)
+    val live = t.steps.any { it.delayText != null || it.boardStop?.scheduledText != null }
+    val boardDelay = t.steps.firstOrNull { it.mode != TransitMode.WALK && it.delayText != null }?.delayText
     Column(
         Modifier
             .fillMaxWidth()
@@ -2081,6 +2109,37 @@ private fun TransitRow(t: TransitItinerary, ink: Color, dim: Color, dark: Boolea
             .padding(horizontal = 12.dp, vertical = 10.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
+        if (countdown != null || boardDelay != null) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                countdown?.let {
+                    Text(
+                        it,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = if (live) SheetPalette.TrafficGreen else ink,
+                    )
+                }
+                if (live) {
+                    Box(Modifier.size(6.dp).clip(CircleShape).background(SheetPalette.TrafficGreen))
+                    Text(
+                        stringResource(R.string.place_transit_live),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = SheetPalette.TrafficGreen,
+                    )
+                }
+                boardDelay?.let {
+                    Text(
+                        it,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = SheetPalette.TrafficRed,
+                        modifier = Modifier.weight(1f, fill = false),
+                    )
+                }
+            }
+        }
         Row(verticalAlignment = Alignment.CenterVertically) {
             val range = listOfNotNull(t.departureText, t.arrivalText).joinToString(" – ")
             Text(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -433,6 +433,9 @@
     <string name="place_transit_stops">%1$d Haltestellen</string> <!-- format -->
     <string name="place_transit_stop_id">Haltestelle %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Tickets &amp; Infos</string>
+    <string name="place_transit_now">Fährt ab</string>
+    <string name="place_transit_in_min">in %1$d Min.</string> <!-- format -->
+    <string name="place_transit_live">Live</string>
     <string name="transit_nav_arrived">Sie sind angekommen.</string>
     <string name="transit_nav_walk">%1$s laufen</string> <!-- format -->
     <string name="transit_nav_take">Nimm %1$s</string> <!-- format -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -433,6 +433,9 @@
     <string name="place_transit_stops">%1$d paradas</string> <!-- format -->
     <string name="place_transit_stop_id">Parada %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Billetes e info</string>
+    <string name="place_transit_now">Saliendo</string>
+    <string name="place_transit_in_min">en %1$d min</string> <!-- format -->
+    <string name="place_transit_live">En directo</string>
     <string name="transit_nav_arrived">Has llegado.</string>
     <string name="transit_nav_walk">Camina %1$s</string> <!-- format -->
     <string name="transit_nav_take">Toma %1$s</string> <!-- format -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -433,6 +433,9 @@
     <string name="place_transit_stops">%1$d arrêts</string> <!-- format -->
     <string name="place_transit_stop_id">Arrêt %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Billets et infos</string>
+    <string name="place_transit_now">Départ imminent</string>
+    <string name="place_transit_in_min">dans %1$d min</string> <!-- format -->
+    <string name="place_transit_live">En direct</string>
     <string name="transit_nav_arrived">Vous êtes arrivé.</string>
     <string name="transit_nav_walk">Marchez %1$s</string> <!-- format -->
     <string name="transit_nav_take">Prenez %1$s</string> <!-- format -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -433,6 +433,9 @@
     <string name="place_transit_stops">%1$d fermate</string> <!-- format -->
     <string name="place_transit_stop_id">Fermata %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Biglietti e info</string>
+    <string name="place_transit_now">In partenza</string>
+    <string name="place_transit_in_min">tra %1$d min</string> <!-- format -->
+    <string name="place_transit_live">In diretta</string>
     <string name="transit_nav_arrived">Sei arrivato.</string>
     <string name="transit_nav_walk">Cammina %1$s</string> <!-- format -->
     <string name="transit_nav_take">Prendi %1$s</string> <!-- format -->

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -431,6 +431,9 @@
     <string name="place_transit_stops">%1$d תחנות</string>
     <string name="place_transit_stop_id">תחנה %1$s</string>
     <string name="place_transit_tickets">כרטיסים &amp; מידע</string>
+    <string name="place_transit_now">יוצא כעת</string>
+    <string name="place_transit_in_min">בעוד %1$d דק׳</string> <!-- format -->
+    <string name="place_transit_live">בשידור חי</string>
     <string name="transit_nav_arrived">הגעת.</string>
     <string name="transit_nav_walk">הלך %1$s</string>
     <string name="transit_nav_take">קח %1$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -454,6 +454,9 @@
     <string name="place_transit_stops">%1$d 停留所</string> <!-- format -->
     <string name="place_transit_stop_id">停留所 %1$s</string> <!-- format -->
     <string name="place_transit_tickets">チケット・運行情報</string>
+    <string name="place_transit_now">まもなく発車</string>
+    <string name="place_transit_in_min">%1$d 分後</string> <!-- format -->
+    <string name="place_transit_live">リアルタイム</string>
     <string name="transit_nav_arrived">目的地に到着しました。</string>
     <string name="transit_nav_walk">徒歩 %1$s</string> <!-- format -->
     <string name="transit_nav_take">%1$s に乗車</string> <!-- format -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -433,6 +433,9 @@
     <string name="place_transit_stops">%1$d haltes</string> <!-- format -->
     <string name="place_transit_stop_id">Halte %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Tickets &amp; info</string>
+    <string name="place_transit_now">Vertrekt nu</string>
+    <string name="place_transit_in_min">over %1$d min</string> <!-- format -->
+    <string name="place_transit_live">Live</string>
     <string name="transit_nav_arrived">Je bent aangekomen.</string>
     <string name="transit_nav_walk">Loop %1$s</string> <!-- format -->
     <string name="transit_nav_take">Neem %1$s</string> <!-- format -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -435,6 +435,9 @@
     <string name="place_transit_stops">%1$d przystanków</string> <!-- format -->
     <string name="place_transit_stop_id">Przystanek %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Bilety i informacje</string>
+    <string name="place_transit_now">Odjeżdża</string>
+    <string name="place_transit_in_min">za %1$d min</string> <!-- format -->
+    <string name="place_transit_live">Na żywo</string>
     <string name="transit_nav_arrived">Dotarłeś na miejsce.</string>
     <string name="transit_nav_walk">Idź %1$s</string> <!-- format -->
     <string name="transit_nav_take">Wsiądź w %1$s</string> <!-- format -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -433,6 +433,9 @@
     <string name="place_transit_stops">%1$d paradas</string> <!-- format -->
     <string name="place_transit_stop_id">Parada %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Bilhetes e info</string>
+    <string name="place_transit_now">A sair</string>
+    <string name="place_transit_in_min">em %1$d min</string> <!-- format -->
+    <string name="place_transit_live">Ao vivo</string>
     <string name="transit_nav_arrived">Chegou.</string>
     <string name="transit_nav_walk">Caminhe %1$s</string> <!-- format -->
     <string name="transit_nav_take">Apanhe %1$s</string> <!-- format -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -435,6 +435,9 @@
     <string name="place_transit_stops">%1$d остановок</string> <!-- format -->
     <string name="place_transit_stop_id">Остановка %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Билеты и информация</string>
+    <string name="place_transit_now">Отправляется</string>
+    <string name="place_transit_in_min">через %1$d мин</string> <!-- format -->
+    <string name="place_transit_live">Онлайн</string>
     <string name="transit_nav_arrived">Вы прибыли.</string>
     <string name="transit_nav_walk">Идите %1$s</string> <!-- format -->
     <string name="transit_nav_take">Сядьте на %1$s</string> <!-- format -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -433,6 +433,9 @@
     <string name="place_transit_stops">%1$d hållplatser</string> <!-- format -->
     <string name="place_transit_stop_id">Hållplats %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Biljetter &amp; info</string>
+    <string name="place_transit_now">Avgår nu</string>
+    <string name="place_transit_in_min">om %1$d min</string> <!-- format -->
+    <string name="place_transit_live">Live</string>
     <string name="transit_nav_arrived">Du har kommit fram.</string>
     <string name="transit_nav_walk">Gå %1$s</string> <!-- format -->
     <string name="transit_nav_take">Ta %1$s</string> <!-- format -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -435,6 +435,9 @@
     <string name="place_transit_stops">%1$d зупинок</string> <!-- format -->
     <string name="place_transit_stop_id">Зупинка %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Квитки та інформація</string>
+    <string name="place_transit_now">Відправляється</string>
+    <string name="place_transit_in_min">через %1$d хв</string> <!-- format -->
+    <string name="place_transit_live">Наживо</string>
     <string name="transit_nav_arrived">Ви прибули.</string>
     <string name="transit_nav_walk">Ідіть %1$s</string> <!-- format -->
     <string name="transit_nav_take">Сідайте на %1$s</string> <!-- format -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -454,6 +454,9 @@
     <string name="place_transit_stops">%1$d 站</string> <!-- format -->
     <string name="place_transit_stop_id">站牌 %1$s</string> <!-- format -->
     <string name="place_transit_tickets">票券與資訊</string>
+    <string name="place_transit_now">即將出發</string>
+    <string name="place_transit_in_min">%1$d 分鐘後</string> <!-- format -->
+    <string name="place_transit_live">即時</string>
     <string name="transit_nav_arrived">你已抵達目的地。</string>
     <string name="transit_nav_walk">步行 %1$s</string> <!-- format -->
     <string name="transit_nav_take">搭乘%1$s</string> <!-- format -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -454,6 +454,9 @@
     <string name="place_transit_stops">%1$d 站</string> <!-- format -->
     <string name="place_transit_stop_id">站点 %1$s</string> <!-- format -->
     <string name="place_transit_tickets">购票与信息</string>
+    <string name="place_transit_now">即将出发</string>
+    <string name="place_transit_in_min">%1$d 分钟后</string> <!-- format -->
+    <string name="place_transit_live">实时</string>
     <string name="transit_nav_arrived">您已到达。</string>
     <string name="transit_nav_walk">步行 %1$s</string> <!-- format -->
     <string name="transit_nav_take">乘坐 %1$s</string> <!-- format -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -460,6 +460,9 @@
     <string name="place_transit_stops">%1$d stops</string> <!-- format -->
     <string name="place_transit_stop_id">Stop %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Tickets &amp; info</string>
+    <string name="place_transit_now">Departing</string>
+    <string name="place_transit_in_min">in %1$d min</string> <!-- format -->
+    <string name="place_transit_live">Live</string>
     <string name="transit_nav_arrived">You have arrived.</string>
     <string name="transit_nav_walk">Walk %1$s</string> <!-- format -->
     <string name="transit_nav_take">Take %1$s</string> <!-- format -->


### PR DESCRIPTION
Each transit option on the results board now leads with a Google-style countdown - "Departing" or "in 7 min" - computed from the parsed departure time against a shared clock that reticks every 30 seconds. Options more than 90 minutes out (where the printed departure time already carries it) or already gone stay unmarked.

When an option carries real-time data (a leg running late, or a time that differs from the timetable), the countdown reads green with a "Live" dot, and the boarding leg's "N min late/early" is surfaced right in the header rather than only in the drill-down.

This is a pure render off fields the transit parser already produces (`TransitItinerary.departureEpochSec`, `TransitStep.delayText`) - no extra fetch, no new endpoint. The countdown wrapper strings are localized in all languages (invariable "min" abbreviation per locale, same pattern as `place_delta_min`).

Docs: FEATURES.md + CLAUDE.md updated.

Canary-tested on the Pixel 4a before merge, per the per-PR canary rule.