### PR TITLE
Fix the speed limit badge: opacity 0 made the maxspeed layer unqueryable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1050,9 +1050,12 @@ architecture note.
   twin layer must be coloured in ALL FOUR apply fns. **Same trap bit the maxspeed "Speed B" query
   layer (fixed 2026-07-13):** its `lineColor("#00000000")` 8-digit-hex string was REJECTED by
   MapLibre's colour parser and fell back to the default OPAQUE BLACK - a 12dp black stripe over
-  every road on the browse map (device report). For an invisible-but-queryable layer use the
-  `@ColorInt` `Color.TRANSPARENT` overload (no string parse) + `lineOpacity(0f)`, and only ADD it
-  while it's needed. **`speedOverlayOn` is MOTION-ARMED (`speedOverlayArmed` in MapScreen, 2026-07-13):**
+  every road on the browse map (device report). **BUT opacity 0 kills the query (2026-07-13, found by ars18 in the
+  vela-dpad fork, A/B-proven on device):** MapLibre skips fully transparent features at render
+  time and queryRenderedFeatures only sees rendered features, so the transparent Speed B layer
+  returned NOTHING and the badge was dead from the moment the black-roads fix landed. An
+  invisible-but-queryable layer needs `lineColor(Color.BLACK)` + `lineOpacity(0.004f)` (one alpha
+  step - invisible on any basemap, still queryable), and only ADD it while it's needed. **`speedOverlayOn` is MOTION-ARMED (`speedOverlayArmed` in MapScreen, 2026-07-13):**
   armed the moment `navigating || mySpeed > 3 m/s`, disarmed after 2 min of stillness - NEVER keyed on
   `driveFollowing` alone. driveFollowing is true on the bare browse map (followMe defaults on), and
   keying the overlay off it mounted the PMTiles sources while browsing AND removed them from the style

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -471,8 +471,13 @@ fun VelaMapView(
                     setSourceLayer("maxspeed") // tippecanoe layer name (build-maxspeed-region.sh: -l maxspeed)
                     setMinZoom(11f)
                     setProperties(
-                        PropertyFactory.lineColor(android.graphics.Color.TRANSPARENT), // @ColorInt, unambiguously transparent
-                        PropertyFactory.lineOpacity(0f),         // belt-and-suspenders: never drawn
+                        // NOT opacity 0: MapLibre skips fully transparent features at render time, and
+                        // queryRenderedFeatures only sees what rendered - the transparent version returned
+                        // nothing, ever, so the badge died with the black-roads fix (found by ars18 in the
+                        // vela-dpad fork; A/B-proven here, 35 mph vs null over the same road). 0.004 is one
+                        // alpha step of black: invisible on any basemap, but the features stay queryable.
+                        PropertyFactory.lineColor(android.graphics.Color.BLACK),
+                        PropertyFactory.lineOpacity(0.004f),
                         PropertyFactory.lineWidth(12f),          // wide hit target for the point query
                     )
                 }


### PR DESCRIPTION
ars18 reported this from the vela-dpad fork and he's right. The black-roads fix set the invisible maxspeed query layer to lineOpacity 0, and MapLibre skips fully transparent features at render time. queryRenderedFeatures only returns rendered features, so the posted-limit poll has come back empty on every tick since that fix landed. The badge has been silently dead.

I A/B'd it on a phone over the same arterial: the opacity-0 build returned null on every poll, the 0.004 build returned the 35 mph limit the moment the query point crossed the road. The layer now draws black at 0.004 opacity, which is one alpha step, invisible against any basemap, but the features stay queryable.