### PR TITLE
Tapping a bus stop opens the stop, not the intersection

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1259,7 +1259,7 @@ class MapViewModel @Inject constructor(
      *  these to avoid a WebView load on every ordinary place; the parser returns null anyway for a
      *  place with no board, so a miss here just means no board, never a wrong one. */
     private val TRANSIT_CAT = Regex(
-        """station|stop|subway|metro|transit|\bbus\b|train|\brail\b|tram|light rail|terminal|ferry|""" +
+        """station|stop|subway|metro|transit|transport|\bhub\b|\bbus\b|train|\brail\b|tram|light rail|terminal|ferry|""" +
             """bahnhof|haltestelle|gare|estaci|estaç|stazione|fermata|estação|estação|halte|stanice|""" +
             """지하철|driehoek|û|вокзал|станц|остановка|停|駅|车站|車站""",
         RegexOption.IGNORE_CASE,
@@ -1606,7 +1606,7 @@ class MapViewModel @Inject constructor(
 
     /** Tapped a POI on the map: show it immediately, then enrich with full
      *  details (hours, rating, …) from a search for that name nearby. */
-    fun onPoiTap(name: String, location: LatLng) {
+    fun onPoiTap(name: String, location: LatLng, poiKind: String? = null) {
         if (consumeAssign(SavedPlace(id = "poi:" + name.hashCode(), name = name, lat = location.lat, lng = location.lng))) return
         // Picking the route origin (or a stop) by tapping the map → adopt this POI, don't open it.
         if (_state.value.pickingStop) {
@@ -1624,6 +1624,24 @@ class MapViewModel @Inject constructor(
         // same-named POIs tapped in quick succession (a chain's two branches) otherwise let the slower
         // resolve for the first hijack the second's sheet, since the old gate matched name only (audit 2026-07-06).
         val placeholder = Place(id = "poi:" + name.hashCode(), name = name, location = location)
+        // A transit STOP is usually named by its intersection ("Main St & 1st Ave"), and Google resolves
+        // that bare string to the road JUNCTION, not the stop - so a tapped stop opened as an "Intersection"
+        // with no board (issue #71 follow-up; verified in a live capture: "<x> & <y>" -> Intersection,
+        // "<x> & <y> bus stop" -> the Stop). When the TAPPED POI's kind says transit (its class/subclass,
+        // not its name, so a business called "Salt & Straw" is untouched), append a mode word to the lookup
+        // so the search returns the stop. Non-transit POIs search by name exactly as before.
+        val transitHint = poiKind?.lowercase()?.let { k ->
+            when {
+                "bus" in k -> "bus stop"
+                "tram" in k || "light_rail" in k -> "tram stop"
+                "subway" in k || "metro" in k -> "station"
+                "railway" in k || "train" in k || "rail" in k -> "station"
+                "ferry" in k -> "ferry terminal"
+                "station" in k || "halt" in k || "platform" in k || "stop" in k || "transit" in k -> "transit stop"
+                else -> null
+            }
+        }
+        val searchQuery = if (transitHint != null && !name.lowercase().contains(transitHint)) "$name $transitHint" else name
         _state.update {
             it.copy(
                 selected = placeholder,
@@ -1648,7 +1666,7 @@ class MapViewModel @Inject constructor(
         }
         viewModelScope.launch {
             val resolved = runCatching {
-                val results = dataSource.search(name, location).places
+                val results = dataSource.search(searchQuery, location).places
                 val nearest = results.minByOrNull { p -> p.location.distanceTo(location) }
                 // A tapped POI can map to several Google listings at the same spot —
                 // e.g. a co-branded "SpeeDee Midas" has a rich "SpeeDee" profile (543

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -216,7 +216,7 @@ fun VelaMapView(
     trafficOn: Boolean,
     transitOn: Boolean = false, // highlight rail (train + subway/tram) lines from the basemap tiles
     previewTarget: LatLng?,
-    onPoiTap: (name: String, location: LatLng) -> Unit,
+    onPoiTap: (name: String, location: LatLng, poiKind: String?) -> Unit,
     onMarkerTap: (index: Int) -> Unit,
     parkingSpot: LatLng? = null, // saved "parked here" pin; tap → onParkingTap
     onParkingTap: () -> Unit = {},
@@ -812,7 +812,11 @@ fun VelaMapView(
                     val hit = feats.firstOrNull { it.geometry() is Point && nameOf(it) != null }
                     if (hit != null) {
                         val pt = hit.geometry() as Point
-                        poiTap.value(nameOf(hit)!!, LatLng(pt.latitude(), pt.longitude()))
+                        // The POI's kind (OMT subclass, e.g. "bus_stop"/"station", else class) tells
+                        // onPoiTap whether it's a transit stop, so it can resolve to the STOP rather than
+                        // the road junction its intersection-name would otherwise search to (issue #71).
+                        val kind = hit.getStringProperty("subclass") ?: hit.getStringProperty("class")
+                        poiTap.value(nameOf(hit)!!, LatLng(pt.latitude(), pt.longitude()), kind)
                         return@handleTap true
                     }
                     val box = RectF(p.x - r, p.y - r, p.x + r, p.y + r)

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -924,7 +924,7 @@ fun PlaceSheet(
             // not listed" (issue #71). Suppress that line whenever a board is loading/present or the
             // category reads like a stop, so a stop never shows the misleading hours placeholder.
             val isTransitStop = stopDepartures != null || stopDeparturesLoading || place.category?.lowercase()?.let { c ->
-                listOf("station", "stop", "transit", "bus", "subway", "metro", "tram", "rail", "ferry", "terminal", "platform").any { it in c }
+                listOf("station", "stop", "transit", "transport", "hub", "bus", "subway", "metro", "tram", "rail", "ferry", "terminal", "platform").any { it in c }
             } == true
             if (place.hours.isNotEmpty()) {
                 HoursSection(place.hours, ink, dim, departments = if (showDepartments) place.departments else emptyList())


### PR DESCRIPTION
Follow-up to the departures board (#91). Tapping a bus stop on the map opened a road **intersection** with no departures, because stops are named by their intersection ("Main St and 1st Ave") and searching that bare string resolves to the junction.

Confirmed in a live logged-out capture: "Mission St & 16th St" resolved to category **Intersection** (no board); "Mission St & 16th St bus stop" resolved to the **Stop** with a board.

**Fix:** the map tap now carries the tapped POI's kind (its map class/subclass, e.g. bus_stop) through onPoiTap. When the kind is transit, the lookup appends a mode word (bus stop / station / tram stop / ferry terminal) so Google returns the stop, with its board. Gating is on the POI **kind**, not its name, so a business literally named "Salt and Straw" is never touched. Also widened the transit-category match to include "transport hub".

Mechanism confirmed in Chrome; needs a quick on-device tap to confirm the end result (the adb hunt for a bus-stop icon in a sparse suburb kept missing).
