### PR TITLE
Share menu: add "Open on the web"

### DIFF
--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -3296,11 +3296,22 @@ private fun ShareIconButton(place: Place, tint: Color) {
         open = false
     }
 
+    // Copy the place's Google Maps link straight to the clipboard (a quiet toast confirms).
+    fun copyLink() {
+        val url = "https://www.google.com/maps/search/?api=1&query=$lat%2C$lng"
+        runCatching {
+            val cm = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+            cm.setPrimaryClip(android.content.ClipData.newPlainText(place.name, url))
+            Toast.makeText(context, context.getString(R.string.place_link_copied), Toast.LENGTH_SHORT).show()
+        }
+        open = false
+    }
+
     Box {
         HeaderCircleButton(Icons.Default.Share, stringResource(R.string.place_share), tint, tint) { open = true }
         VelaMenu(expanded = open, onDismissRequest = { open = false }) {
             item(stringResource(R.string.place_open_web)) { openWeb() }
-            item(stringResource(R.string.place_share_gmaps_link)) { share("${place.name}\nhttps://www.google.com/maps/search/?api=1&query=$lat%2C$lng") }
+            item(stringResource(R.string.place_copy_link)) { copyLink() }
             // A geo: URI opens in ANY maps app (incl. Vela) — no google.com, the
             // degoogled-friendly way to send a pin.
             item(stringResource(R.string.place_share_map_pin)) { share("${place.name}\ngeo:$lat,$lng?q=$lat,$lng(${Uri.encode(place.name)})") }

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -3285,9 +3285,21 @@ private fun ShareIconButton(place: Place, tint: Color) {
         open = false
     }
 
+    // Open this exact place on the Google Maps website (in the browser), not share a link. Prefer the
+    // place's own cid deep-link (opens the real place page); fall back to a name+coords query.
+    fun openWeb() {
+        val cid = place.featureId?.substringAfter(":", "")?.removePrefix("0x")?.takeIf { it.isNotBlank() }
+            ?.let { runCatching { java.math.BigInteger(it, 16).toString() }.getOrNull() }
+        val url = if (cid != null) "https://www.google.com/maps?cid=$cid"
+            else "https://www.google.com/maps/search/?api=1&query=${Uri.encode(place.name)}%20$lat%2C$lng"
+        runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url))) }
+        open = false
+    }
+
     Box {
         HeaderCircleButton(Icons.Default.Share, stringResource(R.string.place_share), tint, tint) { open = true }
         VelaMenu(expanded = open, onDismissRequest = { open = false }) {
+            item(stringResource(R.string.place_open_web)) { openWeb() }
             item(stringResource(R.string.place_share_gmaps_link)) { share("${place.name}\nhttps://www.google.com/maps/search/?api=1&query=$lat%2C$lng") }
             // A geo: URI opens in ANY maps app (incl. Vela) — no google.com, the
             // degoogled-friendly way to send a pin.

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -249,6 +249,8 @@
     <string name="place_share_place">Ort teilen</string>
     <string name="place_share">Teilen</string>
     <string name="place_open_web">Im Web öffnen</string>
+    <string name="place_copy_link">Link kopieren</string>
+    <string name="place_link_copied">Link kopiert</string>
     <string name="place_share_gmaps_link">Google Maps-Link</string>
     <string name="place_share_map_pin">Kartenmarkierung (geo:)</string>
     <string name="place_share_coordinates">Koordinaten</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -248,6 +248,7 @@
     <string name="place_from_the_owner">Vom Inhaber</string>
     <string name="place_share_place">Ort teilen</string>
     <string name="place_share">Teilen</string>
+    <string name="place_open_web">Im Web öffnen</string>
     <string name="place_share_gmaps_link">Google Maps-Link</string>
     <string name="place_share_map_pin">Kartenmarkierung (geo:)</string>
     <string name="place_share_coordinates">Koordinaten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -249,6 +249,8 @@
     <string name="place_share_place">Compartir lugar</string>
     <string name="place_share">Compartir</string>
     <string name="place_open_web">Abrir en la web</string>
+    <string name="place_copy_link">Copiar enlace</string>
+    <string name="place_link_copied">Enlace copiado</string>
     <string name="place_share_gmaps_link">Enlace de Google Maps</string>
     <string name="place_share_map_pin">Marcador del mapa (geo:)</string>
     <string name="place_share_coordinates">Coordenadas</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -248,6 +248,7 @@
     <string name="place_from_the_owner">Del propietario</string>
     <string name="place_share_place">Compartir lugar</string>
     <string name="place_share">Compartir</string>
+    <string name="place_open_web">Abrir en la web</string>
     <string name="place_share_gmaps_link">Enlace de Google Maps</string>
     <string name="place_share_map_pin">Marcador del mapa (geo:)</string>
     <string name="place_share_coordinates">Coordenadas</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -248,6 +248,7 @@
     <string name="place_from_the_owner">Réponse du propriétaire</string>
     <string name="place_share_place">Partager le lieu</string>
     <string name="place_share">Partager</string>
+    <string name="place_open_web">Ouvrir sur le Web</string>
     <string name="place_share_gmaps_link">Lien Google Maps</string>
     <string name="place_share_map_pin">Repère sur la carte (geo:)</string>
     <string name="place_share_coordinates">Coordonnées</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -249,6 +249,8 @@
     <string name="place_share_place">Partager le lieu</string>
     <string name="place_share">Partager</string>
     <string name="place_open_web">Ouvrir sur le Web</string>
+    <string name="place_copy_link">Copier le lien</string>
+    <string name="place_link_copied">Lien copié</string>
     <string name="place_share_gmaps_link">Lien Google Maps</string>
     <string name="place_share_map_pin">Repère sur la carte (geo:)</string>
     <string name="place_share_coordinates">Coordonnées</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -248,6 +248,7 @@
     <string name="place_from_the_owner">Dal proprietario</string>
     <string name="place_share_place">Condividi luogo</string>
     <string name="place_share">Condividi</string>
+    <string name="place_open_web">Apri sul web</string>
     <string name="place_share_gmaps_link">Link Google Maps</string>
     <string name="place_share_map_pin">Segnaposto mappa (geo:)</string>
     <string name="place_share_coordinates">Coordinate</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -249,6 +249,8 @@
     <string name="place_share_place">Condividi luogo</string>
     <string name="place_share">Condividi</string>
     <string name="place_open_web">Apri sul web</string>
+    <string name="place_copy_link">Copia link</string>
+    <string name="place_link_copied">Link copiato</string>
     <string name="place_share_gmaps_link">Link Google Maps</string>
     <string name="place_share_map_pin">Segnaposto mappa (geo:)</string>
     <string name="place_share_coordinates">Coordinate</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -247,6 +247,7 @@
     <string name="place_from_the_owner">מהבעלים</string>
     <string name="place_share_place">שתף מקום</string>
     <string name="place_share">שתף</string>
+    <string name="place_open_web">פתיחה באינטרנט</string>
     <string name="place_share_gmaps_link">קישור Google Maps</string>
     <string name="place_share_map_pin">סימון מפה (geo:)</string>
     <string name="place_share_coordinates">קואורדינטות</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -248,6 +248,8 @@
     <string name="place_share_place">שתף מקום</string>
     <string name="place_share">שתף</string>
     <string name="place_open_web">פתיחה באינטרנט</string>
+    <string name="place_copy_link">העתקת קישור</string>
+    <string name="place_link_copied">הקישור הועתק</string>
     <string name="place_share_gmaps_link">קישור Google Maps</string>
     <string name="place_share_map_pin">סימון מפה (geo:)</string>
     <string name="place_share_coordinates">קואורדינטות</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -264,6 +264,8 @@
     <string name="place_share_place">場所を共有</string>
     <string name="place_share">共有</string>
     <string name="place_open_web">ウェブで開く</string>
+    <string name="place_copy_link">リンクをコピー</string>
+    <string name="place_link_copied">リンクをコピーしました</string>
     <string name="place_share_gmaps_link">Google マップのリンク</string>
     <string name="place_share_map_pin">地図のピン（geo:）</string>
     <string name="place_share_coordinates">座標</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -263,6 +263,7 @@
     <string name="place_from_the_owner">オーナーからの返信</string>
     <string name="place_share_place">場所を共有</string>
     <string name="place_share">共有</string>
+    <string name="place_open_web">ウェブで開く</string>
     <string name="place_share_gmaps_link">Google マップのリンク</string>
     <string name="place_share_map_pin">地図のピン（geo:）</string>
     <string name="place_share_coordinates">座標</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -248,6 +248,7 @@
     <string name="place_from_the_owner">Van de eigenaar</string>
     <string name="place_share_place">Plaats delen</string>
     <string name="place_share">Delen</string>
+    <string name="place_open_web">Openen op internet</string>
     <string name="place_share_gmaps_link">Google Maps-link</string>
     <string name="place_share_map_pin">Kaartspeld (geo:)</string>
     <string name="place_share_coordinates">Coördinaten</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -249,6 +249,8 @@
     <string name="place_share_place">Plaats delen</string>
     <string name="place_share">Delen</string>
     <string name="place_open_web">Openen op internet</string>
+    <string name="place_copy_link">Link kopiëren</string>
+    <string name="place_link_copied">Link gekopieerd</string>
     <string name="place_share_gmaps_link">Google Maps-link</string>
     <string name="place_share_map_pin">Kaartspeld (geo:)</string>
     <string name="place_share_coordinates">Coördinaten</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -249,6 +249,8 @@
     <string name="place_share_place">Udostępnij miejsce</string>
     <string name="place_share">Udostępnij</string>
     <string name="place_open_web">Otwórz w internecie</string>
+    <string name="place_copy_link">Kopiuj link</string>
+    <string name="place_link_copied">Skopiowano link</string>
     <string name="place_share_gmaps_link">Link Google Maps</string>
     <string name="place_share_map_pin">Pinezka mapy (geo:)</string>
     <string name="place_share_coordinates">Współrzędne</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -248,6 +248,7 @@
     <string name="place_from_the_owner">Od właściciela</string>
     <string name="place_share_place">Udostępnij miejsce</string>
     <string name="place_share">Udostępnij</string>
+    <string name="place_open_web">Otwórz w internecie</string>
     <string name="place_share_gmaps_link">Link Google Maps</string>
     <string name="place_share_map_pin">Pinezka mapy (geo:)</string>
     <string name="place_share_coordinates">Współrzędne</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -248,6 +248,7 @@
     <string name="place_from_the_owner">Do proprietário</string>
     <string name="place_share_place">Partilhar local</string>
     <string name="place_share">Partilhar</string>
+    <string name="place_open_web">Abrir na web</string>
     <string name="place_share_gmaps_link">Ligação do Google Maps</string>
     <string name="place_share_map_pin">Marcador de mapa (geo:)</string>
     <string name="place_share_coordinates">Coordenadas</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -249,6 +249,8 @@
     <string name="place_share_place">Partilhar local</string>
     <string name="place_share">Partilhar</string>
     <string name="place_open_web">Abrir na web</string>
+    <string name="place_copy_link">Copiar link</string>
+    <string name="place_link_copied">Link copiado</string>
     <string name="place_share_gmaps_link">Ligação do Google Maps</string>
     <string name="place_share_map_pin">Marcador de mapa (geo:)</string>
     <string name="place_share_coordinates">Coordenadas</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -248,6 +248,7 @@
     <string name="place_from_the_owner">От владельца</string>
     <string name="place_share_place">Поделиться местом</string>
     <string name="place_share">Поделиться</string>
+    <string name="place_open_web">Открыть в интернете</string>
     <string name="place_share_gmaps_link">Ссылка Google Maps</string>
     <string name="place_share_map_pin">Метка на карте (geo:)</string>
     <string name="place_share_coordinates">Координаты</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -249,6 +249,8 @@
     <string name="place_share_place">Поделиться местом</string>
     <string name="place_share">Поделиться</string>
     <string name="place_open_web">Открыть в интернете</string>
+    <string name="place_copy_link">Копировать ссылку</string>
+    <string name="place_link_copied">Ссылка скопирована</string>
     <string name="place_share_gmaps_link">Ссылка Google Maps</string>
     <string name="place_share_map_pin">Метка на карте (geo:)</string>
     <string name="place_share_coordinates">Координаты</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -248,6 +248,7 @@
     <string name="place_from_the_owner">Från ägaren</string>
     <string name="place_share_place">Dela plats</string>
     <string name="place_share">Dela</string>
+    <string name="place_open_web">Öppna på webben</string>
     <string name="place_share_gmaps_link">Google Maps-länk</string>
     <string name="place_share_map_pin">Kartnål (geo:)</string>
     <string name="place_share_coordinates">Koordinater</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -249,6 +249,8 @@
     <string name="place_share_place">Dela plats</string>
     <string name="place_share">Dela</string>
     <string name="place_open_web">Öppna på webben</string>
+    <string name="place_copy_link">Kopiera länk</string>
+    <string name="place_link_copied">Länk kopierad</string>
     <string name="place_share_gmaps_link">Google Maps-länk</string>
     <string name="place_share_map_pin">Kartnål (geo:)</string>
     <string name="place_share_coordinates">Koordinater</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -248,6 +248,7 @@
     <string name="place_from_the_owner">Від власника</string>
     <string name="place_share_place">Поділитися місцем</string>
     <string name="place_share">Поділитися</string>
+    <string name="place_open_web">Відкрити в інтернеті</string>
     <string name="place_share_gmaps_link">Посилання Google Maps</string>
     <string name="place_share_map_pin">Мітка на карті (geo:)</string>
     <string name="place_share_coordinates">Координати</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -249,6 +249,8 @@
     <string name="place_share_place">Поділитися місцем</string>
     <string name="place_share">Поділитися</string>
     <string name="place_open_web">Відкрити в інтернеті</string>
+    <string name="place_copy_link">Копіювати посилання</string>
+    <string name="place_link_copied">Посилання скопійовано</string>
     <string name="place_share_gmaps_link">Посилання Google Maps</string>
     <string name="place_share_map_pin">Мітка на карті (geo:)</string>
     <string name="place_share_coordinates">Координати</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -263,6 +263,7 @@
     <string name="place_from_the_owner">來自業主</string>
     <string name="place_share_place">分享地點</string>
     <string name="place_share">分享</string>
+    <string name="place_open_web">在網頁中開啟</string>
     <string name="place_share_gmaps_link">Google 地圖連結</string>
     <string name="place_share_map_pin">地圖圖釘（geo:）</string>
     <string name="place_share_coordinates">座標</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -264,6 +264,8 @@
     <string name="place_share_place">分享地點</string>
     <string name="place_share">分享</string>
     <string name="place_open_web">在網頁中開啟</string>
+    <string name="place_copy_link">複製連結</string>
+    <string name="place_link_copied">已複製連結</string>
     <string name="place_share_gmaps_link">Google 地圖連結</string>
     <string name="place_share_map_pin">地圖圖釘（geo:）</string>
     <string name="place_share_coordinates">座標</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -264,6 +264,8 @@
     <string name="place_share_place">分享地点</string>
     <string name="place_share">分享</string>
     <string name="place_open_web">在网页中打开</string>
+    <string name="place_copy_link">复制链接</string>
+    <string name="place_link_copied">已复制链接</string>
     <string name="place_share_gmaps_link">Google 地图链接</string>
     <string name="place_share_map_pin">地图图钉 (geo:)</string>
     <string name="place_share_coordinates">坐标</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -263,6 +263,7 @@
     <string name="place_from_the_owner">来自商家</string>
     <string name="place_share_place">分享地点</string>
     <string name="place_share">分享</string>
+    <string name="place_open_web">在网页中打开</string>
     <string name="place_share_gmaps_link">Google 地图链接</string>
     <string name="place_share_map_pin">地图图钉 (geo:)</string>
     <string name="place_share_coordinates">坐标</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,6 +264,7 @@
     <string name="place_from_the_owner">From the owner</string>
     <string name="place_share_place">Share place</string>
     <string name="place_share">Share</string>
+    <string name="place_open_web">Open on the web</string>
     <string name="place_share_gmaps_link">Google Maps link</string>
     <string name="place_share_map_pin">Map pin (geo:)</string>
     <string name="place_share_coordinates">Coordinates</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -265,6 +265,8 @@
     <string name="place_share_place">Share place</string>
     <string name="place_share">Share</string>
     <string name="place_open_web">Open on the web</string>
+    <string name="place_copy_link">Copy link</string>
+    <string name="place_link_copied">Link copied</string>
     <string name="place_share_gmaps_link">Google Maps link</string>
     <string name="place_share_map_pin">Map pin (geo:)</string>
     <string name="place_share_coordinates">Coordinates</string>


### PR DESCRIPTION
Adds an **Open on the web** item to a place's share menu that opens the place on the Google Maps website in the browser (not a share sheet). Prefers the place's own `?cid=` deep-link so it lands on the real place page; falls back to a name + coordinates query when there's no feature id. Localized in all languages.

Device-tested on the 4a (canary11).