### PR TITLE
Don't fly the camera home after closing a far-away place

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1415,7 +1415,11 @@ architecture note.
   (= smoothed `browseBeam` when following, else `displayBearing`). The camera `when` block has a guard branch
   (`!navMode && driveFollowing && myLocation != null`) so a new fix's recomposition can't fire an `animateCamera`
   that fights the glide. Gate lives in `MapScreen` (`followMe`, default true; a `onUserPan` drops it, the locate FAB
-  re-arms it; suppressed while search/place/directions/results own the camera). Feel constants unverified on a real
+  re-arms it; suppressed while search/place/directions/results own the camera). **A programmatic
+  jump > 1 km from the fix ALSO drops it (2026-07-13):** a recents pick / search hit / pasted
+  coordinate only SUSPENDED follow while the sheet owned the camera, so closing the sheet resumed
+  it and glided the map all the way home (device report). A LaunchedEffect on `state.center`
+  disarms follow when the new center lands far from `myLocation`; a nearby POI tap keeps it. Feel constants unverified on a real
   drive - revertible.
 - Nav fixes (2026-07-05, round 2): (1) **Replay arrow** - the replay puck showed only the DOT, never the
   directional arrow. The arrow's visibility keys on the `displayBearing` passed to `applyData`

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -147,6 +147,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.vela.BuildConfig
 import app.vela.core.config.Notice
 import app.vela.core.model.LatLng
+import app.vela.core.model.distanceTo
 import app.vela.core.model.ManeuverType
 import app.vela.core.model.Place
 import app.vela.core.data.RecentPlace
@@ -318,6 +319,16 @@ fun MapScreen(
     // tap raises it again. Suppressed whenever a focus surface owns the camera (search, a place,
     // directions, the results list) so it never fights that framing. Nav has its own follow.
     var followMe by remember { mutableStateOf(true) }
+    // A programmatic camera jump far from the fix (a recents pick, a search hit, a pasted
+    // coordinate, a deep link) means the user went to look somewhere else - drop follow exactly
+    // like a pan would. Without this, follow was only SUSPENDED while the place sheet owned the
+    // camera, so closing the sheet resumed it and the map glided all the way home (device report
+    // 2026-07-13). A POI tapped near the fix keeps follow; 1 km is the "somewhere else" line.
+    LaunchedEffect(state.center) {
+        val c = state.center ?: return@LaunchedEffect
+        val me = state.myLocation ?: return@LaunchedEffect
+        if (followMe && c.distanceTo(me) > 1_000.0) followMe = false
+    }
     val driveFollowing = followMe && !state.navigating && !resultsShown && state.selected == null &&
         !state.directionsOpen && !state.showSteps && !searchOpen && state.pickOnMap == null
     // The posted-limit ("Speed B") overlay is armed by ACTUAL MOTION, never by the bare browse map.


### PR DESCRIPTION
Repro: tap a recents entry for a stop across town, look at it, hit X. The camera glided all the way back to your current location. Drag the map first and it wouldn't happen.

Cause: free-drive follow starts armed and only a manual pan disarms it. A programmatic jump (recents, search, pasted coordinates, deep links) just suspended it while the sheet owned the camera, so closing the sheet let follow resume and it dutifully glided home.

Fix: any programmatic camera move landing more than 1 km from your fix now drops follow, same as a pan. The locate button re-arms it as always, and tapping a POI near you keeps follow like before. Reproduced the exact sequence on a phone and confirmed the camera now stays put after X.