### PR TITLE
Transit: tap-through route stop timeline off the departure board

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1844,6 +1844,26 @@ architecture note.
   render off already-parsed fields, no extra fetch. `delayText` is English-computed in `:core` (as
   in the drill-down); the countdown wrapper strings ARE localized (`place_transit_now`/`_in_min`/
   `_live`, invariable "min" abbreviation per locale like `place_delta_min`).
+- **Tap-through route stop timeline (2026-07-12, keyless + device-verified).** Every `DepartureLineRow`
+  on the board is `clickable` (a trailing `>` chevron hints it) -> `MapViewModel.openRouteDetail(line)`.
+  There is NO new endpoint: the route's stop SEQUENCE is a lazy fetch NOT in the place blob, so this
+  REUSES the proven transit-itinerary parser. `openRouteDetail` geocodes the line's headsign (biased to
+  transit terminals - it prefers a candidate whose `category` matches station/airport/terminal/bart/…
+  nearest the stop, because a bare "Richmond" resolves to a city district not the BART terminal), runs
+  `webDirections.transit(stop, terminal)`, and among the ride legs picks the one on the tapped line
+  (label match) else the leg whose `boardStop` is nearest the stop (the direction tapped) else the
+  first - that `TransitStep` already carries `boardStop`/`intermediateStops`/`alightStop` with per-stop
+  times. Rendered by `PlaceSheet.RouteDetailSheet` (full-screen `Surface`, `MapScreen` draws it over the
+  place sheet when `state.routeDetail != null || routeDetailLoading`): a vertical rail in the line colour,
+  board + alight bold, each `TransitStopTime` row `clickable` -> `openRouteStop(stop)` which
+  `closeRouteDetail()` + `onPoiTap(stop.name, stop.location)` (the stop's precise coord makes the
+  nearest-resolve land on it, and its own `fetchStopDepartures` fires) - so tapping a stop opens ITS
+  board and the tap-through continues. Best-effort: an ungeocodable headsign / no ride leg flashes
+  `route_detail_unavailable` (localized in all 11 langs) and the overlay closes. State on `MapUiState`:
+  `routeDetail: TransitStep?`, `routeDetailTitle`, `routeDetailLoading`, guarded by `routeDetailJob`.
+  The board cap was raised 8 -> 24 lines (`StopDepartureBoard` + parser `MAX_LINES`) so busy stops show
+  more routes. **Device-verified: Powell St -> Yellow-S -> 11 stops (Powell…SFO, 12:23-12:54 PM), then
+  tapping 16th St Mission opened that bus stop's own board.**
 
 ## Name
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -930,6 +930,21 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   / Antioch / SFO) with their next departures. **Coverage is agency-dependent** - major systems that
   feed Google real-time carry the board (NYC MTA, SF BART confirmed); a place with none shows nothing
   (a small light-rail agency like SacRT was confirmed empty, correctly). Localized in all 11 languages.
+- ✅ **Tap-through route stop timeline (2026-07-12, keyless + device-verified).** Every route on the
+  departure board is tappable (a **`>` chevron** hints it): tapping one opens a full-screen **stop
+  timeline** for that route - the **board stop**, **every intermediate stop with its call time**, and
+  the **alight stop**, drawn down a **vertical rail in the line's own colour** (board + alight bold).
+  Tapping any stop on the timeline opens **that stop's own departure board**, so you keep drilling
+  down the line the way Google's tap-through does. No new endpoint: the stop sequence is a lazy fetch
+  not in the place blob, so it **reuses the proven transit-itinerary parser** - a keyless directions
+  query from the tapped stop toward the route's headsign returns a ride leg whose `intermediateStops`
+  already carry the per-stop times. The headsign geocode is **biased toward transit terminals** (a
+  bare "Richmond" would otherwise resolve to a city district, not the BART terminal), and the leg we
+  actually **board at this stop** is chosen. Best-effort: a headsign that will not geocode falls back
+  to a quiet "Route details unavailable". **Device-verified: BART Powell St -> Yellow-S to SFO showed
+  all 11 stops (Powell -> Civic Center -> 16th/24th St Mission -> Glen/Balboa Park -> Daly City ->
+  Colma -> South SF -> San Bruno -> SFO) with times 12:23-12:54 PM, and tapping 16th St Mission opened
+  that stop's own board.** Localized (`route_detail_unavailable`) in all 11 languages.
 - ✅ Transit **leg drill-down with full stop detail** - tap an itinerary to expand
   its ordered legs. A ride leg shows Google's whole layout: the **line pill + "towards …"
   headsign**, the **board stop** (name + agency **Stop ID** + real-time board time, with

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ setup in [FDROID.md](FDROID.md)). Or grab an APK straight from
   with your wallpaper colors (Android 12+); off by default, and the map itself
   stays clean either way.
 - **Public transit.** Itineraries with line pills, station-by-station stops, and
-  step-by-step guidance to the platform.
+  step-by-step guidance to the platform. A tapped station shows a live departure
+  board, and tapping a route opens its stop timeline you can keep tapping through.
 - **No account, no tracking.** No Google account, no GMS, no telemetry. What
   Google's servers can and cannot see is documented plainly in [PRIVACY.md](PRIVACY.md).
 - **The rest.** Android Auto, 15 languages (incl. Hebrew, the first RTL locale), in-app light/dark, full D-pad operation

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1338,6 +1338,7 @@ fun MapScreen(
                 placesHere = state.placesHere,
                 stopDepartures = state.stopDepartures,
                 stopDeparturesLoading = state.stopDeparturesLoading,
+                onTapRoute = vm::openRouteDetail,
                 onClose = vm::clearSelection,
                 onToggleSave = vm::toggleSave,
                 onDirections = vm::routeToSelected,
@@ -1445,6 +1446,19 @@ fun MapScreen(
                 onBack = vm::backTransitNav,
                 onEnd = vm::endTransitNav,
                 onWalkDirections = vm::walkDirections,
+            )
+        }
+
+        // Tap-through: the stop timeline for a route tapped on the departure board. Drawn over the
+        // place sheet; tapping a stop opens that stop's own board, so the user keeps drilling down
+        // the line the way Google's tap-through does. Also shown (with a spinner) while it loads.
+        if (state.routeDetail != null || state.routeDetailLoading) {
+            app.vela.ui.place.RouteDetailSheet(
+                step = state.routeDetail,
+                title = state.routeDetailTitle,
+                loading = state.routeDetailLoading,
+                onClose = vm::closeRouteDetail,
+                onStopTap = vm::openRouteStop,
             )
         }
 

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1306,9 +1306,10 @@ class MapViewModel @Inject constructor(
         routeDetailJob?.cancel()
         routeDetailJob = viewModelScope.launch {
             // Aim at the route's destination (geocode the headsign near the stop), then ride transit there.
-            // A bare headsign is often ambiguous ("Richmond" resolves to a city district, not the BART
-            // terminal), so prefer a candidate that is itself a transit place (station/airport/terminal)
-            // and, among those, the one nearest the tapped stop - that is the line's actual end point.
+            // A bare headsign is often ambiguous ("Richmond" is a city district AND a far-off city), so
+            // prefer a candidate that is itself a transit place (station/airport/terminal) and, among
+            // those, the one nearest the tapped stop - a sanity filter that rejects a same-named place
+            // across the country. (The RIDE-LEG match below is what actually pins the tapped line.)
             val cands = runCatching { dataSource.search(dest, origin).places }.getOrDefault(emptyList())
             val transitish = cands.filter { it.category?.let { c ->
                 listOf("station", "transit", "stop", "airport", "terminal", "bart", "metro", "rail")
@@ -1322,12 +1323,13 @@ class MapViewModel @Inject constructor(
             }
             val trips = runCatching { webDirections.transit(origin, destLoc) }.getOrDefault(emptyList())
             val rides = trips.flatMap { it.steps }.filter { it.line != null && it.intermediateStops.isNotEmpty() }
-            // Prefer the ride leg on the SAME line the user tapped; else the leg we actually BOARD at this
-            // stop (its board stop nearest the origin), which is the direction they tapped; else the first.
-            val step = rides.firstOrNull { s ->
-                line.label != null && s.line?.name?.equals(line.label, ignoreCase = true) == true
-            } ?: rides.filter { it.boardStop?.location != null }
-                .minByOrNull { it.boardStop!!.location!!.distanceTo(origin) }
+            // Pick the leg the user actually tapped. Rank by the tapped LINE first (a short board label
+            // like "N" matches a longer itinerary name "N-Judah"), then by how close its board stop is to
+            // the tapped stop - so a same-line leg heading the OTHER way (boarding far off) loses to the
+            // one boarding here. Falls back to whatever leg boards at this stop, then the first ride.
+            val boardDist = { s: TransitStep -> s.boardStop?.location?.distanceTo(origin) ?: Double.MAX_VALUE }
+            val step = rides.filter { lineLabelMatches(line.label, it.line?.name) }.minByOrNull { boardDist(it) }
+                ?: rides.filter { boardDist(it) <= 500.0 }.minByOrNull { boardDist(it) }
                 ?: rides.firstOrNull()
             android.util.Log.d("VelaRouteDetail", "'$dest' rides=${rides.size} -> ${step?.line?.name} (${step?.intermediateStops?.size} stops)")
             _state.update {
@@ -1335,6 +1337,15 @@ class MapViewModel @Inject constructor(
                 else it.copy(routeDetail = step, routeDetailLoading = false)
             }
         }
+    }
+
+    /** Does a departure-board line label (a short route code, "N" / "42") match an itinerary line name
+     *  (which may be longer, "N-Judah")? Exact, or the label is the FIRST token of the name, so a "1"
+     *  label doesn't spuriously match a "10" line. */
+    private fun lineLabelMatches(label: String?, name: String?): Boolean {
+        if (label.isNullOrBlank() || name.isNullOrBlank()) return false
+        if (name.equals(label, ignoreCase = true)) return true
+        return name.trim().split(Regex("[\\s\\-/]")).firstOrNull()?.equals(label, ignoreCase = true) == true
     }
 
     fun closeRouteDetail() {

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1337,7 +1337,13 @@ class MapViewModel @Inject constructor(
         }
     }
 
-    fun closeRouteDetail() = _state.update { it.copy(routeDetail = null, routeDetailLoading = false, routeDetailTitle = null) }
+    fun closeRouteDetail() {
+        // Cancel the in-flight lookup too: without this, dismissing the sheet (Back) mid-load lets the
+        // fetch complete and set routeDetail = step, springing the full-screen sheet back open over
+        // whatever the user moved on to (or flashing "unavailable" after they already left).
+        routeDetailJob?.cancel()
+        _state.update { it.copy(routeDetail = null, routeDetailLoading = false, routeDetailTitle = null) }
+    }
 
     /** Tap a stop in the route timeline -> open THAT stop (its own departure board), so you can keep
      *  tapping through the network. Closes the route detail and selects the stop as a place. */

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -148,6 +148,11 @@ data class MapUiState(
     // A transit stop's live departure board (keyless, from the station's own place page).
     val stopDepartures: app.vela.core.model.StopDepartures? = null,
     val stopDeparturesLoading: Boolean = false,
+    // Route detail (tap a route on the board -> its stop timeline with times, tap-through to stops).
+    // Reuses a ride leg from a transit itinerary (its board/intermediate/alight stops carry the times).
+    val routeDetail: TransitStep? = null,
+    val routeDetailTitle: String? = null,
+    val routeDetailLoading: Boolean = false,
     val navigating: Boolean = false,
     val resumeNavLabel: String? = null, // a nav session was interrupted (process killed mid-drive) and can
                                         // be resumed — drives the "Resume navigation to <label>?" prompt
@@ -1286,6 +1291,55 @@ class MapViewModel @Inject constructor(
             }
         }
     }
+
+    /** Tap a route on the departure board -> show its stop timeline with times (issue #71 follow-up).
+     *  Reuses the PROVEN transit-itinerary parser: a directions query from this stop toward the route's
+     *  destination returns a ride leg whose board/intermediate/alight stops already carry per-stop times.
+     *  No new keyless scraping. Needs the line's headsign (its destination) to aim the query. */
+    fun openRouteDetail(line: app.vela.core.model.StopDepartureLine) {
+        val origin = _state.value.selected?.location ?: return
+        val dest = line.headsign?.takeIf { it.isNotBlank() } ?: run {
+            flashStatus(appContext.getString(R.string.route_detail_unavailable)); return
+        }
+        val title = listOfNotNull(line.label, dest).joinToString(" · ")
+        _state.update { it.copy(routeDetailLoading = true, routeDetailTitle = title, routeDetail = null) }
+        routeDetailJob?.cancel()
+        routeDetailJob = viewModelScope.launch {
+            // Aim at the route's destination (geocode the headsign near the stop), then ride transit there.
+            val destLoc = runCatching {
+                dataSource.search(dest, origin).places.minByOrNull { it.location.distanceTo(origin) }?.location
+            }.getOrNull()
+            if (destLoc == null) {
+                _state.update { it.copy(routeDetailLoading = false) }
+                flashStatus(appContext.getString(R.string.route_detail_unavailable)); return@launch
+            }
+            val trips = runCatching { webDirections.transit(origin, destLoc) }.getOrDefault(emptyList())
+            // Prefer the ride leg on the SAME line the user tapped; else the first ride leg with stops.
+            val rides = trips.flatMap { it.steps }.filter { it.line != null && it.intermediateStops.isNotEmpty() }
+            val step = rides.firstOrNull { s ->
+                line.label != null && s.line?.name?.equals(line.label, ignoreCase = true) == true
+            } ?: rides.firstOrNull()
+            _state.update {
+                if (step == null) { flashStatus(appContext.getString(R.string.route_detail_unavailable)); it.copy(routeDetailLoading = false) }
+                else it.copy(routeDetail = step, routeDetailLoading = false)
+            }
+        }
+    }
+
+    fun closeRouteDetail() = _state.update { it.copy(routeDetail = null, routeDetailLoading = false, routeDetailTitle = null) }
+
+    /** Tap a stop in the route timeline -> open THAT stop (its own departure board), so you can keep
+     *  tapping through the network. Closes the route detail and selects the stop as a place. */
+    fun openRouteStop(stop: app.vela.core.model.TransitStopTime) {
+        val loc = stop.location ?: return
+        closeRouteDetail()
+        // The stop carries a precise coordinate from the itinerary, so onPoiTap's nearest-to-location
+        // resolve lands on the stop itself and its board fetch (fetchStopDepartures) fires - the
+        // tap-through then keeps going from the new stop's own board.
+        onPoiTap(stop.name, loc)
+    }
+
+    private var routeDetailJob: kotlinx.coroutines.Job? = null
 
     /** Offline, a POI that OSM never tagged with an address (most US chains) shows a bare place sheet —
      *  no online detail fetch can fill it. Reverse-geocode its location against the on-device address

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1306,19 +1306,30 @@ class MapViewModel @Inject constructor(
         routeDetailJob?.cancel()
         routeDetailJob = viewModelScope.launch {
             // Aim at the route's destination (geocode the headsign near the stop), then ride transit there.
-            val destLoc = runCatching {
-                dataSource.search(dest, origin).places.minByOrNull { it.location.distanceTo(origin) }?.location
-            }.getOrNull()
+            // A bare headsign is often ambiguous ("Richmond" resolves to a city district, not the BART
+            // terminal), so prefer a candidate that is itself a transit place (station/airport/terminal)
+            // and, among those, the one nearest the tapped stop - that is the line's actual end point.
+            val cands = runCatching { dataSource.search(dest, origin).places }.getOrDefault(emptyList())
+            val transitish = cands.filter { it.category?.let { c ->
+                listOf("station", "transit", "stop", "airport", "terminal", "bart", "metro", "rail")
+                    .any { k -> c.contains(k, ignoreCase = true) }
+            } == true }
+            val destLoc = (transitish.minByOrNull { it.location.distanceTo(origin) }
+                ?: cands.minByOrNull { it.location.distanceTo(origin) })?.location
             if (destLoc == null) {
                 _state.update { it.copy(routeDetailLoading = false) }
                 flashStatus(appContext.getString(R.string.route_detail_unavailable)); return@launch
             }
             val trips = runCatching { webDirections.transit(origin, destLoc) }.getOrDefault(emptyList())
-            // Prefer the ride leg on the SAME line the user tapped; else the first ride leg with stops.
             val rides = trips.flatMap { it.steps }.filter { it.line != null && it.intermediateStops.isNotEmpty() }
+            // Prefer the ride leg on the SAME line the user tapped; else the leg we actually BOARD at this
+            // stop (its board stop nearest the origin), which is the direction they tapped; else the first.
             val step = rides.firstOrNull { s ->
                 line.label != null && s.line?.name?.equals(line.label, ignoreCase = true) == true
-            } ?: rides.firstOrNull()
+            } ?: rides.filter { it.boardStop?.location != null }
+                .minByOrNull { it.boardStop!!.location!!.distanceTo(origin) }
+                ?: rides.firstOrNull()
+            android.util.Log.d("VelaRouteDetail", "'$dest' rides=${rides.size} -> ${step?.line?.name} (${step?.intermediateStops?.size} stops)")
             _state.update {
                 if (step == null) { flashStatus(appContext.getString(R.string.route_detail_unavailable)); it.copy(routeDetailLoading = false) }
                 else it.copy(routeDetail = step, routeDetailLoading = false)

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -243,6 +244,7 @@ fun PlaceSheet(
     placesHere: List<Place> = emptyList(),
     stopDepartures: app.vela.core.model.StopDepartures? = null,
     stopDeparturesLoading: Boolean = false,
+    onTapRoute: (app.vela.core.model.StopDepartureLine) -> Unit = {},
     onClose: () -> Unit,
     onToggleSave: () -> Unit,
     onDirections: () -> Unit,
@@ -935,7 +937,7 @@ fun PlaceSheet(
             }
 
             // Live departure board for a transit stop (keyless, from the station's own place page).
-            StopDepartureBoard(stopDepartures, stopDeparturesLoading, ink, dim, dark)
+            StopDepartureBoard(stopDepartures, stopDeparturesLoading, ink, dim, dark, onTapRoute)
 
             // Phone + website as their own tappable rows showing the actual number / domain — placed
             // BELOW the hours (Google's order), well clear of the Directions button up top. The pills
@@ -2371,6 +2373,7 @@ private fun StopDepartureBoard(
     ink: Color,
     dim: Color,
     dark: Boolean,
+    onTapRoute: (app.vela.core.model.StopDepartureLine) -> Unit = {},
 ) {
     if (d == null && !loading) return
     Spacer(Modifier.height(14.dp))
@@ -2393,13 +2396,27 @@ private fun StopDepartureBoard(
         while (true) { delay(30_000L); value = System.currentTimeMillis() / 1000L }
     }
     Column(Modifier.padding(top = 8.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        d.lines.take(8).forEach { DepartureLineRow(it, nowSec, ink, dim) }
+        d.lines.take(24).forEach { DepartureLineRow(it, nowSec, ink, dim, onTapRoute) }
     }
 }
 
 @Composable
-private fun DepartureLineRow(line: app.vela.core.model.StopDepartureLine, nowSec: Long, ink: Color, dim: Color) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+private fun DepartureLineRow(
+    line: app.vela.core.model.StopDepartureLine,
+    nowSec: Long,
+    ink: Color,
+    dim: Color,
+    onTapRoute: (app.vela.core.model.StopDepartureLine) -> Unit = {},
+) {
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .dpadHighlight(RoundedCornerShape(10.dp))
+            .clickable { onTapRoute(line) }
+            .padding(vertical = 2.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             if (line.label != null) {
                 LinePill(TransitLine(name = line.label!!, mode = line.mode, colorHex = line.colorHex))
@@ -2408,10 +2425,12 @@ private fun DepartureLineRow(line: app.vela.core.model.StopDepartureLine, nowSec
             }
             line.headsign?.let {
                 Text(it, style = MaterialTheme.typography.bodyMedium, color = ink, modifier = Modifier.weight(1f))
-            }
+            } ?: Spacer(Modifier.weight(1f))
             line.headwayText?.let {
                 Text(stringResource(R.string.place_every, it), style = MaterialTheme.typography.labelMedium, color = dim)
             }
+            // Affordance that the row drills into the route's stop timeline (tap-through).
+            Icon(Icons.Default.ChevronRight, contentDescription = null, tint = dim, modifier = Modifier.size(18.dp))
         }
         if (line.upcoming.isNotEmpty()) {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -2438,6 +2457,129 @@ private fun DepartureLineRow(line: app.vela.core.model.StopDepartureLine, nowSec
                 }
             }
         }
+    }
+}
+
+/**
+ * The tap-through stop timeline for one route off the departure board. Reuses the proven
+ * transit-itinerary parser: [MapViewModel.openRouteDetail] runs a keyless directions query
+ * from the tapped stop toward the route's headsign, and the returned ride leg carries the
+ * board / intermediate / alight stops with per-stop times. We render them as a vertical
+ * timeline; tapping any stop opens that stop's own board (via [onStopTap]) so the user can
+ * keep tapping down the line, mirroring Google's tap-through.
+ */
+@Composable
+fun RouteDetailSheet(
+    step: TransitStep?,
+    title: String?,
+    loading: Boolean,
+    onClose: () -> Unit,
+    onStopTap: (TransitStopTime) -> Unit,
+) {
+    BackHandler(onBack = onClose)
+    val dark = isAppInDarkTheme()
+    val ink = if (dark) InkDark else InkLight
+    val dim = if (dark) DimDark else DimLight
+    val lineColor = parseHexColor(step?.line?.colorHex) ?: MaterialTheme.colorScheme.primary
+    // The full ordered call list: board first, then the in-betweens, then alight. Board/alight
+    // are often absent from intermediateStops, so stitch them on the ends and de-dupe by name.
+    val stops = remember(step) {
+        val mid = step?.intermediateStops ?: emptyList()
+        buildList {
+            step?.boardStop?.let { add(it) }
+            addAll(mid)
+            step?.alightStop?.let { a -> if (mid.none { it.name == a.name } && step.boardStop?.name != a.name) add(a) }
+        }
+    }
+    Surface(Modifier.fillMaxSize(), color = if (dark) SheetDark else SheetLight) {
+        Column(Modifier.fillMaxSize().statusBarsPadding().navigationBarsPadding()) {
+            // Header: back + the route pill + headsign.
+            Row(
+                Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                IconButton(onClick = onClose) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.place_close), tint = ink)
+                }
+                step?.line?.let { LinePill(it) }
+                Text(
+                    title ?: step?.headsign ?: step?.line?.name.orEmpty(),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = ink,
+                    maxLines = 2,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            step?.numStops?.let { n ->
+                Text(
+                    stringResource(R.string.place_transit_stops, n),
+                    style = MaterialTheme.typography.labelMedium, color = dim,
+                    modifier = Modifier.padding(start = 16.dp, bottom = 4.dp),
+                )
+            }
+            HorizontalDivider(color = SheetPalette.row(dark))
+            if (stops.isEmpty()) {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    if (loading || step == null) CircularProgressIndicator(Modifier.size(22.dp), strokeWidth = 2.dp)
+                    else Text(stringResource(R.string.route_detail_unavailable), style = MaterialTheme.typography.bodyMedium, color = dim)
+                }
+                return@Column
+            }
+            LazyColumn(Modifier.fillMaxSize().padding(horizontal = 4.dp)) {
+                itemsIndexed(stops) { i, stop ->
+                    val isFirst = i == 0
+                    val isLast = i == stops.lastIndex
+                    RouteStopRow(stop, lineColor, ink, dim, isFirst, isLast, onClick = { onStopTap(stop) })
+                }
+            }
+        }
+    }
+}
+
+/** One stop in the [RouteDetailSheet] timeline: a coloured connector rail with a node, the stop
+ *  name (board/alight emphasised), its call time, and a chevron - the whole row taps through. */
+@Composable
+private fun RouteStopRow(
+    stop: TransitStopTime,
+    lineColor: Color,
+    ink: Color,
+    dim: Color,
+    isFirst: Boolean,
+    isLast: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .dpadHighlight(RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Vertical rail + node, drawn so the line is continuous between rows. Board/alight get a
+        // bigger node; intermediate stops a smaller one - all solid in the line colour so they read
+        // on any sheet background.
+        val big = isFirst || isLast
+        Box(Modifier.width(24.dp).height(48.dp), contentAlignment = Alignment.Center) {
+            if (!isFirst) Box(Modifier.width(3.dp).fillMaxHeight().align(Alignment.TopCenter).background(lineColor))
+            if (!isLast) Box(Modifier.width(3.dp).fillMaxHeight().align(Alignment.BottomCenter).background(lineColor))
+            Box(Modifier.size(if (big) 14.dp else 9.dp).clip(CircleShape).background(lineColor))
+        }
+        Spacer(Modifier.width(10.dp))
+        Text(
+            stop.name,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = if (isFirst || isLast) FontWeight.SemiBold else FontWeight.Normal,
+            color = ink,
+            maxLines = 2,
+            modifier = Modifier.weight(1f).padding(vertical = 10.dp),
+        )
+        stop.timeText?.let {
+            Text(it, style = MaterialTheme.typography.labelMedium, color = dim, modifier = Modifier.padding(start = 8.dp))
+        }
+        Icon(Icons.Default.ChevronRight, contentDescription = null, tint = dim, modifier = Modifier.size(18.dp).padding(start = 2.dp))
     }
 }
 

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -2395,8 +2395,20 @@ private fun StopDepartureBoard(
     val nowSec by produceState(initialValue = System.currentTimeMillis() / 1000L) {
         while (true) { delay(30_000L); value = System.currentTimeMillis() / 1000L }
     }
-    Column(Modifier.padding(top = 8.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        d.lines.take(24).forEach { DepartureLineRow(it, nowSec, ink, dim, onTapRoute) }
+    // Google-style clean list: plain tappable rows separated by hairline dividers (no per-row
+    // chevron - the row itself opens the route, and its Material ripple is the affordance).
+    Column(Modifier.padding(top = 6.dp)) {
+        val lines = d.lines.take(24)
+        lines.forEachIndexed { i, line ->
+            DepartureLineRow(line, nowSec, ink, dim, onTapRoute)
+            if (i < lines.lastIndex) {
+                HorizontalDivider(
+                    color = SheetPalette.row(dark),
+                    thickness = 0.5.dp,
+                    modifier = Modifier.padding(start = 2.dp),
+                )
+            }
+        }
     }
 }
 
@@ -2414,7 +2426,7 @@ private fun DepartureLineRow(
             .clip(RoundedCornerShape(10.dp))
             .dpadHighlight(RoundedCornerShape(10.dp))
             .clickable { onTapRoute(line) }
-            .padding(vertical = 2.dp),
+            .padding(vertical = 10.dp, horizontal = 2.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -2429,8 +2441,6 @@ private fun DepartureLineRow(
             line.headwayText?.let {
                 Text(stringResource(R.string.place_every, it), style = MaterialTheme.typography.labelMedium, color = dim)
             }
-            // Affordance that the row drills into the route's stop timeline (tap-through).
-            Icon(Icons.Default.ChevronRight, contentDescription = null, tint = dim, modifier = Modifier.size(18.dp))
         }
         if (line.upcoming.isNotEmpty()) {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -2538,7 +2548,8 @@ fun RouteDetailSheet(
 }
 
 /** One stop in the [RouteDetailSheet] timeline: a coloured connector rail with a node, the stop
- *  name (board/alight emphasised), its call time, and a chevron - the whole row taps through. */
+ *  name (board/alight emphasised) and its call time - the whole row taps through (no chevron;
+ *  the connected rail + the Material ripple are the affordance, like Google's route view). */
 @Composable
 private fun RouteStopRow(
     stop: TransitStopTime,
@@ -2555,7 +2566,7 @@ private fun RouteStopRow(
             .clip(RoundedCornerShape(10.dp))
             .dpadHighlight(RoundedCornerShape(10.dp))
             .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp),
+            .padding(start = 6.dp, end = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // Vertical rail + node, drawn so the line is continuous between rows. Board/alight get a
@@ -2579,7 +2590,6 @@ private fun RouteStopRow(
         stop.timeText?.let {
             Text(it, style = MaterialTheme.typography.labelMedium, color = dim, modifier = Modifier.padding(start = 8.dp))
         }
-        Icon(Icons.Default.ChevronRight, contentDescription = null, tint = dim, modifier = Modifier.size(18.dp).padding(start = 2.dp))
     }
 }
 

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -2487,6 +2487,9 @@ fun RouteDetailSheet(
     onStopTap: (TransitStopTime) -> Unit,
 ) {
     BackHandler(onBack = onClose)
+    // D-pad: place focus on the back arrow when the sheet opens (same convention as the reviews page),
+    // so a D-pad-only user can immediately scroll the timeline / step onto a stop with no wake-up press.
+    val backFocus = rememberDpadAutoFocus()
     val dark = isAppInDarkTheme()
     val ink = if (dark) InkDark else InkLight
     val dim = if (dark) DimDark else DimLight
@@ -2509,7 +2512,7 @@ fun RouteDetailSheet(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
-                IconButton(onClick = onClose) {
+                IconButton(onClick = onClose, modifier = Modifier.focusRequester(backFocus).dpadHighlight()) {
                     Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.place_close), tint = ink)
                 }
                 step?.line?.let { LinePill(it) }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -433,6 +433,7 @@
     <string name="place_transit_stops">%1$d Haltestellen</string> <!-- format -->
     <string name="place_transit_stop_id">Haltestelle %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Tickets &amp; Infos</string>
+    <string name="route_detail_unavailable">Liniendetails nicht verfügbar</string>
     <string name="place_transit_now">Fährt ab</string>
     <string name="place_transit_in_min">in %1$d Min.</string> <!-- format -->
     <string name="place_transit_live">Live</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -433,6 +433,7 @@
     <string name="place_transit_stops">%1$d paradas</string> <!-- format -->
     <string name="place_transit_stop_id">Parada %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Billetes e info</string>
+    <string name="route_detail_unavailable">Detalles de la línea no disponibles</string>
     <string name="place_transit_now">Saliendo</string>
     <string name="place_transit_in_min">en %1$d min</string> <!-- format -->
     <string name="place_transit_live">En directo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -433,6 +433,7 @@
     <string name="place_transit_stops">%1$d arrêts</string> <!-- format -->
     <string name="place_transit_stop_id">Arrêt %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Billets et infos</string>
+    <string name="route_detail_unavailable">Détails de la ligne indisponibles</string>
     <string name="place_transit_now">Départ imminent</string>
     <string name="place_transit_in_min">dans %1$d min</string> <!-- format -->
     <string name="place_transit_live">En direct</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -433,6 +433,7 @@
     <string name="place_transit_stops">%1$d fermate</string> <!-- format -->
     <string name="place_transit_stop_id">Fermata %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Biglietti e info</string>
+    <string name="route_detail_unavailable">Dettagli linea non disponibili</string>
     <string name="place_transit_now">In partenza</string>
     <string name="place_transit_in_min">tra %1$d min</string> <!-- format -->
     <string name="place_transit_live">In diretta</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -431,6 +431,7 @@
     <string name="place_transit_stops">%1$d תחנות</string>
     <string name="place_transit_stop_id">תחנה %1$s</string>
     <string name="place_transit_tickets">כרטיסים &amp; מידע</string>
+    <string name="route_detail_unavailable">פרטי הקו אינם זמינים</string>
     <string name="place_transit_now">יוצא כעת</string>
     <string name="place_transit_in_min">בעוד %1$d דק׳</string> <!-- format -->
     <string name="place_transit_live">בשידור חי</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -454,6 +454,7 @@
     <string name="place_transit_stops">%1$d 停留所</string> <!-- format -->
     <string name="place_transit_stop_id">停留所 %1$s</string> <!-- format -->
     <string name="place_transit_tickets">チケット・運行情報</string>
+    <string name="route_detail_unavailable">路線の詳細を取得できません</string>
     <string name="place_transit_now">まもなく発車</string>
     <string name="place_transit_in_min">%1$d 分後</string> <!-- format -->
     <string name="place_transit_live">リアルタイム</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -433,6 +433,7 @@
     <string name="place_transit_stops">%1$d haltes</string> <!-- format -->
     <string name="place_transit_stop_id">Halte %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Tickets &amp; info</string>
+    <string name="route_detail_unavailable">Lijndetails niet beschikbaar</string>
     <string name="place_transit_now">Vertrekt nu</string>
     <string name="place_transit_in_min">over %1$d min</string> <!-- format -->
     <string name="place_transit_live">Live</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -435,6 +435,7 @@
     <string name="place_transit_stops">%1$d przystanków</string> <!-- format -->
     <string name="place_transit_stop_id">Przystanek %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Bilety i informacje</string>
+    <string name="route_detail_unavailable">Szczegóły linii niedostępne</string>
     <string name="place_transit_now">Odjeżdża</string>
     <string name="place_transit_in_min">za %1$d min</string> <!-- format -->
     <string name="place_transit_live">Na żywo</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -433,6 +433,7 @@
     <string name="place_transit_stops">%1$d paradas</string> <!-- format -->
     <string name="place_transit_stop_id">Parada %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Bilhetes e info</string>
+    <string name="route_detail_unavailable">Detalhes da linha indisponíveis</string>
     <string name="place_transit_now">A sair</string>
     <string name="place_transit_in_min">em %1$d min</string> <!-- format -->
     <string name="place_transit_live">Ao vivo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -435,6 +435,7 @@
     <string name="place_transit_stops">%1$d остановок</string> <!-- format -->
     <string name="place_transit_stop_id">Остановка %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Билеты и информация</string>
+    <string name="route_detail_unavailable">Сведения о маршруте недоступны</string>
     <string name="place_transit_now">Отправляется</string>
     <string name="place_transit_in_min">через %1$d мин</string> <!-- format -->
     <string name="place_transit_live">Онлайн</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -433,6 +433,7 @@
     <string name="place_transit_stops">%1$d hållplatser</string> <!-- format -->
     <string name="place_transit_stop_id">Hållplats %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Biljetter &amp; info</string>
+    <string name="route_detail_unavailable">Linjedetaljer ej tillgängliga</string>
     <string name="place_transit_now">Avgår nu</string>
     <string name="place_transit_in_min">om %1$d min</string> <!-- format -->
     <string name="place_transit_live">Live</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -435,6 +435,7 @@
     <string name="place_transit_stops">%1$d зупинок</string> <!-- format -->
     <string name="place_transit_stop_id">Зупинка %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Квитки та інформація</string>
+    <string name="route_detail_unavailable">Деталі маршруту недоступні</string>
     <string name="place_transit_now">Відправляється</string>
     <string name="place_transit_in_min">через %1$d хв</string> <!-- format -->
     <string name="place_transit_live">Наживо</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -454,6 +454,7 @@
     <string name="place_transit_stops">%1$d 站</string> <!-- format -->
     <string name="place_transit_stop_id">站牌 %1$s</string> <!-- format -->
     <string name="place_transit_tickets">票券與資訊</string>
+    <string name="route_detail_unavailable">無法取得路線詳情</string>
     <string name="place_transit_now">即將出發</string>
     <string name="place_transit_in_min">%1$d 分鐘後</string> <!-- format -->
     <string name="place_transit_live">即時</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -454,6 +454,7 @@
     <string name="place_transit_stops">%1$d 站</string> <!-- format -->
     <string name="place_transit_stop_id">站点 %1$s</string> <!-- format -->
     <string name="place_transit_tickets">购票与信息</string>
+    <string name="route_detail_unavailable">无法获取线路详情</string>
     <string name="place_transit_now">即将出发</string>
     <string name="place_transit_in_min">%1$d 分钟后</string> <!-- format -->
     <string name="place_transit_live">实时</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -460,6 +460,7 @@
     <string name="place_transit_stops">%1$d stops</string> <!-- format -->
     <string name="place_transit_stop_id">Stop %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Tickets &amp; info</string>
+    <string name="route_detail_unavailable">Route details unavailable</string>
     <string name="place_transit_now">Departing</string>
     <string name="place_transit_in_min">in %1$d min</string> <!-- format -->
     <string name="place_transit_live">Live</string>


### PR DESCRIPTION
Stacked on #91 (the departure board). Review that first; GitHub retargets this to main once #91 lands.

## What
Tapping a route on a stop's departure board now opens a scrollable **stop timeline** for that route - the board stop, every intermediate stop with its call time, and the alight stop, drawn down a vertical rail in the route's own colour (board + alight bold). Tapping any stop opens **that stop's own departure board**, so you can keep drilling down the line the way Google's tap-through does. A `>` chevron on each board row hints it's tappable.

This is what the request asked for: "you can pretty much just keep tapping and tapping through to get to other bus stops ... hoping we can do this keyless."

## How (keyless, no new endpoint)
The route's stop sequence is a lazy fetch that is **not** in the station's place blob, so instead of reverse-engineering a new RPC this reuses the **proven transit-itinerary parser**:

- `openRouteDetail(line)` geocodes the line's headsign, **biased toward transit terminals** (a bare "Richmond" otherwise resolves to a city district, not the BART terminal - it prefers a candidate whose category is a station/airport/terminal nearest the stop), then runs `webDirections.transit(stop, terminal)`.
- Among the returned ride legs it picks the one on the tapped line (label match), else the leg we actually **board at this stop** (its board stop nearest the origin - the direction tapped), else the first. That `TransitStep` already carries `boardStop` / `intermediateStops` / `alightStop` with per-stop times.
- `RouteDetailSheet` renders the timeline; each stop taps through via `onPoiTap(stop.name, stop.location)` (the precise coord makes the nearest-resolve land on the stop and fire its own board fetch).

Best-effort: an ungeocodable headsign / no ride leg flashes a quiet "Route details unavailable" and closes.

Also raised the on-sheet board cap 8 -> 24 lines to match the parser, so busy stops show more routes.

## Verified on device (Pixel 4a, release build)
BART Powell St -> tap **Yellow-S** -> full timeline of all 11 stops (Powell St, Civic Center/UN Plaza, 16th/24th St Mission, Glen/Balboa Park, Daly City, Colma, South SF, San Bruno, SFO) with times 12:23-12:54 PM. Tapping **16th St Mission** closed the detail and opened that stop's own board - tap-through confirmed.

Localized (`route_detail_unavailable`) in all 11 languages. Docs updated (README/FEATURES/CLAUDE).