### PR TITLE
Stop timeline: GTFS trip data with live/cancelled per stop, Google-style rows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2006,10 +2006,18 @@ architecture note.
   opens a visible gap in the connector line), call times in normal ink with the BOARDING stop's time
   a step bigger (titleMedium SemiBold), and a small status word under every time: dim "Scheduled"
   (`place_transit_scheduled`, all 15 locales) or green "Live" when the stop's realtime differs from
-  its timetable (`scheduledText != timeText`). Cancellations: the timeline's source (the Google
-  itinerary reuse) carries no cancelled flag; Transitous stoptimes DOES (`place.cancelled` - boards
-  currently DROP cancelled runs), so a cancelled-run marker becomes possible once the timeline moves
-  to the GTFS trip endpoint. **Device-verified: Powell St -> Yellow-S -> 11 stops (Powell…SFO, 12:23-12:54 PM), then
+  its timetable (`scheduledText != timeText`). **The timeline's PRIMARY source is the GTFS trip itself
+  (2026-07-13, device-verified):** Transitous boards stamp every departure with its `tripId`
+  (`StopDeparture.tripId`), and `Transitous.tripStops` (`/api/v1/trip`) returns that run's REAL stop
+  sequence - per-stop realtime vs timetable times AND per-stop/-run CANCELLED flags straight from the
+  agency feed (`TransitStopTime.cancelled` renders a red "Cancelled" + struck-through time,
+  `place_transit_cancelled` in all 15 locales). `buildTripStep` (pure, unit-tested) trims the run to
+  start at the tapped stop (nearest stop to the tapped coordinate; a terminus tap keeps the whole
+  run). The headsign-geocode + itinerary-reuse path (`itineraryStep`) remains the FALLBACK for
+  Google-fallback boards (their departures carry no tripId) and trip-fetch failures. NB transit
+  DIRECTIONS still ride Google on purpose (traffic-aware ETAs) - this moved only the stops list.
+  Boards still DROP fully-cancelled runs (`cancelled`/`tripCancelled`/`place.cancelled`); showing
+  them struck-through on the board is an open option. **Device-verified: Powell St -> Yellow-S -> 11 stops (Powell…SFO, 12:23-12:54 PM), then
   tapping 16th St Mission opened that bus stop's own board.** **Per-line arrival depth raised 4 -> 8
   (2026-07-13, user report "only shows the next 4 or so arrivals"):** parser `MAX_TIMES` was 4, AND
   `DepartureLineRow` only rendered `upcoming.first()` + `drop(1).take(3)` = 4 total; both were the cap.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2001,7 +2001,15 @@ architecture note.
   `route_detail_unavailable` (localized in all 11 langs) and the overlay closes. State on `MapUiState`:
   `routeDetail: TransitStep?`, `routeDetailTitle`, `routeDetailLoading`, guarded by `routeDetailJob`.
   The board cap was raised 8 -> 24 lines (`StopDepartureBoard` + parser `MAX_LINES`) so busy stops show
-  more routes. **Device-verified: Powell St -> Yellow-S -> 11 stops (Powell…SFO, 12:23-12:54 PM), then
+  more routes. **Timeline rows are Google's treatment (2026-07-13):** taller rows with a hairline
+  between stops (drawn INSIDE the row's bottom edge, inset 40dp past the rail - an item-level divider
+  opens a visible gap in the connector line), call times in normal ink with the BOARDING stop's time
+  a step bigger (titleMedium SemiBold), and a small status word under every time: dim "Scheduled"
+  (`place_transit_scheduled`, all 15 locales) or green "Live" when the stop's realtime differs from
+  its timetable (`scheduledText != timeText`). Cancellations: the timeline's source (the Google
+  itinerary reuse) carries no cancelled flag; Transitous stoptimes DOES (`place.cancelled` - boards
+  currently DROP cancelled runs), so a cancelled-run marker becomes possible once the timeline moves
+  to the GTFS trip endpoint. **Device-verified: Powell St -> Yellow-S -> 11 stops (Powell…SFO, 12:23-12:54 PM), then
   tapping 16th St Mission opened that bus stop's own board.** **Per-line arrival depth raised 4 -> 8
   (2026-07-13, user report "only shows the next 4 or so arrivals"):** parser `MAX_TIMES` was 4, AND
   `DepartureLineRow` only rendered `upcoming.first()` + `drop(1).take(3)` = 4 total; both were the cap.

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1398,45 +1398,61 @@ class MapViewModel @Inject constructor(
      *  No new keyless scraping. Needs the line's headsign (its destination) to aim the query. */
     fun openRouteDetail(line: app.vela.core.model.StopDepartureLine) {
         val origin = _state.value.selected?.location ?: return
-        val dest = line.headsign?.takeIf { it.isNotBlank() } ?: run {
-            flashStatus(appContext.getString(R.string.route_detail_unavailable)); return
-        }
-        val title = listOfNotNull(line.label, dest).joinToString(" · ")
+        val title = listOfNotNull(line.label, line.headsign?.takeIf { it.isNotBlank() }).joinToString(" · ")
         _state.update { it.copy(routeDetailLoading = true, routeDetailTitle = title, routeDetail = null) }
         routeDetailJob?.cancel()
         routeDetailJob = viewModelScope.launch {
-            // Aim at the route's destination (geocode the headsign near the stop), then ride transit there.
-            // A bare headsign is often ambiguous ("Richmond" is a city district AND a far-off city), so
-            // prefer a candidate that is itself a transit place (station/airport/terminal) and, among
-            // those, the one nearest the tapped stop - a sanity filter that rejects a same-named place
-            // across the country. (The RIDE-LEG match below is what actually pins the tapped line.)
-            val cands = runCatching { dataSource.search(dest, origin).places }.getOrDefault(emptyList())
-            val transitish = cands.filter { it.category?.let { c ->
-                listOf("station", "transit", "stop", "airport", "terminal", "bart", "metro", "rail")
-                    .any { k -> c.contains(k, ignoreCase = true) }
-            } == true }
-            val destLoc = (transitish.minByOrNull { it.location.distanceTo(origin) }
-                ?: cands.minByOrNull { it.location.distanceTo(origin) })?.location
-            if (destLoc == null) {
-                _state.update { it.copy(routeDetailLoading = false) }
-                flashStatus(appContext.getString(R.string.route_detail_unavailable)); return@launch
+            // PRIMARY: the GTFS trip itself. Transitous boards stamp each departure with its tripId,
+            // and /trip returns that run's REAL stop sequence with per-stop realtime and CANCELLED
+            // flags straight from the agency feed - exact where the itinerary reuse below has to
+            // guess at a matching leg, and no headsign geocode at all. Google-fallback boards carry
+            // no tripId, and a failed trip fetch falls through to the itinerary path.
+            val tripId = line.upcoming.firstOrNull { it.tripId != null }?.tripId
+            val gtfs = tripId?.let {
+                withContext(Dispatchers.IO) {
+                    runCatching {
+                        app.vela.core.data.transit.Transitous.tripStops(http, it, origin.lat, origin.lng)
+                    }.getOrNull()
+                }
             }
-            val trips = runCatching { webDirections.transit(origin, destLoc) }.getOrDefault(emptyList())
-            val rides = trips.flatMap { it.steps }.filter { it.line != null && it.intermediateStops.isNotEmpty() }
-            // Pick the leg the user actually tapped. Rank by the tapped LINE first (a short board label
-            // like "N" matches a longer itinerary name "N-Judah"), then by how close its board stop is to
-            // the tapped stop - so a same-line leg heading the OTHER way (boarding far off) loses to the
-            // one boarding here. Falls back to whatever leg boards at this stop, then the first ride.
-            val boardDist = { s: TransitStep -> s.boardStop?.location?.distanceTo(origin) ?: Double.MAX_VALUE }
-            val step = rides.filter { lineLabelMatches(line.label, it.line?.name) }.minByOrNull { boardDist(it) }
-                ?: rides.filter { boardDist(it) <= 500.0 }.minByOrNull { boardDist(it) }
-                ?: rides.firstOrNull()
-            android.util.Log.d("VelaRouteDetail", "'$dest' rides=${rides.size} -> ${step?.line?.name} (${step?.intermediateStops?.size} stops)")
+            android.util.Log.d("VelaRouteDetail", "gtfs=${gtfs != null} tripId=${tripId != null}")
+            val step = gtfs ?: itineraryStep(line, origin)
             _state.update {
                 if (step == null) { flashStatus(appContext.getString(R.string.route_detail_unavailable)); it.copy(routeDetailLoading = false) }
                 else it.copy(routeDetail = step, routeDetailLoading = false)
             }
         }
+    }
+
+    /** The pre-GTFS fallback for the stop timeline: geocode the line's headsign near the stop and
+     *  reuse a transit itinerary's matching ride leg. Used for Google-fallback boards (their
+     *  departures carry no tripId) and when the trip fetch fails. Null when nothing usable. */
+    private suspend fun itineraryStep(line: app.vela.core.model.StopDepartureLine, origin: LatLng): TransitStep? {
+        val dest = line.headsign?.takeIf { it.isNotBlank() } ?: return null
+        // Aim at the route's destination (geocode the headsign near the stop), then ride transit there.
+        // A bare headsign is often ambiguous ("Richmond" is a city district AND a far-off city), so
+        // prefer a candidate that is itself a transit place (station/airport/terminal) and, among
+        // those, the one nearest the tapped stop - a sanity filter that rejects a same-named place
+        // across the country. (The RIDE-LEG match below is what actually pins the tapped line.)
+        val cands = runCatching { dataSource.search(dest, origin).places }.getOrDefault(emptyList())
+        val transitish = cands.filter { it.category?.let { c ->
+            listOf("station", "transit", "stop", "airport", "terminal", "bart", "metro", "rail")
+                .any { k -> c.contains(k, ignoreCase = true) }
+        } == true }
+        val destLoc = (transitish.minByOrNull { it.location.distanceTo(origin) }
+            ?: cands.minByOrNull { it.location.distanceTo(origin) })?.location ?: return null
+        val trips = runCatching { webDirections.transit(origin, destLoc) }.getOrDefault(emptyList())
+        val rides = trips.flatMap { it.steps }.filter { it.line != null && it.intermediateStops.isNotEmpty() }
+        // Pick the leg the user actually tapped. Rank by the tapped LINE first (a short board label
+        // like "N" matches a longer itinerary name "N-Judah"), then by how close its board stop is to
+        // the tapped stop - so a same-line leg heading the OTHER way (boarding far off) loses to the
+        // one boarding here. Falls back to whatever leg boards at this stop, then the first ride.
+        val boardDist = { s: TransitStep -> s.boardStop?.location?.distanceTo(origin) ?: Double.MAX_VALUE }
+        val step = rides.filter { lineLabelMatches(line.label, it.line?.name) }.minByOrNull { boardDist(it) }
+            ?: rides.filter { boardDist(it) <= 500.0 }.minByOrNull { boardDist(it) }
+            ?: rides.firstOrNull()
+        android.util.Log.d("VelaRouteDetail", "'$dest' rides=${rides.size} -> ${step?.line?.name} (${step?.intermediateStops?.size} stops)")
+        return step
     }
 
     /** Does a departure-board line label (a short route code, "N" / "42") match an itinerary line name

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -44,6 +44,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
@@ -2631,7 +2632,7 @@ fun RouteDetailSheet(
                 itemsIndexed(stops) { i, stop ->
                     val isFirst = i == 0
                     val isLast = i == stops.lastIndex
-                    RouteStopRow(stop, lineColor, ink, dim, isFirst, isLast, onClick = { onStopTap(stop) })
+                    RouteStopRow(stop, lineColor, ink, dim, isFirst, isLast, dark, onClick = { onStopTap(stop) })
                 }
             }
         }
@@ -2639,8 +2640,11 @@ fun RouteDetailSheet(
 }
 
 /** One stop in the [RouteDetailSheet] timeline: a coloured connector rail with a node, the stop
- *  name (board/alight emphasised) and its call time - the whole row taps through (no chevron;
- *  the connected rail + the Material ripple are the affordance, like Google's route view). */
+ *  name (board/alight emphasised), its call time in normal ink (the boarding stop's - the next
+ *  departure - a step bigger) and a small status word under the time: a green "Live" when the
+ *  agency feed adjusted this stop's time, else "Scheduled" (Google's treatment). The whole row
+ *  taps through; a hairline between rows (inset past the rail, so the line stays continuous)
+ *  separates the stops. */
 @Composable
 private fun RouteStopRow(
     stop: TransitStopTime,
@@ -2649,37 +2653,63 @@ private fun RouteStopRow(
     dim: Color,
     isFirst: Boolean,
     isLast: Boolean,
+    dark: Boolean,
     onClick: () -> Unit,
 ) {
-    Row(
+    Box(
         Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(10.dp))
             .dpadHighlight(RoundedCornerShape(10.dp))
-            .clickable(onClick = onClick)
-            .padding(start = 6.dp, end = 14.dp),
-        verticalAlignment = Alignment.CenterVertically,
+            .clickable(onClick = onClick),
     ) {
-        // Vertical rail + node, drawn so the line is continuous between rows. Board/alight get a
-        // bigger node; intermediate stops a smaller one - all solid in the line colour so they read
-        // on any sheet background.
-        val big = isFirst || isLast
-        Box(Modifier.width(24.dp).height(48.dp), contentAlignment = Alignment.Center) {
-            if (!isFirst) Box(Modifier.width(3.dp).fillMaxHeight().align(Alignment.TopCenter).background(lineColor))
-            if (!isLast) Box(Modifier.width(3.dp).fillMaxHeight().align(Alignment.BottomCenter).background(lineColor))
-            Box(Modifier.size(if (big) 14.dp else 9.dp).clip(CircleShape).background(lineColor))
+        Row(
+            Modifier.fillMaxWidth().height(IntrinsicSize.Min).padding(start = 6.dp, end = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Vertical rail + node, drawn so the line is continuous between rows. Board/alight get a
+            // bigger node; intermediate stops a smaller one - all solid in the line colour so they read
+            // on any sheet background.
+            val big = isFirst || isLast
+            Box(Modifier.width(24.dp).fillMaxHeight().heightIn(min = 64.dp), contentAlignment = Alignment.Center) {
+                if (!isFirst) Box(Modifier.width(3.dp).fillMaxHeight(0.5f).align(Alignment.TopCenter).background(lineColor))
+                if (!isLast) Box(Modifier.width(3.dp).fillMaxHeight(0.5f).align(Alignment.BottomCenter).background(lineColor))
+                Box(Modifier.size(if (big) 14.dp else 9.dp).clip(CircleShape).background(lineColor))
+            }
+            Spacer(Modifier.width(10.dp))
+            Text(
+                stop.name,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = if (isFirst || isLast) FontWeight.SemiBold else FontWeight.Normal,
+                color = ink,
+                maxLines = 2,
+                modifier = Modifier.weight(1f).padding(vertical = 14.dp),
+            )
+            stop.timeText?.let { time ->
+                // Realtime = the feed gave this stop an adjusted time distinct from the timetable.
+                val live = stop.scheduledText != null && stop.scheduledText != stop.timeText
+                Column(Modifier.padding(start = 8.dp), horizontalAlignment = Alignment.End) {
+                    Text(
+                        time,
+                        style = if (isFirst) MaterialTheme.typography.titleMedium else MaterialTheme.typography.bodyMedium,
+                        fontWeight = if (isFirst) FontWeight.SemiBold else FontWeight.Normal,
+                        color = ink,
+                    )
+                    Text(
+                        stringResource(if (live) R.string.place_transit_live else R.string.place_transit_scheduled),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (live) SheetPalette.TrafficGreen else dim,
+                    )
+                }
+            }
         }
-        Spacer(Modifier.width(10.dp))
-        Text(
-            stop.name,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = if (isFirst || isLast) FontWeight.SemiBold else FontWeight.Normal,
-            color = ink,
-            maxLines = 2,
-            modifier = Modifier.weight(1f).padding(vertical = 10.dp),
-        )
-        stop.timeText?.let {
-            Text(it, style = MaterialTheme.typography.labelMedium, color = dim, modifier = Modifier.padding(start = 8.dp))
+        // Separator between stops, drawn INSIDE the row's bottom edge and inset past the rail:
+        // an item-level divider would open a visible gap in the connector line.
+        if (!isLast) {
+            HorizontalDivider(
+                Modifier.align(Alignment.BottomCenter).padding(start = 40.dp),
+                color = SheetPalette.row(dark),
+            )
         }
     }
 }

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -180,6 +180,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.graphicsLayer
@@ -2693,12 +2694,23 @@ private fun RouteStopRow(
                         time,
                         style = if (isFirst) MaterialTheme.typography.titleMedium else MaterialTheme.typography.bodyMedium,
                         fontWeight = if (isFirst) FontWeight.SemiBold else FontWeight.Normal,
-                        color = ink,
+                        color = if (stop.cancelled) dim else ink,
+                        textDecoration = if (stop.cancelled) TextDecoration.LineThrough else null,
                     )
                     Text(
-                        stringResource(if (live) R.string.place_transit_live else R.string.place_transit_scheduled),
+                        stringResource(
+                            when {
+                                stop.cancelled -> R.string.place_transit_cancelled
+                                live -> R.string.place_transit_live
+                                else -> R.string.place_transit_scheduled
+                            },
+                        ),
                         style = MaterialTheme.typography.labelSmall,
-                        color = if (live) SheetPalette.TrafficGreen else dim,
+                        color = when {
+                            stop.cancelled -> SheetPalette.TrafficRed
+                            live -> SheetPalette.TrafficGreen
+                            else -> dim
+                        },
                     )
                 }
             }
@@ -2708,7 +2720,9 @@ private fun RouteStopRow(
         if (!isLast) {
             HorizontalDivider(
                 Modifier.align(Alignment.BottomCenter).padding(start = 40.dp),
-                color = SheetPalette.row(dark),
+                // A step above the row-surface tint: SheetPalette.row was near-invisible on the
+                // dark sheet (user 2026-07-13).
+                color = dim.copy(alpha = 0.35f),
             )
         }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -444,6 +444,7 @@
     <string name="place_transit_more_times">%1$d weitere</string> <!-- format -->
     <string name="place_transit_view_stops">Haltestellen</string>
     <string name="place_transit_live">Live</string>
+    <string name="place_transit_scheduled">Planmäßig</string>
     <string name="place_departures">Abfahrten</string>
     <string name="place_every">Alle %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Sie sind angekommen.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -445,6 +445,7 @@
     <string name="place_transit_view_stops">Haltestellen</string>
     <string name="place_transit_live">Live</string>
     <string name="place_transit_scheduled">Planmäßig</string>
+    <string name="place_transit_cancelled">Fällt aus</string>
     <string name="place_departures">Abfahrten</string>
     <string name="place_every">Alle %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Sie sind angekommen.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -445,6 +445,7 @@
     <string name="place_transit_view_stops">Paradas</string>
     <string name="place_transit_live">En directo</string>
     <string name="place_transit_scheduled">Programado</string>
+    <string name="place_transit_cancelled">Cancelado</string>
     <string name="place_departures">Salidas</string>
     <string name="place_every">Cada %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Has llegado.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -444,6 +444,7 @@
     <string name="place_transit_more_times">%1$d más</string> <!-- format -->
     <string name="place_transit_view_stops">Paradas</string>
     <string name="place_transit_live">En directo</string>
+    <string name="place_transit_scheduled">Programado</string>
     <string name="place_departures">Salidas</string>
     <string name="place_every">Cada %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Has llegado.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -444,6 +444,7 @@
     <string name="place_transit_more_times">%1$d de plus</string> <!-- format -->
     <string name="place_transit_view_stops">Arrêts</string>
     <string name="place_transit_live">En direct</string>
+    <string name="place_transit_scheduled">Prévu</string>
     <string name="place_departures">Départs</string>
     <string name="place_every">Toutes les %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Vous êtes arrivé.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -445,6 +445,7 @@
     <string name="place_transit_view_stops">Arrêts</string>
     <string name="place_transit_live">En direct</string>
     <string name="place_transit_scheduled">Prévu</string>
+    <string name="place_transit_cancelled">Annulé</string>
     <string name="place_departures">Départs</string>
     <string name="place_every">Toutes les %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Vous êtes arrivé.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -445,6 +445,7 @@
     <string name="place_transit_view_stops">Fermate</string>
     <string name="place_transit_live">In diretta</string>
     <string name="place_transit_scheduled">Programmato</string>
+    <string name="place_transit_cancelled">Cancellato</string>
     <string name="place_departures">Partenze</string>
     <string name="place_every">Ogni %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Sei arrivato.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -444,6 +444,7 @@
     <string name="place_transit_more_times">altri %1$d</string> <!-- format -->
     <string name="place_transit_view_stops">Fermate</string>
     <string name="place_transit_live">In diretta</string>
+    <string name="place_transit_scheduled">Programmato</string>
     <string name="place_departures">Partenze</string>
     <string name="place_every">Ogni %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Sei arrivato.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -443,6 +443,7 @@
     <string name="place_transit_view_stops">תחנות</string>
     <string name="place_transit_live">בשידור חי</string>
     <string name="place_transit_scheduled">מתוכנן</string>
+    <string name="place_transit_cancelled">בוטל</string>
     <string name="place_departures">יציאות</string>
     <string name="place_every">כל %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">הגעת.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -442,6 +442,7 @@
     <string name="place_transit_more_times">עוד %1$d</string> <!-- format -->
     <string name="place_transit_view_stops">תחנות</string>
     <string name="place_transit_live">בשידור חי</string>
+    <string name="place_transit_scheduled">מתוכנן</string>
     <string name="place_departures">יציאות</string>
     <string name="place_every">כל %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">הגעת.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -466,6 +466,7 @@
     <string name="place_transit_view_stops">停留所</string>
     <string name="place_transit_live">リアルタイム</string>
     <string name="place_transit_scheduled">定刻</string>
+    <string name="place_transit_cancelled">運休</string>
     <string name="place_departures">発車時刻</string>
     <string name="place_every">%1$s ごと</string> <!-- format -->
     <string name="transit_nav_arrived">目的地に到着しました。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -465,6 +465,7 @@
     <string name="place_transit_more_times">他 %1$d 件</string> <!-- format -->
     <string name="place_transit_view_stops">停留所</string>
     <string name="place_transit_live">リアルタイム</string>
+    <string name="place_transit_scheduled">定刻</string>
     <string name="place_departures">発車時刻</string>
     <string name="place_every">%1$s ごと</string> <!-- format -->
     <string name="transit_nav_arrived">目的地に到着しました。</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -444,6 +444,7 @@
     <string name="place_transit_more_times">nog %1$d</string> <!-- format -->
     <string name="place_transit_view_stops">Haltes</string>
     <string name="place_transit_live">Live</string>
+    <string name="place_transit_scheduled">Gepland</string>
     <string name="place_departures">Vertrektijden</string>
     <string name="place_every">Elke %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Je bent aangekomen.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -445,6 +445,7 @@
     <string name="place_transit_view_stops">Haltes</string>
     <string name="place_transit_live">Live</string>
     <string name="place_transit_scheduled">Gepland</string>
+    <string name="place_transit_cancelled">Geannuleerd</string>
     <string name="place_departures">Vertrektijden</string>
     <string name="place_every">Elke %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Je bent aangekomen.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -447,6 +447,7 @@
     <string name="place_transit_view_stops">Przystanki</string>
     <string name="place_transit_live">Na żywo</string>
     <string name="place_transit_scheduled">Planowy</string>
+    <string name="place_transit_cancelled">Odwołany</string>
     <string name="place_departures">Odjazdy</string>
     <string name="place_every">Co %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Dotarłeś na miejsce.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -446,6 +446,7 @@
     <string name="place_transit_more_times">jeszcze %1$d</string> <!-- format -->
     <string name="place_transit_view_stops">Przystanki</string>
     <string name="place_transit_live">Na żywo</string>
+    <string name="place_transit_scheduled">Planowy</string>
     <string name="place_departures">Odjazdy</string>
     <string name="place_every">Co %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Dotarłeś na miejsce.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -445,6 +445,7 @@
     <string name="place_transit_view_stops">Paradas</string>
     <string name="place_transit_live">Ao vivo</string>
     <string name="place_transit_scheduled">Programado</string>
+    <string name="place_transit_cancelled">Cancelado</string>
     <string name="place_departures">Partidas</string>
     <string name="place_every">A cada %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Chegou.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -444,6 +444,7 @@
     <string name="place_transit_more_times">mais %1$d</string> <!-- format -->
     <string name="place_transit_view_stops">Paradas</string>
     <string name="place_transit_live">Ao vivo</string>
+    <string name="place_transit_scheduled">Programado</string>
     <string name="place_departures">Partidas</string>
     <string name="place_every">A cada %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Chegou.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -447,6 +447,7 @@
     <string name="place_transit_view_stops">Остановки</string>
     <string name="place_transit_live">Онлайн</string>
     <string name="place_transit_scheduled">По расписанию</string>
+    <string name="place_transit_cancelled">Отменён</string>
     <string name="place_departures">Отправления</string>
     <string name="place_every">Каждые %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Вы прибыли.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -446,6 +446,7 @@
     <string name="place_transit_more_times">ещё %1$d</string> <!-- format -->
     <string name="place_transit_view_stops">Остановки</string>
     <string name="place_transit_live">Онлайн</string>
+    <string name="place_transit_scheduled">По расписанию</string>
     <string name="place_departures">Отправления</string>
     <string name="place_every">Каждые %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Вы прибыли.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -444,6 +444,7 @@
     <string name="place_transit_more_times">%1$d till</string> <!-- format -->
     <string name="place_transit_view_stops">Hållplatser</string>
     <string name="place_transit_live">Live</string>
+    <string name="place_transit_scheduled">Planerad</string>
     <string name="place_departures">Avgångar</string>
     <string name="place_every">Var %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Du har kommit fram.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -445,6 +445,7 @@
     <string name="place_transit_view_stops">Hållplatser</string>
     <string name="place_transit_live">Live</string>
     <string name="place_transit_scheduled">Planerad</string>
+    <string name="place_transit_cancelled">Inställd</string>
     <string name="place_departures">Avgångar</string>
     <string name="place_every">Var %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Du har kommit fram.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -446,6 +446,7 @@
     <string name="place_transit_more_times">ще %1$d</string> <!-- format -->
     <string name="place_transit_view_stops">Зупинки</string>
     <string name="place_transit_live">Наживо</string>
+    <string name="place_transit_scheduled">За розкладом</string>
     <string name="place_departures">Відправлення</string>
     <string name="place_every">Кожні %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Ви прибули.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -447,6 +447,7 @@
     <string name="place_transit_view_stops">Зупинки</string>
     <string name="place_transit_live">Наживо</string>
     <string name="place_transit_scheduled">За розкладом</string>
+    <string name="place_transit_cancelled">Скасовано</string>
     <string name="place_departures">Відправлення</string>
     <string name="place_every">Кожні %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">Ви прибули.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -466,6 +466,7 @@
     <string name="place_transit_view_stops">站點</string>
     <string name="place_transit_live">即時</string>
     <string name="place_transit_scheduled">已排定</string>
+    <string name="place_transit_cancelled">已取消</string>
     <string name="place_departures">發車時刻</string>
     <string name="place_every">每 %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">你已抵達目的地。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -465,6 +465,7 @@
     <string name="place_transit_more_times">還有 %1$d 個</string> <!-- format -->
     <string name="place_transit_view_stops">站點</string>
     <string name="place_transit_live">即時</string>
+    <string name="place_transit_scheduled">已排定</string>
     <string name="place_departures">發車時刻</string>
     <string name="place_every">每 %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">你已抵達目的地。</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -465,6 +465,7 @@
     <string name="place_transit_more_times">还有 %1$d 个</string> <!-- format -->
     <string name="place_transit_view_stops">站点</string>
     <string name="place_transit_live">实时</string>
+    <string name="place_transit_scheduled">已排定</string>
     <string name="place_departures">发车时刻</string>
     <string name="place_every">每 %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">您已到达。</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -466,6 +466,7 @@
     <string name="place_transit_view_stops">站点</string>
     <string name="place_transit_live">实时</string>
     <string name="place_transit_scheduled">已排定</string>
+    <string name="place_transit_cancelled">已取消</string>
     <string name="place_departures">发车时刻</string>
     <string name="place_every">每 %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">您已到达。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -481,6 +481,7 @@
     <string name="place_transit_view_stops">Stops</string>
     <string name="place_transit_live">Live</string>
     <string name="place_transit_scheduled">Scheduled</string>
+    <string name="place_transit_cancelled">Cancelled</string>
     <string name="place_departures">Departures</string>
     <string name="place_every">Every %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">You have arrived.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,6 +480,7 @@
     <string name="place_transit_more_times">%1$d more</string> <!-- format -->
     <string name="place_transit_view_stops">Stops</string>
     <string name="place_transit_live">Live</string>
+    <string name="place_transit_scheduled">Scheduled</string>
     <string name="place_departures">Departures</string>
     <string name="place_every">Every %1$s</string> <!-- format -->
     <string name="transit_nav_arrived">You have arrived.</string>

--- a/core/src/main/java/app/vela/core/data/transit/Transitous.kt
+++ b/core/src/main/java/app/vela/core/data/transit/Transitous.kt
@@ -3,7 +3,10 @@ package app.vela.core.data.transit
 import app.vela.core.model.StopDeparture
 import app.vela.core.model.StopDepartureLine
 import app.vela.core.model.StopDepartures
+import app.vela.core.model.TransitLine
 import app.vela.core.model.TransitMode
+import app.vela.core.model.TransitStep
+import app.vela.core.model.TransitStopTime
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
@@ -56,6 +59,9 @@ object Transitous {
         val headsign: String? = null,
         val routeShortName: String? = null,
         val routeColor: String? = null,
+        val tripId: String? = null,       // keys the /trip stop-sequence fetch
+        val cancelled: Boolean = false,   // this stop's call is cancelled
+        val tripCancelled: Boolean = false, // the whole run is cancelled
     )
 
     @Serializable
@@ -107,7 +113,7 @@ object Transitous {
         data class Key(val label: String?, val headsign: String?)
         val groups = LinkedHashMap<Key, MutableList<StopTime>>()
         for (t in times) {
-            if (t.place.cancelled) continue
+            if (t.place.cancelled || t.cancelled || t.tripCancelled) continue
             groups.getOrPut(Key(t.routeShortName, t.headsign)) { mutableListOf() }.add(t)
         }
         if (groups.isEmpty()) return null
@@ -120,6 +126,7 @@ object Transitous {
                     epochSec = epoch,
                     // realTime = the feed is live-tracking this run; that's the green-dot signal.
                     realtime = t.realTime,
+                    tripId = t.tripId,
                 )
             }.sortedBy { it.epochSec ?: Long.MAX_VALUE }
             StopDepartureLine(
@@ -135,6 +142,105 @@ object Transitous {
             .sortedBy { it.upcoming.firstOrNull()?.epochSec ?: Long.MAX_VALUE }
         if (lines.isEmpty()) return null
         return StopDepartures(stationName = stationName?.takeIf { it.isNotBlank() }, lines = lines)
+    }
+
+    // --- trip stop sequence (the "Stops" timeline) -------------------------------------------------
+
+    @Serializable
+    private data class TripResp(val legs: List<TripLeg> = emptyList())
+
+    @Serializable
+    data class TripLeg(
+        val from: TripStop = TripStop(),
+        val to: TripStop = TripStop(),
+        val intermediateStops: List<TripStop> = emptyList(),
+        val mode: String? = null,
+        val headsign: String? = null,
+        val routeShortName: String? = null,
+        val displayName: String? = null,
+        val routeColor: String? = null,
+        val routeTextColor: String? = null,
+        val realTime: Boolean = false,
+        val cancelled: Boolean = false,
+    )
+
+    @Serializable
+    data class TripStop(
+        val name: String = "",
+        val stopId: String = "",
+        val lat: Double = 0.0,
+        val lon: Double = 0.0,
+        val arrival: String? = null,
+        val departure: String? = null,
+        val scheduledArrival: String? = null,
+        val scheduledDeparture: String? = null,
+        val cancelled: Boolean = false,
+        val tz: String? = null,
+        val stopCode: String? = null,
+    )
+
+    /**
+     * The FULL stop sequence of one GTFS run - the "Stops" timeline behind a departure-board line.
+     * `/api/v1/trip` returns the actual trip the tapped departure belongs to: every stop it calls at,
+     * with per-stop realtime vs timetable times AND per-stop/-run CANCELLED flags straight from the
+     * agency feed - none of which the Google itinerary reuse could provide. The result is trimmed to
+     * start at the stop nearest ([atLat],[atLng]) (the stop whose board was tapped), mapped into the
+     * SAME [TransitStep] the timeline UI already renders. Null on any failure - the caller falls back
+     * to the itinerary-reuse path.
+     */
+    fun tripStops(http: OkHttpClient, tripId: String, atLat: Double, atLng: Double): TransitStep? {
+        val body = get(http, "$BASE/api/v1/trip?tripId=${URLEncoder.encode(tripId, "UTF-8")}") ?: return null
+        val leg = runCatching { json.decodeFromString<TripResp>(body).legs.firstOrNull() }.getOrNull() ?: return null
+        return buildTripStep(leg, atLat, atLng)
+    }
+
+    /** Pure mapping of a trip leg into the timeline's [TransitStep] (unit-tested; no network). */
+    internal fun buildTripStep(leg: TripLeg, atLat: Double, atLng: Double): TransitStep? {
+        val all = buildList {
+            add(leg.from)
+            addAll(leg.intermediateStops)
+            add(leg.to)
+        }.filter { it.name.isNotBlank() }
+        if (all.size < 2) return null
+        // Start the timeline at the tapped stop (the run begins at its origin terminal, often far
+        // before the user's stop). Nearest-by-distance, so it works from a canonical GTFS stop AND
+        // from a Google-resolved listing on a different corner. A terminus tap keeps the full run.
+        val idx = all.indices.minByOrNull { i -> distM(atLat, atLng, all[i].lat, all[i].lon) } ?: 0
+        val stops = if (idx >= all.size - 1) all else all.subList(idx, all.size)
+        val mapped = stops.map { st -> stopTime(st, legCancelled = leg.cancelled) }
+        return TransitStep(
+            mode = modeOf(leg.mode),
+            line = TransitLine(
+                name = leg.routeShortName ?: leg.displayName ?: "",
+                mode = modeOf(leg.mode),
+                colorHex = leg.routeColor?.takeIf { it.isNotBlank() }?.let { if (it.startsWith("#")) it else "#$it" },
+                textColorHex = leg.routeTextColor?.takeIf { it.isNotBlank() }?.let { if (it.startsWith("#")) it else "#$it" },
+            ),
+            headsign = leg.headsign,
+            boardStop = mapped.first(),
+            alightStop = mapped.last(),
+            intermediateStops = mapped.drop(1).dropLast(1),
+            numStops = mapped.size - 1,
+            departText = mapped.first().timeText,
+            arriveText = mapped.last().timeText,
+        )
+    }
+
+    private fun stopTime(st: TripStop, legCancelled: Boolean): TransitStopTime {
+        val shown = st.departure ?: st.arrival ?: st.scheduledDeparture ?: st.scheduledArrival
+        val sched = st.scheduledDeparture ?: st.scheduledArrival
+        val shownEpoch = shown?.let { parseIso(it) }
+        val schedEpoch = sched?.let { parseIso(it) }
+        return TransitStopTime(
+            name = st.name,
+            code = st.stopCode,
+            timeText = shownEpoch?.let { clockText(it, st.tz) },
+            // The timetable time, kept ONLY when realtime moved the shown time - the row UI reads
+            // "scheduled differs" as the live signal, same contract as the itinerary parser.
+            scheduledText = schedEpoch?.takeIf { shownEpoch != null && it != shownEpoch }?.let { clockText(it, st.tz) },
+            location = app.vela.core.model.LatLng(st.lat, st.lon),
+            cancelled = st.cancelled || legCancelled,
+        )
     }
 
     // --- helpers ----------------------------------------------------------------------------------

--- a/core/src/main/java/app/vela/core/model/StopDepartures.kt
+++ b/core/src/main/java/app/vela/core/model/StopDepartures.kt
@@ -32,4 +32,5 @@ data class StopDeparture(
     val clockText: String? = null,    // "4:35 AM" (already localized by Google)
     val epochSec: Long? = null,       // scheduled/real-time departure epoch (seconds)
     val realtime: Boolean = false,
+    val tripId: String? = null,       // GTFS trip id (Transitous boards) - keys the stop-timeline fetch
 )

--- a/core/src/main/java/app/vela/core/model/Transit.kt
+++ b/core/src/main/java/app/vela/core/model/Transit.kt
@@ -22,6 +22,7 @@ data class TransitStopTime(
     val timeText: String? = null,       // the shown (real-time if live) time, "4:35 PM"
     val scheduledText: String? = null,  // the timetable time when it differs, "4:30 PM"
     val location: LatLng? = null,       // stop position (for drawing / walk-leg routing)
+    val cancelled: Boolean = false,     // this call is cancelled (GTFS-Realtime; Google data never sets it)
 )
 
 /**

--- a/core/src/test/java/app/vela/core/data/transit/TransitousTest.kt
+++ b/core/src/test/java/app/vela/core/data/transit/TransitousTest.kt
@@ -46,6 +46,53 @@ class TransitousTest {
         assertNull(Transitous.buildBoard(emptyList(), null))
     }
 
+    private fun ts(name: String, id: String, lat: Double, lng: Double, dep: String, sched: String = dep, cancelled: Boolean = false) =
+        Transitous.TripStop(
+            name = name, stopId = id, lat = lat, lon = lng,
+            departure = dep, scheduledDeparture = sched, tz = "UTC", cancelled = cancelled,
+        )
+
+    @Test
+    fun `trip step trims to the tapped stop and maps realtime plus cancelled`() {
+        val leg = Transitous.TripLeg(
+            from = ts("Origin Terminal", "s1", 37.00, -122.00, "2026-01-01T10:00:00Z"),
+            intermediateStops = listOf(
+                ts("Main St", "s2", 37.01, -122.00, "2026-01-01T10:10:00Z"),
+                // realtime moved this call 3 min late
+                ts("Oak Ave", "s3", 37.02, -122.00, "2026-01-01T10:23:00Z", sched = "2026-01-01T10:20:00Z"),
+                ts("Pine Rd", "s4", 37.03, -122.00, "2026-01-01T10:30:00Z", cancelled = true),
+            ),
+            to = ts("End Terminal", "s5", 37.04, -122.00, "2026-01-01T10:40:00Z"),
+            mode = "BUS", headsign = "End Terminal", routeShortName = "42", routeColor = "00aa00",
+        )
+        // Tapped at Main St -> the timeline starts there, not at the origin terminal.
+        val step = Transitous.buildTripStep(leg, atLat = 37.01, atLng = -122.00)!!
+        assertEquals("Main St", step.boardStop?.name)
+        assertEquals("End Terminal", step.alightStop?.name)
+        assertEquals(listOf("Oak Ave", "Pine Rd"), step.intermediateStops.map { it.name })
+        assertEquals(3, step.numStops)
+        assertEquals("42", step.line?.name)
+        assertEquals("#00aa00", step.line?.colorHex)
+        // Realtime stop keeps the differing timetable time; on-time stops carry none.
+        val oak = step.intermediateStops[0]
+        assertEquals("10:23 AM", oak.timeText)
+        assertEquals("10:20 AM", oak.scheduledText)
+        assertNull(step.boardStop?.scheduledText)
+        assertTrue(step.intermediateStops[1].cancelled)
+        // Tapping the terminus keeps the whole run.
+        val full = Transitous.buildTripStep(leg, atLat = 37.04, atLng = -122.00)!!
+        assertEquals("Origin Terminal", full.boardStop?.name)
+    }
+
+    @Test
+    fun `board departures carry the trip id and drop cancelled runs`() {
+        val live = st("7", "Uptown", "2026-01-01T10:00:00Z").copy(tripId = "t-1")
+        val gone = st("7", "Uptown", "2026-01-01T10:30:00Z").copy(tripId = "t-2", tripCancelled = true)
+        val board = Transitous.buildBoard(listOf(live, gone), null)!!
+        assertEquals(1, board.lines[0].upcoming.size)
+        assertEquals("t-1", board.lines[0].upcoming[0].tripId)
+    }
+
     @Test
     fun `iso parse and clock text`() {
         val epoch = Transitous.parseIso("2026-01-01T20:26:00Z")!!


### PR DESCRIPTION
The stop timeline got two rounds of work.

First the layout, to match how Google draws it: more room per stop, a hairline between rows (inset past the colored rail so the line stays continuous, and drawn a step brighter than before since it was washing out on the dark sheet), times in normal text color, and the boarding stop's time bigger and semibold. Under every time there's now a status word: Scheduled in gray, Live in green when the agency feed moved that stop's time off the timetable, or Cancelled in red with the time struck through.

Second, the data now comes from the GTFS trip itself. Board departures carry their trip id, and tapping Stops fetches that exact run from Transitous: every stop it calls at, realtime vs timetable per stop, and cancelled flags straight from the agency. That's what makes a real Cancelled marker possible, the old itinerary reuse had no such flag. The list starts at the stop you tapped instead of the route's origin terminal.

The old headsign-geocode path sticks around as the fallback for boards that came from the Google page (no trip id) and for trip fetch failures. Routing itself is untouched and still goes through Google.

Unit tests cover the trip mapping and the trip id on the board. Checked on a phone: opens on the tapped stop, green Live on the adjusted calls, separators visible in dark mode.