### PR TITLE
Fix browse-map pan jank: motion-arm the speed overlay (the real 0.4.542 regression)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1036,8 +1036,15 @@ architecture note.
   MapLibre's colour parser and fell back to the default OPAQUE BLACK - a 12dp black stripe over
   every road on the browse map (device report). For an invisible-but-queryable layer use the
   `@ColorInt` `Color.TRANSPARENT` overload (no string parse) + `lineOpacity(0f)`, and only ADD it
-  while it's needed (the maxspeed layer is now gated to `speedOverlayOn` = driving/nav, never on the
-  browse map). Never trust an 8-hex colour STRING for transparency. The FLEET DEFAULT is remote:
+  while it's needed. **`speedOverlayOn` is MOTION-ARMED (`speedOverlayArmed` in MapScreen, 2026-07-13):**
+  armed the moment `navigating || mySpeed > 3 m/s`, disarmed after 2 min of stillness - NEVER keyed on
+  `driveFollowing` alone. driveFollowing is true on the bare browse map (followMe defaults on), and
+  keying the overlay off it mounted the PMTiles sources while browsing AND removed them from the style
+  MID-GESTURE when the first pan dropped followMe - that native style churn was the post-0.4.542
+  "atrocious panning" regression (user device A/B: 542 smooth, wave janky). The hysteresis also stops
+  stoplight churn. The scale bar hides only while `driveFollowing && speedOverlayArmed` (actually
+  free-driving) - `!driveFollowing` alone had it hidden on the whole browse map.
+  Never trust an 8-hex colour STRING for transparency. The FLEET DEFAULT is remote:
   `calibration.json` `defaultMapPalette` (v15) -> `Calibration.defaultMapPalette` -> the VM
   pushes it into `MapColors.remoteDefault` at init + after refresh; a user's explicit pick
   always wins. Changing everyone's default = edit the field, bump version, re-sign, commit

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -320,6 +320,22 @@ fun MapScreen(
     var followMe by remember { mutableStateOf(true) }
     val driveFollowing = followMe && !state.navigating && !resultsShown && state.selected == null &&
         !state.directionsOpen && !state.showSteps && !searchOpen && state.pickOnMap == null
+    // The posted-limit ("Speed B") overlay is armed by ACTUAL MOTION, never by the bare browse map.
+    // driveFollowing alone is true whenever you're just looking at the map (followMe defaults on), and
+    // keying the overlay off it mounted the maxspeed PMTiles sources on the browse map - native tile
+    // fetch + tessellation on every pan/zoom - AND ripped them out of the style MID-GESTURE the moment
+    // a pan dropped followMe. That style churn was the post-0.4.542 "atrocious panning" regression
+    // (device A/B 2026-07-13: 542 smooth, wave builds janky; 542 has no maxspeed overlay). Motion arms
+    // it instantly; stillness disarms after 2 min so stoplights/parking don't churn sources either.
+    var speedOverlayArmed by remember { mutableStateOf(false) }
+    val movingNow = state.navigating || (state.mySpeed ?: 0f) > 3f
+    LaunchedEffect(movingNow) {
+        if (movingNow) speedOverlayArmed = true
+        else if (speedOverlayArmed) {
+            kotlinx.coroutines.delay(120_000)
+            speedOverlayArmed = false
+        }
+    }
     // Bumped when the user grabs the map with a sheet open — each sheet glides down to its
     // minimized form on its bump (see onUserPan below).
     var sheetPanTick by remember { mutableStateOf(0) }
@@ -758,7 +774,7 @@ fun MapScreen(
             addressOverlays = state.addressOverlays,
             maxspeedOverlays = state.maxspeedOverlays,
             onRoadLimitKmh = vm::onOverlayRoadLimit,
-            speedOverlayOn = state.navigating || driveFollowing, // query the overlay only while driving
+            speedOverlayOn = speedOverlayArmed, // motion-armed with hysteresis - NEVER on the parked browse map
 
             trafficControls = state.trafficControls,
             flockCameras = state.flockCameras,
@@ -1637,9 +1653,10 @@ fun MapScreen(
             // (The live-traffic overlay toggle moved to Settings → Map — it's a
             // niche browse-only layer, and nav now shows per-segment route traffic,
             // so it no longer earns a spot on the map.)
-            // Scale bar, bottom-left just past the attribution ⓘ. Hidden while free-driving: the
-            // speed box owns the bottom-left corner then (Google hides the scale in its driving view).
-            if (!driveFollowing) {
+            // Scale bar, bottom-left just past the attribution ⓘ. Hidden only while ACTUALLY
+            // free-driving (moving, speed box on screen) - `!driveFollowing` alone hid it on the
+            // whole browse map, since follow is armed by default (regression, 0.4.542..wave).
+            if (!(driveFollowing && speedOverlayArmed)) {
                 ScaleBar(
                     metersPerPixel = metersPerPixel,
                     dark = darkTheme,


### PR DESCRIPTION
The user's device A/B (542 smooth, wave builds atrocious) pointed here: `speedOverlayOn = navigating || driveFollowing` mounted the invisible maxspeed PMTiles sources on the parked BROWSE map (driveFollowing is true whenever followMe is armed, which is the default), and the first pan gesture dropped followMe and ripped those sources out of the style MID-GESTURE. Native style mutation exactly while touching the map = the atrocious pan/zoom. The earlier heap A/B missed it because it's render-thread work, not Java allocation.

Fix: motion-armed with hysteresis (`speedOverlayArmed`: on at speed > 3 m/s or nav, off after 2 min of stillness). The parked browse map never mounts the overlay, so nothing gets ripped out mid-gesture; stoplights don't churn either. Also restores the browse-map scale bar (hidden since the wave by `!driveFollowing`).

Device-verified on the 4a: scale bar back (visible marker the sources are unmounted while browsing), alive through the hard-pan script. The definitive smoothness verdict is a thumb on the P9 - grab the nightly.