### PR TITLE
Transit stops: drop Reviews + About tabs entirely

### DIFF
--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -3103,14 +3103,20 @@ private fun PlaceTabs(
     onPanelEngaged: () -> Unit = {},
     panelEngaged: Boolean = false,
 ) {
+    // A transit stop shows its departure board + stop timeline, nothing else - Reviews and About
+    // are noise on a bus stop (and the review scrape is skipped for them too). Kill both tabs
+    // entirely (user 2026-07-13); with no Menu photos either, the whole tab bar then vanishes.
+    val isTransitStop = place.category?.lowercase()?.let { c ->
+        listOf("station", "stop", "transit", "transport", "hub", "bus", "subway", "metro", "tram", "rail", "ferry", "terminal", "platform").any { it in c }
+    } == true
     // With the live panel on, the scrape never runs, so reviewsLoading can't summon the tab —
     // any Google-listed place (valid feature id) gets the tab; the panel shows Google's own
     // zero-reviews state if there are none.
-    val hasReviews = app.vela.ui.ShowReviews.on.value && (
+    val hasReviews = !isTransitStop && app.vela.ui.ShowReviews.on.value && (
         place.rating != null || reviews.isNotEmpty() || reviewsLoading || place.featuredReview != null ||
             (app.vela.ui.LiveReviews.on.value && place.featureId?.contains(":") == true)
         )
-    val hasAbout = place.about.isNotEmpty() || place.editorialSummary != null || place.ownerDescription != null
+    val hasAbout = !isTransitStop && (place.about.isNotEmpty() || place.editorialSummary != null || place.ownerDescription != null)
     // Menu photos get their OWN TAB beside Reviews/About (user 2026-07-10) — the gallery's
     // category chip buried them. Detection is by Google's own gallery-tab name (it arrives
     // localized, so match a per-language keyword set; the matched name is reused as the tab


### PR DESCRIPTION
Bus stops now show only the departure board + stop timeline. hasReviews/hasAbout are gated off for transit-category places, so the whole tab bar vanishes on a stop. Pairs with #108 (skip the review scrape for stops). Compile green.