### PR TITLE
Voice: pause playing music while Vela dictation is listening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -721,6 +721,13 @@ Defaults that make the safe path the easy one:
   inner periods stay (St. Paul). The listening pulse uses tween(90) + 1.4x ring travel + a 7x RMS
   gain - the default spring smoothed the ~32 ms level updates into near-stillness. **The mic always shows when the toggle is on** (2026-07-10): with neither the model nor a provider, tapping it OFFERS the Vela voice download (VelaDialog in MapScreen -> `downloadAsrModel()`, the map shows the same VoiceDownloadCard) - a hidden mic made the feature undiscoverable. **The archive is tar.GZIP on `asr-models`** (58 MB vs 47 bz2): bzip2 unpacked at ~15 MB/s on-device (a ~30 s hang); gzip installs in ~2 s. `KokoroInstaller.extractTar` picks the decompressor by magic bytes (upstream Piper voices are still bz2). Accuracy of
   tiny-int8 is the known tradeoff for size/speed; a larger model could be a future catalog entry.
+  **Pauses playing media while listening (2026-07-12):** `WhisperRecognizer.listen` takes
+  `AUDIOFOCUS_GAIN_TRANSIENT` (an `AudioFocusRequest` with `USAGE_ASSISTANT`/`CONTENT_TYPE_SPEECH`)
+  right before `audio.startRecording()` and abandons it in the `finally` after `audio.stop()`, so
+  music/podcasts PAUSE (not just duck - `_TRANSIENT`, not `_MAY_DUCK`) while dictating and resume the
+  instant the utterance ends. Only the in-process path needs it; tier-2 (SYSTEM) hands off to an
+  external recognizer that manages its own focus. Recording itself (an input `AudioRecord`) is
+  unaffected by the output-focus request.
 - **Location is requested in onboarding, NOT on map load (2026-07-10).** `MapScreen`'s
   `LaunchedEffect` only STARTS location when it's already granted; it no longer fires the raw
   system dialog. The first ask lives in `VelaRoot`: when onboarding reaches the location step

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -311,7 +311,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   sheet shows the mic pulsing with your voice; it stops on its own after a beat of silence (or tap
   Done), and the microphone permission is asked only the first time you tap the mic. When both Vela voice and a
   voice-input app are present, a Settings picker chooses which to use (Vela voice by default). Device-verified end to end: download, install, the mic appears, the permission prompt,
-  the listening sheet, and the model transcribing back into the search box.
+  the listening sheet, and the model transcribing back into the search box. **Pauses your music
+  while it listens (2026-07-12):** starting dictation takes transient audio focus
+  (`AUDIOFOCUS_GAIN_TRANSIENT`, assistant usage) so whatever is playing pauses like a phone
+  assistant does, and gives it back the moment the utterance ends so playback resumes.
 - ✅ **Transit lines are opt-in now (2026-07-10).** The purple rail highlight is off by default;
   it reads as mystery lines if you don't know what it is. Settings → Map → "Highlight transit
   lines" brings it back, and an earlier choice is kept either way.

--- a/app/src/main/java/app/vela/voice/WhisperRecognizer.kt
+++ b/app/src/main/java/app/vela/voice/WhisperRecognizer.kt
@@ -46,7 +46,7 @@ class WhisperRecognizer @Inject constructor(
     @Volatile private var loadedLang: String? = null
 
     private val audioManager by lazy { context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager }
-    private var focusRequest: AudioFocusRequest? = null
+    @Volatile private var focusRequest: AudioFocusRequest? = null
 
     /** Take TRANSIENT audio focus so whatever is playing (music, a podcast) pauses while we listen,
      *  the way a phone assistant does - `AUDIOFOCUS_GAIN_TRANSIENT` (not `_MAY_DUCK`) makes media
@@ -212,9 +212,11 @@ class WhisperRecognizer @Inject constructor(
         } catch (t: Throwable) {
             return@withContext null
         } finally {
-            runCatching { audio.stop() }
-            audio.release()
+            // Abandon focus FIRST so the music resumes even if a later call throws; every step is
+            // guarded so one failure can't skip the rest and leave playback paused forever.
             abandonAudioFocus() // let the music resume
+            runCatching { audio.stop() }
+            runCatching { audio.release() }
         }
 
         // Prefer the VAD-trimmed segment (leading/trailing silence stripped → cleaner transcript);

--- a/app/src/main/java/app/vela/voice/WhisperRecognizer.kt
+++ b/app/src/main/java/app/vela/voice/WhisperRecognizer.kt
@@ -3,7 +3,10 @@ package app.vela.voice
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
 import android.media.AudioFormat
+import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.MediaRecorder
 import androidx.core.content.ContextCompat
@@ -41,6 +44,33 @@ class WhisperRecognizer @Inject constructor(
     private val loadLock = Any()
     @Volatile private var recognizer: OfflineRecognizer? = null
     @Volatile private var loadedLang: String? = null
+
+    private val audioManager by lazy { context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager }
+    private var focusRequest: AudioFocusRequest? = null
+
+    /** Take TRANSIENT audio focus so whatever is playing (music, a podcast) pauses while we listen,
+     *  the way a phone assistant does - `AUDIOFOCUS_GAIN_TRANSIENT` (not `_MAY_DUCK`) makes media
+     *  players pause rather than just duck. Abandoned in [abandonAudioFocus] the moment we stop. */
+    private fun requestAudioFocus() {
+        val am = audioManager ?: return
+        val req = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_ASSISTANT)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build(),
+            )
+            .build()
+        focusRequest = req
+        runCatching { am.requestAudioFocus(req) }
+    }
+
+    /** Give focus back so the paused music resumes right after the utterance. */
+    private fun abandonAudioFocus() {
+        val am = audioManager ?: return
+        focusRequest?.let { req -> runCatching { am.abandonAudioFocusRequest(req) } }
+        focusRequest = null
+    }
 
     private companion object {
         const val SAMPLE_RATE = 16000
@@ -161,6 +191,7 @@ class WhisperRecognizer @Inject constructor(
         var sawSpeech = false
         var segment: FloatArray? = null
         try {
+            requestAudioFocus() // pause any playing music/podcast while we listen
             audio.startRecording()
             onListening()
             while (!cancelled() && segment == null && total < SAMPLE_RATE * MAX_SECONDS) {
@@ -183,6 +214,7 @@ class WhisperRecognizer @Inject constructor(
         } finally {
             runCatching { audio.stop() }
             audio.release()
+            abandonAudioFocus() // let the music resume
         }
 
         // Prefer the VAD-trimmed segment (leading/trailing silence stripped → cleaner transcript);


### PR DESCRIPTION
When you tap the mic and Vela's on-device recognizer starts recording, it now takes **transient audio focus** so whatever is playing (music, a podcast) pauses like a phone assistant does, and gives it back the instant the utterance ends so playback resumes.

## How
`WhisperRecognizer.listen()` requests `AUDIOFOCUS_GAIN_TRANSIENT` (an `AudioFocusRequest` with `USAGE_ASSISTANT` / `CONTENT_TYPE_SPEECH`) right before `audio.startRecording()`, and abandons it in the `finally` after `audio.stop()`. `_TRANSIENT` (not `_MAY_DUCK`) makes media players **pause** rather than just duck. Only the in-process Whisper path needs this - the tier-2 handoff to an external voice app lets that app manage its own focus. Requesting output focus doesn't disturb the input `AudioRecord` capture.

## Verified on device (Pixel 4a)
With dictation "Listening…", `dumpsys audio` shows Vela holding focus:
`pack: app.vela -- gain: GAIN_TRANSIENT -- usage=USAGE_ASSISTANT content=CONTENT_TYPE_SPEECH`
and the stack is empty again the moment dictation ends (focus released → paused media resumes).

Docs updated (FEATURES/CLAUDE).