### PR TITLE
Transit stops: skip the review scrape

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1582,6 +1582,10 @@ class MapViewModel @Inject constructor(
     private fun fetchReviews(p: Place, force: Boolean = false) {
         // "Show reviews" off: no review section is rendered, so don't scrape either.
         if (!app.vela.ui.ShowReviews.on.value) return
+        // Transit stops: never scrape reviews. Nobody reads bus-stop reviews, the WebView grind
+        // slows the departure board (the thing you actually opened the stop for), and the section
+        // rendered awkwardly (user 2026-07-13). The board + stop timeline are the content here.
+        if (p.category?.let { TRANSIT_CAT.containsMatchIn(it) } == true) return
         // Supersede any in-flight scrape: the fetcher serializes on a Mutex, so an abandoned
         // 40 s Taco Bell grind would otherwise make the NEXT place's reviews queue behind it
         // (~90 s worst case to first review). Cancelling frees the mutex immediately, and this


### PR DESCRIPTION
Bus-stop reviews are noise: the scrape competed with the departure board load and the section rendered awkwardly. fetchReviews now returns early for TRANSIT_CAT places, so stops show board + timeline only. Compile green; trivial gate, no canary run (quota) - eyeball on the next nightly.