### PR TITLE
Fix black road overlay + transit stop resolution + chevron/search-bar (device-found)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,9 +130,11 @@ Defaults that make the safe path the easy one:
   for real navigation.**
 - **GitHub releases are TWO different things - check the tag before touching one (2026-07-09).**
   `v0.*` tags are app releases (nightly prereleases, weekly stables). Every OTHER tag is
-  **infrastructure file hosting**: `tts-runtime` (the sherpa-onnx AAR CI fetches at build time),
-  `routing-graphs` (137 region graph zips + manifest), `poi-packs` (state place packs + manifest),
-  `address-overlays` and `building-overlays` (PMTiles + manifests). Those assets exist NOWHERE
+  **infrastructure file hosting** (8 as of 2026-07-13): `tts-runtime` (the sherpa-onnx AAR CI
+  fetches at build time), `asr-models` (the Whisper dictation model), `routing-graphs` (region
+  graph zips + manifest), `poi-packs` (state place packs + manifest), `address-overlays`,
+  `building-overlays` and `maxspeed-overlays` (PMTiles + manifests), `map-fonts` (Roboto glyph
+  zip). Those assets exist NOWHERE
   else - not in git, not on any server - the release IS the download backend the app's manifest
   URLs point at. Deleting one takes the corresponding offline feature down globally until its
   workflow rebuilds everything (hours). This is not hypothetical: the first nightly-prune run
@@ -1018,7 +1020,13 @@ architecture note.
   `|pal=` so a switch reloads the style like a theme flip. Post-archive twin layers
   (trails/bikeroutes/pitch/commercial) get harmonious colours in the classic fns - they exist
   in ensureLayers regardless of palette, and an unstyled LineLayer renders BLACK, so any NEW
-  twin layer must be coloured in ALL FOUR apply fns. The FLEET DEFAULT is remote:
+  twin layer must be coloured in ALL FOUR apply fns. **Same trap bit the maxspeed "Speed B" query
+  layer (fixed 2026-07-13):** its `lineColor("#00000000")` 8-digit-hex string was REJECTED by
+  MapLibre's colour parser and fell back to the default OPAQUE BLACK - a 12dp black stripe over
+  every road on the browse map (device report). For an invisible-but-queryable layer use the
+  `@ColorInt` `Color.TRANSPARENT` overload (no string parse) + `lineOpacity(0f)`, and only ADD it
+  while it's needed (the maxspeed layer is now gated to `speedOverlayOn` = driving/nav, never on the
+  browse map). Never trust an 8-hex colour STRING for transparency. The FLEET DEFAULT is remote:
   `calibration.json` `defaultMapPalette` (v15) -> `Calibration.defaultMapPalette` -> the VM
   pushes it into `MapColors.remoteDefault` at init + after refresh; a user's explicit pick
   always wins. Changing everyone's default = edit the field, bump version, re-sign, commit
@@ -1878,9 +1886,16 @@ architecture note.
   times. Rendered by `PlaceSheet.RouteDetailSheet` (full-screen `Surface`, `MapScreen` draws it over the
   place sheet when `state.routeDetail != null || routeDetailLoading`): a vertical rail in the line colour,
   board + alight bold, each `TransitStopTime` row `clickable` -> `openRouteStop(stop)` which
-  `closeRouteDetail()` + `onPoiTap(stop.name, stop.location)` (the stop's precise coord makes the
-  nearest-resolve land on it, and its own `fetchStopDepartures` fires) - so tapping a stop opens ITS
-  board and the tap-through continues. Best-effort: an ungeocodable headsign / no ride leg flashes
+  `closeRouteDetail()` + `onPoiTap(stop.name, stop.location, "transit stop")` - so tapping a stop opens
+  ITS board and the tap-through continues. **The transit KIND is load-bearing (fixed 2026-07-13):**
+  without it `onPoiTap` searched the bare name, which Google resolves to the road JUNCTION, so
+  tap-through threw you to a corner. `onPoiTap`'s pick is now TRANSIT-AWARE when a transit hint is set
+  (map tap on a stop icon OR this tap-through): it takes the nearest LIVE `TRANSIT_CAT` listing within
+  80 m, EXCLUDES `permanentlyClosed`, and SKIPS the most-reviewed-canonical override (a defunct-but-
+  reviewed old shelter was beating the live stop - the "Hwy 527 & Mill Creek Blvd shows Permanently
+  closed" device report). No live stop listing at the coordinate -> the lightweight name+location
+  placeholder stays (a stop name beats an Intersection card; no board without a real stop listing, which
+  is correct). Best-effort: an ungeocodable headsign / no ride leg flashes
   `route_detail_unavailable` (localized in all 11 langs) and the overlay closes. State on `MapUiState`:
   `routeDetail: TransitStep?`, `routeDetailTitle`, `routeDetailLoading`, guarded by `routeDetailJob`.
   The board cap was raised 8 -> 24 lines (`StopDepartureBoard` + parser `MAX_LINES`) so busy stops show

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1381,8 +1381,14 @@ architecture note.
   heading beam is smoothed the way nav is. Implemented as a SECOND per-frame ticker in `VelaMapView`
   (`LaunchedEffect(navMode, driveFollowing)`, sibling of the nav `LaunchedEffect(navMode, routePolyline)`): when
   `driveFollowing` it eases `browseBeam` toward `compassHeading ?: myBearing` (tau 0.15 s) and eases `browseCam`
-  toward `myLocation` north-up (k = 1-exp(-dt/0.16)), driving the ME source (`setMeSource`) + `moveCamera` each
-  frame, with an idle-skip when neither moved (a settled follow doesn't re-upload 60x/s). It OWNS the location
+  toward `myLocation` north-up (k = 1-exp(-dt/**0.22** s), loosened from 0.16 2026-07-13 so the camera keeps
+  CHASING between the ~1 Hz fixes instead of coasting to each and stopping = a continuous glide, nearer the nav
+  feel), driving the ME source (`setMeSource`) + `moveCamera` each frame, with an idle-skip when neither moved
+  (a settled follow doesn't re-upload 60x/s). **The PUCK draws at the EASED position (`browseCam`), not the raw
+  fix (2026-07-13):** at the raw fix the dot teleported forward on the map each fix while the camera eased to
+  catch up (the visible hop); at the eased position it stays centred and glides with the map, the locked
+  puck+camera the nav follow has. (A fuller constant-velocity dead-reckon between fixes is the next step if it
+  still isn't smooth enough - needs a real drive to tune.) It OWNS the location
   source while running, so `applyData` must NOT repaint the raw compass over it - the call sites pass `meBearing`
   (= smoothed `browseBeam` when following, else `displayBearing`). The camera `when` block has a guard branch
   (`!navMode && driveFollowing && myLocation != null`) so a new fix's recomposition can't fire an `animateCamera`

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1123,66 +1123,24 @@ fun MapScreen(
             }
         }
 
-        // Speedometer (Google-style) — bottom-left during nav. The DISPLAYED value is smoothed
-        // (Google shows the fused estimate, not each raw doppler sample — the raw 1 Hz readout
-        // flickered 59/60/61 at a steady cruise), with a small deadband so a stop reads a
-        // clean 0 instead of 1 mph jitter.
-        val speedMps = state.mySpeed
-        if (state.navigating && speedMps != null) {
-            val shownSpeed by animateFloatAsState(
-                targetValue = if (speedMps < 0.4f) 0f else speedMps,
-                animationSpec = tween(durationMillis = 600),
-                label = "speedo",
-            )
-            val (value, unit) = formatSpeed(shownSpeed)
-            val dark = isAppInDarkTheme()
-            // A ROUNDED-RECTANGLE readout (not a circle), same width + corner radius as the SPEED LIMIT
-            // sign above it, so the two stack as a matched pair and the speed is easy to compare against
-            // the limit at a glance (Google's layout). Dark fill keeps it distinct from the white limit sign.
-            Surface(
-                shape = RoundedCornerShape(8.dp),
-                color = SheetPalette.bg(dark),
-                contentColor = SheetPalette.ink(dark),
-                shadowElevation = 4.dp,
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .navigationBarsPadding()
-                    .padding(start = 16.dp, bottom = navBarClearance)
-                    .width(54.dp),
-            ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.padding(vertical = 6.dp, horizontal = 4.dp),
-                ) {
-                    Text("$value", fontSize = 22.sp, fontWeight = FontWeight.Bold, lineHeight = 24.sp)
-                    Text(unit, fontSize = 9.sp, color = SheetPalette.dim(dark), lineHeight = 10.sp)
-                }
-            }
-        }
-
-        // Posted speed-limit sign. Source (#101): prefer the on-device graph's OSM maxspeed and fall
-        // back to the streamed maxspeed overlay ("Speed B"), so a limit shows even with no routing
-        // region downloaded. Visibility (#85): during nav AND during a FREE-DRIVE (moving with no
-        // route open, on the clean map) - in free-drive the overlay poll (speedOverlayOn keys off
-        // driveFollowing) is what feeds it, so combining the two makes the free-drive sign work
-        // without a graph too. Free-drive drops it to the nav-bar line; during nav it sits above the speedo.
-        val freeDriveSpeed = !state.navigating && (state.mySpeed ?: 0f) > 3f &&
+        // Unified speed readout (Google-style), bottom-left while MOVING - during nav AND during a
+        // free-drive (browsing without a route, moving on the clean map). Always shows the current
+        // speed; the posted limit (on-device graph maxspeed, else the streamed "Speed B" overlay)
+        // tucks into the SAME box when known, and it still reads clean as just a speed when no limit
+        // is available. Over the limit -> amber. In free-drive the scale bar hides (below) so the box
+        // owns the corner, like Google's driving view.
+        val movingFree = !state.navigating && (state.mySpeed ?: 0f) > 3f &&
             !searchOpen && state.selected == null && !state.directionsOpen && !state.showSteps && !resultsShown
         val postedLimitKmh = state.speedLimitKmh ?: state.speedLimitOverlayKmh
-        if ((state.navigating || freeDriveSpeed) && postedLimitKmh != null) {
-            SpeedLimitSign(
-                limitKmh = postedLimitKmh,
+        if ((state.navigating && state.mySpeed != null) || movingFree) {
+            SpeedWidget(
                 speedMps = state.mySpeed,
+                limitKmh = postedLimitKmh,
                 imperial = Units.imperial.value,
                 modifier = Modifier
                     .align(Alignment.BottomStart)
                     .navigationBarsPadding()
-                    .padding(
-                        start = 16.dp,
-                        // above the speedo + 8dp gap during nav; in free-drive lift it above the
-                        // bottom-left scale bar so the two don't overlap.
-                        bottom = navBarClearance + if (state.navigating) 68.dp else 46.dp,
-                    ),
+                    .padding(start = 16.dp, bottom = navBarClearance),
             )
         }
 
@@ -1679,15 +1637,18 @@ fun MapScreen(
             // (The live-traffic overlay toggle moved to Settings → Map — it's a
             // niche browse-only layer, and nav now shows per-segment route traffic,
             // so it no longer earns a spot on the map.)
-            // Scale bar, bottom-left just past the attribution ⓘ.
-            ScaleBar(
-                metersPerPixel = metersPerPixel,
-                dark = darkTheme,
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .navigationBarsPadding()
-                    .padding(start = 46.dp, bottom = 16.dp + chromeLift),
-            )
+            // Scale bar, bottom-left just past the attribution ⓘ. Hidden while free-driving: the
+            // speed box owns the bottom-left corner then (Google hides the scale in its driving view).
+            if (!driveFollowing) {
+                ScaleBar(
+                    metersPerPixel = metersPerPixel,
+                    dark = darkTheme,
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .navigationBarsPadding()
+                        .padding(start = 46.dp, bottom = 16.dp + chromeLift),
+                )
+            }
         }
 
         // --- transient surfaces --------------------------------------------
@@ -3404,46 +3365,74 @@ private fun ListEditorDialog(
  * speed is noisy, so a plain > would flap). [limitKmh] is the OSM/GraphHopper value in km/h.
  */
 @Composable
-private fun SpeedLimitSign(
-    limitKmh: Double,
+private fun SpeedWidget(
     speedMps: Float?,
+    limitKmh: Double?,
     imperial: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val (limit, _) = formatSpeedLimit(limitKmh)
-    val speedNow = speedMps?.let { if (imperial) it * 2.236936f else it * 3.6f }
+    val dark = isAppInDarkTheme()
+    // Smooth the DISPLAYED speed (Google shows the fused estimate, not each raw doppler sample - the
+    // raw 1 Hz readout flickered 59/60/61 at a steady cruise), with a small deadband so a stop reads
+    // a clean 0 instead of 1 mph jitter.
+    val shownSpeed by animateFloatAsState(
+        targetValue = (speedMps ?: 0f).let { if (it < 0.4f) 0f else it },
+        animationSpec = tween(durationMillis = 600),
+        label = "speed",
+    )
+    val (value, unit) = formatSpeed(shownSpeed)
+    val speedDisp = if (imperial) shownSpeed * 2.236936f else shownSpeed * 3.6f
+    val limitDisp = limitKmh?.let { formatSpeedLimit(it).first }
     val tol = if (imperial) 3f else 5f
-    val over = speedNow != null && speedNow > limit + tol
-    val ink = Color(0xFF202124)
-    val numberColor = if (over) Color(0xFFD32F2F) else ink
-    if (imperial) {
-        Surface(
-            shape = RoundedCornerShape(8.dp),
-            color = Color.White,
-            shadowElevation = 4.dp,
-            border = BorderStroke(2.dp, ink),
-            modifier = modifier.width(54.dp),
+    val over = limitDisp != null && speedDisp > limitDisp + tol
+    val overColor = Color(0xFFE8514A)
+    val signInk = Color(0xFF202124)
+
+    // ONE box: the posted limit as a regulatory sign on top (US "SPEED LIMIT" square / metric red
+    // roundel) when known, the current speed always below. Reads clean as just a speed with no limit.
+    Surface(
+        shape = RoundedCornerShape(14.dp),
+        color = SheetPalette.bg(dark),
+        contentColor = SheetPalette.ink(dark),
+        shadowElevation = 4.dp,
+        modifier = modifier.widthIn(min = 58.dp),
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(5.dp),
+            modifier = Modifier.padding(6.dp),
         ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.padding(vertical = 5.dp, horizontal = 4.dp),
-            ) {
-                Text("SPEED", color = ink, fontSize = 8.sp, fontWeight = FontWeight.SemiBold, lineHeight = 9.sp)
-                Text("LIMIT", color = ink, fontSize = 8.sp, fontWeight = FontWeight.SemiBold, lineHeight = 9.sp)
-                Text("$limit", color = numberColor, fontSize = 22.sp, fontWeight = FontWeight.Bold, lineHeight = 24.sp)
+            if (limitDisp != null) {
+                if (imperial) {
+                    Surface(
+                        shape = RoundedCornerShape(7.dp),
+                        color = Color.White,
+                        border = BorderStroke(1.5.dp, signInk),
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier.padding(horizontal = 9.dp, vertical = 3.dp),
+                        ) {
+                            Text("SPEED", color = Color(0xFF3C4043), fontSize = 7.sp, fontWeight = FontWeight.SemiBold, lineHeight = 8.sp)
+                            Text("LIMIT", color = Color(0xFF3C4043), fontSize = 7.sp, fontWeight = FontWeight.SemiBold, lineHeight = 8.sp)
+                            Text("$limitDisp", color = if (over) overColor else signInk, fontSize = 19.sp, fontWeight = FontWeight.Bold, lineHeight = 21.sp)
+                        }
+                    }
+                } else {
+                    Surface(
+                        shape = CircleShape,
+                        color = Color.White,
+                        border = BorderStroke(3.5.dp, Color(0xFFD32F2F)),
+                        modifier = Modifier.size(42.dp),
+                    ) {
+                        Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                            Text("$limitDisp", color = if (over) overColor else signInk, fontSize = 17.sp, fontWeight = FontWeight.Bold)
+                        }
+                    }
+                }
             }
-        }
-    } else {
-        Surface(
-            shape = CircleShape,
-            color = Color.White,
-            shadowElevation = 4.dp,
-            border = BorderStroke(5.dp, Color(0xFFD32F2F)),
-            modifier = modifier.size(56.dp),
-        ) {
-            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-                Text("$limit", color = numberColor, fontSize = 20.sp, fontWeight = FontWeight.Bold)
-            }
+            Text("$value", fontSize = 25.sp, fontWeight = FontWeight.Bold, lineHeight = 27.sp, color = if (over) overColor else SheetPalette.ink(dark))
+            Text(unit, fontSize = 9.sp, color = SheetPalette.dim(dark), lineHeight = 10.sp)
         }
     }
 }

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1390,10 +1390,11 @@ class MapViewModel @Inject constructor(
     fun openRouteStop(stop: app.vela.core.model.TransitStopTime) {
         val loc = stop.location ?: return
         closeRouteDetail()
-        // The stop carries a precise coordinate from the itinerary, so onPoiTap's nearest-to-location
-        // resolve lands on the stop itself and its board fetch (fetchStopDepartures) fires - the
-        // tap-through then keeps going from the new stop's own board.
-        onPoiTap(stop.name, loc)
+        // Pass a transit KIND (not just name+coord): without it, onPoiTap searched the bare stop name,
+        // which Google resolves to the road JUNCTION - so tap-through kept throwing you to a corner
+        // (device 2026-07-13). The hint makes it search "<name> transit stop" and prefer the live
+        // stop listing, same as a map tap on the stop; its board then fires and the tap-through continues.
+        onPoiTap(stop.name, loc, "transit stop")
     }
 
     private var routeDetailJob: kotlinx.coroutines.Job? = null
@@ -1779,24 +1780,33 @@ class MapViewModel @Inject constructor(
             val resolved = runCatching {
                 val results = dataSource.search(searchQuery, location).places
                 val nearest = results.minByOrNull { p -> p.location.distanceTo(location) }
-                // A tapped POI can map to several Google listings at the same spot —
-                // e.g. a co-branded "SpeeDee Midas" has a rich "SpeeDee" profile (543
-                // reviews) AND a sparse "Midas" one (2 reviews), both at 2000 F St.
-                // Among listings essentially AT the tap (~35 m) the most-reviewed is
-                // the maintained, canonical one. But two *genuinely distinct* shops
-                // can also share a spot (a strip mall), so only override the nearest
-                // result when the canonical listing CLEARLY dominates by review count
-                // (a true duplicate, not a close call). Results are already filtered
-                // by the POI's own name, which keeps this from wandering off-place.
-                val canonical = results
-                    .filter { it.location.distanceTo(location) < 35.0 }
-                    .maxByOrNull { it.reviewCount ?: 0 }
-                val pick = if (canonical != null && nearest != null &&
-                    (canonical.reviewCount ?: 0) >= 2 * (nearest.reviewCount ?: 0) + 5
-                ) {
-                    canonical
+                val pick = if (transitHint != null) {
+                    // Transit tap: pick the OPERATING stop, not the nearest/most-reviewed thing at the
+                    // coordinate. A stop's spot usually ALSO has a road junction (Google's "Intersection")
+                    // and can carry a stale PERMANENTLY-CLOSED old shelter; nearest/most-reviewed lands on
+                    // those (device 2026-07-13: "Hwy 527 & Mill Creek Blvd" opened a Permanently-closed old
+                    // stop; the route tap-through threw you to a corner). Take the nearest LIVE
+                    // transit-category listing near the tap, and SKIP the most-reviewed override (a
+                    // defunct-but-reviewed shelter must not beat the live stop). No such listing -> null,
+                    // so the lightweight name+location placeholder set above stays (a stop name beats a
+                    // corner; there's no board without a real stop listing anyway).
+                    results.asSequence()
+                        .filter { !it.permanentlyClosed && it.location.distanceTo(location) < 80.0 }
+                        .filter { p -> p.category?.let { c -> TRANSIT_CAT.containsMatchIn(c) } == true }
+                        .minByOrNull { it.location.distanceTo(location) }
                 } else {
-                    nearest
+                    // A tapped POI can map to several Google listings at one spot - e.g. a co-branded
+                    // "SpeeDee Midas" has a rich "SpeeDee" profile (543 reviews) AND a sparse "Midas" one,
+                    // both at 2000 F St. Among listings ~AT the tap (35 m) the most-reviewed is the
+                    // maintained, canonical one, but two genuinely distinct shops can also share a spot
+                    // (a strip mall), so only override nearest when the canonical listing CLEARLY dominates
+                    // by review count (a true duplicate, not a close call).
+                    val canonical = results
+                        .filter { it.location.distanceTo(location) < 35.0 }
+                        .maxByOrNull { it.reviewCount ?: 0 }
+                    if (canonical != null && nearest != null &&
+                        (canonical.reviewCount ?: 0) >= 2 * (nearest.reviewCount ?: 0) + 5
+                    ) canonical else nearest
                 }
                 pick to results
             }.getOrNull()

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -440,13 +440,18 @@ fun VelaMapView(
     }
 
     // Posted-speed-limit overlay (OSM maxspeed PMTiles, streamed): an INVISIBLE-but-queryable line layer.
-    // We never draw it (transparent), but a wide-ish line means queryRenderedFeatures under the puck reliably
-    // hits the road segment, and reading its `maxspeed` tag gives the "Speed B" online limit without a
-    // downloaded routing graph. minZoom low so it's present at nav/free-drive zoom (z16 tiles overzoom).
-    LaunchedEffect(maxspeedOverlays, styleRef) {
+    // We never draw it, but a wide-ish line means queryRenderedFeatures under the puck reliably hits the
+    // road segment, and reading its `maxspeed` tag gives the "Speed B" online limit without a downloaded
+    // routing graph. minZoom low so it's present at nav/free-drive zoom (z16 tiles overzoom).
+    // ONLY added while speedOverlayOn (driving/nav) - the poll reads it only then, and adding it during a
+    // plain browse was pure overhead AND rendered a BLACK stripe over every road: MapLibre's colour parser
+    // rejected the 8-digit "#00000000" and fell back to its default OPAQUE BLACK. Fixed by the transparent
+    // @ColorInt overload (no string parsing) and by not carrying the layer on the browse map at all.
+    LaunchedEffect(maxspeedOverlays, styleRef, speedOverlayOn) {
         val style = styleRef ?: return@LaunchedEffect
         runCatching { style.layers.filter { it.id.startsWith("vela-ms-") }.forEach { style.removeLayer(it) } }
         runCatching { style.sources.filter { it.id.startsWith("vela-ms-src-") }.forEach { style.removeSource(it) } }
+        if (!speedOverlayOn) return@LaunchedEffect // no query layer on the browse map
         maxspeedOverlays.forEachIndexed { i, uri ->
             runCatching {
                 val srcId = "vela-ms-src-$i"
@@ -455,7 +460,8 @@ fun VelaMapView(
                     setSourceLayer("maxspeed") // tippecanoe layer name (build-maxspeed-region.sh: -l maxspeed)
                     setMinZoom(11f)
                     setProperties(
-                        PropertyFactory.lineColor("#00000000"), // fully transparent - present for querying, never seen
+                        PropertyFactory.lineColor(android.graphics.Color.TRANSPARENT), // @ColorInt, unambiguously transparent
+                        PropertyFactory.lineOpacity(0f),         // belt-and-suspenders: never drawn
                         PropertyFactory.lineWidth(12f),          // wide hit target for the point query
                     )
                 }

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -619,7 +619,10 @@ fun VelaMapView(
                         browseCam[1] = cp.target?.longitude ?: loc.lng
                     }
                 }
-                val k = (1f - kotlin.math.exp(-dt / 0.16f)).toDouble()
+                // tau 0.22 s (was 0.16): a slightly longer time-constant keeps the camera CHASING
+                // between the ~1 Hz fixes instead of coasting to each one and stopping, so the follow
+                // reads as a continuous glide (closer to the nav feel) rather than a per-second ease.
+                val k = (1f - kotlin.math.exp(-dt / 0.22f)).toDouble()
                 browseCam[0] += (loc.lat - browseCam[0]) * k
                 browseCam[1] += (loc.lng - browseCam[1]) * k
                 camLat = browseCam[0]; camLng = browseCam[1]
@@ -634,7 +637,13 @@ fun VelaMapView(
                 kotlin.math.abs(camLng - lastBrowse[1]) > 1e-6 ||
                 kotlin.math.abs(beam - lastBrowse[2]) > 0.4
             if (moved) {
-                setMeSource(style, loc, beam)
+                // Draw the puck at the EASED follow position (camLat/camLng), not the raw fix: at the
+                // raw fix the dot teleported forward on the map each 1 Hz fix while the camera eased to
+                // catch up (the visible hop). At the eased position the dot stays centred and glides with
+                // the map - the same locked puck+camera the nav follow shows. (Falls back to the raw fix
+                // while pinching, when the camera isn't easing.)
+                val puckAt = if (cam != null && !scaling[0]) LatLng(camLat, camLng) else loc
+                setMeSource(style, puckAt, beam)
                 if (cam != null && !scaling[0]) {
                     cam.moveCamera(CameraUpdateFactory.newLatLng(MLLatLng(camLat, camLng)))
                 }

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -301,9 +301,15 @@ fun PlaceSheet(
     // detents equal that height, so every detent computation resolves to it and the drag can't
     // resize the sheet.
     val singleDetent = isParking
+    // A transit stop's departure board is a scrollable half-sheet (Google's UX): cap its expanded
+    // detent at PEEK so the chevron/drag can't grow it into empty space above a short board and, in
+    // doing so, cover + hide the search bar for no gain (device report 2026-07-13: "tapping the
+    // chevron on a stop with nothing more to show still hides the search bar"). Long boards scroll
+    // within the half-sheet. Paired with the onExpandedChange gate below so it never reports "covered".
+    val isTransitBoard = stopDepartures != null || stopDeparturesLoading
     val minH = if (singleDetent) screenH * 0.30f else screenH * 0.26f
     val peekH = if (singleDetent) screenH * 0.30f else screenH * 0.56f
-    val expH = if (singleDetent) screenH * 0.30f else screenH * 0.92f
+    val expH = if (singleDetent) screenH * 0.30f else if (isTransitBoard) peekH else screenH * 0.92f
     fun detentFor(expanded: Boolean, minimized: Boolean) = when {
         expanded -> expH
         minimized -> minH
@@ -529,7 +535,9 @@ fun PlaceSheet(
     // Report the expanded detent up: MapScreen kills the search bar's taps while the sheet
     // covers it (a tap on the sliver of bar behind an expanded sheet opened search OVER the
     // place card, user 2026-07-11).
-    LaunchedEffect(expandedState.value) { onExpandedChange(expandedState.value) }
+    // A transit board is capped at peek (see above), so it never actually covers the search bar -
+    // never report it as expanded, or the bar would hide with the sheet nowhere near it.
+    LaunchedEffect(expandedState.value, isTransitBoard) { onExpandedChange(expandedState.value && !isTransitBoard) }
     val onPanelEngaged: () -> Unit = {
         reviewsEngaged.value = true
         scope.launch {


### PR DESCRIPTION
Three bugs found testing the 0712 nightly (v0.4.612).

## Black stripe over every road (P0, device-confirmed fixed on a 4a)
The maxspeed 'Speed B' query layer used `lineColor("#00000000")` - an 8-digit hex string MapLibre's parser rejects, so it fell back to the default **opaque black**, a 12dp stripe over every road with maxspeed coverage. It was also added during plain browsing (every `onViewport`) for no reason. Fix: `@ColorInt Color.TRANSPARENT` + `lineOpacity(0f)`, and only add the layer while `speedOverlayOn` (driving/nav).

## Transit stop -> corner / 'Permanently closed' (bugs C+D)
`onPoiTap` re-searched by name and picked nearest/most-reviewed, which for a stop is the road junction or a stale reviewed shelter. Now transit-aware: nearest **live** `TRANSIT_CAT` listing within 80 m, excludes `permanentlyClosed`, skips the most-reviewed override; keeps the stop-name placeholder when only an intersection exists. Route tap-through now passes the transit kind it was dropping.

## Chevron hid the search bar with nothing to expand (bug B)
Transit board is now a capped scrollable half-sheet that never covers the search bar and never reports 'expanded'.

Compiles + `:core:test` green. Black overlay device-verified gone; the transit/chevron fixes are code-verified (hard to repro the exact stop remotely) - good to confirm on the next nightly.