### PR TITLE
Departure board: vertical list of every embedded time (with per-row countdown)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1937,8 +1937,7 @@ architecture note.
   (2026-07-13, user report "only shows the next 4 or so arrivals"):** parser `MAX_TIMES` was 4, AND
   `DepartureLineRow` only rendered `upcoming.first()` + `drop(1).take(3)` = 4 total; both were the cap.
   Now `MAX_TIMES` = 8 and the trailing times render in a **`FlowRow`** so a busy stop's extra departures
-  WRAP to more rows instead of overflowing the single Row (which is why they were capped at 3). If Google
-  embeds fewer than 8 in the anonymous place blob, the board just shows what's there.
+  WRAP to more rows instead of overflowing the single Row (which is why they were capped at 3). **Superseded 2026-07-13: per-line depth is now a VERTICAL LIST of every embedded time** (parser `MAX_TIMES` = 30 ceiling; `DepartureLineRow` stacks the trailing departures one-per-row, each with its own "in N min" countdown, instead of the wrapping FlowRow). The board blob only carries the next several, so the list length is data-driven, not the cap.
 
 ## Name
 

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -33,7 +33,6 @@ import app.vela.ui.theme.isAppInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -2436,7 +2435,6 @@ private fun StopDepartureBoard(
 }
 
 @Composable
-@OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
 private fun DepartureLineRow(
     line: app.vela.core.model.StopDepartureLine,
     nowSec: Long,
@@ -2486,13 +2484,19 @@ private fun DepartureLineRow(
                 }
                 if (live) Box(Modifier.size(6.dp).clip(CircleShape).background(SheetPalette.TrafficGreen))
             }
-            // The rest of the upcoming departures, quiet — a FlowRow so a busy stop's many times WRAP to
-            // more rows instead of overflowing a single line (they used to be capped at 3 to fit one Row).
+            // The rest of the upcoming departures as a VERTICAL LIST — one per line, each with its own
+            // "in N min" countdown, so a busy stop shows every embedded time cleanly instead of a wrapped
+            // wall of clock times (user 2026-07-13). The board data itself sets how many there are.
             val rest = line.upcoming.drop(1)
             if (rest.isNotEmpty()) {
-                FlowRow(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    rest.forEach {
-                        Text(it.clockText.orEmpty(), style = MaterialTheme.typography.bodySmall, color = dim)
+                Column(Modifier.padding(top = 2.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    rest.forEach { dep ->
+                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                            Text(dep.clockText.orEmpty(), style = MaterialTheme.typography.bodySmall, color = dim)
+                            departsInLabel(dep.epochSec, nowSec)?.let {
+                                Text("· $it", style = MaterialTheme.typography.bodySmall, color = dim)
+                            }
+                        }
                     }
                 }
             }

--- a/core/src/main/java/app/vela/core/data/google/parse/StopDeparturesParser.kt
+++ b/core/src/main/java/app/vela/core/data/google/parse/StopDeparturesParser.kt
@@ -273,6 +273,8 @@ object StopDeparturesParser {
         }
     }
 
-    private const val MAX_TIMES = 8 // upcoming departures kept per line — Google shows a similar depth on a busy stop
+    // Keep every upcoming departure the board embeds per line (rendered as a vertical list). The board
+    // blob only carries the next several, not the whole day, so 30 is a safety ceiling, not a real limit.
+    private const val MAX_TIMES = 30
     private const val MAX_LINES = 24
 }


### PR DESCRIPTION
Per-line departures now render as a vertical list, one time per row each with its own "in N min" countdown, instead of a wrapping row capped at 8. Parser ceiling raised to 30 so the board shows every time it embeds (the blob only carries the next several, so length is data-driven). Compiles clean, core tests pass; pending 4A canary.