### PR TITLE
Paste coordinates into the search box

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -528,6 +528,11 @@ Defaults that make the safe path the easy one:
   address in the result row (glyph + text in title ink, theme-responsive) and bold inline on the
   place sheet's price/category line (user 2026-07-10). EV chargers carry NO detail in the
   keyless response (probed 2026-07-10 - type marker only, no price/kW/availability); see ROADMAP.
+- **Typed coordinates drop a pin (2026-07-13):** pasting "47.61, -122.33" (or a geo: string) into
+  the search box goes through `MapLinkParser.parseBareCoordinate` (strict whole-string match, both
+  halves need a decimal point, range-checked, unit-tested) -> the same reverse-geocoded pin a
+  long-press drops, instead of hitting the search endpoint as text. Addresses with numbers still
+  search normally. External geo:/Maps links were already handled (`openDeepLink`).
 - **Map tap resolution order (`VelaMapView` click listener, 2026-07-08).** A single tap (24dp hit box)
   resolves, in priority: (1) our search-result pin → `onMarkerTap`; (2) an ambient Google POI dot →
   `onAmbientTap`; (3) a greyed alternate route line → `onSelectAlternate`; (4) a NAMED basemap POI

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1068,6 +1068,16 @@ class MapViewModel @Inject constructor(
 
     private fun runSearch(q: String, near: LatLng?) {
         if (q.isEmpty()) return
+        // Pasted coordinates ("47.61, -122.33" or a geo: string) drop a reverse-geocoded pin
+        // there instead of going to the search endpoint as text - same handling a bare external
+        // geo: link gets. Strict whole-string match, so addresses with numbers still search.
+        MapLinkParser.parseBareCoordinate(q)?.let { link ->
+            val at = LatLng(link.lat!!, link.lng!!)
+            recentStore.add(q)
+            _state.update { it.copy(recents = recentStore.recent(), suggestions = emptyList(), searching = false, center = at) }
+            onMapLongPress(at)
+            return
+        }
         // Re-poll connectivity per search: the registered callback alone proved able to
         // wedge `offline` on (missed onAvailable after doze) until an app relaunch.
         _state.update { val off = !isOnline(); if (it.offline != off) it.copy(offline = off) else it }

--- a/core/src/main/java/app/vela/core/data/MapLinkParser.kt
+++ b/core/src/main/java/app/vela/core/data/MapLinkParser.kt
@@ -21,6 +21,20 @@ data class MapLink(val query: String? = null, val lat: Double? = null, val lng: 
  */
 object MapLinkParser {
     private val COORD = Regex("""(-?\d{1,3}\.\d+),\s*(-?\d{1,3}\.\d+)""")
+
+    /** A BARE typed coordinate ("47.61, -122.33", also "geo:47.61,-122.33"), so pasting
+     *  coordinates into the search box drops a pin instead of running a text search.
+     *  Strict: the whole string must be the pair (a street address with numbers stays a
+     *  search), both halves need a decimal point, and the values must be a plausible
+     *  lat/lng. Null otherwise. */
+    fun parseBareCoordinate(raw: String): MapLink? {
+        val text = raw.trim().removePrefix("geo:").trim()
+        val m = COORD.matchEntire(text) ?: return null
+        val lat = m.groupValues[1].toDoubleOrNull() ?: return null
+        val lng = m.groupValues[2].toDoubleOrNull() ?: return null
+        if (lat !in -90.0..90.0 || lng !in -180.0..180.0) return null
+        return MapLink(lat = lat, lng = lng)
+    }
     private val AT = Regex("""@(-?\d{1,3}\.\d+),(-?\d{1,3}\.\d+)""")
 
     /** A pasted share link worth resolving over the network (short links carry nothing

--- a/core/src/test/java/app/vela/core/MapLinkParserTest.kt
+++ b/core/src/test/java/app/vela/core/MapLinkParserTest.kt
@@ -73,4 +73,21 @@ class MapLinkParserTest {
     @Test fun hasTargetGate() {
         assertTrue(MapLinkParser.parse("geo:38.5,-121.7")!!.hasTarget)
     }
+
+    @Test fun bareTypedCoordinates() {
+        val ok = MapLinkParser.parseBareCoordinate("47.6097, -122.3331")!!
+        assertEquals(47.6097, ok.lat!!, 1e-9)
+        assertEquals(-122.3331, ok.lng!!, 1e-9)
+        // geo: prefix works too
+        assertEquals(31.7767, MapLinkParser.parseBareCoordinate("geo:31.7767,35.2274")!!.lat!!, 1e-9)
+        // an address with numbers is NOT a coordinate
+        assertNull(MapLinkParser.parseBareCoordinate("1451 W Covell Blvd, Davis"))
+        // trailing text disqualifies (must be the whole string)
+        assertNull(MapLinkParser.parseBareCoordinate("47.6, -122.3 area"))
+        // out-of-range values are rejected
+        assertNull(MapLinkParser.parseBareCoordinate("91.0, 10.0"))
+        assertNull(MapLinkParser.parseBareCoordinate("47.0, 181.0"))
+        // integers without a decimal point stay a search
+        assertNull(MapLinkParser.parseBareCoordinate("5, 7"))
+    }
 }


### PR DESCRIPTION
You can paste coordinates like 47.61, -122.33 (or a geo: string) into the search box and the map flies there and drops the same reverse-geocoded pin a long press makes. Before this the string just went to Google as a text search.

The match is deliberately strict. It has to be the entire string, both numbers need a decimal point, and the values have to be a plausible lat/lng, so a street address like 1451 W Covell Blvd still searches normally. Covered by unit tests and checked on a phone: typed a coordinate pair, got the pin and the address sheet at the right spot. External geo: links already worked; this brings the typed path up to par.