### PR TITLE
Flock cameras: show at route-overview zoom + diagnostics for the 'don't see them' report

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -3832,11 +3832,18 @@ class MapViewModel @Inject constructor(
             delay(350)
             val padLat = (north - south) * 0.5; val padLng = (east - west) * 0.5
             val s = south - padLat; val n = north + padLat; val w = west - padLng; val e = east + padLng
-            val res = runCatching {
-                withContext(Dispatchers.IO) {
-                    app.vela.core.data.OverpassAlprCameras.fetchInBox(http, s, w, n, e)
-                }
-            }.getOrNull() ?: return@launch
+            // fetchInBox returns NULL on failure (network/timeout/non-2xx), an empty list on a clean
+            // "no cameras here". Record both to the shareable diagnostic (Settings -> Diagnostics): on
+            // GrapheneOS adb logcat can't see app logs, so this is how a "cameras don't show" report is
+            // actually diagnosable - the user shares diagnostics and the fetch outcome is right there.
+            val res = withContext(Dispatchers.IO) {
+                runCatching { app.vela.core.data.OverpassAlprCameras.fetchInBox(http, s, w, n, e) }.getOrNull()
+            }
+            if (res == null) {
+                diag.record("flock", "camera fetch failed at z${"%.1f".format(zoom)}", "Overpass box [$s,$w,$n,$e]")
+                android.util.Log.i("VelaFlock", "fetch FAILED zoom=$zoom")
+                return@launch
+            }
             flockBox = doubleArrayOf(s, w, n, e)
             val cLat0 = (s + n) / 2; val cLng0 = (w + e) / 2
             val lngScale = kotlin.math.cos(Math.toRadians(cLat0))
@@ -3844,6 +3851,7 @@ class MapViewModel @Inject constructor(
                 val dLat = it.loc.lat - cLat0; val dLng = (it.loc.lng - cLng0) * lngScale
                 dLat * dLat + dLng * dLng
             }.take(CONTROLS_ONSCREEN_CAP)
+            diag.record("flock", "showing ${kept.size} camera(s) at z${"%.1f".format(zoom)}", if (res.size != kept.size) "fetched ${res.size}, capped" else null)
             android.util.Log.i("VelaFlock", "fetched=${res.size} kept=${kept.size} zoom=$zoom")
             _state.update { it.copy(flockCameras = kept) }
         }
@@ -4018,7 +4026,12 @@ class MapViewModel @Inject constructor(
     companion object {
         const val KEY_DISMISSED = "dismissed"
         const val CONTROLS_MIN_ZOOM = 16.0 // draw traffic lights/stop signs only when zoomed in this close
-        const val FLOCK_MIN_ZOOM = 13.0 // ALPR cameras are sparse - show them from a neighbourhood zoom
+        // ALPR cameras are sparse, so show them from a WIDE zoom - lowered 13 -> 11 (2026-07-13) so
+        // they're visible on a whole-ROUTE overview, not just after you zoom into a neighbourhood. The
+        // "I know this route has cameras but don't see any" report was almost certainly this: a route
+        // overview sits at ~z11-12, under the old z13 gate. The tag is rare, so the wider Overpass box
+        // stays light (and the on-screen count is capped).
+        const val FLOCK_MIN_ZOOM = 11.0
         const val CONTROLS_ONSCREEN_CAP = 400 // max controls handed to the map (nearest-to-center wins) — a
                                               // dense metro's padded box can carry 1000+, and every handed
                                               // symbol is re-collided per drag frame (budget-GPU jank)


### PR DESCRIPTION
Addresses the 'I know this route has cameras but don't see any' report.

**Root cause (most likely):** cameras only drew at z13+ (neighbourhood zoom), but a whole-route overview sits at ~z11-12 - so nothing showed until you zoomed in. Lowered `FLOCK_MIN_ZOOM` 13 -> 11.

**Diagnosability:** the fetch outcome is now recorded to the shareable diagnostic (Settings -> Diagnostics). This 4a is GrapheneOS, which blocks app logs from `adb logcat`, so I couldn't read the fetch result on-device - now a 'cameras don't show' report is diagnosable from a shared diagnostic (shows `showing N` vs `fetch failed`).

**Not a regression:** the display code is byte-identical to when it was device-verified drawing cameras (task #170); the merge only *added* the route-avoid `fetchAlong`. Data confirmed present (60+ DeFlock cameras in the area). Reminder that the map display and the routing avoid are two separate toggles, both needed.

Compiles clean.