### PR TITLE
Departure boards refresh while open

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1896,7 +1896,11 @@ architecture note.
   and `stoptimes` on the nearest stop's PARENT station id returns EVERY route with realtime flags and
   the agency's own route colours - a hub's bays merge for free (device-verified: a corner that gave 1
   route via the Google blob shows 6 lines with official pill colours + live countdowns). The result maps
-  into the SAME StopDepartures model, so the whole board UI renders unchanged. The Google blob paths
+  into the SAME StopDepartures model, so the whole board UI renders unchanged. **Transitous boards
+  REFRESH every 30 s while the sheet is open (2026-07-13):** `startBoardRefresh` re-queries the open
+  feed on the countdown clock's cadence and swaps the board in place, self-cancelling the moment the
+  selection changes; Google-fallback boards stay one-shot on purpose (a refresh there is a whole
+  WebView load). The Google blob paths
   (fetchBoardFrom / resolveIntersectionStopBoard) remain the FALLBACK where Transitous lacks coverage.
   `buildBoard` is pure + unit-tested (TransitousTest). Remaining phase-2 candidate: transit
   directions via `/api/v1/plan` as a FALLBACK only - Google stays the primary transit router on

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1343,6 +1343,30 @@ class MapViewModel @Inject constructor(
     /** A transit stop's live departure board, from the station's own place page (keyless, anonymous).
      *  Only fired for places whose category reads like a transit stop AND that carry a feature id
      *  (needed for the `?cid=` deep-link); guarded to the still-selected place when it returns. */
+    private var boardRefreshJob: kotlinx.coroutines.Job? = null
+
+    /** Keep a Transitous board fresh while its sheet is open: re-query the open feed every 30 s
+     *  (one small JSON call, same cadence as the countdown clock) and swap the board in place.
+     *  Ends itself the moment the selection changes. Google-page boards are NOT refreshed - that
+     *  path is a full WebView load, and its realtime drift is the price of the fallback. */
+    private fun startBoardRefresh(selId: String, lat: Double, lng: Double) {
+        boardRefreshJob?.cancel()
+        boardRefreshJob = viewModelScope.launch {
+            while (true) {
+                kotlinx.coroutines.delay(30_000)
+                if (_state.value.selected?.id != selId) return@launch
+                val fresh = withContext(Dispatchers.IO) {
+                    runCatching { app.vela.core.data.transit.Transitous.board(http, lat, lng) }.getOrNull()
+                }
+                if (fresh != null && fresh.lines.isNotEmpty()) {
+                    _state.update { st ->
+                        if (st.selected?.id == selId) st.copy(stopDepartures = fresh) else st
+                    }
+                }
+            }
+        }
+    }
+
     private fun fetchStopDepartures(p: Place) {
         val fid = p.featureId
         if (fid.isNullOrBlank() || !fid.contains(":")) return
@@ -1365,6 +1389,7 @@ class MapViewModel @Inject constructor(
                     if (st.selected?.featureId != fid) st
                     else st.copy(stopDepartures = board, stopDeparturesLoading = false)
                 }
+                startBoardRefresh(p.id, p.location.lat, p.location.lng)
                 return@launch
             }
             // FALLBACK: the Google place-page blob (agency-dependent, one route at hubs - but better
@@ -1969,6 +1994,9 @@ class MapViewModel @Inject constructor(
                             stopDeparturesLoading = false,
                         )
                     } else it
+                }
+                if (board != null && board.lines.isNotEmpty()) {
+                    startBoardRefresh(placeholder.id, location.lat, location.lng)
                 }
             }
         }
@@ -4048,6 +4076,7 @@ class MapViewModel @Inject constructor(
                 if (st.selected?.id != placeholder.id) st
                 else st.copy(stopDepartures = board?.takeIf { it.lines.isNotEmpty() }, stopDeparturesLoading = false)
             }
+            if (board != null && board.lines.isNotEmpty()) startBoardRefresh(placeholder.id, stop.lat, stop.lon)
         }
     }
 

--- a/core/src/main/java/app/vela/core/data/transit/Transitous.kt
+++ b/core/src/main/java/app/vela/core/data/transit/Transitous.kt
@@ -28,8 +28,10 @@ import java.util.TimeZone
  * colours. Querying a stop's PARENT station id aggregates all its child stops/bays (verified live),
  * so a multi-bay transit center gets one complete merged board for free.
  *
- * Google's blob parse stays as the FALLBACK where Transitous has no coverage. Fair use: called once
- * per opened stop (no polling); the User-Agent identifies the app per the Transitous policy.
+ * Google's blob parse stays as the FALLBACK where Transitous has no coverage. Fair use: one fetch
+ * per opened stop plus a 30 s refresh while its sheet stays open (the VM's startBoardRefresh, same
+ * cadence as the countdown clock, self-cancelling on selection change); the User-Agent identifies
+ * the app per the Transitous policy.
  */
 object Transitous {
     // The community instance. A self-hosted MOTIS is a drop-in swap if Vela ever outgrows fair use.


### PR DESCRIPTION
The board was fetched once when the sheet opened, so leaving it up for a few minutes meant stale times while only the countdown ticked. That's also part of why our times could drift from Google's, since theirs live-update.

Transitous boards now re-fetch every 30 seconds while the sheet is open, same cadence the countdown clock already runs on. It's one small JSON call per tick, and the loop cancels itself as soon as the selection changes. Boards that came from the Google page fallback stay a one-shot on purpose, since refreshing those would mean a full WebView load every 30 seconds.

Watched on a phone: ticks every 30 seconds with the board open, zero ticks after closing the sheet.