### PR TITLE
Canonical GTFS transit stops on the map with an offline area cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1874,10 +1874,28 @@ architecture note.
   route via the Google blob shows 6 lines with official pill colours + live countdowns). The result maps
   into the SAME StopDepartures model, so the whole board UI renders unchanged. The Google blob paths
   (fetchBoardFrom / resolveIntersectionStopBoard) remain the FALLBACK where Transitous lacks coverage.
-  `buildBoard` is pure + unit-tested (TransitousTest). PHASE 2 candidates: transit directions via
-  `/api/v1/plan` (replacing WebDirectionsFetcher), stops drawn on the map from `map/stops` (replacing
-  the OSM basemap stop icons + all tap correlation - the endpoint is verified to return canonical
-  GTFS stop positions per bbox).
+  `buildBoard` is pure + unit-tested (TransitousTest). Remaining phase-2 candidate: transit
+  directions via `/api/v1/plan` as a FALLBACK only - Google stays the primary transit router on
+  purpose (its ETAs are traffic/history-aware; GTFS-RT only knows current lateness).
+- **Canonical GTFS stops drawn on the map (2026-07-13, phase 2 of the Transitous adoption,
+  device-verified).** At z >= 15 (`TRANSIT_STOPS_MIN_ZOOM`) the viewport's transit stops come from
+  `Transitous.stopsInBox` (`map/stops`) and draw as a blue bus badge + stop-name label
+  (`TRANSIT_STOPS_LAYER` in VelaMapView, sibling of the flock layer: area-cached box in the VM,
+  350 ms settle, identity-gated source upload). One icon per STATION - bays dedupe onto their
+  `parentId` in the VM, matching how the board queries the parent. **Tapping an icon opens the
+  board DIRECTLY by stop id** (`onTransitStopTap` -> a lightweight `gtfs:<stopId>` place +
+  `Transitous.boardFor` - zero Google resolution, zero name correlation; device-verified: tap ->
+  named stop sheet + live board in one hop). **Wherever this layer has coverage the basemap's OSM
+  bus icons hide** (applyData flips `poi_transit`'s filter to exclude class "bus", restoring the
+  captured original filter when coverage goes - rail/airport stay basemap) so a stop can't draw
+  twice at slightly different corners. **Offline floor = `app/data/TransitStopCache`**: every
+  successful viewport fetch overwrites its area in a 24-area LRU JSON on disk, so the places a
+  user actually visits keep fresh canonical stops with no extra machinery (the flock-dataset
+  freshness property; global GTFS is too big to bundle, the visited-area cache is the
+  equivalent). Offline/fetch-failure reads the covering cached area; a never-visited area falls
+  back to the OSM basemap icons (filter restored). A fetch blip never blanks drawn stops.
+  Regional GTFS stop packs (whole-state stops baked into the poi-pack pipeline) are the future
+  hard-offline version - see task/ROADMAP.
 - **Share diagnostics is functional now (2026-07-13):** `DiagLog` (opt-in breadcrumb ring, :core)
   PERSISTS to a bounded `filesDir/diag_log.jsonl` (appended per event, reloaded at init, deleted on
   opt-out) - it was in-memory only, and since the bug being reported usually killed or preceded a

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -933,6 +933,16 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   boarding leg's **"N min late/early"** is surfaced right in the header (it was only in the
   drill-down before). Pure render off already-parsed fields (`TransitItinerary.departureEpochSec`,
   `TransitStep.delayText`), no extra fetch; localized in all 11 languages.
+- ✅ **Canonical transit stops on the map (2026-07-13, Transitous, device-verified).** At street
+  zoom the bus stops you see are the agencies' own GTFS stop positions from Transitous (`map/stops`
+  per viewport, area-cached), drawn as a blue bus badge with the official stop name - one icon per
+  station (bays collapse onto their parent). **Tapping a stop opens its live departure board
+  instantly by stop id** - no Google lookup, no name matching, so intersection-named stops and
+  multi-bay hubs just work. Where this layer has coverage the OSM basemap's bus icons hide (no
+  doubled stops); rail/airport icons stay basemap. **Stops keep working offline**: every area you
+  browse online is cached to disk (24-area LRU) and redraws with no signal - the same
+  continuously-fresh property as the surveillance-camera dataset; never-visited areas fall back
+  to the OSM icons.
 - ✅ **Live stop departure board (2026-07-12, keyless + device-verified).** Tapping a transit
   station (subway / rail / BART / bus stop) shows Google's **"See departure board"** right in the
   place sheet: each line and direction with its **route number in its real line colour** (the "14"/

--- a/app/src/main/java/app/vela/data/TransitStopCache.kt
+++ b/app/src/main/java/app/vela/data/TransitStopCache.kt
@@ -1,0 +1,101 @@
+package app.vela.data
+
+import android.content.Context
+import app.vela.core.data.transit.Transitous
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * Disk cache of Transitous stop AREAS - the offline floor for the transit-stop map layer.
+ *
+ * Every ONLINE viewport fetch overwrites its area here, so the places a user actually visits keep
+ * fresh, canonical GTFS stops with no extra machinery: the cache is continuously updated as a side
+ * effect of normal use (the same property the flock dataset gets from its weekly re-bake - stops are
+ * far too numerous globally to bundle, so the visited-area cache is the equivalent). Offline, the map
+ * layer reads whatever area covers the view; a never-visited area falls back to the OSM basemap icons.
+ *
+ * Bounded LRU of [MAX_AREAS] areas in one JSON file (~a few hundred KB at worst); loaded lazily,
+ * written on each store. Thread-safe via a plain lock - writes are rare (one per NEW area).
+ */
+class TransitStopCache(private val context: Context) {
+    private val lock = Any()
+    private val file = File(context.filesDir, "transit_stops_cache.json")
+    private var areas: MutableList<Area>? = null // lazy; oldest first
+
+    data class Area(val south: Double, val west: Double, val north: Double, val east: Double, val stops: List<Transitous.MapStop>, val at: Long)
+
+    /** Cache the stops fetched for a box (replacing any area it substantially overlaps). */
+    fun store(south: Double, west: Double, north: Double, east: Double, stops: List<Transitous.MapStop>) = synchronized(lock) {
+        val list = loadLocked()
+        list.removeAll { a -> overlaps(a, south, west, north, east) }
+        list.add(Area(south, west, north, east, stops, System.currentTimeMillis()))
+        while (list.size > MAX_AREAS) list.removeAt(0)
+        persistLocked(list)
+    }
+
+    /** Stops for a cached area covering the CENTER of the requested box, or null when uncovered. */
+    fun lookup(south: Double, west: Double, north: Double, east: Double): List<Transitous.MapStop>? = synchronized(lock) {
+        val cLat = (south + north) / 2; val cLng = (west + east) / 2
+        return loadLocked().lastOrNull { a -> cLat in a.south..a.north && cLng in a.west..a.east }?.stops
+    }
+
+    private fun overlaps(a: Area, s: Double, w: Double, n: Double, e: Double): Boolean {
+        val cLat = (s + n) / 2; val cLng = (w + e) / 2
+        return cLat in a.south..a.north && cLng in a.west..a.east
+    }
+
+    private fun loadLocked(): MutableList<Area> {
+        areas?.let { return it }
+        val out = mutableListOf<Area>()
+        runCatching {
+            if (file.exists()) {
+                val arr = JSONArray(file.readText())
+                for (i in 0 until arr.length()) {
+                    val o = arr.getJSONObject(i)
+                    val stopsArr = o.getJSONArray("stops")
+                    val stops = ArrayList<Transitous.MapStop>(stopsArr.length())
+                    for (j in 0 until stopsArr.length()) {
+                        val st = stopsArr.getJSONObject(j)
+                        stops.add(
+                            Transitous.MapStop(
+                                name = st.optString("n"),
+                                stopId = st.optString("i"),
+                                parentId = st.optString("p").takeIf { it.isNotEmpty() },
+                                lat = st.optDouble("la"),
+                                lon = st.optDouble("lo"),
+                            ),
+                        )
+                    }
+                    out.add(Area(o.getDouble("s"), o.getDouble("w"), o.getDouble("n"), o.getDouble("e"), stops, o.optLong("t")))
+                }
+            }
+        }
+        areas = out
+        return out
+    }
+
+    private fun persistLocked(list: MutableList<Area>) {
+        runCatching {
+            val arr = JSONArray()
+            for (a in list) {
+                val stops = JSONArray()
+                for (st in a.stops) {
+                    stops.put(
+                        JSONObject()
+                            .put("n", st.name).put("i", st.stopId).put("p", st.parentId ?: "")
+                            .put("la", st.lat).put("lo", st.lon),
+                    )
+                }
+                arr.put(
+                    JSONObject()
+                        .put("s", a.south).put("w", a.west).put("n", a.north).put("e", a.east)
+                        .put("t", a.at).put("stops", stops),
+                )
+            }
+            file.writeText(arr.toString())
+        }
+    }
+
+    private companion object { const val MAX_AREAS = 24 }
+}

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -778,6 +778,8 @@ fun MapScreen(
 
             trafficControls = state.trafficControls,
             flockCameras = state.flockCameras,
+            transitStops = state.transitStops,
+            onTransitStopTap = vm::onTransitStopTap,
             navBannerBottomPx = if (state.navigating) navBannerBottomPx else 0,
             onAmbientTap = { i -> state.ambientPois.getOrNull(i)?.let(vm::selectPlace) },
             onCameraIdle = vm::onCameraIdle,

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -778,7 +778,10 @@ fun MapScreen(
 
             trafficControls = state.trafficControls,
             flockCameras = state.flockCameras,
-            transitStops = state.transitStops,
+            // Hide the tapped stop's own badge while it is selected - the red selected-place pin
+            // drops at the same coordinate and the two bus glyphs stacked read as a glitch
+            // (user 2026-07-13). Structural list equality keeps the identity gate quiet.
+            transitStops = state.transitStops.filterNot { st -> state.selected?.id == "gtfs:${st.stopId}" },
             onTransitStopTap = vm::onTransitStopTap,
             navBannerBottomPx = if (state.navigating) navBannerBottomPx else 0,
             onAmbientTap = { i -> state.ambientPois.getOrNull(i)?.let(vm::selectPlace) },

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -133,6 +133,7 @@ data class MapUiState(
                                                       // .pmtiles — rendered beneath OSM to fill gaps
     val trafficControls: List<app.vela.core.data.TrafficControl> = emptyList(), // OSM lights+stop signs drawn at high zoom
     val flockCameras: List<app.vela.core.data.AlprCamera> = emptyList(), // ALPR/Flock cameras (DeFlock/OSM), high zoom
+    val transitStops: List<app.vela.core.data.transit.Transitous.MapStop> = emptyList(), // canonical GTFS stops (Transitous), high zoom
     val directionsOpen: Boolean = false,
     val directionsReversed: Boolean = false, // route from the place back to you
     val directionsOrigin: Place? = null,     // custom "From" (null = your live location)
@@ -3467,6 +3468,7 @@ class MapViewModel @Inject constructor(
         refreshTrafficControls(south, west, north, east, zoom) // + traffic lights / stop signs at high zoom
         lastFlockViewport = doubleArrayOf(south, west, north, east, zoom)
         refreshFlock(south, west, north, east, zoom) // + ALPR/Flock cameras when the layer is on
+        refreshTransitStops(south, west, north, east, zoom) // + canonical GTFS stop icons at street zoom
         // Half-diagonal of the visible box — used to hand the map only the POIs near the view (the
         // rest can't render anyway), so an old budget phone isn't dragging 800 symbols through the
         // collider every frame.
@@ -3840,6 +3842,9 @@ class MapViewModel @Inject constructor(
     private var controlsJob: Job? = null
     private var controlsBox: DoubleArray? = null // [s,w,n,e] of the last fetched (padded) box
     private var flockBox: DoubleArray? = null
+    private var transitStopsBox: DoubleArray? = null
+    private var transitStopsJob: Job? = null
+    private val transitStopCache by lazy { app.vela.data.TransitStopCache(appContext) }
     private var lastFlockViewport: DoubleArray? = null
     private var flockJob: Job? = null
 
@@ -3895,6 +3900,85 @@ class MapViewModel @Inject constructor(
      *  so turning it on shows cameras without needing a pan first. */
     fun refreshFlockNow() {
         lastFlockViewport?.let { refreshFlock(it[0], it[1], it[2], it[3], it[4]) }
+    }
+
+    /** Canonical GTFS transit stops for the viewport (Transitous `map/stops`), the same area-cached,
+     *  350 ms-debounced contract as the traffic-controls layer. Every ONLINE fetch also refreshes the
+     *  DISK cache ([TransitStopCache]) - the offline floor: with no network, a previously visited
+     *  area's stops still draw (the OSM basemap icons cover never-visited areas). Stops replace the
+     *  OSM bus icons wherever this layer has coverage (VelaMapView hides poi_transit's bus class then). */
+    private fun refreshTransitStops(south: Double, west: Double, north: Double, east: Double, zoom: Double) {
+        if (zoom < TRANSIT_STOPS_MIN_ZOOM) {
+            transitStopsBox = null
+            transitStopsJob?.cancel()
+            if (_state.value.transitStops.isNotEmpty()) _state.update { it.copy(transitStops = emptyList()) }
+            return
+        }
+        val cLat = (south + north) / 2; val cLng = (west + east) / 2
+        transitStopsBox?.let { b ->
+            val insLat = (b[2] - b[0]) * 0.25; val insLng = (b[3] - b[1]) * 0.25
+            if (cLat in (b[0] + insLat)..(b[2] - insLat) && cLng in (b[1] + insLng)..(b[3] - insLng)) return
+        }
+        transitStopsJob?.cancel()
+        transitStopsJob = viewModelScope.launch {
+            delay(350)
+            val padLat = (north - south) * 0.5; val padLng = (east - west) * 0.5
+            val s0 = south - padLat; val n0 = north + padLat; val w0 = west - padLng; val e0 = east + padLng
+            val live = withContext(Dispatchers.IO) {
+                runCatching { app.vela.core.data.transit.Transitous.stopsInBox(http, s0, w0, n0, e0) }.getOrNull()
+            }
+            val stops = if (live != null) {
+                withContext(Dispatchers.IO) { runCatching { transitStopCache.store(s0, w0, n0, e0, live) } }
+                live
+            } else {
+                // Offline / fetch failed: the disk cache is the floor. Null there too -> keep whatever
+                // is drawn (don't blank the layer on a blip) and leave the box unset so we retry.
+                withContext(Dispatchers.IO) { runCatching { transitStopCache.lookup(s0, w0, n0, e0) }.getOrNull() } ?: return@launch
+            }
+            transitStopsBox = doubleArrayOf(s0, w0, n0, e0)
+            // One icon per station: bays collapse onto their parent (the board queries the parent anyway).
+            val deduped = stops.groupBy { it.parentId ?: it.stopId }.map { (_, group) -> group.first() }
+            _state.update { it.copy(transitStops = deduped) }
+        }
+    }
+
+    /** A tapped Transitous stop icon: open a lightweight place at the stop and fetch its board
+     *  DIRECTLY by stop id - no Google resolution, no name correlation. */
+    fun onTransitStopTap(stop: app.vela.core.data.transit.Transitous.MapStop) {
+        val placeholder = Place(
+            id = "gtfs:${stop.stopId}",
+            name = stop.name,
+            location = app.vela.core.model.LatLng(stop.lat, stop.lon),
+            category = "Bus stop",
+        )
+        reviewsJob?.cancel()
+        _state.update {
+            it.copy(
+                selected = placeholder,
+                results = emptyList(),
+                center = placeholder.location,
+                placesHere = emptyList(),
+                reviews = emptyList(),
+                stopDepartures = null,
+                stopDeparturesLoading = true,
+                reviewsLoading = false,
+                reviewsFound = 0,
+                loadingDetails = false,
+                photosLoading = false,
+                pickingOrigin = false,
+                pickingStop = false,
+                directionsOpen = false,
+            )
+        }
+        viewModelScope.launch {
+            val board = withContext(Dispatchers.IO) {
+                runCatching { app.vela.core.data.transit.Transitous.boardFor(http, stop) }.getOrNull()
+            }
+            _state.update { st ->
+                if (st.selected?.id != placeholder.id) st
+                else st.copy(stopDepartures = board?.takeIf { it.lines.isNotEmpty() }, stopDeparturesLoading = false)
+            }
+        }
     }
 
     /** ALPR/Flock cameras for the viewport, when the layer is on. Mirrors [refreshTrafficControls]:
@@ -4140,6 +4224,7 @@ class MapViewModel @Inject constructor(
         // 2026-07-13). Back to 13: the box is bounded, and the fetch is now streamed (OverpassAlprCameras)
         // so it can't blow the heap. Route-overview visibility is a separate follow-up.
         const val FLOCK_MIN_ZOOM = 13.0
+        const val TRANSIT_STOPS_MIN_ZOOM = 15.0 // GTFS stop icons from street-ish zoom (denser than cameras)
         const val CONTROLS_ONSCREEN_CAP = 400 // max controls handed to the map (nearest-to-center wins) — a
                                               // dense metro's padded box can carry 1000+, and every handed
                                               // symbol is re-collided per drag frame (budget-GPU jank)

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -110,6 +110,10 @@ private const val STOP_IMG = "vela-stop"
 private const val FLOCK_SRC = "vela-flock-src" // ALPR/Flock cameras (DeFlock/OSM) drawn at high zoom
 private const val FLOCK_LAYER = "vela-flock"
 private const val FLOCK_IMG = "vela-flock-cam"
+private const val TRANSIT_STOPS_SRC = "vela-transit-stops-src" // canonical GTFS stops (Transitous)
+private const val TRANSIT_STOPS_LAYER = "vela-transit-stops"
+private const val TRANSIT_STOP_IMG = "vela-transit-stop"
+private const val TRANSIT_STOP_INDEX_PROP = "vela_transit_stop_index"
 private const val AMBIENT_INDEX_PROP = "vela-ambient-index"
 private const val ACCURACY_SRC = "vela-me-accuracy-src"
 private const val ACCURACY_LAYER = "vela-me-accuracy"
@@ -159,6 +163,9 @@ private var lastAccuracyM: Float? = null
 private var parkingApplied = false // distinguishes "never applied" from "applied null"
 private var lastAppliedControls: List<app.vela.core.data.TrafficControl>? = null
 private var lastAppliedFlock: List<app.vela.core.data.AlprCamera>? = null
+private var lastAppliedTransitStops: List<app.vela.core.data.transit.Transitous.MapStop>? = null
+private var lastTransitBusHidden: Boolean? = null // gate the poi_transit filter flip
+private var origPoiTransitFilter: Expression? = null // basemap filter to restore when coverage goes
 private var lastOsmPoiVis: String? = null // identity-gate the basemap-POI visibility flips
 private var lastControlsVis: String? = null // identity-gate the traffic-control visibility flips
 private var lastAppliedRouteLine: List<LatLng>? = null // identity-gate the route upload — applyData runs
@@ -227,6 +234,7 @@ fun VelaMapView(
     onParkingTap: () -> Unit = {},
     ambientPois: List<MapMarker> = emptyList(),
     onAmbientTap: (index: Int) -> Unit = {},
+    onTransitStopTap: (app.vela.core.data.transit.Transitous.MapStop) -> Unit = {},
     buildingOverlays: List<String> = emptyList(), // full pmtiles:// source URIs (file:// downloaded / https:// streamed)
     addressOverlays: List<String> = emptyList(), // pmtiles:// URIs for house-number labels (streamed, OpenAddresses)
     maxspeedOverlays: List<String> = emptyList(), // pmtiles:// URIs for the posted-speed overlay (streamed); read under the puck
@@ -234,6 +242,7 @@ fun VelaMapView(
     speedOverlayOn: Boolean = false, // only query the overlay while it can matter (driving / navigating)
     trafficControls: List<app.vela.core.data.TrafficControl> = emptyList(), // OSM lights + stop signs drawn at high zoom
     flockCameras: List<app.vela.core.data.AlprCamera> = emptyList(), // ALPR/Flock cameras drawn at high zoom
+    transitStops: List<app.vela.core.data.transit.Transitous.MapStop> = emptyList(), // canonical GTFS stops at street zoom
     navBannerBottomPx: Int = 0, // measured screen-Y of the maneuver banner's bottom edge; drops the compass below it during nav
     onCameraIdle: (center: LatLng) -> Unit,
     onMapLongPress: (location: LatLng) -> Unit,
@@ -264,6 +273,8 @@ fun VelaMapView(
     val poiTap = rememberUpdatedState(onPoiTap)
     val markerTap = rememberUpdatedState(onMarkerTap)
     val ambientTap = rememberUpdatedState(onAmbientTap)
+    val transitStopTap = rememberUpdatedState(onTransitStopTap)
+    val transitStopsNow = rememberUpdatedState(transitStops)
     val parkingTap = rememberUpdatedState(onParkingTap)
     val cameraIdle = rememberUpdatedState(onCameraIdle)
     val longPress = rememberUpdatedState(onMapLongPress)
@@ -922,6 +933,13 @@ fun VelaMapView(
                         ambientTap.value(amb.getNumberProperty(AMBIENT_INDEX_PROP).toInt())
                         return@handleTap true
                     }
+                    // A canonical GTFS stop icon (Transitous layer): open the stop's board directly
+                    // by stop id - no name resolution at all.
+                    val gtfsStop = feats.firstOrNull { it.hasProperty(TRANSIT_STOP_INDEX_PROP) }
+                    if (gtfsStop != null) {
+                        transitStopsNow.value.getOrNull(gtfsStop.getNumberProperty(TRANSIT_STOP_INDEX_PROP).toInt())
+                            ?.let { st -> transitStopTap.value(st); return@handleTap true }
+                    }
                     // Tap a greyed alternate route line to switch to it (Google-style).
                     val altHit = map.queryRenderedFeatures(
                         RectF(p.x - r, p.y - r, p.x + r, p.y + r), ALT_ROUTE_LAYER,
@@ -1302,18 +1320,21 @@ fun VelaMapView(
                 lastAppliedAmbient = null
                 lastAppliedControls = null
                 lastAppliedFlock = null
+                lastAppliedTransitStops = null
+                lastTransitBusHidden = null
+                origPoiTransitFilter = null
                 lastAppliedRouteLine = null
                 lastGradM[0] = -1e9 // force the nav split to re-render on the fresh style
                 PoiIcons.addTo(context, style)
                 if (applyKeylessTheme) applyMapTheme(style, darkTheme) else tuneMapTiler(style, darkTheme)
-                applyData(map, style, context, darkTheme, ambientCoversView, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, flockCameras, displayLoc, meBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
+                applyData(map, style, context, darkTheme, ambientCoversView, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, flockCameras, transitStops, displayLoc, meBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
                 ensureTraffic(style, trafficOn)
                 ensureTransit(style, transitOn)
                 ensureTopography(style, topographyOn)
             }
         } else {
             styleRef?.let {
-                applyData(map, it, context, darkTheme, ambientCoversView, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, flockCameras, displayLoc, meBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
+                applyData(map, it, context, darkTheme, ambientCoversView, routePolyline, routeColor, routeDashed, routeTrafficSpans, alternates, altColor, markers, ambientPois, trafficControls, flockCameras, transitStops, displayLoc, meBearing, myAccuracyM, locationStale, previewTarget, routeProgress, navMode, parkingSpot)
                 ensureTraffic(it, trafficOn)
                 ensureTransit(it, transitOn)
                 ensureTopography(it, topographyOn)
@@ -1938,6 +1959,40 @@ private fun ensureLayers(style: Style) {
                     PropertyFactory.iconAllowOverlap(true),
                     PropertyFactory.iconIgnorePlacement(true),
                     PropertyFactory.iconPadding(2f),
+                )
+            },
+        )
+    }
+    // Canonical GTFS transit stops (Transitous). One icon per station (bays dedupe in the VM);
+    // replaces the OSM basemap bus icons wherever this layer has coverage (poi_transit filter flips
+    // in applyData). Drawn beneath the flock layer, above the ambient POIs.
+    if (style.getImage(TRANSIT_STOP_IMG) == null) style.addImage(TRANSIT_STOP_IMG, transitStopBitmap())
+    if (style.getSource(TRANSIT_STOPS_SRC) == null) {
+        style.addSource(GeoJsonSource(TRANSIT_STOPS_SRC))
+        val stopSize = Expression.interpolate(
+            Expression.linear(), Expression.zoom(),
+            Expression.stop(15f, 0.62f),
+            Expression.stop(17f, 0.92f),
+            Expression.stop(19f, 1.2f),
+        )
+        style.addLayer(
+            SymbolLayer(TRANSIT_STOPS_LAYER, TRANSIT_STOPS_SRC).apply {
+                setMinZoom(15f)
+                setProperties(
+                    PropertyFactory.iconImage(TRANSIT_STOP_IMG),
+                    PropertyFactory.iconSize(stopSize),
+                    PropertyFactory.iconAllowOverlap(true),
+                    PropertyFactory.iconIgnorePlacement(true),
+                    PropertyFactory.iconPadding(2f),
+                    PropertyFactory.textField(Expression.get("name")),
+                    PropertyFactory.textFont(arrayOf("Noto Sans Regular")),
+                    PropertyFactory.textSize(10.5f),
+                    PropertyFactory.textOptional(true),
+                    PropertyFactory.textAnchor(Property.TEXT_ANCHOR_TOP),
+                    PropertyFactory.textOffset(arrayOf(0f, 1.1f)),
+                    PropertyFactory.textColor("#7f8ba0"),
+                    PropertyFactory.textHaloColor("#0e1626"),
+                    PropertyFactory.textHaloWidth(1.1f),
                 )
             },
         )
@@ -2835,6 +2890,7 @@ private fun applyData(
     ambientPois: List<MapMarker>,
     trafficControls: List<app.vela.core.data.TrafficControl>,
     flockCameras: List<app.vela.core.data.AlprCamera>,
+    transitStops: List<app.vela.core.data.transit.Transitous.MapStop>,
     me: LatLng?,
     bearing: Float?,
     meAccuracyM: Float?,
@@ -3051,6 +3107,42 @@ private fun applyData(
         )
         style.getSourceAs<GeoJsonSource>(FLOCK_SRC)?.setGeoJson(flockFc)
         lastAppliedFlock = flockCameras
+    }
+
+    // Canonical GTFS stops (Transitous). Feature index -> the VM's stop list for the tap handler.
+    if (transitStops != lastAppliedTransitStops) {
+        val stopsFc = FeatureCollection.fromFeatures(
+            transitStops.mapIndexed { i, st ->
+                Feature.fromGeometry(Point.fromLngLat(st.lon, st.lat)).apply {
+                    addNumberProperty(TRANSIT_STOP_INDEX_PROP, i)
+                    addStringProperty("name", st.name)
+                }
+            },
+        )
+        style.getSourceAs<GeoJsonSource>(TRANSIT_STOPS_SRC)?.setGeoJson(stopsFc)
+        lastAppliedTransitStops = transitStops
+    }
+    // While the canonical layer has coverage here, hide the basemap's own OSM bus icons (class
+    // "bus" in poi_transit) so the same stop can't draw twice at slightly different corners;
+    // rail/airport stay basemap. Original filter captured once per style load and restored when
+    // coverage goes (offline in an uncached area).
+    val hideOsmBus = transitStops.isNotEmpty()
+    if (hideOsmBus != lastTransitBusHidden) {
+        runCatching {
+            (style.getLayer("poi_transit") as? SymbolLayer)?.let { poi ->
+                if (origPoiTransitFilter == null) origPoiTransitFilter = poi.filter
+                val orig = origPoiTransitFilter
+                val noBus = Expression.neq(Expression.get("class"), Expression.literal("bus"))
+                poi.setFilter(
+                    when {
+                        hideOsmBus && orig != null -> Expression.all(orig, noBus)
+                        hideOsmBus -> noBus
+                        else -> orig ?: Expression.literal(true)
+                    },
+                )
+            }
+        }
+        lastTransitBusHidden = hideOsmBus
     }
 
     // The location source: in browse mode applyData owns it (set it from the fix here);
@@ -3294,5 +3386,26 @@ private fun alprCameraBitmap(): Bitmap {
     val arm = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0xFFFFFFFF.toInt(); strokeWidth = 2.4f; style = Paint.Style.STROKE }
     c.drawLine(17f, 18f, 17f, 12f, arm)
     c.drawLine(12f, 12f, 24f, 12f, arm)
+    return bmp
+}
+
+/** Canonical GTFS stop badge: a small blue circle with a white bus glyph, the same marker
+ *  language as the ALPR badge but round + transit-blue so it reads as a stop, not a POI. */
+private fun transitStopBitmap(): Bitmap {
+    val s = 40
+    val bmp = Bitmap.createBitmap(s, s, Bitmap.Config.ARGB_8888)
+    val c = Canvas(bmp)
+    val white = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0xFFFFFFFF.toInt() }
+    val blue = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0xFF1A73E8.toInt() } // transit blue
+    val cx = s / 2f
+    c.drawCircle(cx, cx, cx - 1.5f, white) // rim
+    c.drawCircle(cx, cx, cx - 3.5f, blue)
+    // Bus glyph in white: body, windshield band, wheels.
+    val body = android.graphics.RectF(12f, 11f, 28f, 26f)
+    c.drawRoundRect(body, 3.5f, 3.5f, white)
+    val band = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = blue.color }
+    c.drawRect(14f, 15f, 26f, 20.5f, band) // window band
+    c.drawCircle(15.5f, 27.5f, 2.2f, white) // wheels
+    c.drawCircle(24.5f, 27.5f, 2.2f, white)
     return bmp
 }

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1969,11 +1969,13 @@ private fun ensureLayers(style: Style) {
     if (style.getImage(TRANSIT_STOP_IMG) == null) style.addImage(TRANSIT_STOP_IMG, transitStopBitmap())
     if (style.getSource(TRANSIT_STOPS_SRC) == null) {
         style.addSource(GeoJsonSource(TRANSIT_STOPS_SRC))
+        // Deliberately a touch smaller than the POI markers (stops are dense), but not tiny -
+        // the first cut (0.62-1.2) read too small on device (user 2026-07-13).
         val stopSize = Expression.interpolate(
             Expression.linear(), Expression.zoom(),
-            Expression.stop(15f, 0.62f),
-            Expression.stop(17f, 0.92f),
-            Expression.stop(19f, 1.2f),
+            Expression.stop(15f, 0.78f),
+            Expression.stop(17f, 1.1f),
+            Expression.stop(19f, 1.4f),
         )
         style.addLayer(
             SymbolLayer(TRANSIT_STOPS_LAYER, TRANSIT_STOPS_SRC).apply {

--- a/core/src/main/java/app/vela/core/data/transit/Transitous.kt
+++ b/core/src/main/java/app/vela/core/data/transit/Transitous.kt
@@ -68,14 +68,26 @@ object Transitous {
 
     // --- API --------------------------------------------------------------------------------------
 
+    /** All transit stops inside the bbox. Null on FAILURE (network/decode) vs empty on a clean
+     *  "no stops here" - callers area-cache success only, like the traffic-controls layer. */
+    fun stopsInBox(http: OkHttpClient, south: Double, west: Double, north: Double, east: Double): List<MapStop>? {
+        val body = get(http, "$BASE/api/v1/map/stops?min=$south,$west&max=$north,$east") ?: return null
+        return runCatching { json.decodeFromString<List<MapStop>>(body) }.getOrNull()
+    }
+
     /** Transit stops within roughly [radiusM] of the point, nearest first. Empty on any failure. */
     fun stopsNear(http: OkHttpClient, lat: Double, lng: Double, radiusM: Double = 200.0): List<MapStop> {
         val dLat = radiusM / 111_320.0
         val dLng = radiusM / (111_320.0 * Math.cos(Math.toRadians(lat)))
-        val url = "$BASE/api/v1/map/stops?min=${lat - dLat},${lng - dLng}&max=${lat + dLat},${lng + dLng}"
-        val body = get(http, url) ?: return emptyList()
-        return runCatching { json.decodeFromString<List<MapStop>>(body) }.getOrDefault(emptyList())
+        return stopsInBox(http, lat - dLat, lng - dLng, lat + dLat, lng + dLng).orEmpty()
             .sortedBy { distM(lat, lng, it.lat, it.lon) }
+    }
+
+    /** The board for a KNOWN stop (a tapped map icon) - no proximity lookup needed. Queries the
+     *  parent station when the stop has one, so a hub icon shows the whole merged board. */
+    fun boardFor(http: OkHttpClient, stop: MapStop): StopDepartures? {
+        val times = stopTimes(http, stop.parentId ?: stop.stopId).ifEmpty { return null }
+        return buildBoard(times, stationName = stop.name)
     }
 
     /** The next [n] departures at [stopId] (a parent-station id aggregates all its child stops). */


### PR DESCRIPTION
The bus stops on the map now come from Transitous instead of whatever OSM happens to have. At street zoom (z15+) each viewport pulls the agencies' actual GTFS stop positions and draws them as a blue bus badge with the official stop name. Bays collapse onto their parent station so a transit center gets one icon.

Tapping a stop opens its departure board straight off the stop id. No Google search, no name matching, which was the root of all the intersection-stop weirdness. Tested on a phone: tap a corner stop, get the named sheet with route pill, live countdown, and the full departure list in one hop.

Where this layer has coverage the basemap's own OSM bus icons hide so you don't get the same stop drawn on two corners. Rail and airport icons stay on the basemap, and areas Transitous doesn't cover keep the OSM icons.

Offline: every area you browse gets saved to a small on-disk cache (24 most recent areas), so the places you actually frequent keep their stops with no signal. Same idea as the camera dataset staying fresh. A failed fetch never blanks stops that are already drawn.

Whole-state GTFS stop packs through the existing pack pipeline would be the hard-offline version for areas never visited online, that's a follow-up. Transit directions stay on Google for the traffic-aware ETAs.