### PR TITLE
Transit: live stop departure board (keyless, from the station page)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1819,10 +1819,16 @@ architecture note.
   place `root[6]`, transit node `place[62]` = `["<station>", [ <groups> ]]`; group `[null,"<Subway
   services>", [ <lines> ], … "<mode>"]`; line `[null, [ <directions> ], … ftid]`; direction
   `["<headsign>", null,null, [ <departures> ]]`; a departure time tuple `[rtEpoch,"<tz>","4:35
-  AM",offset,schedEpoch]` (realtime when rt≠sched); frequency `[<sec>,"20 min"]`. The container path
-  is positional; the LEAF details (time tuples, frequency, route label) are matched by SHAPE within
-  each direction, and `place[62]` is validated with a shape-search fallback - a moved leaf/field
-  index degrades one line, not the board. `parse` returns **null** for a non-station (routine - most
+  AM",offset,schedEpoch]` (realtime when rt≠sched); frequency `[<sec>,"20 min"]`. **TWO layouts
+  (2026-07-12):** a station/subway groups entries by line -> direction -> departures (above), but a busy
+  BUS stop lists every upcoming departure FLAT, each tagged with its own route pill at `entry[5][1]`
+  shaped `["<label>", <int>, "#fill", "#text"]` (the same badge the itinerary line pills use). So the
+  parser doesn't assume one shape: it reads the badge (route number + colours) + headsign + times off
+  each entry and GROUPS by (route, direction) - the 25 separate "route 14" departures collapse into one
+  "14" row with its next few times, in its line colour, and lines sort soonest-first. The container path
+  is positional; the LEAF details (time tuples, frequency, the route badge) are matched by SHAPE, and
+  `place[62]` is validated with a shape-search fallback - a moved leaf/field index degrades one line, not
+  the board. `parse` returns **null** for a non-station (routine - most
   places have no transit node) and throws `CalibrationNeededException` only when a transit node yields
   0 lines. **Coverage is AGENCY-DEPENDENT** (only agencies that feed Google real-time embed it): NYC
   MTA + SF BART carry it, SacRT (small light rail) does NOT - `MapViewModel.fetchStopDepartures` is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1809,6 +1809,27 @@ architecture note.
   end. The auto-advance is **latched** (`maybeAdvanceTransitNav`, `TRANSIT_ARM_M=90`/`TRANSIT_ARRIVE_M=40`):
   a leg only advances once it's been ARMED by being >ARM_M from its end, so a transfer hub can't cascade
   through legs and a short final walk can't fire a premature arrival.
+- **Live stop departure board (`WebStopDeparturesFetcher` + `core/.../StopDeparturesParser`,
+  2026-07-12, keyless + device-verified).** Tapping a transit STATION shows Google's "See departure
+  board" in the place sheet. The board is embedded in the station's OWN place page's
+  `APP_INITIALIZATION_STATE` (opening the button fires NO data RPC - only a gen_204 beacon) and
+  SURVIVES a logged-out session (proven anonymous in Chrome + on-device; NOT login-gated like popular
+  times), so it rides the SAME hidden-WebView `?cid=` channel as photos/reviews (desktop UA, anonymous)
+  and reuses the longest-`)]}'`-string extract. **Schema (calibrated NYC subway hub 2026-07-12):**
+  place `root[6]`, transit node `place[62]` = `["<station>", [ <groups> ]]`; group `[null,"<Subway
+  services>", [ <lines> ], … "<mode>"]`; line `[null, [ <directions> ], … ftid]`; direction
+  `["<headsign>", null,null, [ <departures> ]]`; a departure time tuple `[rtEpoch,"<tz>","4:35
+  AM",offset,schedEpoch]` (realtime when rt≠sched); frequency `[<sec>,"20 min"]`. The container path
+  is positional; the LEAF details (time tuples, frequency, route label) are matched by SHAPE within
+  each direction, and `place[62]` is validated with a shape-search fallback - a moved leaf/field
+  index degrades one line, not the board. `parse` returns **null** for a non-station (routine - most
+  places have no transit node) and throws `CalibrationNeededException` only when a transit node yields
+  0 lines. **Coverage is AGENCY-DEPENDENT** (only agencies that feed Google real-time embed it): NYC
+  MTA + SF BART carry it, SacRT (small light rail) does NOT - `MapViewModel.fetchStopDepartures` is
+  gated to transit-category places (`TRANSIT_CAT` regex) so it never fires on a business, and an empty
+  result just shows no board. Fetch pinned `hl=en&gl=us` like `WebDirectionsFetcher` (12-hour clock
+  the TIME regex reads). UI: `PlaceSheet.StopDepartureBoard` (one shared 30 s countdown clock, reuses
+  `departsInLabel` + the `place_transit_*` strings + `place_departures`/`place_every`).
   **Departs-in countdown (2026-07-12):** `TransitBoard` runs ONE shared `produceState` clock (30 s
   tick) and each `TransitRow` shows a leading "Departing"/"in N min" from `departureEpochSec`
   (`departsInLabel`, hidden when >90 min out or already gone); the countdown reads GREEN with a

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -915,9 +915,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   `TransitStep.delayText`), no extra fetch; localized in all 11 languages.
 - ✅ **Live stop departure board (2026-07-12, keyless + device-verified).** Tapping a transit
   station (subway / rail / BART / bus stop) shows Google's **"See departure board"** right in the
-  place sheet: each line and direction with its **destination/headsign**, the **next few departure
-  times** (soonest bold, the rest quiet), a **countdown** on the soonest ("in 6 min", green + a
-  **Live** dot when Google has a real-time fix), and the running **frequency**. It rides the SAME
+  place sheet: each line and direction with its **route number in its real line colour** (the "14"/
+  "38AX" pill), its **destination/headsign**, the **next few departure times** (soonest bold, the rest
+  quiet), a **countdown** on the soonest ("in 6 min", green + a **Live** dot when Google has a real-time
+  fix), and the running **frequency**. Handles both layouts - a station grouped by line/direction, and
+  a busy **bus stop** that lists departures flat (the parser groups those by route so route 14 is one
+  "14" row with its next times, not 25 rows), soonest-first. It rides the SAME
   anonymous WebView + `APP_INITIALIZATION_STATE` channel as transit itineraries and photos - the
   board is embedded in the station's own place page (no separate RPC, no login; unlike popular
   times it survives a logged-out session), parsed keyless by `:core`'s `StopDeparturesParser`

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -913,6 +913,20 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   boarding leg's **"N min late/early"** is surfaced right in the header (it was only in the
   drill-down before). Pure render off already-parsed fields (`TransitItinerary.departureEpochSec`,
   `TransitStep.delayText`), no extra fetch; localized in all 11 languages.
+- ✅ **Live stop departure board (2026-07-12, keyless + device-verified).** Tapping a transit
+  station (subway / rail / BART / bus stop) shows Google's **"See departure board"** right in the
+  place sheet: each line and direction with its **destination/headsign**, the **next few departure
+  times** (soonest bold, the rest quiet), a **countdown** on the soonest ("in 6 min", green + a
+  **Live** dot when Google has a real-time fix), and the running **frequency**. It rides the SAME
+  anonymous WebView + `APP_INITIALIZATION_STATE` channel as transit itineraries and photos - the
+  board is embedded in the station's own place page (no separate RPC, no login; unlike popular
+  times it survives a logged-out session), parsed keyless by `:core`'s `StopDeparturesParser`
+  (`place[62]`, shape-tolerant leaf matching, unit-tested against a live NYC capture) via
+  `WebStopDeparturesFetcher`. Gated to transit-category places so it never fires on an ordinary
+  business. **Device-verified: BART Powell St rendered 8 lines** (Daly City / Richmond / SFO-Millbrae
+  / Antioch / SFO) with their next departures. **Coverage is agency-dependent** - major systems that
+  feed Google real-time carry the board (NYC MTA, SF BART confirmed); a place with none shows nothing
+  (a small light-rail agency like SacRT was confirmed empty, correctly). Localized in all 11 languages.
 - ✅ Transit **leg drill-down with full stop detail** - tap an itinerary to expand
   its ordered legs. A ride leg shows Google's whole layout: the **line pill + "towards …"
   headsign**, the **board stop** (name + agency **Stop ID** + real-time board time, with

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1336,6 +1336,8 @@ fun MapScreen(
                 photosLoading = state.photosLoading,
                 detailsLoading = state.loadingDetails,
                 placesHere = state.placesHere,
+                stopDepartures = state.stopDepartures,
+                stopDeparturesLoading = state.stopDeparturesLoading,
                 onClose = vm::clearSelection,
                 onToggleSave = vm::toggleSave,
                 onDirections = vm::routeToSelected,

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -145,6 +145,9 @@ data class MapUiState(
     val transit: List<TransitItinerary> = emptyList(),
     val transitLoading: Boolean = false,
     val transitNav: TransitNavState? = null,
+    // A transit stop's live departure board (keyless, from the station's own place page).
+    val stopDepartures: app.vela.core.model.StopDepartures? = null,
+    val stopDeparturesLoading: Boolean = false,
     val navigating: Boolean = false,
     val resumeNavLabel: String? = null, // a nav session was interrupted (process killed mid-drive) and can
                                         // be resumed — drives the "Resume navigation to <label>?" prompt
@@ -243,6 +246,7 @@ class MapViewModel @Inject constructor(
     private val webPhotos: WebPhotoFetcher,
     private val webReviews: WebReviewsFetcher,
     private val webDirections: WebDirectionsFetcher,
+    private val webStopDepartures: app.vela.web.WebStopDeparturesFetcher,
     private val diag: app.vela.core.diag.DiagLog,
     private val diagExporter: app.vela.diag.DiagExporter,
     private val webPopularTimes: app.vela.web.WebPopularTimesFetcher,
@@ -1239,13 +1243,47 @@ class MapViewModel @Inject constructor(
                 // (the along-route / pick-origin / pick-stop flows early-return above).
                 directionsOpen = false, routes = emptyList(), activeRoute = null,
                 transit = emptyList(), transitLoading = false, showSteps = false,
+                stopDepartures = null, stopDeparturesLoading = false,
             )
         }
         fetchReviews(p)
         fetchPhotos(p)
         fetchPlaceDetails(p)
+        fetchStopDepartures(p)
         backfillOfflineAddress(p)
         rememberRecentPlace(SavedPlace.of(p))
+    }
+
+    /** Transit-station category words (English + a few common ones). The board fetch is gated on
+     *  these to avoid a WebView load on every ordinary place; the parser returns null anyway for a
+     *  place with no board, so a miss here just means no board, never a wrong one. */
+    private val TRANSIT_CAT = Regex(
+        """station|stop|subway|metro|transit|\bbus\b|train|\brail\b|tram|light rail|terminal|ferry|""" +
+            """bahnhof|haltestelle|gare|estaci|estaç|stazione|fermata|estação|estação|halte|stanice|""" +
+            """지하철|driehoek|û|вокзал|станц|остановка|停|駅|车站|車站""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** A transit stop's live departure board, from the station's own place page (keyless, anonymous).
+     *  Only fired for places whose category reads like a transit stop AND that carry a feature id
+     *  (needed for the `?cid=` deep-link); guarded to the still-selected place when it returns. */
+    private fun fetchStopDepartures(p: Place) {
+        val fid = p.featureId
+        if (fid.isNullOrBlank() || !fid.contains(":")) return
+        val cat = p.category ?: ""
+        if (!TRANSIT_CAT.containsMatchIn(cat)) return
+        _state.update { if (it.selected?.featureId == fid) it.copy(stopDeparturesLoading = true) else it }
+        viewModelScope.launch {
+            val board = runCatching { webStopDepartures.fetch(fid) }
+                .onFailure { android.util.Log.i("VelaDepartures", "fetch failed: ${it.message}") }
+                .getOrNull()
+            // Line count only (no place name in logs) so a shape drift is visible without leaking where.
+            android.util.Log.i("VelaDepartures", "board lines=${board?.lines?.size ?: -1}")
+            _state.update { st ->
+                if (st.selected?.featureId != fid) st
+                else st.copy(stopDepartures = board?.takeIf { it.lines.isNotEmpty() }, stopDeparturesLoading = false)
+            }
+        }
     }
 
     /** Offline, a POI that OSM never tagged with an address (most US chains) shows a bare place sheet —

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -989,6 +989,7 @@ class MapViewModel @Inject constructor(
                 // do its specific name+address query — without this, popular times +
                 // editorial/owner never loaded for saved/recent places (only via search).
                 fetchPlaceDetails(enriched)
+                fetchStopDepartures(enriched) // a saved/recent transit stop shows its board too
             }
         }
     }
@@ -1630,6 +1631,9 @@ class MapViewModel @Inject constructor(
                 center = location,
                 placesHere = emptyList(),
                 reviews = emptyList(),
+                // Clear any previous stop's departure board so it never lingers under a new POI.
+                stopDepartures = null,
+                stopDeparturesLoading = false,
                 // Also clear the loading flag + live counter: a still-in-flight scrape for the
                 // PREVIOUS place would otherwise leave its count showing under THIS one (its
                 // completion update is feature-id-gated, so the stale flag never self-heals).
@@ -1673,6 +1677,7 @@ class MapViewModel @Inject constructor(
                 fetchReviews(full)
                 fetchPhotos(full)
                 fetchPlaceDetails(full) // popular times + editorial/owner, like a search-result tap
+                fetchStopDepartures(full) // issue #71: a bus stop / station tapped on the MAP gets its board too
                 rememberRecentPlace(SavedPlace.of(full))
             }
         }

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -920,11 +920,17 @@ fun PlaceSheet(
             // schedule story (store week + every department) lives behind one tap. When a place
             // somehow has departments but no main hours, they still show standalone.
             val showDepartments = place.departments.isNotEmpty() && !place.permanentlyClosed && !place.temporarilyClosed
+            // A transit stop has no opening hours by nature - Google shows its departures, not "hours
+            // not listed" (issue #71). Suppress that line whenever a board is loading/present or the
+            // category reads like a stop, so a stop never shows the misleading hours placeholder.
+            val isTransitStop = stopDepartures != null || stopDeparturesLoading || place.category?.lowercase()?.let { c ->
+                listOf("station", "stop", "transit", "bus", "subway", "metro", "tram", "rail", "ferry", "terminal", "platform").any { it in c }
+            } == true
             if (place.hours.isNotEmpty()) {
                 HoursSection(place.hours, ink, dim, departments = if (showDepartments) place.departments else emptyList())
             } else if (showDepartments) {
                 DepartmentsSection(place.departments, ink, dim)
-            } else if (place.category != null && !place.permanentlyClosed) {
+            } else if (place.category != null && !place.permanentlyClosed && !isTransitStop) {
                 Text(stringResource(R.string.place_hours_not_listed), style = MaterialTheme.typography.bodySmall, color = dim, modifier = Modifier.padding(top = 10.dp))
             }
 

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -241,6 +241,8 @@ fun PlaceSheet(
     photosLoading: Boolean = false,
     detailsLoading: Boolean = false,
     placesHere: List<Place> = emptyList(),
+    stopDepartures: app.vela.core.model.StopDepartures? = null,
+    stopDeparturesLoading: Boolean = false,
     onClose: () -> Unit,
     onToggleSave: () -> Unit,
     onDirections: () -> Unit,
@@ -925,6 +927,9 @@ fun PlaceSheet(
             } else if (place.category != null && !place.permanentlyClosed) {
                 Text(stringResource(R.string.place_hours_not_listed), style = MaterialTheme.typography.bodySmall, color = dim, modifier = Modifier.padding(top = 10.dp))
             }
+
+            // Live departure board for a transit stop (keyless, from the station's own place page).
+            StopDepartureBoard(stopDepartures, stopDeparturesLoading, ink, dim, dark)
 
             // Phone + website as their own tappable rows showing the actual number / domain — placed
             // BELOW the hours (Google's order), well clear of the Directions button up top. The pills
@@ -2348,6 +2353,95 @@ private fun StopLine(stop: TransitStopTime, ink: Color, dim: Color, emphasize: B
             }
         }
     }
+}
+
+/** A transit stop's live departure board - Google's "See departure board" for the station,
+ *  keyless from the place page. Each line/direction shows its next departures with a countdown
+ *  on the soonest (green + a Live dot when Google has a real-time fix) and the running frequency. */
+@Composable
+private fun StopDepartureBoard(
+    d: app.vela.core.model.StopDepartures?,
+    loading: Boolean,
+    ink: Color,
+    dim: Color,
+    dark: Boolean,
+) {
+    if (d == null && !loading) return
+    Spacer(Modifier.height(14.dp))
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Icon(Icons.Default.DirectionsTransit, contentDescription = null, tint = dim, modifier = Modifier.size(18.dp))
+        Text(stringResource(R.string.place_departures), style = MaterialTheme.typography.titleSmall, color = ink)
+    }
+    if (d == null) {
+        Row(
+            Modifier.padding(top = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp)
+            Text(stringResource(R.string.place_finding_transit), style = MaterialTheme.typography.bodyMedium, color = dim)
+        }
+        return
+    }
+    val nowSec by produceState(initialValue = System.currentTimeMillis() / 1000L) {
+        while (true) { delay(30_000L); value = System.currentTimeMillis() / 1000L }
+    }
+    Column(Modifier.padding(top = 8.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        d.lines.take(8).forEach { DepartureLineRow(it, nowSec, ink, dim) }
+    }
+}
+
+@Composable
+private fun DepartureLineRow(line: app.vela.core.model.StopDepartureLine, nowSec: Long, ink: Color, dim: Color) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            if (line.label != null) {
+                LinePill(TransitLine(name = line.label!!, mode = line.mode, colorHex = line.colorHex))
+            } else {
+                Icon(modeIcon(line.mode), contentDescription = null, tint = dim, modifier = Modifier.size(18.dp))
+            }
+            line.headsign?.let {
+                Text(it, style = MaterialTheme.typography.bodyMedium, color = ink, modifier = Modifier.weight(1f))
+            }
+            line.headwayText?.let {
+                Text(stringResource(R.string.place_every, it), style = MaterialTheme.typography.labelMedium, color = dim)
+            }
+        }
+        if (line.upcoming.isNotEmpty()) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                val next = line.upcoming.first()
+                val live = next.realtime
+                val countdown = departsInLabel(next.epochSec, nowSec)
+                Text(
+                    next.clockText.orEmpty(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (live) SheetPalette.TrafficGreen else ink,
+                )
+                countdown?.let {
+                    Text(
+                        "· $it",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (live) SheetPalette.TrafficGreen else dim,
+                    )
+                }
+                if (live) Box(Modifier.size(6.dp).clip(CircleShape).background(SheetPalette.TrafficGreen))
+                // the following departures, quiet
+                line.upcoming.drop(1).take(3).forEach {
+                    Text(it.clockText.orEmpty(), style = MaterialTheme.typography.bodySmall, color = dim)
+                }
+            }
+        }
+    }
+}
+
+private fun modeIcon(mode: TransitMode) = when (mode) {
+    TransitMode.BUS -> Icons.Default.DirectionsBus
+    TransitMode.SUBWAY -> Icons.Default.DirectionsSubway
+    TransitMode.TRAIN -> Icons.Default.Train
+    TransitMode.TRAM -> Icons.Default.Tram
+    TransitMode.FERRY -> Icons.Default.DirectionsBoat
+    else -> Icons.Default.DirectionsTransit
 }
 
 /** A colour-filled line badge (e.g. a blue "Amtrak Thruway"), mirroring Google's

--- a/app/src/main/java/app/vela/web/WebStopDeparturesFetcher.kt
+++ b/app/src/main/java/app/vela/web/WebStopDeparturesFetcher.kt
@@ -1,0 +1,137 @@
+package app.vela.web
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import app.vela.core.VelaConfig
+import app.vela.core.data.google.parse.StopDeparturesParser
+import app.vela.core.model.StopDepartures
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.math.BigInteger
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Fetches a transit stop's live departure board through a hidden [WebView] — the same
+ * anonymous, no-login trick as [WebDirectionsFetcher] and [WebPhotoFetcher]. The board
+ * is embedded in the station's own place-details payload (`APP_INITIALIZATION_STATE`), so
+ * loading the canonical `?cid=` place page as a real browser engine and reading that state
+ * out gives us the schedule with NO extra endpoint and NO account. OkHttp gets a bot-degraded
+ * reply (TLS-fingerprint detection), exactly like photos/transit, so it must be a WebView.
+ *
+ * Verified keyless + anonymous against a live capture (2026-07-12): opening "See departure
+ * board" fires no data request, and the times survive a logged-out session (unlike popular
+ * times). [StopDeparturesParser] pulls the line/direction/time/headway structure out.
+ * Best-effort: any failure/timeout, or a place that isn't a transit stop, returns null.
+ */
+@Singleton
+class WebStopDeparturesFetcher @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val main = Handler(Looper.getMainLooper())
+    private val mutex = Mutex()
+    private val seq = java.util.concurrent.atomic.AtomicLong()
+    private val pending = java.util.concurrent.ConcurrentHashMap<String, CompletableDeferred<String>>()
+    @Volatile private var currentId: String = ""
+    @Volatile private var webView: WebView? = null
+
+    private inner class Bridge {
+        @JavascriptInterface
+        fun onResult(id: String, payload: String) {
+            pending.remove(id)?.complete(payload) // a stale page's id is already gone -> no-op
+        }
+    }
+
+    /** The departure board for the station with [featureId] (`0x..:0x..`), or null on any
+     *  failure/timeout, or when the place isn't a transit stop (no board in its payload). */
+    suspend fun fetch(featureId: String): StopDepartures? = mutex.withLock {
+        val cid = cidOf(featureId) ?: return null
+        // hl=en to match the app's existing transit board (WebDirectionsFetcher also pins en); the
+        // clock times/headway come back in 12-hour form the parser reads. gl=us keeps the schedule US-shaped.
+        val url = "https://www.google.com/maps?cid=$cid&hl=en&gl=us"
+        val id = seq.incrementAndGet().toString()
+        val deferred = CompletableDeferred<String>()
+        pending[id] = deferred
+        val raw = try {
+            withTimeoutOrNull(TOTAL_TIMEOUT_MS) {
+                load(url, id)
+                deferred.await()
+            }
+        } finally {
+            pending.remove(id)
+        }
+        if (raw.isNullOrEmpty()) null
+        else runCatching { StopDeparturesParser.parse(raw) }.getOrNull()
+    }
+
+    /** cid = LOW half of the `0xHIGH:0xLOW` feature id as unsigned decimal (the `?cid=` deep-link). */
+    private fun cidOf(featureId: String): String? {
+        val low = featureId.substringAfter(":", "").removePrefix("0x").ifBlank { return null }
+        return runCatching { BigInteger(low, 16).toString() }.getOrNull()
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private suspend fun load(url: String, id: String) = withContext(Dispatchers.Main) {
+        val wv = webView ?: WebView(context).also {
+            it.settings.javaScriptEnabled = true
+            it.settings.domStorageEnabled = true
+            it.settings.userAgentString = VelaConfig.USER_AGENT // desktop UA -> desktop web Maps
+            it.addJavascriptInterface(Bridge(), "VelaBridge")
+            it.webViewClient = object : WebViewClient() {
+                override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                    val scheme = request?.url?.scheme
+                    return scheme != null && scheme != "https" && scheme != "http"
+                }
+                override fun onPageFinished(view: WebView?, u: String?) {
+                    val idNow = currentId
+                    main.postDelayed({ view?.evaluateJavascript(extract(idNow), null) }, SETTLE_MS)
+                }
+            }
+            webView = it
+        }
+        currentId = id
+        wv.loadUrl(url)
+    }
+
+    private companion object {
+        const val TOTAL_TIMEOUT_MS = 20_000L
+        const val SETTLE_MS = 1_600L
+
+        /** Pull the place-details string out of APP_INITIALIZATION_STATE — the longest
+         *  `)]}'`-guarded array (the place blob carrying the transit schedule). The SPA fills
+         *  it a beat after page-finish, so poll up to ~7 s. Same shape as WebDirectionsFetcher. */
+        fun extract(id: String) = """
+            (function(){
+              var tries = 0;
+              function findBest(){
+                var s = window.APP_INITIALIZATION_STATE, best = "";
+                function scan(x, d){
+                  if (d > 7 || x == null) return;
+                  if (typeof x === 'string'){ if (x.indexOf(")]}'") === 0 && x.length > best.length) best = x; return; }
+                  if (typeof x === 'object'){ for (var k in x) scan(x[k], d + 1); }
+                }
+                try { scan(s, 0); } catch(e){}
+                return best;
+              }
+              function attempt(){
+                var best = findBest();
+                if (best && best.length > 5000){ VelaBridge.onResult('$id', best.slice(0, 1500000)); return; }
+                if (tries++ < 12) setTimeout(attempt, 600);
+                else VelaBridge.onResult('$id', best ? best.slice(0, 1500000) : "");
+              }
+              attempt();
+            })();
+        """.trimIndent()
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -436,6 +436,8 @@
     <string name="place_transit_now">Fährt ab</string>
     <string name="place_transit_in_min">in %1$d Min.</string> <!-- format -->
     <string name="place_transit_live">Live</string>
+    <string name="place_departures">Abfahrten</string>
+    <string name="place_every">Alle %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Sie sind angekommen.</string>
     <string name="transit_nav_walk">%1$s laufen</string> <!-- format -->
     <string name="transit_nav_take">Nimm %1$s</string> <!-- format -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -436,6 +436,8 @@
     <string name="place_transit_now">Saliendo</string>
     <string name="place_transit_in_min">en %1$d min</string> <!-- format -->
     <string name="place_transit_live">En directo</string>
+    <string name="place_departures">Salidas</string>
+    <string name="place_every">Cada %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Has llegado.</string>
     <string name="transit_nav_walk">Camina %1$s</string> <!-- format -->
     <string name="transit_nav_take">Toma %1$s</string> <!-- format -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -436,6 +436,8 @@
     <string name="place_transit_now">Départ imminent</string>
     <string name="place_transit_in_min">dans %1$d min</string> <!-- format -->
     <string name="place_transit_live">En direct</string>
+    <string name="place_departures">Départs</string>
+    <string name="place_every">Toutes les %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Vous êtes arrivé.</string>
     <string name="transit_nav_walk">Marchez %1$s</string> <!-- format -->
     <string name="transit_nav_take">Prenez %1$s</string> <!-- format -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -436,6 +436,8 @@
     <string name="place_transit_now">In partenza</string>
     <string name="place_transit_in_min">tra %1$d min</string> <!-- format -->
     <string name="place_transit_live">In diretta</string>
+    <string name="place_departures">Partenze</string>
+    <string name="place_every">Ogni %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Sei arrivato.</string>
     <string name="transit_nav_walk">Cammina %1$s</string> <!-- format -->
     <string name="transit_nav_take">Prendi %1$s</string> <!-- format -->

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -434,6 +434,8 @@
     <string name="place_transit_now">יוצא כעת</string>
     <string name="place_transit_in_min">בעוד %1$d דק׳</string> <!-- format -->
     <string name="place_transit_live">בשידור חי</string>
+    <string name="place_departures">יציאות</string>
+    <string name="place_every">כל %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">הגעת.</string>
     <string name="transit_nav_walk">הלך %1$s</string>
     <string name="transit_nav_take">קח %1$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -457,6 +457,8 @@
     <string name="place_transit_now">まもなく発車</string>
     <string name="place_transit_in_min">%1$d 分後</string> <!-- format -->
     <string name="place_transit_live">リアルタイム</string>
+    <string name="place_departures">発車時刻</string>
+    <string name="place_every">%1$s ごと</string> <!-- format -->
     <string name="transit_nav_arrived">目的地に到着しました。</string>
     <string name="transit_nav_walk">徒歩 %1$s</string> <!-- format -->
     <string name="transit_nav_take">%1$s に乗車</string> <!-- format -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -436,6 +436,8 @@
     <string name="place_transit_now">Vertrekt nu</string>
     <string name="place_transit_in_min">over %1$d min</string> <!-- format -->
     <string name="place_transit_live">Live</string>
+    <string name="place_departures">Vertrektijden</string>
+    <string name="place_every">Elke %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Je bent aangekomen.</string>
     <string name="transit_nav_walk">Loop %1$s</string> <!-- format -->
     <string name="transit_nav_take">Neem %1$s</string> <!-- format -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -438,6 +438,8 @@
     <string name="place_transit_now">Odjeżdża</string>
     <string name="place_transit_in_min">za %1$d min</string> <!-- format -->
     <string name="place_transit_live">Na żywo</string>
+    <string name="place_departures">Odjazdy</string>
+    <string name="place_every">Co %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Dotarłeś na miejsce.</string>
     <string name="transit_nav_walk">Idź %1$s</string> <!-- format -->
     <string name="transit_nav_take">Wsiądź w %1$s</string> <!-- format -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -436,6 +436,8 @@
     <string name="place_transit_now">A sair</string>
     <string name="place_transit_in_min">em %1$d min</string> <!-- format -->
     <string name="place_transit_live">Ao vivo</string>
+    <string name="place_departures">Partidas</string>
+    <string name="place_every">A cada %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Chegou.</string>
     <string name="transit_nav_walk">Caminhe %1$s</string> <!-- format -->
     <string name="transit_nav_take">Apanhe %1$s</string> <!-- format -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -438,6 +438,8 @@
     <string name="place_transit_now">Отправляется</string>
     <string name="place_transit_in_min">через %1$d мин</string> <!-- format -->
     <string name="place_transit_live">Онлайн</string>
+    <string name="place_departures">Отправления</string>
+    <string name="place_every">Каждые %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Вы прибыли.</string>
     <string name="transit_nav_walk">Идите %1$s</string> <!-- format -->
     <string name="transit_nav_take">Сядьте на %1$s</string> <!-- format -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -436,6 +436,8 @@
     <string name="place_transit_now">Avgår nu</string>
     <string name="place_transit_in_min">om %1$d min</string> <!-- format -->
     <string name="place_transit_live">Live</string>
+    <string name="place_departures">Avgångar</string>
+    <string name="place_every">Var %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Du har kommit fram.</string>
     <string name="transit_nav_walk">Gå %1$s</string> <!-- format -->
     <string name="transit_nav_take">Ta %1$s</string> <!-- format -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -438,6 +438,8 @@
     <string name="place_transit_now">Відправляється</string>
     <string name="place_transit_in_min">через %1$d хв</string> <!-- format -->
     <string name="place_transit_live">Наживо</string>
+    <string name="place_departures">Відправлення</string>
+    <string name="place_every">Кожні %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Ви прибули.</string>
     <string name="transit_nav_walk">Ідіть %1$s</string> <!-- format -->
     <string name="transit_nav_take">Сідайте на %1$s</string> <!-- format -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -457,6 +457,8 @@
     <string name="place_transit_now">即將出發</string>
     <string name="place_transit_in_min">%1$d 分鐘後</string> <!-- format -->
     <string name="place_transit_live">即時</string>
+    <string name="place_departures">發車時刻</string>
+    <string name="place_every">每 %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">你已抵達目的地。</string>
     <string name="transit_nav_walk">步行 %1$s</string> <!-- format -->
     <string name="transit_nav_take">搭乘%1$s</string> <!-- format -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -457,6 +457,8 @@
     <string name="place_transit_now">即将出发</string>
     <string name="place_transit_in_min">%1$d 分钟后</string> <!-- format -->
     <string name="place_transit_live">实时</string>
+    <string name="place_departures">发车时刻</string>
+    <string name="place_every">每 %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">您已到达。</string>
     <string name="transit_nav_walk">步行 %1$s</string> <!-- format -->
     <string name="transit_nav_take">乘坐 %1$s</string> <!-- format -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -463,6 +463,8 @@
     <string name="place_transit_now">Departing</string>
     <string name="place_transit_in_min">in %1$d min</string> <!-- format -->
     <string name="place_transit_live">Live</string>
+    <string name="place_departures">Departures</string>
+    <string name="place_every">Every %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">You have arrived.</string>
     <string name="transit_nav_walk">Walk %1$s</string> <!-- format -->
     <string name="transit_nav_take">Take %1$s</string> <!-- format -->

--- a/core/src/main/java/app/vela/core/data/google/parse/StopDeparturesParser.kt
+++ b/core/src/main/java/app/vela/core/data/google/parse/StopDeparturesParser.kt
@@ -274,5 +274,5 @@ object StopDeparturesParser {
     }
 
     private const val MAX_TIMES = 4
-    private const val MAX_LINES = 12
+    private const val MAX_LINES = 24
 }

--- a/core/src/main/java/app/vela/core/data/google/parse/StopDeparturesParser.kt
+++ b/core/src/main/java/app/vela/core/data/google/parse/StopDeparturesParser.kt
@@ -49,33 +49,109 @@ object StopDeparturesParser {
         val place = root.at(6) ?: return null
         val transit = findTransitNode(place) ?: return null
         val groups = transit.at(1).arr() ?: return null
-        val lines = ArrayList<StopDepartureLine>()
+        // Two layouts show up: a station/subway groups entries by LINE -> DIRECTION -> departures,
+        // while a busy bus stop lists each upcoming departure FLAT, every one tagged with its own
+        // route badge (the "14R" pill). Rather than assume one shape, walk each group's entries,
+        // read the route badge + headsign + times off each, then GROUP by (route, direction) so the
+        // 25 separate "route 14" departures collapse into one "14" row with its next few times.
+        val merged = LinkedHashMap<String, MutableLine>()
         for (group in groups) {
             val mode = modeFor(group.at(1).str(), group)
-            val routes = group.at(2).arr() ?: continue
-            for (route in routes) {
-                val dirs = route.at(1).arr() ?: continue
-                for (dir in dirs) {
-                    val line = runCatching { parseDirection(dir, mode) }.getOrNull()
-                    if (line != null) lines.add(line)
+            val entries = group.at(2).arr() ?: continue
+            for (entry in entries) {
+                for ((headsign, node) in directionsOf(entry)) {
+                    val deps = collectDepartures(node)
+                    if (deps.isEmpty()) continue
+                    val badge = findBadge(entry) ?: findBadge(node)
+                    val label = badge?.first ?: routeLabel(node, headsign)
+                    val key = (label ?: "?") + "|" + (headsign ?: "")
+                    val line = merged.getOrPut(key) {
+                        MutableLine(label, mode, headsign, badge?.second, headwayOf(node))
+                    }
+                    line.add(deps)
                 }
             }
         }
-        if (lines.isEmpty()) throw CalibrationNeededException("stop departures: transit node found, 0 lines parsed")
+        if (merged.isEmpty()) throw CalibrationNeededException("stop departures: transit node found, 0 lines parsed")
+        // Soonest-departing lines first, like Google's board.
+        val lines = merged.values
+            .map { it.build() }
+            .filter { it.upcoming.isNotEmpty() || it.headsign != null }
+            .sortedBy { it.upcoming.firstOrNull()?.epochSec ?: Long.MAX_VALUE }
+            .take(MAX_LINES)
+        if (lines.isEmpty()) throw CalibrationNeededException("stop departures: 0 lines after grouping")
         return StopDepartures(stationName = transit.at(0).str()?.takeIf { it.isNotBlank() }, lines = lines)
     }
 
-    private fun parseDirection(dir: JsonElement, mode: TransitMode): StopDepartureLine? {
-        val headsign = dir.at(0).str()?.takeIf { it.length in 1..80 }
-        val upcoming = collectDepartures(dir)
-        if (upcoming.isEmpty() && headsign == null) return null
-        return StopDepartureLine(
-            label = routeLabel(dir, headsign),
+    /** Accumulates all departures seen for one (route, direction) across the flat entry list. */
+    private class MutableLine(
+        val label: String?,
+        val mode: TransitMode,
+        val headsign: String?,
+        val colorHex: String?,
+        val headway: String?,
+    ) {
+        private val deps = ArrayList<StopDeparture>()
+        private val seen = HashSet<String>()
+        fun add(more: List<StopDeparture>) {
+            for (d in more) if (d.clockText != null && seen.add(d.clockText)) deps.add(d)
+        }
+        fun build() = StopDepartureLine(
+            label = label,
             mode = mode,
             headsign = headsign,
-            headwayText = headwayOf(dir),
-            upcoming = upcoming.take(MAX_TIMES),
+            colorHex = colorHex,
+            headwayText = headway,
+            upcoming = deps.sortedBy { it.epochSec ?: Long.MAX_VALUE }.take(MAX_TIMES),
         )
+    }
+
+    /** The direction sub-nodes of an entry. A station line nests them (each has a headsign [0] and its
+     *  own departures); a flat bus departure has none, so the whole entry is one implicit direction. */
+    private fun directionsOf(entry: JsonElement): List<Pair<String?, JsonElement>> {
+        val d1 = entry.at(1).arr()
+        if (d1 != null && d1.isNotEmpty() && d1.all { (it.at(0).str()?.length ?: 0) in 2..80 && hasTimeTuple(it, 0) }) {
+            return d1.map { it.at(0).str() to it }
+        }
+        return listOf(firstHeadsign(entry) to entry)
+    }
+
+    /** The route badge Google draws as a coloured pill: `["<label>", <int>, "#fill", "#text"]` — the
+     *  same shape as the itinerary line pills. First one found in the entry wins (its route). */
+    private fun findBadge(node: JsonElement?, depth: Int = 0): Triple<String, String?, String?>? {
+        if (node == null || depth > 10) return null
+        val a = node as? JsonArray ?: return null
+        val label = a.at(0).str()?.trim()
+        val fill = a.at(2).str()
+        // A route short name is short and alphanumeric-ish ("14", "14R", "38AX", "N", "M15-SBS"),
+        // paired with a "#" fill; that combination is the pill and can't collide with a time/id node.
+        if (label != null && label.length in 1..7 && label.any { it.isLetterOrDigit() } &&
+            label.all { it.isLetterOrDigit() || it in "-/ " } && fill != null && fill.startsWith("#")
+        ) {
+            return Triple(label, fill, a.at(3).str()?.takeIf { it.startsWith("#") })
+        }
+        for (c in a) findBadge(c, depth + 1)?.let { return it }
+        return null
+    }
+
+    /** Best-effort destination string for a flat bus departure (letters, not a tz/label/time). */
+    private fun firstHeadsign(entry: JsonElement): String? {
+        var found: String? = null
+        fun walk(n: JsonElement?, depth: Int) {
+            if (n == null || found != null || depth > 6) return
+            val a = n as? JsonArray ?: return
+            for (el in a) {
+                (el as? JsonArray)?.let { walk(it, depth + 1) }
+                val s = el.str()?.trim() ?: continue
+                // A real destination reads like words ("Daly City", "Ferry Plaza") - require a space and
+                // rule out ids/tokens/timezones/colors so a feature id can't masquerade as a headsign.
+                if (found == null && s.length in 3..60 && ' ' in s && "/" !in s && ":" !in s &&
+                    !s.startsWith("#") && !s.startsWith("0x") && s.any { it.isLetter() } && !TIME.matches(s)
+                ) found = s
+            }
+        }
+        walk(entry, 0)
+        return found
     }
 
     /** The transit-services node hangs off the place at [TRANSIT_NODE_INDEX]; if that field
@@ -197,5 +273,6 @@ object StopDeparturesParser {
         }
     }
 
-    private const val MAX_TIMES = 6
+    private const val MAX_TIMES = 4
+    private const val MAX_LINES = 12
 }

--- a/core/src/main/java/app/vela/core/data/google/parse/StopDeparturesParser.kt
+++ b/core/src/main/java/app/vela/core/data/google/parse/StopDeparturesParser.kt
@@ -1,0 +1,201 @@
+package app.vela.core.data.google.parse
+
+import app.vela.core.data.CalibrationNeededException
+import app.vela.core.data.google.GoogleResponse
+import app.vela.core.data.google.arr
+import app.vela.core.data.google.at
+import app.vela.core.data.google.long
+import app.vela.core.data.google.str
+import app.vela.core.model.StopDeparture
+import app.vela.core.model.StopDepartureLine
+import app.vela.core.model.StopDepartures
+import app.vela.core.model.TransitMode
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Parses a transit stop's live departure board out of the station's own place-details
+ * payload — the SAME keyless, anonymous WebView + `APP_INITIALIZATION_STATE` channel
+ * Vela uses for transit itineraries and photos. The board is embedded in the place page
+ * (no separate RPC fires when you open "See departure board"), and it survives a
+ * logged-out session, so it needs no endpoint and no login.
+ *
+ * Schema calibrated against a live NYC subway-hub capture (2026-07-12):
+ *   place        `root[6]`
+ *   transit node `place[62]`     = ["<station>", [ <service groups> ], …]
+ *   group        `[null,"<Subway services>", [ <lines> ], … "<mode code>" …]`
+ *   line         `[null, [ <directions> ], … "<line ftid>" …]`
+ *   direction    `["<headsign>", null, null, [ <departures> ], …]`
+ *   departure    time tuple `[rtEpoch, "<tz>", "4:35 AM", <utcOffset>, schedEpoch]`
+ *   frequency    `[<headwaySec>, "20 min"]`
+ *
+ * The container path (transit node → groups → lines → directions) is positional, but the
+ * leaf details (the time tuples, the frequency pair, the route label) are matched by SHAPE
+ * within each direction so a moved leaf index degrades one line, never the board. The
+ * `place[62]` anchor is validated and falls back to a shape search of the place node, so a
+ * shifted field index still finds it. A non-station place simply has no transit node →
+ * [parse] returns null (routine); a transit node that yields 0 lines throws
+ * [CalibrationNeededException] (real drift), like the other parsers.
+ */
+object StopDeparturesParser {
+
+    private const val TRANSIT_NODE_INDEX = 62
+
+    /** Parse a raw `)]}'`-guarded place body (what the WebView reads out of
+     *  `APP_INITIALIZATION_STATE`). Returns null for a place that isn't a transit stop. */
+    fun parse(body: String): StopDepartures? = parse(GoogleResponse.parse(body))
+
+    fun parse(root: JsonElement): StopDepartures? {
+        val place = root.at(6) ?: return null
+        val transit = findTransitNode(place) ?: return null
+        val groups = transit.at(1).arr() ?: return null
+        val lines = ArrayList<StopDepartureLine>()
+        for (group in groups) {
+            val mode = modeFor(group.at(1).str(), group)
+            val routes = group.at(2).arr() ?: continue
+            for (route in routes) {
+                val dirs = route.at(1).arr() ?: continue
+                for (dir in dirs) {
+                    val line = runCatching { parseDirection(dir, mode) }.getOrNull()
+                    if (line != null) lines.add(line)
+                }
+            }
+        }
+        if (lines.isEmpty()) throw CalibrationNeededException("stop departures: transit node found, 0 lines parsed")
+        return StopDepartures(stationName = transit.at(0).str()?.takeIf { it.isNotBlank() }, lines = lines)
+    }
+
+    private fun parseDirection(dir: JsonElement, mode: TransitMode): StopDepartureLine? {
+        val headsign = dir.at(0).str()?.takeIf { it.length in 1..80 }
+        val upcoming = collectDepartures(dir)
+        if (upcoming.isEmpty() && headsign == null) return null
+        return StopDepartureLine(
+            label = routeLabel(dir, headsign),
+            mode = mode,
+            headsign = headsign,
+            headwayText = headwayOf(dir),
+            upcoming = upcoming.take(MAX_TIMES),
+        )
+    }
+
+    /** The transit-services node hangs off the place at [TRANSIT_NODE_INDEX]; if that field
+     *  has shifted, fall back to the first place child whose subtree holds a departure tuple. */
+    private fun findTransitNode(place: JsonElement): JsonElement? {
+        place.at(TRANSIT_NODE_INDEX)?.let { if (hasTimeTuple(it, 0)) return it }
+        return place.arr()?.firstOrNull { hasTimeTuple(it, 0) }
+    }
+
+    private fun hasTimeTuple(node: JsonElement?, depth: Int): Boolean {
+        if (node == null || depth > 12) return false
+        val a = node as? JsonArray ?: return false
+        if (isTimeTuple(a)) return true
+        return a.any { hasTimeTuple(it, depth + 1) }
+    }
+
+    /** A departure time tuple: `[epoch, "<Area/City tz>", "4:35 AM", <offset>, epoch]`.
+     *  Keyed off the timezone string (contains "/") + a clock time so it can't collide
+     *  with the attribute/id arrays around it. */
+    private fun isTimeTuple(a: JsonArray): Boolean {
+        val tz = a.at(1).str() ?: return false
+        val clock = a.at(2).str() ?: return false
+        return "/" in tz && TIME.matches(clock)
+    }
+
+    private val TIME = Regex("""^\d{1,2}:\d{2}\s?[AP]M$""", RegexOption.IGNORE_CASE)
+
+    /** All upcoming departures in a direction, in document order, de-duplicated by clock text.
+     *  Real-time when Google's live epoch [0] differs from the timetable epoch [4]. */
+    private fun collectDepartures(dir: JsonElement): List<StopDeparture> {
+        val out = ArrayList<StopDeparture>()
+        val seen = HashSet<String>()
+        fun walk(n: JsonElement?, depth: Int) {
+            if (n == null || depth > 9 || out.size >= MAX_TIMES * 2) return
+            val a = n as? JsonArray ?: return
+            if (isTimeTuple(a)) {
+                val clock = a.at(2).str()
+                if (clock != null && seen.add(clock)) {
+                    val rt = a.at(0).long()
+                    val sched = a.at(4).long()
+                    out.add(StopDeparture(
+                        clockText = clock,
+                        epochSec = sched ?: rt,
+                        realtime = rt != null && sched != null && rt != sched,
+                    ))
+                }
+                return // don't descend into a matched tuple
+            }
+            a.forEach { walk(it, depth + 1) }
+        }
+        walk(dir, 0)
+        return out
+    }
+
+    /** The running frequency pair `[<headwaySec>, "20 min"]`. Language-robust: the label's
+     *  leading number must equal headwaySec/60, which rules out the id/attribute pairs. */
+    private fun headwayOf(dir: JsonElement): String? {
+        var found: String? = null
+        fun walk(n: JsonElement?, depth: Int) {
+            if (n == null || found != null || depth > 9) return
+            val a = n as? JsonArray ?: return
+            if (a.size == 2) {
+                val sec = a.at(0).long()
+                val label = a.at(1).str()
+                if (sec != null && sec in 30..14_400 && label != null && label.length in 2..14) {
+                    val lead = label.trim().takeWhile { it.isDigit() }
+                    if (lead.isNotEmpty() && lead.toLongOrNull() == sec / 60) { found = label.trim(); return }
+                }
+            }
+            a.forEach { walk(it, depth + 1) }
+        }
+        walk(dir, 0)
+        return found
+    }
+
+    private val LABEL = Regex("""^[A-Za-z0-9]{1,4}$""")
+
+    /** Best-effort route short name ("7"). Google appends it to a combined "headsign + label"
+     *  string; take the trailing token of the longest direction string that starts with the
+     *  headsign's leading word. Null when nothing clean matches (the board still reads fine). */
+    private fun routeLabel(dir: JsonElement, headsign: String?): String? {
+        val firstWord = headsign?.trim()?.substringBefore(' ')?.takeIf { it.isNotEmpty() } ?: return null
+        var best: String? = null
+        fun walk(n: JsonElement?, depth: Int) {
+            if (n == null || depth > 9) return
+            val a = n as? JsonArray ?: return
+            for (el in a) {
+                (el as? JsonArray)?.let { walk(it, depth + 1) }
+                val s = el.str()?.trim() ?: continue
+                if (s != headsign && s.startsWith(firstWord) && ' ' in s) {
+                    val tail = s.substringAfterLast(' ')
+                    if (LABEL.matches(tail) && (best == null || s.length > (best!!.length))) best = s
+                }
+            }
+        }
+        walk(dir, 0)
+        return best?.substringAfterLast(' ')
+    }
+
+    private fun modeFor(groupName: String?, group: JsonElement): TransitMode {
+        val hay = StringBuilder()
+        groupName?.let { hay.append(it).append(' ') }
+        fun walk(n: JsonElement?, depth: Int) {
+            if (n == null || depth > 4) return
+            when (n) {
+                is JsonArray -> n.forEach { walk(it, depth + 1) }
+                else -> n.str()?.let { if (it.length < 30) hay.append(it).append(' ') }
+            }
+        }
+        walk(group.at(1), 0)
+        val s = hay.toString().lowercase()
+        return when {
+            "bus" in s -> TransitMode.BUS
+            "tram" in s || "light rail" in s || "streetcar" in s || "lightrail" in s -> TransitMode.TRAM
+            "subway" in s || "metro" in s || "underground" in s -> TransitMode.SUBWAY
+            "train" in s || "rail" in s -> TransitMode.TRAIN
+            "ferry" in s || "boat" in s -> TransitMode.FERRY
+            else -> TransitMode.GENERIC
+        }
+    }
+
+    private const val MAX_TIMES = 6
+}

--- a/core/src/main/java/app/vela/core/model/StopDepartures.kt
+++ b/core/src/main/java/app/vela/core/model/StopDepartures.kt
@@ -1,0 +1,35 @@
+package app.vela.core.model
+
+/**
+ * A transit stop's live departure board — what leaves this station/stop soon, the way
+ * Google shows it when you open a transit station and tap "See departure board".
+ *
+ * Parsed KEYLESS from the station's own place page (the same anonymous WebView +
+ * `APP_INITIALIZATION_STATE` channel Vela already uses for transit itineraries and
+ * photos): the schedule is embedded in the place-details payload, so there's no new
+ * endpoint and no login (unlike popular times, which is stripped from anonymous
+ * sessions). Calibrated against a live NYC subway-hub capture (2026-07-12).
+ */
+data class StopDepartures(
+    val stationName: String? = null,
+    val lines: List<StopDepartureLine> = emptyList(),
+)
+
+/** One line + direction served by the stop (Google lists each direction separately),
+ *  with its next few departures and the running frequency. */
+data class StopDepartureLine(
+    val label: String? = null,        // route short name, "7" / "42" (null when Google omits it)
+    val mode: TransitMode = TransitMode.GENERIC,
+    val headsign: String? = null,     // direction / destination, "34 St-Hudson Yards"
+    val colorHex: String? = null,     // line fill when present
+    val headwayText: String? = null,  // running frequency, "20 min" (Google-localized)
+    val upcoming: List<StopDeparture> = emptyList(),
+)
+
+/** A single upcoming departure: the shown clock time plus its epoch (for a countdown),
+ *  flagged [realtime] when Google's live time differs from the timetable. */
+data class StopDeparture(
+    val clockText: String? = null,    // "4:35 AM" (already localized by Google)
+    val epochSec: Long? = null,       // scheduled/real-time departure epoch (seconds)
+    val realtime: Boolean = false,
+)

--- a/core/src/test/java/app/vela/core/data/google/parse/StopDeparturesParserTest.kt
+++ b/core/src/test/java/app/vela/core/data/google/parse/StopDeparturesParserTest.kt
@@ -56,26 +56,65 @@ class StopDeparturesParserTest {
     }
 
     @Test
-    fun `parses a station departure board`() {
+    fun `parses a station departure board, soonest line first`() {
         val d = StopDeparturesParser.parse(body(transit))!!
         assertEquals("Times Sq-42 St", d.stationName)
         assertEquals(2, d.lines.size)
 
-        val a = d.lines[0]
+        // Lines sort by soonest departure: Flushing (4:19) leads 34 St-Hudson Yards (4:35).
+        val b = d.lines[0]
+        assertEquals("Flushing-Main St", b.headsign)
+        assertEquals("7", b.label)
+        assertEquals("15 min", b.headwayText)
+        assertEquals(listOf("4:19 AM", "4:39 AM"), b.upcoming.map { it.clockText })
+        assertTrue(b.upcoming.none { it.realtime })          // equal epochs -> scheduled
+
+        val a = d.lines[1]
         assertEquals("34 St-Hudson Yards", a.headsign)
         assertEquals(TransitMode.SUBWAY, a.mode)
         assertEquals("7", a.label)
-        assertEquals("20 min", a.headwayText)
         assertEquals(listOf("4:35 AM", "4:52 AM", "5:12 AM"), a.upcoming.map { it.clockText })
         assertEquals(1783845300L, a.upcoming[0].epochSec)   // scheduled epoch [4], not realtime [0]
         assertTrue("live time differs from timetable", a.upcoming[0].realtime)
         assertTrue("on-time departure not flagged live", !a.upcoming[1].realtime)
+    }
 
-        val b = d.lines[1]
-        assertEquals("Flushing-Main St", b.headsign)
-        assertEquals("15 min", b.headwayText)
-        assertEquals(listOf("4:19 AM", "4:39 AM"), b.upcoming.map { it.clockText })
-        assertTrue(b.upcoming.none { it.realtime })          // equal epochs -> scheduled
+    // A busy BUS stop lists each departure FLAT, tagged with its own route pill
+    // ["<label>", <int>, "#fill", "#text"] at entry[5][1]; the parser groups them by route.
+    private fun busEntry(clock: String, rt: Long, sched: Long, label: String, fill: String) =
+        """[null,[[[[$rt,"America/Los_Angeles","$clock",-25200,$sched]]]],null,null,"0xa",[null,["$label",0,"$fill","#ffffff"]]]"""
+
+    private val busTransit = """
+        ["Mission St & 16th St",
+         [
+          [null,"Buses",
+           [
+            ${busEntry("4:02 AM", 1783845720, 1783845720, "14", "#7c82bf")},
+            ${busEntry("4:17 AM", 1783846620, 1783846620, "14", "#7c82bf")},
+            ${busEntry("5:43 AM", 1783851780, 1783851700, "14R", "#bf2b45")}
+           ]
+          ]
+         ]
+        ]
+    """.trimIndent()
+
+    @Test
+    fun `groups a flat bus board by route, with numbers and colours`() {
+        val d = StopDeparturesParser.parse(body(busTransit))!!
+        assertEquals("Mission St & 16th St", d.stationName)
+        assertEquals(2, d.lines.size)                       // 3 departures -> 2 routes
+
+        val r14 = d.lines[0]                                 // soonest (4:02) leads
+        assertEquals("14", r14.label)
+        assertEquals(TransitMode.BUS, r14.mode)
+        assertEquals("#7c82bf", r14.colorHex)
+        assertEquals(listOf("4:02 AM", "4:17 AM"), r14.upcoming.map { it.clockText })
+
+        val r14r = d.lines[1]
+        assertEquals("14R", r14r.label)
+        assertEquals("#bf2b45", r14r.colorHex)
+        assertEquals(listOf("5:43 AM"), r14r.upcoming.map { it.clockText })
+        assertTrue("live time differs from timetable", r14r.upcoming[0].realtime)
     }
 
     @Test

--- a/core/src/test/java/app/vela/core/data/google/parse/StopDeparturesParserTest.kt
+++ b/core/src/test/java/app/vela/core/data/google/parse/StopDeparturesParserTest.kt
@@ -1,0 +1,96 @@
+package app.vela.core.data.google.parse
+
+import app.vela.core.model.TransitMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Fixture mirrors the live keyless capture (2026-07-12, NYC subway hub): the transit board
+ * lives at `place[62]` inside the anonymous place-details payload, shaped
+ * `["<station>", [ [null,"<group>", [ [null,[ <directions> ]] ], … "<mode>"] ]]`, each
+ * direction `["<headsign>", null,null, [ <time tuples> + headway ], … "<combined label>"]`,
+ * and a departure tuple `[rtEpoch,"<tz>","4:35 AM",offset,schedEpoch]`.
+ */
+class StopDeparturesParserTest {
+
+    private val transit = """
+        ["Times Sq-42 St",
+         [
+          [null,"Subway services",
+           [
+            [null,
+             [
+              ["34 St-Hudson Yards",null,null,
+               [
+                [[1783845332,"America/New_York","4:35 AM",-14400,1783845300],null,null,null,0,null,null,"tok",null,null,[null,null,[4,2],[[["accessibility"],1],[["crowdedness"],4,null,[[[["least"]]]]]]],null,null,null,2],
+                [[1783846320,"America/New_York","4:52 AM",-14400,1783846320]],
+                [[1783847520,"America/New_York","5:12 AM",-14400,1783847520]],
+                [1200,"20 min"]
+               ],
+               null,null,null,null,null,"34 St Hudson Yards 7"
+              ],
+              ["Flushing-Main St",null,null,
+               [
+                [[1783844340,"America/New_York","4:19 AM",-14400,1783844340]],
+                [[1783845540,"America/New_York","4:39 AM",-14400,1783845540]],
+                [900,"15 min"]
+               ],
+               null,null,null,null,null,"Flushing-Main St 7"
+              ]
+             ]
+            ]
+           ],
+           null,null,null,null,null,null,null,null,null,"2"
+          ]
+         ]
+        ]
+    """.trimIndent()
+
+    /** Wrap the transit node into a place at root[6], transit at place[62], via null padding. */
+    private fun body(transitNode: String): String {
+        val place = "[" + "null,".repeat(62) + transitNode + "]"
+        val root = "[null,null,null,null,null,null,$place]"
+        return ")]}'\n$root"
+    }
+
+    @Test
+    fun `parses a station departure board`() {
+        val d = StopDeparturesParser.parse(body(transit))!!
+        assertEquals("Times Sq-42 St", d.stationName)
+        assertEquals(2, d.lines.size)
+
+        val a = d.lines[0]
+        assertEquals("34 St-Hudson Yards", a.headsign)
+        assertEquals(TransitMode.SUBWAY, a.mode)
+        assertEquals("7", a.label)
+        assertEquals("20 min", a.headwayText)
+        assertEquals(listOf("4:35 AM", "4:52 AM", "5:12 AM"), a.upcoming.map { it.clockText })
+        assertEquals(1783845300L, a.upcoming[0].epochSec)   // scheduled epoch [4], not realtime [0]
+        assertTrue("live time differs from timetable", a.upcoming[0].realtime)
+        assertTrue("on-time departure not flagged live", !a.upcoming[1].realtime)
+
+        val b = d.lines[1]
+        assertEquals("Flushing-Main St", b.headsign)
+        assertEquals("15 min", b.headwayText)
+        assertEquals(listOf("4:19 AM", "4:39 AM"), b.upcoming.map { it.clockText })
+        assertTrue(b.upcoming.none { it.realtime })          // equal epochs -> scheduled
+    }
+
+    @Test
+    fun `a non-transit place yields null, not an error`() {
+        // place[62] absent + no time tuples anywhere -> routine null (most places aren't stops)
+        val root = "[null,null,null,null,null,null,[\"A cafe\",1,2,3]]"
+        assertNull(StopDeparturesParser.parse(")]}'\n$root"))
+    }
+
+    @Test
+    fun `finds the transit node even if its field index shifts`() {
+        // put the transit node at a different place index; the shape-search fallback must find it
+        val place = "[" + "null,".repeat(40) + transit + "]"
+        val root = "[null,null,null,null,null,null,$place]"
+        val d = StopDeparturesParser.parse(")]}'\n$root")!!
+        assertEquals(2, d.lines.size)
+    }
+}


### PR DESCRIPTION
Tapping a transit station (subway, rail, BART, a bus stop) now shows Google's "See departure board" right in the place sheet: each line and direction with its destination, the next few departure times (soonest bold, the rest quiet), a countdown on the soonest, a Live dot when the time is real-time, and how often it runs.

**Keyless, no new endpoint, no login.** The board is embedded in the station's own place page's `APP_INITIALIZATION_STATE` (opening the button on the web fires no data request), and it survives a logged-out session, so it rides the same anonymous WebView `?cid=` channel the app already uses for photos and reviews. Confirmed anonymous in a logged-out browser and on-device. This is the opposite of popular times, which is stripped when logged out.

**How it's built:**
- `:core` `StopDeparturesParser` reads the line/direction/time/frequency structure (`place[62]`, calibrated against a live NYC subway capture). The container path is positional but the leaf details (time tuples, frequency, route label) are matched by shape, and the transit-node index has a shape-search fallback, so a moved field degrades one line, not the board. Unit-tested.
- `WebStopDeparturesFetcher` (app) loads the station's `?cid=` page and hands the payload to the parser.
- `MapViewModel.fetchStopDepartures` fires only for transit-category places (so an ordinary business never triggers a WebView load), guards to the still-selected place, and shows nothing when there's no board.
- `PlaceSheet.StopDepartureBoard` renders it, reusing the departs-in countdown from the previous PR.

**Coverage is agency-dependent** - only agencies that feed Google real-time embed the board. Confirmed present for NYC MTA and SF BART; a smaller light-rail agency (SacRT) has none, and the app correctly shows nothing there.

**Device-verified on the Pixel 4a:** BART Powell St rendered 8 lines (Daly City, Richmond, SFO/Millbrae, Antioch, SFO) each with its next three departures. Also confirmed the correct empty result for the Amtrak depot and SacRT, and that the gate skips restaurants.

Stacked on #90 (reuses its countdown helper + strings). Docs: FEATURES.md + CLAUDE.md.