### PR TITLE
Transitous departure boards (open GTFS realtime, Google as fallback)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1864,6 +1864,20 @@ architecture note.
   is idempotent on relaunch. NB "avoid" still only RE-RANKS the alternates Google/OSRM offer (fewest-camera
   within a small detour); it does NOT graph-route around cameras. **To publish the first hosted copy, dispatch
   Actions -> "Flock cameras" once** (until then every install just uses the bundled floor).
+- **Transitous is the PRIMARY departure-board source (2026-07-13, phase 1 of the GTFS adoption).**
+  `core/data/transit/Transitous` talks to the community MOTIS instance at `api.transitous.org` - the
+  open-GTFS + GTFS-Realtime aggregator (transit's FOSSGIS-OSRM: keyless, fair-use, identifying UA sent).
+  `fetchStopDepartures` now calls `Transitous.board(lat,lng)` FIRST for any transit-category or
+  Intersection place: `map/stops` finds the stop by PROXIMITY (no Google/OSM name correlation at all),
+  and `stoptimes` on the nearest stop's PARENT station id returns EVERY route with realtime flags and
+  the agency's own route colours - a hub's bays merge for free (device-verified: a corner that gave 1
+  route via the Google blob shows 6 lines with official pill colours + live countdowns). The result maps
+  into the SAME StopDepartures model, so the whole board UI renders unchanged. The Google blob paths
+  (fetchBoardFrom / resolveIntersectionStopBoard) remain the FALLBACK where Transitous lacks coverage.
+  `buildBoard` is pure + unit-tested (TransitousTest). PHASE 2 candidates: transit directions via
+  `/api/v1/plan` (replacing WebDirectionsFetcher), stops drawn on the map from `map/stops` (replacing
+  the OSM basemap stop icons + all tap correlation - the endpoint is verified to return canonical
+  GTFS stop positions per bbox).
 - **Share diagnostics is functional now (2026-07-13):** `DiagLog` (opt-in breadcrumb ring, :core)
   PERSISTS to a bounded `filesDir/diag_log.jsonl` (appended per event, reloaded at init, deleted on
   opt-out) - it was in-memory only, and since the bug being reported usually killed or preceded a

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1314,14 +1314,34 @@ class MapViewModel @Inject constructor(
         val fid = p.featureId
         if (fid.isNullOrBlank() || !fid.contains(":")) return
         val cat = p.category ?: ""
-        when {
-            // A real transit listing: its own place page carries the board.
-            TRANSIT_CAT.containsMatchIn(cat) -> fetchBoardFrom(fid, selectedFid = fid)
-            // A bus stop named by its intersection ("Main St & 1st Ave") that Google resolved to
-            // the ROAD JUNCTION ("Intersection") rather than the co-located Stop - so its own page has NO
-            // board (device 2026-07-13). Re-resolve to the stop and pull ITS board, the same
-            // way onPoiTap does for a tapped stop icon. The board attaches to the intersection sheet.
-            cat.contains("intersection", ignoreCase = true) -> resolveIntersectionStopBoard(p)
+        val isTransit = TRANSIT_CAT.containsMatchIn(cat)
+        val isIntersection = cat.contains("intersection", ignoreCase = true)
+        if (!isTransit && !isIntersection) return
+        // PRIMARY: Transitous (open GTFS + realtime, keyless). One proximity lookup at the place's own
+        // coordinate - no name correlation against Google/OSM at all - and unlike Google's anonymous
+        // page it returns EVERY route at the stop (a hub's parent station merges all its bays). The
+        // Google blob paths below stay as the fallback where Transitous has no coverage.
+        _state.update { if (it.selected?.featureId == fid) it.copy(stopDeparturesLoading = true) else it }
+        viewModelScope.launch {
+            val board = withContext(Dispatchers.IO) {
+                runCatching { app.vela.core.data.transit.Transitous.board(http, p.location.lat, p.location.lng) }.getOrNull()
+            }
+            android.util.Log.i("VelaDepartures", "transitous lines=${board?.lines?.size ?: -1}")
+            if (board != null && board.lines.isNotEmpty()) {
+                _state.update { st ->
+                    if (st.selected?.featureId != fid) st
+                    else st.copy(stopDepartures = board, stopDeparturesLoading = false)
+                }
+                return@launch
+            }
+            // FALLBACK: the Google place-page blob (agency-dependent, one route at hubs - but better
+            // than nothing where the open feeds lack the agency).
+            when {
+                isTransit -> fetchBoardFrom(fid, selectedFid = fid)
+                // A stop named by its corner resolves to Google's "Intersection" entity, whose own page
+                // has no board - re-resolve to the co-located stop listing (device 2026-07-13).
+                else -> resolveIntersectionStopBoard(p)
+            }
         }
     }
 

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -301,15 +301,12 @@ fun PlaceSheet(
     // detents equal that height, so every detent computation resolves to it and the drag can't
     // resize the sheet.
     val singleDetent = isParking
-    // A transit stop's departure board is a scrollable half-sheet (Google's UX): cap its expanded
-    // detent at PEEK so the chevron/drag can't grow it into empty space above a short board and, in
-    // doing so, cover + hide the search bar for no gain (device report 2026-07-13: "tapping the
-    // chevron on a stop with nothing more to show still hides the search bar"). Long boards scroll
-    // within the half-sheet. Paired with the onExpandedChange gate below so it never reports "covered".
-    val isTransitBoard = stopDepartures != null || stopDeparturesLoading
+    // Transit stops expand FULL-SCREEN like any other place (the short-lived peek cap from earlier
+    // today blocked maximizing a stop entirely - reported independently by the user and issue #71's
+    // reporter within hours; with real multi-route boards the full detent has plenty to show).
     val minH = if (singleDetent) screenH * 0.30f else screenH * 0.26f
     val peekH = if (singleDetent) screenH * 0.30f else screenH * 0.56f
-    val expH = if (singleDetent) screenH * 0.30f else if (isTransitBoard) peekH else screenH * 0.92f
+    val expH = if (singleDetent) screenH * 0.30f else screenH * 0.92f
     fun detentFor(expanded: Boolean, minimized: Boolean) = when {
         expanded -> expH
         minimized -> minH
@@ -535,9 +532,7 @@ fun PlaceSheet(
     // Report the expanded detent up: MapScreen kills the search bar's taps while the sheet
     // covers it (a tap on the sliver of bar behind an expanded sheet opened search OVER the
     // place card, user 2026-07-11).
-    // A transit board is capped at peek (see above), so it never actually covers the search bar -
-    // never report it as expanded, or the bar would hide with the sheet nowhere near it.
-    LaunchedEffect(expandedState.value, isTransitBoard) { onExpandedChange(expandedState.value && !isTransitBoard) }
+    LaunchedEffect(expandedState.value) { onExpandedChange(expandedState.value) }
     val onPanelEngaged: () -> Unit = {
         reviewsEngaged.value = true
         scope.launch {

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -636,7 +636,14 @@ fun PlaceSheet(
             // Hidden entirely when "Load photos" is off (the fetch is skipped too, but the
             // search response can seed a preview photo — don't show it either).
             app.vela.ui.SheetFold(extrasComposed, extrasFraction) {
-            if (app.vela.ui.LoadPhotos.on.value && (place.photoUrls.isNotEmpty() || photosLoading)) {
+            // Most transit stops have NO photos, so the pulsing placeholder tiles read as a perpetual
+            // loading animation for nothing (user 2026-07-13) - suppress the shimmer for transit places
+            // entirely; if the fetch does land photos, the row simply appears with them.
+            val transitNoShimmer = stopDepartures != null || stopDeparturesLoading ||
+                place.category?.lowercase()?.let { c ->
+                    listOf("station", "stop", "transit", "transport", "hub", "bus", "subway", "metro", "tram", "rail", "ferry", "terminal", "platform").any { it in c }
+                } == true
+            if (app.vela.ui.LoadPhotos.on.value && (place.photoUrls.isNotEmpty() || (photosLoading && !transitNoShimmer))) {
                 // (The All/Menu category chips that used to sit here are gone — the Menu TAB is
                 // the menu surface now, and the other categories read as noise; user 2026-07-10.)
                 val shown = remember(place.photoUrls) { place.photoUrls.indices.toList() }
@@ -659,7 +666,7 @@ fun PlaceSheet(
                     }
                     // The full gallery scrapes in the background a beat after the sheet opens —
                     // pulse placeholder tiles so it reads as "more photos loading", not "done".
-                    if (photosLoading) {
+                    if (photosLoading && !transitNoShimmer) {
                         item { PhotoShimmerTile(dim) }
                         if (place.photoUrls.isEmpty()) {
                             item { PhotoShimmerTile(dim) }

--- a/core/src/main/java/app/vela/core/data/transit/Transitous.kt
+++ b/core/src/main/java/app/vela/core/data/transit/Transitous.kt
@@ -1,0 +1,174 @@
+package app.vela.core.data.transit
+
+import app.vela.core.model.StopDeparture
+import app.vela.core.model.StopDepartureLine
+import app.vela.core.model.StopDepartures
+import app.vela.core.model.TransitMode
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.net.URLEncoder
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * **Transitous** (transitous.org) - the community-run, keyless public-transit API over the world's
+ * open GTFS + GTFS-Realtime feeds (MOTIS server). It is to transit what FOSSGIS OSRM is to road
+ * routing: canonical agency data, no account, fair-use community hosting.
+ *
+ * This client covers Vela's DEPARTURE BOARDS (phase 1 of the Transitous adoption): [board] finds the
+ * stop(s) at a coordinate via `map/stops` and reads `stoptimes` - which, unlike Google's anonymous
+ * place page, returns EVERY route serving the stop, with realtime flags and the agency's own route
+ * colours. Querying a stop's PARENT station id aggregates all its child stops/bays (verified live),
+ * so a multi-bay transit center gets one complete merged board for free.
+ *
+ * Google's blob parse stays as the FALLBACK where Transitous has no coverage. Fair use: called once
+ * per opened stop (no polling); the User-Agent identifies the app per the Transitous policy.
+ */
+object Transitous {
+    // The community instance. A self-hosted MOTIS is a drop-in swap if Vela ever outgrows fair use.
+    const val BASE = "https://api.transitous.org"
+    private const val UA = "VelaMaps/0.4 (+https://github.com/PimpinPumpkin/Vela)"
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // --- wire DTOs (only the fields Vela reads) --------------------------------------------------
+
+    @Serializable
+    data class MapStop(
+        val name: String = "",
+        val stopId: String = "",
+        val parentId: String? = null,
+        val lat: Double = 0.0,
+        val lon: Double = 0.0,
+    )
+
+    @Serializable
+    private data class StopTimesResp(val stopTimes: List<StopTime> = emptyList())
+
+    @Serializable
+    data class StopTime(
+        val place: StPlace = StPlace(),
+        val mode: String? = null,
+        val realTime: Boolean = false,
+        val headsign: String? = null,
+        val routeShortName: String? = null,
+        val routeColor: String? = null,
+    )
+
+    @Serializable
+    data class StPlace(
+        val departure: String? = null,
+        val scheduledDeparture: String? = null,
+        val tz: String? = null,
+        val cancelled: Boolean = false,
+    )
+
+    // --- API --------------------------------------------------------------------------------------
+
+    /** Transit stops within roughly [radiusM] of the point, nearest first. Empty on any failure. */
+    fun stopsNear(http: OkHttpClient, lat: Double, lng: Double, radiusM: Double = 200.0): List<MapStop> {
+        val dLat = radiusM / 111_320.0
+        val dLng = radiusM / (111_320.0 * Math.cos(Math.toRadians(lat)))
+        val url = "$BASE/api/v1/map/stops?min=${lat - dLat},${lng - dLng}&max=${lat + dLat},${lng + dLng}"
+        val body = get(http, url) ?: return emptyList()
+        return runCatching { json.decodeFromString<List<MapStop>>(body) }.getOrDefault(emptyList())
+            .sortedBy { distM(lat, lng, it.lat, it.lon) }
+    }
+
+    /** The next [n] departures at [stopId] (a parent-station id aggregates all its child stops). */
+    fun stopTimes(http: OkHttpClient, stopId: String, n: Int = 50): List<StopTime> {
+        val url = "$BASE/api/v1/stoptimes?stopId=${URLEncoder.encode(stopId, "UTF-8")}&n=$n"
+        val body = get(http, url) ?: return emptyList()
+        return runCatching { json.decodeFromString<StopTimesResp>(body).stopTimes }.getOrDefault(emptyList())
+    }
+
+    /**
+     * The full departure board for the stop at ([lat], [lng]): nearest stop GROUP within ~200 m
+     * (grouped by parent station so a hub's bays merge into one board), grouped by (route, headsign)
+     * into the same [StopDepartures] model the Google-blob parser feeds - the whole board UI (pills,
+     * countdowns, day markers) renders it unchanged. Null when Transitous has nothing here (no
+     * coverage, no stop, network failure) - the caller falls back to the Google path.
+     */
+    fun board(http: OkHttpClient, lat: Double, lng: Double): StopDepartures? {
+        val stops = stopsNear(http, lat, lng)
+        if (stops.isEmpty()) return null
+        // Prefer the nearest stop's PARENT station (aggregates every bay); fall back to the stop itself.
+        val nearest = stops.first()
+        val queryId = nearest.parentId ?: nearest.stopId
+        val times = stopTimes(http, queryId).ifEmpty { return null }
+        return buildBoard(times, stationName = nearest.name)
+    }
+
+    /** Pure grouping of raw stop times into the board model (unit-tested; no network). */
+    internal fun buildBoard(times: List<StopTime>, stationName: String?, nowMs: Long = System.currentTimeMillis()): StopDepartures? {
+        data class Key(val label: String?, val headsign: String?)
+        val groups = LinkedHashMap<Key, MutableList<StopTime>>()
+        for (t in times) {
+            if (t.place.cancelled) continue
+            groups.getOrPut(Key(t.routeShortName, t.headsign)) { mutableListOf() }.add(t)
+        }
+        if (groups.isEmpty()) return null
+        val lines = groups.map { (k, ts) ->
+            val deps = ts.mapNotNull { t ->
+                val iso = t.place.departure ?: t.place.scheduledDeparture ?: return@mapNotNull null
+                val epoch = parseIso(iso) ?: return@mapNotNull null
+                StopDeparture(
+                    clockText = clockText(epoch, t.place.tz),
+                    epochSec = epoch,
+                    // realTime = the feed is live-tracking this run; that's the green-dot signal.
+                    realtime = t.realTime,
+                )
+            }.sortedBy { it.epochSec ?: Long.MAX_VALUE }
+            StopDepartureLine(
+                label = k.label,
+                mode = modeOf(ts.firstOrNull()?.mode),
+                headsign = k.headsign,
+                colorHex = ts.firstOrNull()?.routeColor?.takeIf { it.isNotBlank() }?.let { if (it.startsWith("#")) it else "#$it" },
+                headwayText = null,
+                upcoming = deps,
+            )
+        }
+            .filter { it.upcoming.isNotEmpty() }
+            .sortedBy { it.upcoming.firstOrNull()?.epochSec ?: Long.MAX_VALUE }
+        if (lines.isEmpty()) return null
+        return StopDepartures(stationName = stationName?.takeIf { it.isNotBlank() }, lines = lines)
+    }
+
+    // --- helpers ----------------------------------------------------------------------------------
+
+    private fun get(http: OkHttpClient, url: String): String? = runCatching {
+        http.newCall(Request.Builder().url(url).header("User-Agent", UA).build()).execute().use { resp ->
+            if (!resp.isSuccessful) null else resp.body?.string()
+        }
+    }.getOrNull()
+
+    /** ISO-8601 UTC ("2026-07-13T20:26:00Z") to epoch seconds. */
+    internal fun parseIso(iso: String): Long? = runCatching { java.time.Instant.parse(iso).epochSecond }.getOrNull()
+
+    /** 12-hour clock text in the STOP's timezone (falls back to the device zone), matching the
+     *  Google-board format the row UI and its TIME-based logic already render. */
+    internal fun clockText(epochSec: Long, tz: String?): String {
+        val fmt = SimpleDateFormat("h:mm a", Locale.US)
+        fmt.timeZone = tz?.let { runCatching { TimeZone.getTimeZone(it) }.getOrNull() } ?: TimeZone.getDefault()
+        return fmt.format(Date(epochSec * 1000))
+    }
+
+    private fun modeOf(mode: String?): TransitMode = when (mode?.uppercase()) {
+        "BUS", "COACH" -> TransitMode.BUS
+        "TRAM" -> TransitMode.TRAM
+        "SUBWAY", "METRO" -> TransitMode.SUBWAY
+        "RAIL", "HIGHSPEED_RAIL", "LONG_DISTANCE", "NIGHT_RAIL", "REGIONAL_RAIL", "REGIONAL_FAST_RAIL" -> TransitMode.TRAIN
+        "FERRY" -> TransitMode.FERRY
+        else -> TransitMode.GENERIC
+    }
+
+    private fun distM(aLat: Double, aLng: Double, bLat: Double, bLng: Double): Double {
+        val mPerLng = 111_320.0 * Math.cos(Math.toRadians(aLat))
+        val dx = (aLng - bLng) * mPerLng
+        val dy = (aLat - bLat) * 111_320.0
+        return Math.sqrt(dx * dx + dy * dy)
+    }
+}

--- a/core/src/test/java/app/vela/core/data/transit/TransitousTest.kt
+++ b/core/src/test/java/app/vela/core/data/transit/TransitousTest.kt
@@ -1,0 +1,56 @@
+package app.vela.core.data.transit
+
+import app.vela.core.model.TransitMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TransitousTest {
+
+    private fun st(
+        route: String?, headsign: String?, iso: String,
+        realtime: Boolean = false, color: String? = null, mode: String = "BUS", cancelled: Boolean = false,
+    ) = Transitous.StopTime(
+        place = Transitous.StPlace(departure = iso, scheduledDeparture = iso, tz = "UTC", cancelled = cancelled),
+        mode = mode, realTime = realtime, headsign = headsign, routeShortName = route, routeColor = color,
+    )
+
+    @Test
+    fun `groups by route and headsign, sorts lines soonest first`() {
+        val board = Transitous.buildBoard(
+            listOf(
+                st("42", "Downtown", "2026-01-01T10:20:00Z"),
+                st("Rapid Blue", "Airport", "2026-01-01T10:05:00Z", realtime = true, color = "00aa00"),
+                st("42", "Downtown", "2026-01-01T10:40:00Z"),
+                st("42", "Uptown", "2026-01-01T10:30:00Z"),
+            ),
+            stationName = "Main St Station",
+        )!!
+        assertEquals("Main St Station", board.stationName)
+        assertEquals(3, board.lines.size)
+        // soonest line leads: the named line at 10:05
+        assertEquals("Rapid Blue", board.lines[0].label)
+        assertEquals("#00aa00", board.lines[0].colorHex)   // hex prefix added
+        assertTrue(board.lines[0].upcoming[0].realtime)
+        // route 42 Downtown keeps BOTH its times, sorted
+        val downtown = board.lines.first { it.label == "42" && it.headsign == "Downtown" }
+        assertEquals(2, downtown.upcoming.size)
+        assertTrue(downtown.upcoming[0].epochSec!! < downtown.upcoming[1].epochSec!!)
+        assertEquals(TransitMode.BUS, downtown.mode)
+    }
+
+    @Test
+    fun `cancelled runs are dropped, empty board is null`() {
+        assertNull(Transitous.buildBoard(listOf(st("1", "A", "2026-01-01T10:00:00Z", cancelled = true)), null))
+        assertNull(Transitous.buildBoard(emptyList(), null))
+    }
+
+    @Test
+    fun `iso parse and clock text`() {
+        val epoch = Transitous.parseIso("2026-01-01T20:26:00Z")!!
+        assertEquals(1767299160L, epoch)
+        assertEquals("8:26 PM", Transitous.clockText(epoch, "UTC"))
+        assertNull(Transitous.parseIso("not-a-time"))
+    }
+}


### PR DESCRIPTION
Phase 1 of moving transit off the Google scrape, per the reliability discussion.

## What

- New `core/data/transit/Transitous` client for the community [Transitous](https://transitous.org) API (MOTIS over the world's open GTFS + GTFS-Realtime feeds — transit's FOSSGIS-OSRM: keyless, fair-use, identifying UA).
- `fetchStopDepartures` calls `Transitous.board(lat, lng)` **first** for any transit-category or Intersection place. The stop is found by **proximity** at the place's own coordinate (`map/stops`), killing all the Google/OSM name-correlation for boards; `stoptimes` on the nearest stop's **parent station** returns **every route** with realtime flags and the agency's official route colours — a multi-bay transit center merges into one complete board for free.
- The Google blob paths stay as the **fallback** where Transitous lacks the agency.
- Maps into the existing `StopDepartures` model, so the whole board UI (pills, countdowns, day markers, expanders, Stops action) renders unchanged. `buildBoard` is pure + unit-tested.

## Device-verified (4A)

Same corner, same minute: **1 route** via the Google page vs **6 lines** via Transitous — named BRT lines in their official colours, numbered routes in theirs, live green countdowns with the realtime dot, hours+minutes formatting.

## Notes

- Fair use: one request pair per opened stop, no polling.
- Phase 2 candidates (separate PRs): transit **directions** via `/plan` (replacing the WebView itinerary scrape), and **stops drawn on the map** from `map/stops` (replacing the OSM basemap stop icons + tap correlation entirely — the endpoint verifiably returns canonical GTFS stop positions per bbox).
