### PR TITLE
Departure board: show up to 8 arrivals per line (was capped at 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1924,7 +1924,12 @@ architecture note.
   `routeDetail: TransitStep?`, `routeDetailTitle`, `routeDetailLoading`, guarded by `routeDetailJob`.
   The board cap was raised 8 -> 24 lines (`StopDepartureBoard` + parser `MAX_LINES`) so busy stops show
   more routes. **Device-verified: Powell St -> Yellow-S -> 11 stops (Powell…SFO, 12:23-12:54 PM), then
-  tapping 16th St Mission opened that bus stop's own board.**
+  tapping 16th St Mission opened that bus stop's own board.** **Per-line arrival depth raised 4 -> 8
+  (2026-07-13, user report "only shows the next 4 or so arrivals"):** parser `MAX_TIMES` was 4, AND
+  `DepartureLineRow` only rendered `upcoming.first()` + `drop(1).take(3)` = 4 total; both were the cap.
+  Now `MAX_TIMES` = 8 and the trailing times render in a **`FlowRow`** so a busy stop's extra departures
+  WRAP to more rows instead of overflowing the single Row (which is why they were capped at 3). If Google
+  embeds fewer than 8 in the anonymous place blob, the board just shows what's there.
 
 ## Name
 

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -33,6 +33,7 @@ import app.vela.ui.theme.isAppInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -2435,6 +2436,7 @@ private fun StopDepartureBoard(
 }
 
 @Composable
+@OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
 private fun DepartureLineRow(
     line: app.vela.core.model.StopDepartureLine,
     nowSec: Long,
@@ -2483,9 +2485,15 @@ private fun DepartureLineRow(
                     )
                 }
                 if (live) Box(Modifier.size(6.dp).clip(CircleShape).background(SheetPalette.TrafficGreen))
-                // the following departures, quiet
-                line.upcoming.drop(1).take(3).forEach {
-                    Text(it.clockText.orEmpty(), style = MaterialTheme.typography.bodySmall, color = dim)
+            }
+            // The rest of the upcoming departures, quiet — a FlowRow so a busy stop's many times WRAP to
+            // more rows instead of overflowing a single line (they used to be capped at 3 to fit one Row).
+            val rest = line.upcoming.drop(1)
+            if (rest.isNotEmpty()) {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                    rest.forEach {
+                        Text(it.clockText.orEmpty(), style = MaterialTheme.typography.bodySmall, color = dim)
+                    }
                 }
             }
         }

--- a/core/src/main/java/app/vela/core/data/google/parse/StopDeparturesParser.kt
+++ b/core/src/main/java/app/vela/core/data/google/parse/StopDeparturesParser.kt
@@ -273,6 +273,6 @@ object StopDeparturesParser {
         }
     }
 
-    private const val MAX_TIMES = 4
+    private const val MAX_TIMES = 8 // upcoming departures kept per line — Google shows a similar depth on a busy stop
     private const val MAX_LINES = 24
 }


### PR DESCRIPTION
## Problem

A busy bus stop's departure board only ever showed the next ~4 arrivals for a route, far fewer than Google shows for the same stop.

## Cause

Two caps stacked:
- The parser kept only `MAX_TIMES = 4` upcoming departures per line.
- `DepartureLineRow` rendered only `upcoming.first()` + `upcoming.drop(1).take(3)` = 4 total, because they sat in a single non-wrapping `Row` that would overflow with more.

## Fix

- Raise parser `MAX_TIMES` to 8.
- Render the trailing departures in a `FlowRow` so a busy stop's extra times wrap onto more rows instead of overflowing one line.

Where Google embeds fewer than 8 times in the anonymous place page, the board just shows what's there. Parser tests unaffected (fixtures have ≤3 departures each).

## Testing

- `:core` tests pass, app compiles clean.
- Pending: 4A canary device test (bundled with the other open PRs per the canary rule).
