### PR TITLE
Stop timeline: scroll back to passed stops, cross out moved times

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2061,9 +2061,13 @@ architecture note.
   (`StopDeparture.tripId`), and `Transitous.tripStops` (`/api/v1/trip`) returns that run's REAL stop
   sequence - per-stop realtime vs timetable times AND per-stop/-run CANCELLED flags straight from the
   agency feed (`TransitStopTime.cancelled` renders a red "Cancelled" + struck-through time,
-  `place_transit_cancelled` in all 15 locales). `buildTripStep` (pure, unit-tested) trims the run to
-  start at the tapped stop (nearest stop to the tapped coordinate; a terminus tap keeps the whole
-  run). The headsign-geocode + itinerary-reuse path (`itineraryStep`) remains the FALLBACK for
+  `place_transit_cancelled` in all 15 locales). `buildTripStep` (pure, unit-tested) BOARDS at the tapped stop
+  (nearest to the tapped coordinate; a terminus tap boards at the origin) and puts the stops the
+  run already called at into `TransitStep.priorStops` - the sheet renders them GREYED above with a
+  grey rail (the coloured rail starts at your stop, Google's treatment) and opens scrolled to the
+  boarding stop (`rememberLazyListState(initialFirstVisibleItemIndex = priors)`). A moved time
+  renders the timetable time struck through beside the live one - red when late, green when early
+  or on time (`TransitStopTime.delayMin`, signed; the feed carries EARLY runs too, verified live). The headsign-geocode + itinerary-reuse path (`itineraryStep`) remains the FALLBACK for
   Google-fallback boards (their departures carry no tripId) and trip-fetch failures. NB transit
   DIRECTIONS still ride Google on purpose (traffic-aware ETAs) - this moved only the stops list.
   Boards still DROP fully-cancelled runs (`cancelled`/`tripCancelled`/`place.cancelled`); showing

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -76,6 +76,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material3.TextButton
 import androidx.compose.material.icons.filled.MyLocation
@@ -2584,11 +2585,14 @@ fun RouteDetailSheet(
     val ink = if (dark) InkDark else InkLight
     val dim = if (dark) DimDark else DimLight
     val lineColor = parseHexColor(step?.line?.colorHex) ?: MaterialTheme.colorScheme.primary
-    // The full ordered call list: board first, then the in-betweens, then alight. Board/alight
-    // are often absent from intermediateStops, so stitch them on the ends and de-dupe by name.
+    // The full ordered call list: the stops the run ALREADY passed (greyed above, Google-style),
+    // then board, the in-betweens, and alight. Board/alight are often absent from
+    // intermediateStops, so stitch them on the ends and de-dupe by name.
+    val prior = step?.priorStops ?: emptyList()
     val stops = remember(step) {
         val mid = step?.intermediateStops ?: emptyList()
         buildList {
+            addAll(prior)
             step?.boardStop?.let { add(it) }
             addAll(mid)
             step?.alightStop?.let { a -> if (mid.none { it.name == a.name } && step.boardStop?.name != a.name) add(a) }
@@ -2629,11 +2633,13 @@ fun RouteDetailSheet(
                 }
                 return@Column
             }
-            LazyColumn(Modifier.fillMaxSize().padding(horizontal = 4.dp)) {
+            // Open ON the boarding stop; the already-passed stops are a scroll-up away.
+            val listState = rememberLazyListState(initialFirstVisibleItemIndex = prior.size)
+            LazyColumn(Modifier.fillMaxSize().padding(horizontal = 4.dp), state = listState) {
                 itemsIndexed(stops) { i, stop ->
-                    val isFirst = i == 0
+                    val isBoard = i == prior.size
                     val isLast = i == stops.lastIndex
-                    RouteStopRow(stop, lineColor, ink, dim, isFirst, isLast, dark, onClick = { onStopTap(stop) })
+                    RouteStopRow(stop, lineColor, ink, dim, isBoard, isLast, dark, past = i < prior.size, isTop = i == 0, onClick = { onStopTap(stop) })
                 }
             }
         }
@@ -2655,6 +2661,8 @@ private fun RouteStopRow(
     isFirst: Boolean,
     isLast: Boolean,
     dark: Boolean,
+    past: Boolean = false, // the run already called here - greyed, no status word (Google-style)
+    isTop: Boolean = isFirst, // first VISIBLE row (no rail above); differs from isFirst when priors show
     onClick: () -> Unit,
 ) {
     Box(
@@ -2672,17 +2680,22 @@ private fun RouteStopRow(
             // bigger node; intermediate stops a smaller one - all solid in the line colour so they read
             // on any sheet background.
             val big = isFirst || isLast
+            // Passed stops grey their node and the rail segments touching them, so the coloured
+            // line visually STARTS at the boarding stop (Google's treatment).
+            val nodeColor = if (past) dim.copy(alpha = 0.45f) else lineColor
+            val topRail = if (past || isFirst) dim.copy(alpha = 0.45f) else lineColor
+            val bottomRail = if (past) dim.copy(alpha = 0.45f) else lineColor
             Box(Modifier.width(24.dp).fillMaxHeight().heightIn(min = 64.dp), contentAlignment = Alignment.Center) {
-                if (!isFirst) Box(Modifier.width(3.dp).fillMaxHeight(0.5f).align(Alignment.TopCenter).background(lineColor))
-                if (!isLast) Box(Modifier.width(3.dp).fillMaxHeight(0.5f).align(Alignment.BottomCenter).background(lineColor))
-                Box(Modifier.size(if (big) 14.dp else 9.dp).clip(CircleShape).background(lineColor))
+                if (!isTop) Box(Modifier.width(3.dp).fillMaxHeight(0.5f).align(Alignment.TopCenter).background(topRail))
+                if (!isLast) Box(Modifier.width(3.dp).fillMaxHeight(0.5f).align(Alignment.BottomCenter).background(bottomRail))
+                Box(Modifier.size(if (big) 14.dp else 9.dp).clip(CircleShape).background(nodeColor))
             }
             Spacer(Modifier.width(10.dp))
             Text(
                 stop.name,
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = if (isFirst || isLast) FontWeight.SemiBold else FontWeight.Normal,
-                color = ink,
+                color = if (past) dim else ink,
                 maxLines = 2,
                 modifier = Modifier.weight(1f).padding(vertical = 14.dp),
             )
@@ -2690,28 +2703,49 @@ private fun RouteStopRow(
                 // Realtime = the feed gave this stop an adjusted time distinct from the timetable.
                 val live = stop.scheduledText != null && stop.scheduledText != stop.timeText
                 Column(Modifier.padding(start = 8.dp), horizontalAlignment = Alignment.End) {
-                    Text(
-                        time,
-                        style = if (isFirst) MaterialTheme.typography.titleMedium else MaterialTheme.typography.bodyMedium,
-                        fontWeight = if (isFirst) FontWeight.SemiBold else FontWeight.Normal,
-                        color = if (stop.cancelled) dim else ink,
-                        textDecoration = if (stop.cancelled) TextDecoration.LineThrough else null,
-                    )
-                    Text(
-                        stringResource(
-                            when {
-                                stop.cancelled -> R.string.place_transit_cancelled
-                                live -> R.string.place_transit_live
-                                else -> R.string.place_transit_scheduled
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        // Google's treatment for a moved time: the timetable time crossed out
+                        // beside the live one, green when on time or early, red when late.
+                        if (live && !past && !stop.cancelled) {
+                            Text(
+                                stop.scheduledText!!,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = dim,
+                                textDecoration = TextDecoration.LineThrough,
+                                modifier = Modifier.padding(end = 6.dp),
+                            )
+                        }
+                        Text(
+                            time,
+                            style = if (isFirst) MaterialTheme.typography.titleMedium else MaterialTheme.typography.bodyMedium,
+                            fontWeight = if (isFirst) FontWeight.SemiBold else FontWeight.Normal,
+                            color = when {
+                                stop.cancelled || past -> dim
+                                live && (stop.delayMin ?: 0) > 0 -> SheetPalette.TrafficRed
+                                live -> SheetPalette.TrafficGreen
+                                else -> ink
                             },
-                        ),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = when {
-                            stop.cancelled -> SheetPalette.TrafficRed
-                            live -> SheetPalette.TrafficGreen
-                            else -> dim
-                        },
-                    )
+                            textDecoration = if (stop.cancelled) TextDecoration.LineThrough else null,
+                        )
+                    }
+                    // Passed stops carry no status word - the grey says it already.
+                    if (!past) {
+                        Text(
+                            stringResource(
+                                when {
+                                    stop.cancelled -> R.string.place_transit_cancelled
+                                    live -> R.string.place_transit_live
+                                    else -> R.string.place_transit_scheduled
+                                },
+                            ),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = when {
+                                stop.cancelled -> SheetPalette.TrafficRed
+                                live -> SheetPalette.TrafficGreen
+                                else -> dim
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/core/src/main/java/app/vela/core/data/transit/Transitous.kt
+++ b/core/src/main/java/app/vela/core/data/transit/Transitous.kt
@@ -214,12 +214,14 @@ object Transitous {
             add(leg.to)
         }.filter { it.name.isNotBlank() }
         if (all.size < 2) return null
-        // Start the timeline at the tapped stop (the run begins at its origin terminal, often far
-        // before the user's stop). Nearest-by-distance, so it works from a canonical GTFS stop AND
-        // from a Google-resolved listing on a different corner. A terminus tap keeps the full run.
-        val idx = all.indices.minByOrNull { i -> distM(atLat, atLng, all[i].lat, all[i].lon) } ?: 0
-        val stops = if (idx >= all.size - 1) all else all.subList(idx, all.size)
-        val mapped = stops.map { st -> stopTime(st, legCancelled = leg.cancelled) }
+        // The timeline BOARDS at the tapped stop (nearest-by-distance, so it works from a canonical
+        // GTFS stop AND from a Google-resolved listing on a different corner); the stops the run
+        // already called at go into priorStops so the view can show them greyed above, Google-style.
+        // A terminus tap boards at the origin instead (an arrivals-only view has no ride left).
+        val idx = (all.indices.minByOrNull { i -> distM(atLat, atLng, all[i].lat, all[i].lon) } ?: 0)
+            .let { if (it >= all.size - 1) 0 else it }
+        val prior = all.subList(0, idx).map { st -> stopTime(st, legCancelled = leg.cancelled) }
+        val mapped = all.subList(idx, all.size).map { st -> stopTime(st, legCancelled = leg.cancelled) }
         return TransitStep(
             mode = modeOf(leg.mode),
             line = TransitLine(
@@ -235,6 +237,7 @@ object Transitous {
             numStops = mapped.size - 1,
             departText = mapped.first().timeText,
             arriveText = mapped.last().timeText,
+            priorStops = prior,
         )
     }
 
@@ -243,15 +246,19 @@ object Transitous {
         val sched = st.scheduledDeparture ?: st.scheduledArrival
         val shownEpoch = shown?.let { parseIso(it) }
         val schedEpoch = sched?.let { parseIso(it) }
+        val moved = schedEpoch != null && shownEpoch != null && schedEpoch != shownEpoch
         return TransitStopTime(
             name = st.name,
             code = st.stopCode,
             timeText = shownEpoch?.let { clockText(it, st.tz) },
             // The timetable time, kept ONLY when realtime moved the shown time - the row UI reads
             // "scheduled differs" as the live signal, same contract as the itinerary parser.
-            scheduledText = schedEpoch?.takeIf { shownEpoch != null && it != shownEpoch }?.let { clockText(it, st.tz) },
+            scheduledText = if (moved) clockText(schedEpoch!!, st.tz) else null,
             location = app.vela.core.model.LatLng(st.lat, st.lon),
             cancelled = st.cancelled || legCancelled,
+            // Signed minutes off the timetable (negative = early) so the row can colour a late
+            // call differently from an early one - the feed carries both (verified live).
+            delayMin = if (moved) (((shownEpoch!! - schedEpoch!!) / 60).toInt()) else null,
         )
     }
 

--- a/core/src/main/java/app/vela/core/model/Transit.kt
+++ b/core/src/main/java/app/vela/core/model/Transit.kt
@@ -23,6 +23,7 @@ data class TransitStopTime(
     val scheduledText: String? = null,  // the timetable time when it differs, "4:30 PM"
     val location: LatLng? = null,       // stop position (for drawing / walk-leg routing)
     val cancelled: Boolean = false,     // this call is cancelled (GTFS-Realtime; Google data never sets it)
+    val delayMin: Int? = null,          // realtime minus timetable, minutes; negative = running early
 )
 
 /**
@@ -45,6 +46,9 @@ data class TransitStep(
     val numStops: Int? = null,                // "Ride 17 stops"
     val delayText: String? = null,            // "5 min late" / "2 min early" (real-time)
     val intermediateStops: List<TransitStopTime> = emptyList(), // the in-between stops
+    // Stops the run calls at BEFORE the boarding stop (the stop-timeline view shows them greyed
+    // above your stop, Google-style). Empty for itinerary-sourced steps.
+    val priorStops: List<TransitStopTime> = emptyList(),
     // Walk-leg endpoints (from the adjacent stops / itinerary origin+dest) — used to fetch
     // turn-by-turn walking directions for the leg on demand (OSRM foot). Null for ride legs.
     val walkFrom: LatLng? = null,

--- a/core/src/test/java/app/vela/core/data/transit/TransitousTest.kt
+++ b/core/src/test/java/app/vela/core/data/transit/TransitousTest.kt
@@ -65,23 +65,37 @@ class TransitousTest {
             to = ts("End Terminal", "s5", 37.04, -122.00, "2026-01-01T10:40:00Z"),
             mode = "BUS", headsign = "End Terminal", routeShortName = "42", routeColor = "00aa00",
         )
-        // Tapped at Main St -> the timeline starts there, not at the origin terminal.
+        // Tapped at Main St -> the timeline BOARDS there; the origin terminal it already
+        // passed goes into priorStops (shown greyed above, Google-style).
         val step = Transitous.buildTripStep(leg, atLat = 37.01, atLng = -122.00)!!
         assertEquals("Main St", step.boardStop?.name)
+        assertEquals(listOf("Origin Terminal"), step.priorStops.map { it.name })
         assertEquals("End Terminal", step.alightStop?.name)
         assertEquals(listOf("Oak Ave", "Pine Rd"), step.intermediateStops.map { it.name })
         assertEquals(3, step.numStops)
         assertEquals("42", step.line?.name)
         assertEquals("#00aa00", step.line?.colorHex)
-        // Realtime stop keeps the differing timetable time; on-time stops carry none.
+        // Realtime stop keeps the differing timetable time + a signed delay (3 min late here);
+        // on-time stops carry neither.
         val oak = step.intermediateStops[0]
         assertEquals("10:23 AM", oak.timeText)
         assertEquals("10:20 AM", oak.scheduledText)
+        assertEquals(3, oak.delayMin)
         assertNull(step.boardStop?.scheduledText)
+        assertNull(step.boardStop?.delayMin)
         assertTrue(step.intermediateStops[1].cancelled)
-        // Tapping the terminus keeps the whole run.
+        // An EARLY call carries a negative delay.
+        val earlyLeg = leg.copy(
+            intermediateStops = listOf(
+                ts("Main St", "s2", 37.01, -122.00, "2026-01-01T10:08:00Z", sched = "2026-01-01T10:10:00Z"),
+            ),
+        )
+        val early = Transitous.buildTripStep(earlyLeg, atLat = 37.00, atLng = -122.00)!!
+        assertEquals(-2, early.intermediateStops[0].delayMin)
+        // Tapping the terminus keeps the whole run boarding at the origin, nothing prior.
         val full = Transitous.buildTripStep(leg, atLat = 37.04, atLng = -122.00)!!
         assertEquals("Origin Terminal", full.boardStop?.name)
+        assertTrue(full.priorStops.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
Two more pieces of Google's stop timeline.

You can scroll up past your stop now. The stops the run already called at sit above it, greyed out with a grey rail, and the colored line starts at your boarding stop. The list still opens right on your stop so nothing changes unless you scroll.

When realtime moves a departure, the timetable time shows crossed out next to the live one. Red when the bus is running late, green when it's early or on time. The feed carries early runs the same way it carries late ones (checked a live stop where a route was running a minute ahead of schedule), so both render correctly. This rides the same per-stop realtime the GTFS trip endpoint already gave us, no new fetches.

Checked on a phone against a live run that was three minutes behind: crossed-out schedule times, red live times down the whole list, greyed history above the boarding stop, and the list opened on the right row.