### PR TITLE
Docs: transit data sources - the Transitous/Google division of labour

### DIFF
--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -8,7 +8,8 @@ Deeper detail is in [`SPEC.md`](../SPEC.md); this is the index into it.
 | **Basemap** | Open vector tiles (OpenFreeMap / Protomaps) via MapLibre - keyless, no Google | `core/data/tiles/`, `app/ui/map/VelaMapView.kt` |
 | **Search, places, reviews, hours** | Per-user keyless scrape of `google.com` `pb` endpoints (browser-like session token); responses are positional arrays walked by calibrated index paths | `core/data/google/`, SPEC §3 |
 | **Photo gallery** | Hidden **anonymous WebView** same-origin-fetches the gallery RPC (OkHttp gets a bot-degraded reply) | `app/web/WebPhotoFetcher.kt` |
-| **Public transit** | Hidden WebView reads the directions SPA's `APP_INITIALIZATION_STATE` | `app/web/WebDirectionsFetcher.kt`, `core/…/TransitParser` |
+| **Transit directions** | Hidden WebView reads Google's directions SPA (traffic-aware itineraries) | `app/web/WebDirectionsFetcher.kt`, `core/…/TransitParser` |
+| **Departure boards** | **Transitous** (open GTFS + GTFS-Realtime, keyless) primary; Google place-page blob as fallback | `core/data/transit/Transitous.kt` |
 | **Turn-by-turn routing** | **FOSSGIS OSRM** (open) - complete street-named steps incl. highway `ref`/exit/lanes; retried on blips | `core/data/RouteGeometry.kt` |
 | **Traffic ETA + jam reroute** | Google's directions overlaid on the OSRM route; re-runs OSRM through Google's path only when they diverge (option 3) | `GoogleMapsDataSource.directions`/`applyTraffic` |
 | **Offline routing** | On-device **GraphHopper** CH graphs, one per region, downloaded from a 135-region world catalog | `core/data/GraphHopperRouteEngine.kt`, `app/offline/RoutingGraphStore.kt`, `tools/routing-regions.json` |
@@ -24,3 +25,25 @@ Deeper detail is in [`SPEC.md`](../SPEC.md); this is the index into it.
 | **Parking spot memory** | One tap on the P button saves where you parked (teal pin, walking directions back); long-press for the history so an accidental overwrite never loses the car | `core/data/ParkingStore.kt` |
 | **Fix drift without an app update** | ECDSA-signed remote `calibration.json` (pb templates, field-index paths, JS transforms) + notices, verified against a pinned key | `core/config/CalibrationStore.kt`, SPEC §5 |
 | **Distribution** | Code push to `main` → signed nightly prerelease (docs-only changes don't cut releases); weekly promote to stable (same APK); Obtainium tracks stable by default, nightlies via the prerelease toggle; a self-hosted F-Droid repo serves both channels ([FDROID.md](../FDROID.md)) | `.github/workflows/ci.yml` + `promote-stable.yml` + `fdroid-repo.yml` |
+
+
+## Transit data: who provides what
+
+Vela's transit stack deliberately mixes two sources, each doing the thing it is genuinely better at.
+This split matters for debugging and for knowing what breaks when one side has an outage.
+
+| Piece | Source | Why |
+|---|---|---|
+| **Departure board** on a stop | **Transitous first** (open GTFS + GTFS-Realtime via the community MOTIS server, keyless). Google's anonymous place page is the fallback. | The open feeds return **every** route at a stop with realtime lateness and the agency's own route colours, and a multi-bay transit center merges through its parent station. Google's anonymous page embeds as little as one route at big hubs. |
+| **Transit directions** (picking a bus route A to B) | **Google** (hidden WebView reading the directions page). | Google's itinerary ETAs can reflect live road traffic on the bus's route; GTFS-Realtime only knows a bus is *currently* late, not that it *will be* slowed. Riders comparing route options benefit from the prediction, so Google keeps this job. A Transitous fallback for outages is planned. |
+| **Stop icons on the map** | OSM basemap tiles today; moving to Transitous stop positions (canonical GTFS) with OSM as the offline floor. | OSM stop data is community-maintained and sometimes marks stops agencies do not serve; GTFS positions come from the agencies themselves. |
+| **Route stop list** (tap a route on the board) | Google itinerary reuse today; moving to the GTFS trip's own stop sequence. | The trip data is exact - the actual run you tapped, every stop it makes - where the itinerary reuse guesses at a matching leg. |
+| **Realtime lateness** | GTFS-Realtime through Transitous (the green live dot and adjusted times on boards). | Straight from the agency feed; no scraping involved. |
+
+How the fallback behaves: when Transitous has no coverage for an agency, boards silently fall back to
+Google's page and show whatever it embeds. When Google's scrape breaks (the standing risk of any
+keyless path), boards keep working because they no longer depend on it. Directions currently have no
+fallback beyond Google's own OSRM-assisted paths; that is the next reliability gap to close.
+
+Offline: stop icons render from downloaded map tiles, and region place packs carry stop names for
+offline search. Boards and directions are online by nature - schedules are realtime data.

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -36,7 +36,7 @@ This split matters for debugging and for knowing what breaks when one side has a
 |---|---|---|
 | **Departure board** on a stop | **Transitous first** (open GTFS + GTFS-Realtime via the community MOTIS server, keyless). Google's anonymous place page is the fallback. | The open feeds return **every** route at a stop with realtime lateness and the agency's own route colours, and a multi-bay transit center merges through its parent station. Google's anonymous page embeds as little as one route at big hubs. |
 | **Transit directions** (picking a bus route A to B) | **Google** (hidden WebView reading the directions page). | Google's itinerary ETAs can reflect live road traffic on the bus's route; GTFS-Realtime only knows a bus is *currently* late, not that it *will be* slowed. Riders comparing route options benefit from the prediction, so Google keeps this job. A Transitous fallback for outages is planned. |
-| **Stop icons on the map** | OSM basemap tiles today; moving to Transitous stop positions (canonical GTFS) with OSM as the offline floor. | OSM stop data is community-maintained and sometimes marks stops agencies do not serve; GTFS positions come from the agencies themselves. |
+| **Stop icons on the map** | **Transitous stop positions** (canonical GTFS) at street zoom; the OSM basemap icons stay wherever Transitous has no coverage. Tapping an icon opens the board directly by stop id. | GTFS positions come from the agencies themselves; OSM stop data is community-maintained and sometimes marks stops agencies do not serve. The direct stop-id tap also skips the fragile name matching between map data and Google listings. |
 | **Route stop list** (tap a route on the board) | Google itinerary reuse today; moving to the GTFS trip's own stop sequence. | The trip data is exact - the actual run you tapped, every stop it makes - where the itinerary reuse guesses at a matching leg. |
 | **Realtime lateness** | GTFS-Realtime through Transitous (the green live dot and adjusted times on boards). | Straight from the agency feed; no scraping involved. |
 
@@ -45,5 +45,7 @@ Google's page and show whatever it embeds. When Google's scrape breaks (the stan
 keyless path), boards keep working because they no longer depend on it. Directions currently have no
 fallback beyond Google's own OSRM-assisted paths; that is the next reliability gap to close.
 
-Offline: stop icons render from downloaded map tiles, and region place packs carry stop names for
-offline search. Boards and directions are online by nature - schedules are realtime data.
+Offline: every area browsed online keeps its canonical stops in a small on-disk cache, so the
+places you frequent redraw their stops with no signal; never-visited areas fall back to the OSM
+icons in downloaded map tiles, and region place packs carry stop names for offline search. Boards
+and directions are online by nature - schedules are realtime data.


### PR DESCRIPTION
Starts the nitty-gritty transit documentation (#184 grows it from here). It spells out which source powers each piece of the transit stack and why. The main point worth writing down: transit directions stay on Google on purpose, because its bus ETAs account for road traffic where GTFS-Realtime only knows a bus is currently late. Departure boards and the stop icons run on the open feeds with Google as the fallback. Also fixes the stale one-row summary in the capability table.