### PR TITLE
Transit: hide reviews/about only for BARE stops (fix rated-building regression)

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1582,10 +1582,12 @@ class MapViewModel @Inject constructor(
     private fun fetchReviews(p: Place, force: Boolean = false) {
         // "Show reviews" off: no review section is rendered, so don't scrape either.
         if (!app.vela.ui.ShowReviews.on.value) return
-        // Transit stops: never scrape reviews. Nobody reads bus-stop reviews, the WebView grind
-        // slows the departure board (the thing you actually opened the stop for), and the section
-        // rendered awkwardly (user 2026-07-13). The board + stop timeline are the content here.
-        if (p.category?.let { TRANSIT_CAT.containsMatchIn(it) } == true) return
+        // BARE transit stops: never scrape reviews. A bus stop's content is its departure board, not
+        // reviews (the WebView grind competed with the board load and rendered awkwardly). But gate on
+        // "transit-category AND UNRATED", not category alone - a rated transit CENTER (a real building
+        // people review) must KEEP its reviews (user 2026-07-13: broad category gate wrongly killed
+        // them). Real buildings carry a Google rating; bare stops don't.
+        if (p.rating == null && p.category?.let { TRANSIT_CAT.containsMatchIn(it) } == true) return
         // Supersede any in-flight scrape: the fetcher serializes on a Mutex, so an abandoned
         // 40 s Taco Bell grind would otherwise make the NEXT place's reviews queue behind it
         // (~90 s worst case to first review). Cancelling frees the mutex immediately, and this

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -3103,20 +3103,22 @@ private fun PlaceTabs(
     onPanelEngaged: () -> Unit = {},
     panelEngaged: Boolean = false,
 ) {
-    // A transit stop shows its departure board + stop timeline, nothing else - Reviews and About
-    // are noise on a bus stop (and the review scrape is skipped for them too). Kill both tabs
-    // entirely (user 2026-07-13); with no Menu photos either, the whole tab bar then vanishes.
-    val isTransitStop = place.category?.lowercase()?.let { c ->
+    // A BARE bus stop (transit-category AND no rating, i.e. no real review content) shows only its
+    // departure board + stop timeline - Reviews/About are noise there. But a RATED transit CENTER
+    // (a real building people review) keeps both tabs: gate on the bare-stop signal, NOT category
+    // alone, or real buildings lose their reviews (user 2026-07-13 regression). Real buildings carry
+    // a Google rating / reviews / a featured review; bare stops carry none.
+    val isTransitCategory = place.category?.lowercase()?.let { c ->
         listOf("station", "stop", "transit", "transport", "hub", "bus", "subway", "metro", "tram", "rail", "ferry", "terminal", "platform").any { it in c }
     } == true
-    // With the live panel on, the scrape never runs, so reviewsLoading can't summon the tab —
-    // any Google-listed place (valid feature id) gets the tab; the panel shows Google's own
-    // zero-reviews state if there are none.
-    val hasReviews = !isTransitStop && app.vela.ui.ShowReviews.on.value && (
+    val isBareStop = isTransitCategory && place.rating == null && reviews.isEmpty() && place.featuredReview == null
+    // The LiveReviews clause summons a review tab for ANY Google place (valid feature id) even with
+    // zero reviews - that's the ONLY clause suppressed for a bare stop; real review content still shows.
+    val hasReviews = app.vela.ui.ShowReviews.on.value && (
         place.rating != null || reviews.isNotEmpty() || reviewsLoading || place.featuredReview != null ||
-            (app.vela.ui.LiveReviews.on.value && place.featureId?.contains(":") == true)
+            (app.vela.ui.LiveReviews.on.value && place.featureId?.contains(":") == true && !isBareStop)
         )
-    val hasAbout = !isTransitStop && (place.about.isNotEmpty() || place.editorialSummary != null || place.ownerDescription != null)
+    val hasAbout = !isBareStop && (place.about.isNotEmpty() || place.editorialSummary != null || place.ownerDescription != null)
     // Menu photos get their OWN TAB beside Reviews/About (user 2026-07-10) — the gallery's
     // category chip buried them. Detection is by Google's own gallery-tab name (it arrives
     // localized, so match a per-language keyword set; the matched name is reused as the tab


### PR DESCRIPTION
Fixes the regression from #108/#109: gating reviews/About on transit *category* alone also stripped them from real transit-center buildings that have ratings + reviews. Now gated on a bare-stop signal (transit-category AND no rating AND no reviews AND no featured review), so rated buildings keep everything and only content-less bus stops are reduced to the board. Will 4A-canary before merge.