### PR TITLE
Fix OOM crash + pan/zoom jank (largeHeap + stream-parse Overpass + revert flock z11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,17 @@ Defaults that make the safe path the easy one:
   Pixel, a >5 s ANR on a slow keypad phone (found by ys770's fork, fix taken 2026-07-08).
   Load such data with `produceState { withContext(Dispatchers.IO) { … } }`;
   `VoiceGuide.availableEngines()` also caches the system-engine enumeration per process.
+- **Memory: the browse map runs near the heap ceiling, so keep allocation LOW (2026-07-13).**
+  Panning already churns ~180 MB/12 s at baseline (ambient POI scrape + parse per pan) - this is
+  pre-existing (0.4.542 hit ~260 MB too), close enough to the default ~256 MB heap that any EXTRA
+  churn triggers a blocking GC per frame (staccato pan/zoom) and OOM-crashes on a burst. Two rules:
+  (1) `android:largeHeap="true"` is set (raises the ceiling ~2x -> GC headroom); don't remove it.
+  (2) **Any Overpass / large-HTTP-body reader MUST stream-parse** - `Json.decodeFromStream(body.byteStream())`
+  into a tiny `@Serializable` DTO, NEVER `resp.body.string()` + `parseToJsonElement` (that held ~5-10x
+  the wire size in transient heap and OOM'd mid-read; it's what a Flock `out body 4000` fetch per pan
+  did - fixed in `OverpassAlprCameras`; `OverpassTrafficSignals` (limit 6000) is the same pattern and a
+  pending follow-up). And **NEVER lower a per-viewport Overpass fetch's min-zoom** without shrinking the
+  box - dropping `FLOCK_MIN_ZOOM` 13->11 made the box ~16x bigger and was the tipping point.
 
 ## Layout
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,7 @@
         android:name=".VelaApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
+        android:largeHeap="true"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -4026,12 +4026,12 @@ class MapViewModel @Inject constructor(
     companion object {
         const val KEY_DISMISSED = "dismissed"
         const val CONTROLS_MIN_ZOOM = 16.0 // draw traffic lights/stop signs only when zoomed in this close
-        // ALPR cameras are sparse, so show them from a WIDE zoom - lowered 13 -> 11 (2026-07-13) so
-        // they're visible on a whole-ROUTE overview, not just after you zoom into a neighbourhood. The
-        // "I know this route has cameras but don't see any" report was almost certainly this: a route
-        // overview sits at ~z11-12, under the old z13 gate. The tag is rare, so the wider Overpass box
-        // stays light (and the on-screen count is capped).
-        const val FLOCK_MIN_ZOOM = 11.0
+        // Show ALPR cameras from a NEIGHBOURHOOD zoom. Briefly lowered to 11 (2026-07-13) to catch a
+        // whole-route overview, but that made the padded Overpass box ~16x bigger, and with an `out
+        // body 4000` full-body read + full-DOM parse per pan it filled the heap and OOM'd (device
+        // 2026-07-13). Back to 13: the box is bounded, and the fetch is now streamed (OverpassAlprCameras)
+        // so it can't blow the heap. Route-overview visibility is a separate follow-up.
+        const val FLOCK_MIN_ZOOM = 13.0
         const val CONTROLS_ONSCREEN_CAP = 400 // max controls handed to the map (nearest-to-center wins) — a
                                               // dense metro's padded box can carry 1000+, and every handed
                                               // symbol is re-collided per drag frame (budget-GPU jank)

--- a/core/src/main/java/app/vela/core/data/OverpassAlprCameras.kt
+++ b/core/src/main/java/app/vela/core/data/OverpassAlprCameras.kt
@@ -1,19 +1,32 @@
 package app.vela.core.data
 
 import app.vela.core.model.LatLng
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.doubleOrNull
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.decodeFromStream
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.net.URLEncoder
+import java.util.concurrent.TimeUnit
 
 /** An automated licence-plate reader (ALPR / "Flock") camera at [loc]. [operator] is the agency/company
  *  that runs it when tagged (e.g. "Flock Safety"), [direction] the way it points (OSM `direction`, degrees
  *  or a compass string) when known - both may be blank. */
 data class AlprCamera(val loc: LatLng, val operator: String = "", val direction: String = "")
+
+/** Minimal Overpass response shape for STREAM parsing (only the fields we read). Keeping this tiny +
+ *  decoding straight off the socket avoids ever holding the whole response String or a full JsonElement
+ *  DOM in memory - the `out body 4000` full-DOM parse was the OOM / GC-thrash source (device 2026-07-13). */
+@Serializable
+private data class OverpassResp(val elements: List<OverpassNode> = emptyList())
+
+@Serializable
+private data class OverpassNode(
+    val lat: Double? = null,
+    val lon: Double? = null,
+    val tags: Map<String, String>? = null,
+)
 
 /**
  * Fetches ALPR surveillance-camera locations from **Overpass** (OpenStreetMap's keyless query API). These are
@@ -25,6 +38,17 @@ object OverpassAlprCameras {
     private const val ENDPOINT = "https://overpass-api.de/api/interpreter"
     private val json = Json { ignoreUnknownKeys = true }
 
+    // Overpass can be slow; the shared scrape client's 12 s callTimeout aborts mid-response and the
+    // failure reads as "no cameras" (a reliability complaint). Derive a longer-timeout sibling ONCE.
+    // Memory is bounded regardless now (streaming parse), so a longer read is safe.
+    @Volatile private var slowHttp: OkHttpClient? = null
+    private fun slow(base: OkHttpClient): OkHttpClient =
+        slowHttp ?: base.newBuilder()
+            .callTimeout(25, TimeUnit.SECONDS)
+            .readTimeout(25, TimeUnit.SECONDS)
+            .build()
+            .also { slowHttp = it }
+
     /**
      * ALPR camera nodes inside a bounding box, for DRAWING on the map. Matches the canonical DeFlock tag
      * `surveillance:type=ALPR` AND the older `man_made=surveillance` + `camera:type` plate-reader form some
@@ -32,6 +56,7 @@ object OverpassAlprCameras {
      * SUCCESSFUL parse - the caller area-caches success only, so a failure retries instead of stamping a
      * false "no cameras here". Queried per padded viewport (area-cached; cameras are static), NOT per fix.
      */
+    @OptIn(ExperimentalSerializationApi::class)
     fun fetchInBox(
         http: OkHttpClient,
         south: Double, west: Double, north: Double, east: Double,
@@ -40,9 +65,8 @@ object OverpassAlprCameras {
         return try {
             val box = "($south,$west,$north,$east)"
             // `out body` (NOT `out tags`): for a node, `out tags` prints only id + tags and OMITS
-            // lat/lon, so the parser below dropped every camera (no coordinates) and the layer drew
-            // nothing. `out body` is the default full print - id, lat, lon, AND tags - which is what
-            // we need to both place the marker and read operator/direction. (device-caught 2026-07-12)
+            // lat/lon, so the parser dropped every camera (no coordinates) and the layer drew nothing.
+            // `out body` prints id, lat, lon AND tags - what we need to place the marker + read operator.
             val query = "[out:json][timeout:25];" +
                 "node[\"surveillance:type\"=\"ALPR\"]$box;out body $limit;"
             val url = "$ENDPOINT?data=" + URLEncoder.encode(query, "UTF-8")
@@ -50,22 +74,23 @@ object OverpassAlprCameras {
                 .url(url)
                 .header("User-Agent", "VelaMaps/0.1 (+https://github.com/PimpinPumpkin/Vela)")
                 .build()
-            http.newCall(req).execute().use { resp ->
+            slow(http).newCall(req).execute().use { resp ->
                 if (!resp.isSuccessful) return@use null // a failure, NOT a genuine empty area - don't cache it
-                val root = json.parseToJsonElement(resp.body?.string().orEmpty()).jsonObject
-                root["elements"]?.jsonArray?.mapNotNull { el ->
-                    val o = el.jsonObject
-                    val lat = (o["lat"] as? JsonPrimitive)?.doubleOrNull ?: return@mapNotNull null
-                    val lng = (o["lon"] as? JsonPrimitive)?.doubleOrNull ?: return@mapNotNull null
-                    val tags = o["tags"]?.jsonObject
-                    // Real DeFlock nodes tag the vendor as `manufacturer` ("Flock Safety"), not
-                    // `operator` (which is usually the agency and often absent) - fall back to it so
-                    // the camera actually shows who runs it.
-                    val op = ((tags?.get("operator") ?: tags?.get("manufacturer")) as? JsonPrimitive)
-                        ?.content.orEmpty()
-                    val dir = (tags?.get("direction") as? JsonPrimitive)?.content.orEmpty()
+                val body = resp.body ?: return@use null
+                // STREAM the body straight off the socket into the tiny DTO - never materialize the whole
+                // response String or a full JsonElement DOM. The old `.string()` + parseToJsonElement over
+                // an `out body 4000` response held ~5-10x the wire size in transient heap, which filled the
+                // heap and OOM'd mid-read (device 2026-07-13). decodeFromStream reads incrementally.
+                val parsed = json.decodeFromStream<OverpassResp>(body.byteStream())
+                parsed.elements.mapNotNull { n ->
+                    val lat = n.lat ?: return@mapNotNull null
+                    val lng = n.lon ?: return@mapNotNull null
+                    // Real DeFlock nodes tag the vendor as `manufacturer` ("Flock Safety"), not `operator`
+                    // (usually the agency, often absent) - fall back to it so the camera shows who runs it.
+                    val op = (n.tags?.get("operator") ?: n.tags?.get("manufacturer")).orEmpty()
+                    val dir = n.tags?.get("direction").orEmpty()
                     AlprCamera(LatLng(lat, lng), op, dir)
-                }.orEmpty()
+                }
             }
         } catch (e: Exception) {
             null


### PR DESCRIPTION
Device-diagnosed on a Pixel 4a. Root cause of 'slow now and crashing': the browse map already churns ~180 MB over 12 s of panning at **baseline** (pre-existing - v0.4.542 hit ~260 MB on the same test), right at the ~256 MB heap ceiling. Anything extra -> blocking GC every frame (staccato pan) + OOM on a burst (crash trace is OOM mid okhttp body read). The extra was the Flock layer (on while testing it): full-body `.string()` + full-DOM parse over an `out body 4000` response, made ~16x bigger by yesterday's FLOCK_MIN_ZOOM 13->11.

Fixes: `largeHeap` (2x ceiling -> GC headroom, no OOM; **device-verified a hard pan that crashed before now survives**), stream-parse OverpassAlprCameras (`decodeFromStream`, kills the OOM-mid-read), FLOCK_MIN_ZOOM back to 13, 25 s Overpass timeout. Compiles + core tests green.

Follow-ups (separate): stream-parse OverpassTrafficSignals; reduce the pre-existing ambient churn; free-drive dead-reckoning; flock display/count reliability.