### PR TITLE
Feature-phone support: adaptive density + small-screen D-pad focus fixes (from vela-dpad)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -861,6 +861,13 @@ Defaults that make the safe path the easy one:
   on frame 1);
   the map is key-driven via `app/ui/map/MapDpadController.kt` (wired in `VelaMapView`, key
   handling + crosshair + zoom buttons in `MapScreen`).
+  **AdaptiveDensity (2026-07-13, from the vela-dpad fork by ars18/alltechdev):** `ui/AdaptiveDensity.wrap`
+  (chained FIRST in both `attachBaseContext`s) shrinks the app's effective density so tiny feature-phone
+  screens report >= 360dp of logical width - chips/dialogs/rows fit instead of clipping. It is a HARD
+  NO-OP at >= 360dp (ordinary phones byte-identical); tuned visually on 240x320-class flip phones by the
+  fork author. Same commit brought `Modifier.dpadAutoFocus(requester)` (confirm-until-landed retry on a
+  caller-owned requester - the weak rememberDpadAutoFocus can bail before focus actually lands) and the
+  Settings DOWN-from-Back bridge (TopAppBar -> content Column crossing clears focus otherwise).
   **Detection is CONSERVATIVE - do not loosen it (fixed 2026-07-08).** `rememberDpadFirstDevice`
   (`detectDpadFirst`) returns true ONLY for a genuinely touchless device (`!FEATURE_TOUCHSCREEN`)
   or a PHYSICAL (non-virtual) `InputDevice` with `SOURCE_DPAD`. It must NOT count the framework's

--- a/app/src/main/java/app/vela/MainActivity.kt
+++ b/app/src/main/java/app/vela/MainActivity.kt
@@ -25,7 +25,8 @@ class MainActivity : ComponentActivity() {
     /** Apply the in-app language override to this Activity's resources (no-op when following the
      *  system locale) so `stringResource` resolves in the chosen language. */
     override fun attachBaseContext(newBase: Context) {
-        super.attachBaseContext(AppLocale.wrap(newBase))
+        // Adaptive small-screen density first (a no-op on normal screens), then the language override.
+        super.attachBaseContext(AppLocale.wrap(app.vela.ui.AdaptiveDensity.wrap(newBase)))
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/app/vela/VelaApp.kt
+++ b/app/src/main/java/app/vela/VelaApp.kt
@@ -25,7 +25,7 @@ class VelaApp : Application() {
      *  system), so `getString` from the ViewModel/nav-notification also localizes — resolved at launch
      *  from the saved pref (an in-session change re-reads it on next launch). */
     override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(AppLocale.wrap(base))
+        super.attachBaseContext(AppLocale.wrap(app.vela.ui.AdaptiveDensity.wrap(base)))
     }
 
     override fun onCreate() {

--- a/app/src/main/java/app/vela/ui/AdaptiveDensity.kt
+++ b/app/src/main/java/app/vela/ui/AdaptiveDensity.kt
@@ -1,0 +1,44 @@
+package app.vela.ui
+
+import android.content.Context
+import android.content.res.Configuration
+import kotlin.math.roundToInt
+
+/**
+ * Adaptive UI density for tiny (feature-phone) screens - the app CHECKS the screen and scales its own
+ * density so the layout fits.
+ *
+ * Standard Material layouts assume roughly [MIN_WIDTH_DP] of logical width (48dp touch targets, list
+ * paddings, dialog button rows). On a 240px-wide feature phone that only exists at higher density, the
+ * logical width is far below that, so controls crowd and clip. Rather than hand-fix every screen for
+ * every device, this overrides the app's effective `densityDpi` ONCE (at [wrap], from
+ * `attachBaseContext`) so a small screen reports at least [MIN_WIDTH_DP] dp of width - then every screen
+ * lays out with room, in one place.
+ *
+ * It ONLY ever SHRINKS a small screen; a normal/large screen (>= [MIN_WIDTH_DP] wide) is a byte-for-byte
+ * no-op, so ordinary phones are untouched. The cost is physically smaller text on a tiny panel, so
+ * [MIN_WIDTH_DP] is tuned VISUALLY on the real target sizes (240x320, 320x240). Mirrors [AppLocale.wrap]
+ * and is chained with it in MainActivity/VelaApp.attachBaseContext.
+ */
+object AdaptiveDensity {
+    /** Ensure the app has at least this much logical width (dp). Tunable; verify visually per device. */
+    const val MIN_WIDTH_DP = 360
+
+    /** Wrap a base [Context] with a shrunk density iff the screen is narrower than [MIN_WIDTH_DP].
+     * Reads only the incoming [Configuration] (runs from `attachBaseContext`, before any init). */
+    fun wrap(base: Context): Context {
+        val cfg = base.resources.configuration
+        val widthDp = cfg.screenWidthDp
+        // Unknown (0) or already wide enough -> leave the default path byte-for-byte untouched.
+        if (widthDp <= 0 || widthDp >= MIN_WIDTH_DP) return base
+        val scale = widthDp.toFloat() / MIN_WIDTH_DP            // < 1 : shrink dp -> more fits
+        val out = Configuration(cfg).apply {
+            densityDpi = (cfg.densityDpi * scale).roundToInt().coerceAtLeast(1)
+            // Report the larger logical size that the shrunk density buys, so layouts see the room.
+            screenWidthDp = (screenWidthDp / scale).roundToInt()
+            screenHeightDp = (screenHeightDp / scale).roundToInt()
+            smallestScreenWidthDp = (smallestScreenWidthDp / scale).roundToInt()
+        }
+        return base.createConfigurationContext(out)
+    }
+}

--- a/app/src/main/java/app/vela/ui/AppLocale.kt
+++ b/app/src/main/java/app/vela/ui/AppLocale.kt
@@ -96,6 +96,11 @@ object AppLocale {
         Locale.setDefault(locale)
         val config = Configuration(base.resources.configuration)
         config.setLocale(locale)
+        // Force the RTL/LTR direction from the chosen locale. setLocale only auto-updates
+        // layoutDirection when the config's direction wasn't already set, but AdaptiveDensity.wrap
+        // runs first and hands over a config with an explicit (LTR) direction, so Hebrew never
+        // flipped the layout without this (found + fixed in the vela-dpad fork).
+        config.setLayoutDirection(locale)
         return base.createConfigurationContext(config)
     }
 

--- a/app/src/main/java/app/vela/ui/DpadFocus.kt
+++ b/app/src/main/java/app/vela/ui/DpadFocus.kt
@@ -179,6 +179,33 @@ fun Modifier.dpadAutoFocus(): Modifier = composed {
 }
 
 /**
+ * Robust auto-focus for a **caller-owned** [requester] - use when the element's focus must also be
+ * re-requested elsewhere (e.g. Settings routes an UP from its top row back to the Back button via
+ * `requester.requestFocus()`, so the screen needs a handle on the requester, not just a Modifier).
+ * Same confirm-until-landed retry as [dpadAutoFocus] (re-requests every 50 ms up to ~2 s until
+ * `onFocusEvent` confirms focus truly landed, then stops so it never fights the user) - but on a
+ * requester you own. Prefer this over `rememberDpadAutoFocus()` + `.focusRequester(...)`: the weak
+ * helper bails the instant `requestFocus()` doesn't throw, even when focus never actually landed,
+ * so a screen can open UNfocused (device-verified on a 240x320 feature phone). No-op under touch.
+ */
+fun Modifier.dpadAutoFocus(requester: FocusRequester): Modifier = composed {
+    val dpadFirst = rememberDpadFirstDevice()
+    var focused by remember { mutableStateOf(false) }
+    LaunchedEffect(dpadFirst) {
+        if (dpadFirst) {
+            repeat(40) {
+                if (focused) return@LaunchedEffect
+                runCatching { requester.requestFocus() }
+                kotlinx.coroutines.delay(50)
+            }
+        }
+    }
+    this
+        .focusRequester(requester)
+        .onFocusEvent { focused = it.isFocused }
+}
+
+/**
  * Makes a text field D-pad ESCAPABLE: UP/DOWN move focus to the previous/next form control
  * instead of being swallowed by the field's own cursor handling. Without this, a single- or
  * multi-line `TextField`/`BasicTextField` eats the vertical arrows, trapping focus on the

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -88,6 +88,7 @@ import app.vela.ui.theme.ThemeMode
 import app.vela.ui.dpadHighlight // D-pad-only operation (docs/dpad.md)
 import app.vela.ui.dpadFieldEscape
 import app.vela.ui.dpadSwallowHorizontal
+import app.vela.ui.dpadAutoFocus
 import app.vela.ui.rememberDpadAutoFocus
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -134,14 +135,31 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
     // D-pad-first (docs/dpad.md): Settings must open already focused — land on the back
     // button (top of screen) so the first arrow press enters the content, never a wasted
     // "wake up focus" press. No-op under touch.
-    val settingsAutoFocus = rememberDpadAutoFocus()
+    // Robust dpadAutoFocus(requester): confirms focus actually LANDED (the weak rememberDpadAutoFocus
+    // left Back unfocused on open on a 240x320 feature phone). Caller-owned requester because the top
+    // row routes its UP back to Back below.
+    val settingsAutoFocus = remember { FocusRequester() }
+    val topRowFocus = remember { FocusRequester() } // first content row (Back routes its DOWN here)
     var atTopItem by remember { mutableStateOf(false) }   // top content row focused? (routes its UP to Back)
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.settings_title)) },
                 navigationIcon = {
-                    IconButton(onClick = onBack, modifier = Modifier.focusRequester(settingsAutoFocus).dpadSwallowHorizontal()) {
+                    IconButton(
+                        onClick = onBack,
+                        // DOWN from Back must ENTER the content list: Compose's directional search can't
+                        // cross from the TopAppBar into the scrolling Column and CLEARS focus instead
+                        // (device-verified at 240x320) - route DOWN straight to the first content row.
+                        modifier = Modifier
+                            .dpadAutoFocus(settingsAutoFocus)
+                            .onKeyEvent { ev ->
+                                if (ev.key == Key.DirectionDown && ev.type == KeyEventType.KeyDown) {
+                                    runCatching { topRowFocus.requestFocus() }; true
+                                } else false
+                            }
+                            .dpadSwallowHorizontal(),
+                    ) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.settings_back))
                     }
                 },
@@ -175,8 +193,9 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 label = stringResource(R.string.settings_follow_system),
                 selected = AppTheme.mode.value == ThemeMode.SYSTEM,
                 onClick = { AppTheme.set(context, ThemeMode.SYSTEM) },
-                // The top focusable row: track when it holds focus so the Column routes its UP to Back.
-                modifier = Modifier.onFocusEvent { atTopItem = it.isFocused },
+                // The top focusable row: Back routes its DOWN here (focusRequester), and we track when
+                // it holds focus so the Column routes its UP back to Back.
+                modifier = Modifier.focusRequester(topRowFocus).onFocusEvent { atTopItem = it.isFocused },
             )
             SelectableRow(
                 label = stringResource(R.string.settings_theme_light),


### PR DESCRIPTION
Ports the feature-phone work from alltechdev/vela-dpad (commit 7440849) with credit. The fork's history predates the repo rewrite so this is a hand port, not a merge.

Normal phones aren't affected: the density wrapper is a hard no-op at 360dp and up, it hands back the context unchanged. Only sub-360dp screens (the 240x320 flip phone class) get scaled so standard layouts fit. The fork author tuned the scaling on real hardware.

Also brings over two D-pad focus fixes, both no-ops under touch: a retrying auto-focus helper (the old one could leave Settings open with nothing focused) and a bridge so pressing down from the Back button in Settings lands in the content instead of dropping focus. And a follow-up fix from the fork: the density wrapper bakes an LTR direction into the config before the locale wrapper runs, which silently broke Hebrew's right-to-left layout, so the locale wrapper now forces the direction from the chosen language.

Skipped the fork's test harness and fork-specific doc changes. Compiles clean here; the fork author verified on four flip phone models.