### PR TITLE
Speed limit: online 'Speed B' streamer — posted limit without a routing graph (device-verified)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1111,6 +1111,17 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   OSM `maxspeed` (partial)** - strong on highways/EU/urban, sparse on US residential. **Remaining to light it
   up for everyone: re-bake + re-host the region graphs with `max_speed` (CI), then a fresh region download
   shows it** (a version-discriminator so *existing* offline graphs auto-re-download is a small follow-up).
+- 🟡 **Speed-limit STREAMER - online maxspeed everywhere (2026-07-12, app-side built; needs an on-road/demo-drive check).**
+  The "Speed B" source so a posted limit shows **without a downloaded routing graph**. The data half already
+  ships: `scripts/build-maxspeed-region.sh` + CI bake each region's OSM `maxspeed` ways into a small PMTiles
+  overlay on the `maxspeed-overlays` release (all 50 US states hosted, e.g. Washington 31 MB). The app half now
+  **streams** the covering region's PMTiles (`MaxspeedOverlayStore`, no download - MapLibre range-fetches the
+  visible tiles), adds it as an **invisible-but-queryable** line layer, and every ~2.5 s while driving
+  `queryRenderedFeatures` under the puck reads the `maxspeed` tag (`OsmMaxspeed.parseKmh`, unit-tested: bare
+  km/h, `mph`, `none`/country-codes → null). The sign now prefers the offline graph and **falls back to this
+  overlay** (`speedLimitKmh ?: speedLimitOverlayKmh`), so it lights up anywhere online. Keyless, ODbL. Compiles
+  + the parser is unit-tested; the on-device query (rect size / z16-overzoom / cadence) wants a real or demo
+  drive to confirm the sign reads the right number.
 - ⬜ Speed-camera + hazard alerts (lane guidance ✅ done above)
 - ✅ **Android Auto - first cut shipped 2026-07-08** (see the entry at the top of this section). The old
   "needs GMS, out of scope" call was wrong: the car app library is plain androidx, and a sideload runs fine

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1123,6 +1123,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   **Device-verified on a simulate-driving run (4a, no WA routing graph downloaded): the streamed overlay read
   72.42 km/h under the puck on the arterial and the sign showed "SPEED LIMIT 45" (`offline=null`).** Parser
   unit-tested; the WA maxspeed PMTiles streamed live (~640 range requests) and kept up with the demo puck.
+- ✅ **Speedometer = a rounded rectangle now, not a circle (2026-07-12).** The traveling-speed readout during
+  nav was a dark circle, which read differently from the rounded-rect SPEED LIMIT sign right above it. It's now
+  a **rounded rectangle the same width + corner radius as the limit sign**, so the two stack as a matched pair
+  (Google's layout) and your speed is trivially comparable to the posted limit at a glance. Dark fill keeps it
+  distinct from the white limit sign. Device-verified paired on a drive: "SPEED LIMIT 45" over "45 mph".
 - ⬜ Speed-camera + hazard alerts (lane guidance ✅ done above)
 - ✅ **Android Auto - first cut shipped 2026-07-08** (see the entry at the top of this section). The old
   "needs GMS, out of scope" call was wrong: the car app library is plain androidx, and a sideload runs fine

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1111,7 +1111,7 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   OSM `maxspeed` (partial)** - strong on highways/EU/urban, sparse on US residential. **Remaining to light it
   up for everyone: re-bake + re-host the region graphs with `max_speed` (CI), then a fresh region download
   shows it** (a version-discriminator so *existing* offline graphs auto-re-download is a small follow-up).
-- 🟡 **Speed-limit STREAMER - online maxspeed everywhere (2026-07-12, app-side built; needs an on-road/demo-drive check).**
+- ✅ **Speed-limit STREAMER - online maxspeed everywhere (2026-07-12, device-verified on a simulated drive).**
   The "Speed B" source so a posted limit shows **without a downloaded routing graph**. The data half already
   ships: `scripts/build-maxspeed-region.sh` + CI bake each region's OSM `maxspeed` ways into a small PMTiles
   overlay on the `maxspeed-overlays` release (all 50 US states hosted, e.g. Washington 31 MB). The app half now
@@ -1119,9 +1119,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   visible tiles), adds it as an **invisible-but-queryable** line layer, and every ~2.5 s while driving
   `queryRenderedFeatures` under the puck reads the `maxspeed` tag (`OsmMaxspeed.parseKmh`, unit-tested: bare
   km/h, `mph`, `none`/country-codes → null). The sign now prefers the offline graph and **falls back to this
-  overlay** (`speedLimitKmh ?: speedLimitOverlayKmh`), so it lights up anywhere online. Keyless, ODbL. Compiles
-  + the parser is unit-tested; the on-device query (rect size / z16-overzoom / cadence) wants a real or demo
-  drive to confirm the sign reads the right number.
+  overlay** (`speedLimitKmh ?: speedLimitOverlayKmh`), so it lights up anywhere online. Keyless, ODbL.
+  **Device-verified on a simulate-driving run (4a, no WA routing graph downloaded): the streamed overlay read
+  72.42 km/h under the puck on the arterial and the sign showed "SPEED LIMIT 45" (`offline=null`).** Parser
+  unit-tested; the WA maxspeed PMTiles streamed live (~640 range requests) and kept up with the demo puck.
 - ⬜ Speed-camera + hazard alerts (lane guidance ✅ done above)
 - ✅ **Android Auto - first cut shipped 2026-07-08** (see the entry at the top of this section). The old
   "needs GMS, out of scope" call was wrong: the car app library is plain androidx, and a sideload runs fine

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,6 +52,14 @@ android {
             "\"${(project.findProperty("overlayManifestUrl") as String?)
                 ?: "https://github.com/PimpinPumpkin/Vela/releases/download/building-overlays/building-overlay-manifest.json"}\"",
         )
+        // Posted speed-limit overlay (OSM maxspeed, ODbL) PMTiles catalog — the "Speed B" online source that
+        // shows a limit WITHOUT the offline routing graph. Same override pattern (-PmaxspeedManifestUrl=…).
+        buildConfigField(
+            "String",
+            "MAXSPEED_MANIFEST_URL",
+            "\"${(project.findProperty("maxspeedManifestUrl") as String?)
+                ?: "https://github.com/PimpinPumpkin/Vela/releases/download/maxspeed-overlays/maxspeed-overlay-manifest.json"}\"",
+        )
         // Open house-number (address-point) overlay (OpenAddresses) PMTiles catalog — same override pattern
         // (-PaddressManifestUrl=…). Rendered as a SymbolLayer of house numbers where OSM lacks addr:housenumber.
         buildConfigField(

--- a/app/src/main/java/app/vela/offline/MaxspeedOverlayStore.kt
+++ b/app/src/main/java/app/vela/offline/MaxspeedOverlayStore.kt
@@ -1,0 +1,61 @@
+package app.vela.offline
+
+import android.content.Context
+import app.vela.core.model.LatLng
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The "Speed B" source: the hosted **posted-speed-limit PMTiles overlays** (OSM `maxspeed` ways, built by
+ * `scripts/build-maxspeed-region.sh`), consumed STREAMING - unlike the routing/building/address stores this
+ * never downloads a file, it just hands the map view a `pmtiles://https://…` URI so MapLibre range-fetches
+ * only the visible tiles. The map adds it as an invisible line layer and `queryRenderedFeatures` under the
+ * puck reads the `maxspeed` tag, so a posted-limit sign shows anywhere online without the offline graph.
+ *
+ * Manifest is the same `{regions:[{id,name,url,sizeMb,bbox:[S,W,N,E]}]}` shape as the other overlays; fetched
+ * once and cached in memory for the process (speed limits don't move). Best-effort - a failure just means no
+ * online limit (the offline graph or a blank sign stands in).
+ */
+@Singleton
+class MaxspeedOverlayStore @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val http: OkHttpClient,
+) {
+    /** One catalog row: a region's streamed PMTiles [url] and its [s]/[w]/[n]/[e] bbox. */
+    data class Region(val id: String, val url: String, val s: Double, val w: Double, val n: Double, val e: Double) {
+        fun covers(p: LatLng) = p.lat in s..n && p.lng in w..e
+        fun area() = (n - s) * (e - w)
+    }
+
+    @Volatile private var cached: List<Region>? = null
+
+    /** Fetch + cache the overlay catalog (once per process). Empty on any failure. */
+    suspend fun manifest(manifestUrl: String): List<Region> {
+        cached?.let { return it }
+        val fetched = withContext(Dispatchers.IO) {
+            runCatching {
+                val json = http.newCall(Request.Builder().url(manifestUrl).build()).execute()
+                    .use { r -> if (!r.isSuccessful) error("HTTP ${r.code}"); r.body!!.string() }
+                val arr = JSONObject(json).getJSONArray("regions")
+                (0 until arr.length()).map { i ->
+                    val o = arr.getJSONObject(i)
+                    val b = o.getJSONArray("bbox") // [S, W, N, E]
+                    Region(o.getString("id"), o.getString("url"), b.getDouble(0), b.getDouble(1), b.getDouble(2), b.getDouble(3))
+                }
+            }.getOrDefault(emptyList())
+        }
+        if (fetched.isNotEmpty()) cached = fetched
+        return fetched
+    }
+
+    /** The streamed `pmtiles://https://…` source URIs for the overlays covering [center] (smallest region
+     *  first, so a state overlay wins over a whole-country one). Empty when no overlay covers the point. */
+    suspend fun sourcesFor(center: LatLng, manifestUrl: String): List<String> =
+        manifest(manifestUrl).filter { it.covers(center) }.sortedBy { it.area() }.map { "pmtiles://${it.url}" }
+}

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1131,8 +1131,11 @@ fun MapScreen(
             )
             val (value, unit) = formatSpeed(shownSpeed)
             val dark = isAppInDarkTheme()
+            // A ROUNDED-RECTANGLE readout (not a circle), same width + corner radius as the SPEED LIMIT
+            // sign above it, so the two stack as a matched pair and the speed is easy to compare against
+            // the limit at a glance (Google's layout). Dark fill keeps it distinct from the white limit sign.
             Surface(
-                shape = CircleShape,
+                shape = RoundedCornerShape(8.dp),
                 color = SheetPalette.bg(dark),
                 contentColor = SheetPalette.ink(dark),
                 shadowElevation = 4.dp,
@@ -1140,15 +1143,14 @@ fun MapScreen(
                     .align(Alignment.BottomStart)
                     .navigationBarsPadding()
                     .padding(start = 16.dp, bottom = navBarClearance)
-                    .size(60.dp),
+                    .width(54.dp),
             ) {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.padding(vertical = 6.dp, horizontal = 4.dp),
                 ) {
-                    Text("$value", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
-                    Text(unit, style = MaterialTheme.typography.labelSmall, color = SheetPalette.dim(dark))
+                    Text("$value", fontSize = 22.sp, fontWeight = FontWeight.Bold, lineHeight = 24.sp)
+                    Text(unit, fontSize = 9.sp, color = SheetPalette.dim(dark), lineHeight = 10.sp)
                 }
             }
         }
@@ -1165,7 +1167,7 @@ fun MapScreen(
                 modifier = Modifier
                     .align(Alignment.BottomStart)
                     .navigationBarsPadding()
-                    .padding(start = 16.dp, bottom = navBarClearance + 68.dp), // above the 60dp speedo + 8dp gap
+                    .padding(start = 16.dp, bottom = navBarClearance + 52.dp), // above the ~44dp speedo rect + 8dp gap
             )
         }
 

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -752,6 +752,10 @@ fun MapScreen(
             ambientPois = ambientMarkersOf(state),
             buildingOverlays = state.buildingOverlays,
             addressOverlays = state.addressOverlays,
+            maxspeedOverlays = state.maxspeedOverlays,
+            onRoadLimitKmh = vm::onOverlayRoadLimit,
+            speedOverlayOn = state.navigating || driveFollowing, // query the overlay only while driving
+
             trafficControls = state.trafficControls,
             navBannerBottomPx = if (state.navigating) navBannerBottomPx else 0,
             onAmbientTap = { i -> state.ambientPois.getOrNull(i)?.let(vm::selectPlace) },
@@ -1149,11 +1153,13 @@ fun MapScreen(
             }
         }
 
-        // Posted speed-limit sign — sits just above the speedometer during nav, when the on-device
-        // graph knows the current road's OSM maxspeed (hidden otherwise; sparse OSM coverage = often blank).
-        if (state.navigating && state.speedLimitKmh != null) {
+        // Posted speed-limit sign — sits just above the speedometer during nav. Prefers the on-device graph
+        // (instant, exact) and falls back to the streamed maxspeed overlay ("Speed B"), so a limit shows
+        // even with no routing region downloaded (hidden only when neither source knows it).
+        val postedLimitKmh = state.speedLimitKmh ?: state.speedLimitOverlayKmh
+        if (state.navigating && postedLimitKmh != null) {
             SpeedLimitSign(
-                limitKmh = state.speedLimitKmh!!,
+                limitKmh = postedLimitKmh,
                 speedMps = state.mySpeed,
                 imperial = Units.imperial.value,
                 modifier = Modifier

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -3478,6 +3478,7 @@ class MapViewModel @Inject constructor(
     /** The map reports the posted limit (km/h, or null) it read from the streaming overlay layer under the
      *  puck. Only the online source; the offline graph fills [speedLimitKmh] directly. */
     fun onOverlayRoadLimit(kmh: Double?) {
+        android.util.Log.i("VelaSpeedB", "overlay maxspeed=$kmh km/h (offline=${_state.value.speedLimitKmh})")
         if (kmh != _state.value.speedLimitOverlayKmh) _state.update { it.copy(speedLimitOverlayKmh = kmh) }
     }
 

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -87,6 +87,11 @@ data class MapUiState(
                                    // fix carried none. The puck's Kalman measures ONLY from this: feeding
                                    // it the held mySpeed re-injected a stale braking speed at high gain
                                    // every fix, which is what kept the puck "moving" at a red light.
+    // Posted limit read STREAMING from the hosted maxspeed PMTiles overlay (the map queries the invisible
+    // overlay layer under the puck). The "Speed B" online source used when the offline graph can't answer
+    // ([speedLimitKmh] null) - so a limit shows anywhere online without a downloaded region.
+    val maxspeedOverlays: List<String> = emptyList(), // pmtiles://https:// source URIs covering the view
+    val speedLimitOverlayKmh: Double? = null,
     val speedLimitKmh: Double? = null, // posted limit of the current road (OSM maxspeed via GraphHopper),
                                        // km/h; null = unknown/untagged/no offline graph → badge hidden.
                                        // Converted to the display unit at the badge.
@@ -250,6 +255,7 @@ class MapViewModel @Inject constructor(
     private val routingGraphStore: app.vela.offline.RoutingGraphStore,
     private val poiPackStore: app.vela.offline.PoiPackStore,
     private val overlayStore: app.vela.offline.OverlayTileStore,
+    private val maxspeedStore: app.vela.offline.MaxspeedOverlayStore,
     private val routeEngine: app.vela.core.data.RouteEngine,
     private val http: okhttp3.OkHttpClient,
     private val selfUpdater: app.vela.update.SelfUpdater,
@@ -3133,6 +3139,7 @@ class MapViewModel @Inject constructor(
         mapCenter = center
         refreshBuildingOverlays(center) // stream the building overlay for whatever region is now in view
         refreshAddressOverlays(center) // + house-number labels for that region
+        refreshMaxspeedOverlay(center) // + the posted-speed-limit overlay (read under the puck for the sign)
         refreshTrafficControls(south, west, north, east, zoom) // + traffic lights / stop signs at high zoom
         // Half-diagonal of the visible box — used to hand the map only the POIs near the view (the
         // rest can't render anyway), so an old budget phone isn't dragging 800 symbols through the
@@ -3455,6 +3462,23 @@ class MapViewModel @Inject constructor(
             val distinct = uris.distinct()
             if (distinct != _state.value.buildingOverlays) _state.update { it.copy(buildingOverlays = distinct) }
         }
+    }
+
+    /** Stream the posted-speed-limit overlay covering [center] so the map can read a limit under the puck
+     *  ("Speed B"). Streaming-only (no download): MapLibre range-fetches the visible tiles. De-duped so
+     *  panning within one region doesn't churn the source. */
+    private fun refreshMaxspeedOverlay(center: LatLng? = mapCenter ?: _state.value.myLocation) {
+        val c = center ?: return
+        viewModelScope.launch {
+            val uris = runCatching { maxspeedStore.sourcesFor(c, app.vela.BuildConfig.MAXSPEED_MANIFEST_URL) }.getOrDefault(emptyList())
+            if (uris != _state.value.maxspeedOverlays) _state.update { it.copy(maxspeedOverlays = uris) }
+        }
+    }
+
+    /** The map reports the posted limit (km/h, or null) it read from the streaming overlay layer under the
+     *  puck. Only the online source; the offline graph fills [speedLimitKmh] directly. */
+    fun onOverlayRoadLimit(kmh: Double?) {
+        if (kmh != _state.value.speedLimitOverlayKmh) _state.update { it.copy(speedLimitOverlayKmh = kmh) }
     }
 
     @Volatile

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -3478,8 +3478,10 @@ class MapViewModel @Inject constructor(
     /** The map reports the posted limit (km/h, or null) it read from the streaming overlay layer under the
      *  puck. Only the online source; the offline graph fills [speedLimitKmh] directly. */
     fun onOverlayRoadLimit(kmh: Double?) {
-        android.util.Log.i("VelaSpeedB", "overlay maxspeed=$kmh km/h (offline=${_state.value.speedLimitKmh})")
-        if (kmh != _state.value.speedLimitOverlayKmh) _state.update { it.copy(speedLimitOverlayKmh = kmh) }
+        if (kmh != _state.value.speedLimitOverlayKmh) {
+            android.util.Log.i("VelaSpeedB", "overlay maxspeed=$kmh km/h (offline=${_state.value.speedLimitKmh})")
+            _state.update { it.copy(speedLimitOverlayKmh = kmh) }
+        }
     }
 
     @Volatile

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -224,6 +224,9 @@ fun VelaMapView(
     onAmbientTap: (index: Int) -> Unit = {},
     buildingOverlays: List<String> = emptyList(), // full pmtiles:// source URIs (file:// downloaded / https:// streamed)
     addressOverlays: List<String> = emptyList(), // pmtiles:// URIs for house-number labels (streamed, OpenAddresses)
+    maxspeedOverlays: List<String> = emptyList(), // pmtiles:// URIs for the posted-speed overlay (streamed); read under the puck
+    onRoadLimitKmh: (Double?) -> Unit = {}, // reports the maxspeed (km/h) read from the overlay under the puck, or null
+    speedOverlayOn: Boolean = false, // only query the overlay while it can matter (driving / navigating)
     trafficControls: List<app.vela.core.data.TrafficControl> = emptyList(), // OSM lights + stop signs drawn at high zoom
     navBannerBottomPx: Int = 0, // measured screen-Y of the maneuver banner's bottom edge; drops the compass below it during nav
     onCameraIdle: (center: LatLng) -> Unit,
@@ -414,6 +417,63 @@ fun VelaMapView(
                 }
                 if (below != null) style.addLayerBelow(layer, below) else style.addLayer(layer)
             }
+        }
+    }
+
+    // Posted-speed-limit overlay (OSM maxspeed PMTiles, streamed): an INVISIBLE-but-queryable line layer.
+    // We never draw it (transparent), but a wide-ish line means queryRenderedFeatures under the puck reliably
+    // hits the road segment, and reading its `maxspeed` tag gives the "Speed B" online limit without a
+    // downloaded routing graph. minZoom low so it's present at nav/free-drive zoom (z16 tiles overzoom).
+    LaunchedEffect(maxspeedOverlays, styleRef) {
+        val style = styleRef ?: return@LaunchedEffect
+        runCatching { style.layers.filter { it.id.startsWith("vela-ms-") }.forEach { style.removeLayer(it) } }
+        runCatching { style.sources.filter { it.id.startsWith("vela-ms-src-") }.forEach { style.removeSource(it) } }
+        maxspeedOverlays.forEachIndexed { i, uri ->
+            runCatching {
+                val srcId = "vela-ms-src-$i"
+                style.addSource(VectorSource(srcId, uri))
+                val layer = LineLayer("vela-ms-$i", srcId).apply {
+                    setSourceLayer("maxspeed") // tippecanoe layer name (build-maxspeed-region.sh: -l maxspeed)
+                    setMinZoom(11f)
+                    setProperties(
+                        PropertyFactory.lineColor("#00000000"), // fully transparent - present for querying, never seen
+                        PropertyFactory.lineWidth(12f),          // wide hit target for the point query
+                    )
+                }
+                style.addLayer(layer)
+            }
+        }
+    }
+
+    // Poll the streamed maxspeed overlay under the puck (~2.5 s) while driving/navigating and report the
+    // posted limit up, so a sign shows online with no routing graph. Uses the RAW fix (maxspeed needs no
+    // sub-metre precision), projected to screen, queried off the invisible line layer. Main-thread (Compose)
+    // so queryRenderedFeatures is legal; runCatching guards a mid-teardown style.
+    val latestFix = rememberUpdatedState(myLocation)
+    val latestMs = rememberUpdatedState(maxspeedOverlays)
+    LaunchedEffect(speedOverlayOn) {
+        if (!speedOverlayOn) { onRoadLimitKmh(null); return@LaunchedEffect }
+        while (true) {
+            val m = mapRef
+            val fix = latestFix.value
+            if (m != null && fix != null && latestMs.value.isNotEmpty()) {
+                val kmh = runCatching {
+                    val p = m.projection.toScreenLocation(org.maplibre.android.geometry.LatLng(fix.lat, fix.lng))
+                    val r = 14f
+                    val layers = latestMs.value.indices.map { "vela-ms-$it" }.toTypedArray()
+                    m.queryRenderedFeatures(android.graphics.RectF(p.x - r, p.y - r, p.x + r, p.y + r), *layers)
+                        .asSequence()
+                        .mapNotNull { f ->
+                            app.vela.core.data.OsmMaxspeed.fromTags(
+                                f.getStringProperty("maxspeed"),
+                                f.getStringProperty("maxspeed:forward"),
+                                f.getStringProperty("maxspeed:backward"),
+                            )
+                        }.firstOrNull()
+                }.getOrNull()
+                onRoadLimitKmh(kmh)
+            }
+            kotlinx.coroutines.delay(2500)
         }
     }
 

--- a/core/src/main/java/app/vela/core/data/OsmMaxspeed.kt
+++ b/core/src/main/java/app/vela/core/data/OsmMaxspeed.kt
@@ -1,0 +1,39 @@
+package app.vela.core.data
+
+/**
+ * Parses an OSM `maxspeed` tag value into km/h - the "Speed B" online source reads these raw strings out
+ * of the hosted speed-limit PMTiles overlay (built by `scripts/build-maxspeed-region.sh`), unlike the
+ * offline GraphHopper path which reads a pre-decoded encoded value.
+ *
+ * OSM maxspeed is messy: a bare number is km/h ("50"), an explicit unit may follow ("30 mph", "50 km/h"),
+ * and a lot of non-numeric forms exist. We deliberately return **null** (unknown) rather than guess for:
+ *  - `none` (a derestricted autobahn) - a real number is not known, and a fake one is worse than a blank;
+ *  - implicit country codes (`DE:urban`, `GB:nsl_single`, `RO:motorway`) - resolving those needs a
+ *    per-country default table we don't ship;
+ *  - `signals` / `variable` / `unknown` and anything else without a leading number.
+ * Same spirit as the offline path blanking on the ambiguous 150 km/h cap.
+ */
+object OsmMaxspeed {
+    private const val MPH_TO_KMH = 1.609344
+    // A leading number, optional decimal, optional unit. Implicit codes ("de:urban") have no leading
+    // digit so they never match → null. A list/range ("50; 30") takes the first value.
+    private val NUM = Regex("""^\s*(\d+(?:\.\d+)?)\s*(mph|km/?h|kph)?""")
+
+    /** [raw] OSM maxspeed string → km/h, or null when it isn't a knowable posted number. Range-checked
+     *  to 1..200 km/h so a garbage tag can't drive a nonsense sign. */
+    fun parseKmh(raw: String?): Double? {
+        val s = raw?.trim()?.lowercase() ?: return null
+        if (s.isEmpty() || s == "none" || s == "signals" || s == "variable" || s == "unknown") return null
+        if (s == "walk") return 7.0 // OSM's living-street "walking pace" convention
+        val m = NUM.find(s) ?: return null
+        val num = m.groupValues[1].toDoubleOrNull() ?: return null
+        val kmh = if (m.groupValues[2] == "mph") num * MPH_TO_KMH else num // bare or km/h ⇒ km/h
+        return kmh.takeIf { it in 1.0..200.0 }
+    }
+
+    /** Pick the best posted value from a maxspeed feature's tags, preferring the plain `maxspeed`, then a
+     *  directional one (we don't yet know travel direction on the overlay, so forward wins as the common
+     *  carriageway sense). Returns km/h or null. */
+    fun fromTags(maxspeed: String?, forward: String? = null, backward: String? = null): Double? =
+        parseKmh(maxspeed) ?: parseKmh(forward) ?: parseKmh(backward)
+}

--- a/core/src/test/java/app/vela/core/data/OsmMaxspeedTest.kt
+++ b/core/src/test/java/app/vela/core/data/OsmMaxspeedTest.kt
@@ -1,0 +1,54 @@
+package app.vela.core.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class OsmMaxspeedTest {
+    @Test fun bareNumberIsKmh() {
+        assertEquals(50.0, OsmMaxspeed.parseKmh("50")!!, 1e-6)
+        assertEquals(30.0, OsmMaxspeed.parseKmh("30")!!, 1e-6)
+    }
+
+    @Test fun mphConverts() {
+        assertEquals(30 * 1.609344, OsmMaxspeed.parseKmh("30 mph")!!, 1e-6)
+        assertEquals(65 * 1.609344, OsmMaxspeed.parseKmh("65 mph")!!, 1e-6)
+    }
+
+    @Test fun explicitKmhUnit() {
+        assertEquals(50.0, OsmMaxspeed.parseKmh("50 km/h")!!, 1e-6)
+        assertEquals(50.0, OsmMaxspeed.parseKmh("50 kmh")!!, 1e-6)
+        assertEquals(50.0, OsmMaxspeed.parseKmh("50 kph")!!, 1e-6)
+    }
+
+    @Test fun unknownFormsAreNull() {
+        assertNull(OsmMaxspeed.parseKmh("none"))       // derestricted
+        assertNull(OsmMaxspeed.parseKmh("DE:urban"))   // implicit country code
+        assertNull(OsmMaxspeed.parseKmh("GB:nsl_single"))
+        assertNull(OsmMaxspeed.parseKmh("signals"))
+        assertNull(OsmMaxspeed.parseKmh("variable"))
+        assertNull(OsmMaxspeed.parseKmh(null))
+        assertNull(OsmMaxspeed.parseKmh(""))
+        assertNull(OsmMaxspeed.parseKmh("   "))
+    }
+
+    @Test fun walkIsSlow() {
+        assertEquals(7.0, OsmMaxspeed.parseKmh("walk")!!, 1e-6)
+    }
+
+    @Test fun listTakesFirst() {
+        assertEquals(50.0, OsmMaxspeed.parseKmh("50; 30")!!, 1e-6)
+    }
+
+    @Test fun garbageIsRangeChecked() {
+        assertNull(OsmMaxspeed.parseKmh("0"))     // below floor
+        assertNull(OsmMaxspeed.parseKmh("9999"))  // above ceiling
+    }
+
+    @Test fun fromTagsPrefersPlainThenDirectional() {
+        assertEquals(50.0, OsmMaxspeed.fromTags("50", "30 mph", null)!!, 1e-6)
+        assertEquals(30 * 1.609344, OsmMaxspeed.fromTags(null, "30 mph", null)!!, 1e-6)
+        assertEquals(40.0, OsmMaxspeed.fromTags("none", null, "40")!!, 1e-6) // plain unknown → falls through
+        assertNull(OsmMaxspeed.fromTags("none", "signals", null))
+    }
+}


### PR DESCRIPTION
The app half of the posted-speed overlay. The data half already ships (#88 bakes + hosts OSM `maxspeed` as per-region PMTiles — **all 50 US states**, e.g. Washington 31 MB). This makes a posted-limit sign show **without a downloaded routing graph**, anywhere online.

## How
- **`OsmMaxspeed.parseKmh`** (`:core`) — parse OSM maxspeed strings → km/h (bare = km/h, `mph` converts, `none`/country-codes/`signals` → null). **Unit-tested, 8 cases.**
- **`MaxspeedOverlayStore`** — resolve + **stream** the covering region's PMTiles from the hosted manifest (`pmtiles://https://…`, no download; MapLibre range-fetches the visible tiles).
- **`VelaMapView`** — add each overlay as an **invisible (transparent) but queryable** line layer, and poll `queryRenderedFeatures` under the puck ~every 2.5 s while driving to read the `maxspeed` tag → report km/h up.
- **`MapViewModel`** — `refreshMaxspeedOverlay` on viewport + `onOverlayRoadLimit`; the sign now reads the offline graph FIRST and falls back to this overlay (`speedLimitKmh ?: speedLimitOverlayKmh`), so it lights up with no region downloaded. Gated to driving/navigating (no query, no fetch otherwise). Keyless, ODbL.

## Status — needs an on-road / demo-drive check
Compiles; the parser is unit-tested; the manifest + tiles are confirmed hosted. What I could **not** verify on the bench: the actual on-device read value. The query only runs while *driving* (navigating or free-drive follow), so a parked device at a residential spot (no `maxspeed` tag) can't exercise it. A real or simulate-driving run on an arterial is needed to confirm the sign shows the right number — watch `adb logcat -s VelaSpeedB` for `overlay maxspeed=<kmh>`. The query rect (14 px) / poll cadence (2.5 s) may want tuning from that drive.

Pairs with #85 (show the sign while free-driving too) when both land.