### PR TITLE
Flock cameras: Overpass endpoint failover (504 no longer blanks the layer)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1827,7 +1827,16 @@ architecture note.
   metros (Atlanta metro ~1571 nodes, greater Everett WA ~211), sparse in a given ~1 km high-zoom box, so cameras show
   best around arterials at a neighbourhood zoom, not a quiet residential block. NB you can't browse to a far city and
   see them if free-drive-follow keeps recentering on your GPS - it fetches YOUR viewport (fine for the real use case:
-  you driving through a covered area).
+  you driving through a covered area). **THIRD bug found 2026-07-13 (device): the fetch used a SINGLE hardcoded
+  endpoint `overpass-api.de`, which regularly answers HTTP 504 "dispatcher" under load - so a fetch over a box that
+  genuinely HAS cameras failed and the layer silently stayed empty, on BOTH the map AND the route-count path (both
+  call `fetchInBox`).** Fixed with **`OverpassEndpoints`** (`core/data`): a shared endpoint list (primary +
+  `kumi.systems` / `maps.mail.ru` / `private.coffee` mirrors) and a `run(http, query){ onBody }` failover runner
+  that tries each endpoint in turn, uses the FIRST 2xx, and returns null only when EVERY endpoint fails. **All three
+  keyless Overpass callers route through it** (`OverpassAlprCameras`, `OverpassTrafficSignals`, `OverpassPois`), so
+  one overloaded instance no longer blanks flock cameras, stop signs/lights, or the offline OSM POI/address index.
+  Proven: `overpass-api.de` was 504-ing while `maps.mail.ru` returned 16 Flock nodes over the same Mill Creek box.
+  **Any NEW keyless Overpass fetch MUST go through `OverpassEndpoints.run`, never a bare hardcoded endpoint.**
 - **Public transit uses the same hidden WebView** (`app/web/WebDirectionsFetcher`).
   A plain `/maps/preview/directions` GET with the transit flag (`!3e3`) is silently
   downgraded to a *driving* reply (same TLS-fingerprint bot-detection as photos), so

--- a/core/src/main/java/app/vela/core/data/OverpassAlprCameras.kt
+++ b/core/src/main/java/app/vela/core/data/OverpassAlprCameras.kt
@@ -6,8 +6,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 
 /** An automated licence-plate reader (ALPR / "Flock") camera at [loc]. [operator] is the agency/company
@@ -35,7 +33,6 @@ private data class OverpassNode(
  * area-cached, viewport-fetched contract. Coverage is OSM's/DeFlock's - strong in the US, growing elsewhere.
  */
 object OverpassAlprCameras {
-    private const val ENDPOINT = "https://overpass-api.de/api/interpreter"
     private val json = Json { ignoreUnknownKeys = true }
 
     // Overpass can be slow; the shared scrape client's 12 s callTimeout aborts mid-response and the
@@ -62,38 +59,29 @@ object OverpassAlprCameras {
         south: Double, west: Double, north: Double, east: Double,
         limit: Int = 4000,
     ): List<AlprCamera>? {
-        return try {
-            val box = "($south,$west,$north,$east)"
-            // `out body` (NOT `out tags`): for a node, `out tags` prints only id + tags and OMITS
-            // lat/lon, so the parser dropped every camera (no coordinates) and the layer drew nothing.
-            // `out body` prints id, lat, lon AND tags - what we need to place the marker + read operator.
-            val query = "[out:json][timeout:25];" +
-                "node[\"surveillance:type\"=\"ALPR\"]$box;out body $limit;"
-            val url = "$ENDPOINT?data=" + URLEncoder.encode(query, "UTF-8")
-            val req = Request.Builder()
-                .url(url)
-                .header("User-Agent", "VelaMaps/0.1 (+https://github.com/PimpinPumpkin/Vela)")
-                .build()
-            slow(http).newCall(req).execute().use { resp ->
-                if (!resp.isSuccessful) return@use null // a failure, NOT a genuine empty area - don't cache it
-                val body = resp.body ?: return@use null
-                // STREAM the body straight off the socket into the tiny DTO - never materialize the whole
-                // response String or a full JsonElement DOM. The old `.string()` + parseToJsonElement over
-                // an `out body 4000` response held ~5-10x the wire size in transient heap, which filled the
-                // heap and OOM'd mid-read (device 2026-07-13). decodeFromStream reads incrementally.
-                val parsed = json.decodeFromStream<OverpassResp>(body.byteStream())
-                parsed.elements.mapNotNull { n ->
-                    val lat = n.lat ?: return@mapNotNull null
-                    val lng = n.lon ?: return@mapNotNull null
-                    // Real DeFlock nodes tag the vendor as `manufacturer` ("Flock Safety"), not `operator`
-                    // (usually the agency, often absent) - fall back to it so the camera shows who runs it.
-                    val op = (n.tags?.get("operator") ?: n.tags?.get("manufacturer")).orEmpty()
-                    val dir = n.tags?.get("direction").orEmpty()
-                    AlprCamera(LatLng(lat, lng), op, dir)
-                }
+        val box = "($south,$west,$north,$east)"
+        // `out body` (NOT `out tags`): for a node, `out tags` prints only id + tags and OMITS
+        // lat/lon, so the parser dropped every camera (no coordinates) and the layer drew nothing.
+        // `out body` prints id, lat, lon AND tags - what we need to place the marker + read operator.
+        val query = "[out:json][timeout:25];" +
+            "node[\"surveillance:type\"=\"ALPR\"]$box;out body $limit;"
+        // Failover across mirrors: a 504 from the primary overpass-api.de (common under load) used to fail
+        // the whole fetch and silently blank the layer. run() returns null only when EVERY endpoint fails.
+        return OverpassEndpoints.run(slow(http), query) { body ->
+            // STREAM the body straight off the socket into the tiny DTO - never materialize the whole
+            // response String or a full JsonElement DOM. The old `.string()` + parseToJsonElement over
+            // an `out body 4000` response held ~5-10x the wire size in transient heap, which filled the
+            // heap and OOM'd mid-read (device 2026-07-13). decodeFromStream reads incrementally.
+            val parsed = json.decodeFromStream<OverpassResp>(body.byteStream())
+            parsed.elements.mapNotNull { n ->
+                val lat = n.lat ?: return@mapNotNull null
+                val lng = n.lon ?: return@mapNotNull null
+                // Real DeFlock nodes tag the vendor as `manufacturer` ("Flock Safety"), not `operator`
+                // (usually the agency, often absent) - fall back to it so the camera shows who runs it.
+                val op = (n.tags?.get("operator") ?: n.tags?.get("manufacturer")).orEmpty()
+                val dir = n.tags?.get("direction").orEmpty()
+                AlprCamera(LatLng(lat, lng), op, dir)
             }
-        } catch (e: Exception) {
-            null
         }
     }
 

--- a/core/src/main/java/app/vela/core/data/OverpassAlprCameras.kt
+++ b/core/src/main/java/app/vela/core/data/OverpassAlprCameras.kt
@@ -35,14 +35,17 @@ private data class OverpassNode(
 object OverpassAlprCameras {
     private val json = Json { ignoreUnknownKeys = true }
 
-    // Overpass can be slow; the shared scrape client's 12 s callTimeout aborts mid-response and the
-    // failure reads as "no cameras" (a reliability complaint). Derive a longer-timeout sibling ONCE.
-    // Memory is bounded regardless now (streaming parse), so a longer read is safe.
+    // Per-endpoint client for the failover runner. The ALPR query is TINY (one tag over a viewport box,
+    // <1 s from a healthy server), so a modest 15 s cap is ample - and it BOUNDS the failover: with four
+    // endpoints, a dead/overloaded mirror that hangs would otherwise cost 25 s each (~90 s all-in, observed
+    // on-device when the primary 504'd and mirrors were slow). 15 s call + 8 s connect abandons a bad
+    // endpoint fast enough to reach a working one, while still tolerating a briefly-slow-but-alive server.
     @Volatile private var slowHttp: OkHttpClient? = null
     private fun slow(base: OkHttpClient): OkHttpClient =
         slowHttp ?: base.newBuilder()
-            .callTimeout(25, TimeUnit.SECONDS)
-            .readTimeout(25, TimeUnit.SECONDS)
+            .callTimeout(15, TimeUnit.SECONDS)
+            .connectTimeout(8, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
             .build()
             .also { slowHttp = it }
 

--- a/core/src/main/java/app/vela/core/data/OverpassEndpoints.kt
+++ b/core/src/main/java/app/vela/core/data/OverpassEndpoints.kt
@@ -1,0 +1,56 @@
+package app.vela.core.data
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.ResponseBody
+import java.net.URLEncoder
+
+/**
+ * Shared endpoint list + failover runner for every keyless **Overpass** (OpenStreetMap query API) fetch in
+ * Vela: ALPR/Flock cameras ([OverpassAlprCameras]), traffic controls ([OverpassTrafficSignals]) and the
+ * offline OSM POI/address index ([OverpassPois]).
+ *
+ * A single hardcoded endpoint was a real reliability hole. The main instance `overpass-api.de` regularly
+ * returns HTTP 504 "dispatcher" errors when it's under load (observed 2026-07-13 - the exact failure behind
+ * a "Flock cameras never show" report: the fetch failed and the layer silently stayed empty). [run] tries
+ * each endpoint in turn and uses the FIRST that answers 2xx, so one overloaded mirror no longer takes a
+ * whole feature down; the caller only sees a failure when EVERY endpoint is unreachable.
+ */
+object OverpassEndpoints {
+    private const val USER_AGENT = "VelaMaps/0.1 (+https://github.com/PimpinPumpkin/Vela)"
+
+    /** Primary first, then community mirrors. Order is preference; each is tried until one answers 2xx.
+     *  All speak the same Overpass QL, so the query string is endpoint-agnostic. */
+    val ENDPOINTS = listOf(
+        "https://overpass-api.de/api/interpreter",
+        "https://overpass.kumi.systems/api/interpreter",
+        "https://maps.mail.ru/osm/tools/overpass/api/interpreter",
+        "https://overpass.private.coffee/api/interpreter",
+    )
+
+    /**
+     * Run [query] against each endpoint in order and hand the FIRST successful (2xx) response body to
+     * [onBody], returning its result. A non-2xx status, a network error, a timeout or an exception thrown
+     * while parsing one endpoint's body all fall through to the NEXT endpoint. Returns null only when every
+     * endpoint failed - callers treat that as "fetch failed" (distinct from a successful-but-empty parse, so
+     * a transient outage is never cached as an authoritative "nothing here").
+     *
+     * [onBody] must fully consume the body before it returns; it runs inside the response's `use` block.
+     */
+    fun <T> run(http: OkHttpClient, query: String, onBody: (ResponseBody) -> T): T? {
+        for (ep in ENDPOINTS) {
+            val url = "$ep?data=" + URLEncoder.encode(query, "UTF-8")
+            val req = Request.Builder().url(url).header("User-Agent", USER_AGENT).build()
+            try {
+                http.newCall(req).execute().use { resp ->
+                    val body = resp.body
+                    if (resp.isSuccessful && body != null) return onBody(body)
+                    // non-2xx or no body: fall through to the next endpoint
+                }
+            } catch (e: Exception) {
+                // network / timeout / parse error on this endpoint - try the next one
+            }
+        }
+        return null
+    }
+}

--- a/core/src/main/java/app/vela/core/data/OverpassPois.kt
+++ b/core/src/main/java/app/vela/core/data/OverpassPois.kt
@@ -11,8 +11,6 @@ import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import java.net.URLEncoder
 
 /**
  * Fetches named POIs in a bounding box from **Overpass** (OpenStreetMap's keyless
@@ -20,7 +18,6 @@ import java.net.URLEncoder
  * no-backend source behind offline search. Best-effort: any failure → empty.
  */
 object OverpassPois {
-    private const val ENDPOINT = "https://overpass-api.de/api/interpreter"
     private val json = Json { ignoreUnknownKeys = true }
 
     /** Named amenities/shops/tourism POIs in [south,west]..[north,east], capped. */
@@ -44,16 +41,10 @@ object OverpassPois {
             "(nwr[amenity][name]($bbox);node[shop][name]($bbox);nwr[tourism][name]($bbox);" +
             "node[\"public_transport\"][name]($bbox);nwr[leisure][name]($bbox);" +
             "nwr[boundary=national_park][name]($bbox););out center $limit;"
-        val url = "$ENDPOINT?data=" + URLEncoder.encode(query, "UTF-8")
-        val req = Request.Builder()
-            .url(url)
-            .header("User-Agent", "VelaMaps/0.1 (+https://github.com/PimpinPumpkin/Vela)")
-            .build()
-        http.newCall(req).execute().use { resp ->
-            if (!resp.isSuccessful) return emptyList()
-            val root = json.parseToJsonElement(resp.body?.string().orEmpty()).jsonObject
+        OverpassEndpoints.run(http, query) { body ->
+            val root = json.parseToJsonElement(body.string()).jsonObject
             root["elements"]?.jsonArray?.mapNotNull { el -> toPlace(el.jsonObject) }.orEmpty()
-        }
+        } ?: emptyList()
     } catch (e: Exception) {
         emptyList()
     }
@@ -72,16 +63,10 @@ object OverpassPois {
         val bbox = "$south,$west,$north,$east"
         val query = "[out:json][timeout:120];" +
             "(node[\"addr:housenumber\"]($bbox);way[\"addr:housenumber\"]($bbox););out center $limit;"
-        val url = "$ENDPOINT?data=" + URLEncoder.encode(query, "UTF-8")
-        val req = Request.Builder()
-            .url(url)
-            .header("User-Agent", "VelaMaps/0.1 (+https://github.com/PimpinPumpkin/Vela)")
-            .build()
-        http.newCall(req).execute().use { resp ->
-            if (!resp.isSuccessful) return emptyList()
-            val root = json.parseToJsonElement(resp.body?.string().orEmpty()).jsonObject
+        OverpassEndpoints.run(http, query) { body ->
+            val root = json.parseToJsonElement(body.string()).jsonObject
             root["elements"]?.jsonArray?.mapNotNull { el -> toAddr(el.jsonObject) }.orEmpty()
-        }
+        } ?: emptyList()
     } catch (e: Exception) {
         emptyList()
     }
@@ -105,16 +90,10 @@ object OverpassPois {
         val query = "[out:json][timeout:120];" +
             "way[\"highway\"~\"^(motorway|trunk|primary|secondary|tertiary|unclassified|" +
             "residential|living_street|service|road)(_link)?$\"][\"name\"]($bbox);out geom $limit;"
-        val url = "$ENDPOINT?data=" + URLEncoder.encode(query, "UTF-8")
-        val req = Request.Builder()
-            .url(url)
-            .header("User-Agent", "VelaMaps/0.1 (+https://github.com/PimpinPumpkin/Vela)")
-            .build()
-        http.newCall(req).execute().use { resp ->
-            if (!resp.isSuccessful) return emptyList()
-            val root = json.parseToJsonElement(resp.body?.string().orEmpty()).jsonObject
+        OverpassEndpoints.run(http, query) { body ->
+            val root = json.parseToJsonElement(body.string()).jsonObject
             root["elements"]?.jsonArray?.flatMap { el -> toStreetPts(el.jsonObject) }.orEmpty()
-        }
+        } ?: emptyList()
     } catch (e: Exception) {
         emptyList()
     }

--- a/core/src/main/java/app/vela/core/data/OverpassTrafficSignals.kt
+++ b/core/src/main/java/app/vela/core/data/OverpassTrafficSignals.kt
@@ -7,8 +7,6 @@ import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import java.net.URLEncoder
 
 /**
  * Fetches TRAFFIC-SIGNAL locations (OSM `highway=traffic_signals` nodes) near a route from **Overpass**
@@ -22,7 +20,6 @@ import java.net.URLEncoder
 data class TrafficControl(val loc: LatLng, val stop: Boolean)
 
 object OverpassTrafficSignals {
-    private const val ENDPOINT = "https://overpass-api.de/api/interpreter"
     private val json = Json { ignoreUnknownKeys = true }
 
     /**
@@ -39,58 +36,40 @@ object OverpassTrafficSignals {
         south: Double, west: Double, north: Double, east: Double,
         limit: Int = 6000,
     ): List<TrafficControl>? {
-        return try {
-            val box = "($south,$west,$north,$east)"
-            val query = "[out:json][timeout:25];" +
-                "(node[\"highway\"=\"traffic_signals\"]$box;node[\"highway\"=\"stop\"]$box;);out $limit;"
-            val url = "$ENDPOINT?data=" + URLEncoder.encode(query, "UTF-8")
-            val req = Request.Builder()
-                .url(url)
-                .header("User-Agent", "VelaMaps/0.1 (+https://github.com/PimpinPumpkin/Vela)")
-                .build()
-            http.newCall(req).execute().use { resp ->
-                if (!resp.isSuccessful) return@use null // a failure, NOT a genuine empty area — don't cache it
-                val root = json.parseToJsonElement(resp.body?.string().orEmpty()).jsonObject
-                root["elements"]?.jsonArray?.mapNotNull { el ->
-                    val o = el.jsonObject
-                    val lat = (o["lat"] as? JsonPrimitive)?.doubleOrNull ?: return@mapNotNull null
-                    val lng = (o["lon"] as? JsonPrimitive)?.doubleOrNull ?: return@mapNotNull null
-                    val kind = (o["tags"]?.jsonObject?.get("highway") as? JsonPrimitive)?.content
-                    TrafficControl(LatLng(lat, lng), stop = kind == "stop")
-                }.orEmpty()
-            }
-        } catch (e: Exception) {
-            null
+        val box = "($south,$west,$north,$east)"
+        val query = "[out:json][timeout:25];" +
+            "(node[\"highway\"=\"traffic_signals\"]$box;node[\"highway\"=\"stop\"]$box;);out $limit;"
+        // Failover across mirrors (see OverpassEndpoints): a 504 from the primary no longer blanks the layer.
+        // run() returns null only when EVERY endpoint fails — a real failure, not a genuine empty area.
+        return OverpassEndpoints.run(http, query) { body ->
+            val root = json.parseToJsonElement(body.string()).jsonObject
+            root["elements"]?.jsonArray?.mapNotNull { el ->
+                val o = el.jsonObject
+                val lat = (o["lat"] as? JsonPrimitive)?.doubleOrNull ?: return@mapNotNull null
+                val lng = (o["lon"] as? JsonPrimitive)?.doubleOrNull ?: return@mapNotNull null
+                val kind = (o["tags"]?.jsonObject?.get("highway") as? JsonPrimitive)?.content
+                TrafficControl(LatLng(lat, lng), stop = kind == "stop")
+            }.orEmpty()
         }
     }
 
     /** Traffic-signal node coordinates within the route's bounding box (padded a little). */
     fun fetchAlong(http: OkHttpClient, polyline: List<LatLng>, limit: Int = 4000): List<LatLng> {
         if (polyline.size < 2) return emptyList()
-        return try {
         val pad = 0.003 // ~300 m, so a signal just off the sampled line still lands in the box
         val s = polyline.minOf { it.lat } - pad
         val n = polyline.maxOf { it.lat } + pad
         val w = polyline.minOf { it.lng } - pad
         val e = polyline.maxOf { it.lng } + pad
         val query = "[out:json][timeout:25];node[\"highway\"=\"traffic_signals\"]($s,$w,$n,$e);out $limit;"
-        val url = "$ENDPOINT?data=" + URLEncoder.encode(query, "UTF-8")
-        val req = Request.Builder()
-            .url(url)
-            .header("User-Agent", "VelaMaps/0.1 (+https://github.com/PimpinPumpkin/Vela)")
-            .build()
-        http.newCall(req).execute().use { resp ->
-            if (!resp.isSuccessful) return@use emptyList()
-            val root = json.parseToJsonElement(resp.body?.string().orEmpty()).jsonObject
+        return OverpassEndpoints.run(http, query) { body ->
+            val root = json.parseToJsonElement(body.string()).jsonObject
             root["elements"]?.jsonArray?.mapNotNull { el ->
                 val o = el.jsonObject
                 val lat = (o["lat"] as? JsonPrimitive)?.doubleOrNull ?: return@mapNotNull null
                 val lng = (o["lon"] as? JsonPrimitive)?.doubleOrNull ?: return@mapNotNull null
                 LatLng(lat, lng)
             }.orEmpty()
-        }
-        } catch (e: Exception) {
-            emptyList()
-        }
+        } ?: emptyList()
     }
 }


### PR DESCRIPTION
## Problem

Flock/ALPR surveillance cameras weren't showing up on the map or in the route "passes N cameras" count, even where cameras are mapped. Device debugging traced it to the Overpass fetch: it went through a single hardcoded endpoint, `overpass-api.de`, which regularly returns **HTTP 504 "dispatcher" overload** errors under load. When that happens the fetch fails and the layer silently stays empty. The data and parsing were fine all along, the one endpoint was just down.

Proven on a live box: `overpass-api.de` returned 504 while the `maps.mail.ru` mirror returned 16 Flock Safety nodes over the same area.

## Fix

New `OverpassEndpoints` (`core/data`): a shared endpoint list (primary + `kumi.systems` / `maps.mail.ru` / `private.coffee` mirrors) and a `run(http, query){ onBody }` failover runner that tries each endpoint in turn, uses the first that answers 2xx, and reports failure only when every endpoint is unreachable.

All three keyless Overpass callers now route through it, so one overloaded instance can't blank a whole feature:
- `OverpassAlprCameras` (Flock cameras, map + route count)
- `OverpassTrafficSignals` (stop signs + traffic lights)
- `OverpassPois` (offline OSM POI + address index)

## Testing

- `:core` compiles clean, all `:core` tests pass.
- Endpoint failover verified against the live outage (504 primary, mirror returned cameras).
- Pending: 4A canary device test (bundled with the other open PRs per the canary rule).

