### PR TITLE
House numbers only at the 50 ft zoom or closer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -671,7 +671,7 @@ Defaults that make the safe path the easy one:
   the faint `building-3d` extrusion). The fill needs a matching **`setMaxZoom(24f)`** to re-open the top;
   keep it. `building-3d` (fill-extrusion) is gated to **z16+** on purpose (the flat fill carries the
   browse-zoom footprint look; extrusion is the per-pixel-expensive part on a Pixel 5a). (2) **House
-  numbers** render via the runtime `vela-housenumber` SymbolLayer (OMT `housenumber` source-layer, `minZoom 17.5` - Google shows house numbers only at street level; 16 surfaced them too soon, user 2026-07-06) - 
+  numbers** render via the runtime `vela-housenumber` SymbolLayer (OMT `housenumber` source-layer, `minZoom 19` - numbers only at the ~50 ft scale-bar view; 17.5 still carpeted whole blocks, user 2026-07-13) - 
   OpenFreeMap **does** serve that source-layer (verified vs the live TileJSON + z14 tiles), so it works;
   coverage is OSM `addr:housenumber` (partial), not a render bug. The `vela-addr-*` overlay number
   layers anchor to `CONTROLS_CLAIM_LAYER` (above basemap labels, below the ambient icons) - NOT the
@@ -1775,7 +1775,7 @@ architecture note.
   with `number`/`street`; **42 US states have a `statewide` source**, the rest are county-only). Render:
   `VelaMapView`'s `LaunchedEffect(addressOverlays, …)` adds a `VectorSource` (the URI) + a **`SymbolLayer`**
   `setSourceLayer("address")`, `textField(get("number"))`, `textFont(["Noto Sans Regular"])`, size 10, grey +
-  white halo, **minZoom 17.5** (in lockstep with the basemap `vela-housenumber` layer - Google shows house numbers only at true street level ~z17.5-18; 16 carpeted the 200-400 ft views, user 2026-07-06) - 
+  white halo, **minZoom 19** (in lockstep with the basemap `vela-housenumber` layer - numbers only at the ~50 ft scale-bar view; 17.5 still carpeted whole blocks, user 2026-07-13) - 
   inserted below `vela-controls` (see the LAYER ORDER warning below). **Streams online exactly like buildings**
   (`MapViewModel.refreshAddressOverlays(center)` on every camera-idle → the union of up to the 3
   smallest covering regions' `pmtiles://https://…` URIs - same spilled-bbox shadowing fix as the building

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -505,7 +505,7 @@ fun VelaMapView(
     // House-number labels from the open ADDRESS overlay (OpenAddresses PMTiles of points): a SymbolLayer of the
     // `number` field, STREAMED for the region in view — fills in house numbers where OSM has no `addr:housenumber`
     // (the same gap the building overlay fills for footprints). Matched to the basemap `vela-housenumber` style
-    // (Noto Sans 10, grey + white halo). minZoom 17.5 so numbers only appear at street level (Google-style) and
+    // (Noto Sans 10, grey + white halo). minZoom 19 so numbers only appear when truly close (~50 ft scale) and
     // collision thins dense blocks. INSERTED BELOW the controls CLAIM layer (which sits below the ambient POI
     // icons) — NOT addLayer/top: MapLibre places symbols TOPMOST-LAYER-FIRST, so numbers stacked above the
     // ambient layer grabbed their collision boxes before the business icons placed, EVICTING them at z16+
@@ -532,7 +532,7 @@ fun VelaMapView(
                 val layer =
                     SymbolLayer("vela-addr-$i", srcId).apply {
                         setSourceLayer("address") // tippecanoe layer name (build-address-region.sh: -l address)
-                        setMinZoom(17.5f) // Google shows house numbers only at STREET level (~z17.5-18); 16 carpeted the map in numbers ("too soon")
+                        setMinZoom(19f) // numbers only when truly close (~50 ft scale bar); 17.5 still carpeted whole blocks (user 2026-07-13)
                         setProperties(
                             PropertyFactory.textField(Expression.get("number")),
                             PropertyFactory.textFont(arrayOf("Noto Sans Regular")),
@@ -1636,9 +1636,10 @@ private fun ensureLayers(style: Style) {
                 setSourceLayer("housenumber")
                 // OpenFreeMap DOES serve the OMT `housenumber` source-layer (verified against the
                 // live TileJSON + z14 tiles), so this renders where OSM has `addr:housenumber`.
-                // 17.5 matches Google: house numbers only at true street level, not neighbourhood zoom
+                // 19 = the ~50 ft scale-bar view: numbers only when truly close, in lockstep with the
+                // address-overlay layers; 17.5 still carpeted whole blocks in numbers (user 2026-07-13)
                 // (16 carpeted the map — user 2026-07-06). Keep in lockstep with the vela-addr overlay.
-                setMinZoom(17.5f)
+                setMinZoom(19f)
                 setProperties(
                     PropertyFactory.textField(Expression.get("housenumber")),
                     PropertyFactory.textFont(arrayOf("Noto Sans Regular")),


### PR DESCRIPTION
House numbers now wait until you're really close. Both number layers (the OSM basemap numbers and the OpenAddresses overlay, which move together on purpose) go from zoom 17.5 to 19, which is about the 50 ft scale bar reading.

At 17.5 a neighborhood view still had every block carpeted in numbers. At 19 the map stays clean until you're zoomed in far enough that a specific address is what you're actually looking for. Checked on a phone: the view that used to show four numbers at 100 ft is clean now, and they come back one level deeper at 50 ft.