### PR TITLE
Fix house numbers never rendering on a cold start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1802,7 +1802,17 @@ architecture note.
   with `number`/`street`; **42 US states have a `statewide` source**, the rest are county-only). Render:
   `VelaMapView`'s `LaunchedEffect(addressOverlays, …)` adds a `VectorSource` (the URI) + a **`SymbolLayer`**
   `setSourceLayer("address")`, `textField(get("number"))`, `textFont(["Noto Sans Regular"])`, size 10, grey +
-  white halo, **minZoom 19** (in lockstep with the basemap `vela-housenumber` layer - numbers only at the ~50 ft scale-bar view; 17.5 still carpeted whole blocks, user 2026-07-13) - 
+  white halo, **minZoom 17 + stepped textOpacity (0 below z19, 1 at 19+)** - the visible behaviour is
+  still numbers-only-at-the-~50-ft-view (17.5 carpeted whole blocks, user 2026-07-13), but the zoom gate
+  CANNOT live in the layer's minZoom: the address archives carry tiles **only at z16-17**, and **MapLibre's
+  pmtiles path never cold-fetches a tile clamped 2+ levels below the camera on a cold source** - minZoom 19
+  meant a fresh launch that zoomed straight in fetched nothing, silently (`querySourceFeatures` = 0 forever),
+  and it *looked* intermittent because tiles resident from a lower-zoom browse overzoom fine. The layer
+  arms at 17 (being in zoom range is what drives tile fetching, even with the text invisible) and the 50 ft
+  gate is the opacity step (found + fixed by alltechdev in the vela-dpad fork, ported 2026-07-13; issue #131).
+  Residual edge: a session whose camera STARTS past ~z19 without ever dipping lower still fetches nothing - rare,
+  the camera restores to browse zoom. NB the opacity-0 = invisible-to-queryRenderedFeatures gotcha (PR #125)
+  doesn't bite here: below z19 the numbers were never tappable anyway - 
   inserted below `vela-controls` (see the LAYER ORDER warning below). **Streams online exactly like buildings**
   (`MapViewModel.refreshAddressOverlays(center)` on every camera-idle → the union of up to the 3
   smallest covering regions' `pmtiles://https://…` URIs - same spilled-bbox shadowing fix as the building

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -552,14 +552,20 @@ fun VelaMapView(
                         // cold-fetches a tile clamped 2+ levels below the camera - a layer minZoom of 19
                         // meant a cold source (fresh launch, zoom straight in) fetched nothing, silently,
                         // until some lower-zoom browse made tiles resident. So the layer arms at 17
-                        // (in-zoom-range is what drives fetching) and the 50 ft UX gate lives in
-                        // textOpacity instead (0 below 19; 17.5 still carpeted whole blocks, user 2026-07-13).
+                        // (in-zoom-range is what drives fetching) and the 50 ft UX gate lives in the
+                        // TEXT FIELD: empty below z19, the number at 19+. Empty text means no symbols
+                        // exist at 17-18.9 at all - an opacity-0 gate was tried first and worked, but
+                        // it left every number doing invisible placement work each frame in the densest
+                        // band on the map (19 still = the ~50 ft view; 17.5 carpeted whole blocks,
+                        // user 2026-07-13).
                         setMinZoom(17f)
                         setProperties(
-                            PropertyFactory.textOpacity(
-                                Expression.step(Expression.zoom(), Expression.literal(0f), Expression.stop(19f, 1f)),
+                            PropertyFactory.textField(
+                                Expression.step(
+                                    Expression.zoom(), Expression.literal(""),
+                                    Expression.stop(19f, Expression.get("number")),
+                                ),
                             ),
-                            PropertyFactory.textField(Expression.get("number")),
                             PropertyFactory.textFont(arrayOf("Noto Sans Regular")),
                             PropertyFactory.textSize(10f),
                             PropertyFactory.textColor(txt),

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -548,8 +548,17 @@ fun VelaMapView(
                 val layer =
                     SymbolLayer("vela-addr-$i", srcId).apply {
                         setSourceLayer("address") // tippecanoe layer name (build-address-region.sh: -l address)
-                        setMinZoom(19f) // numbers only when truly close (~50 ft scale bar); 17.5 still carpeted whole blocks (user 2026-07-13)
+                        // The archive carries tiles only at z16-17, and MapLibre's pmtiles path never
+                        // cold-fetches a tile clamped 2+ levels below the camera - a layer minZoom of 19
+                        // meant a cold source (fresh launch, zoom straight in) fetched nothing, silently,
+                        // until some lower-zoom browse made tiles resident. So the layer arms at 17
+                        // (in-zoom-range is what drives fetching) and the 50 ft UX gate lives in
+                        // textOpacity instead (0 below 19; 17.5 still carpeted whole blocks, user 2026-07-13).
+                        setMinZoom(17f)
                         setProperties(
+                            PropertyFactory.textOpacity(
+                                Expression.step(Expression.zoom(), Expression.literal(0f), Expression.stop(19f, 1f)),
+                            ),
                             PropertyFactory.textField(Expression.get("number")),
                             PropertyFactory.textFont(arrayOf("Noto Sans Regular")),
                             PropertyFactory.textSize(10f),


### PR DESCRIPTION
alltechdev found this porting the address overlay into his fork and offered it back in #131. Our 50 ft zoom gate lived in the layer's minZoom (19), but the address PMTiles only carry tiles at z16-17, and MapLibre's pmtiles path won't cold-fetch a tile clamped two or more levels below the camera when the source has nothing resident. So a fresh launch that zoomed straight in fetched nothing, silently, forever. It looked intermittent because tiles already resident from browsing at a lower zoom overzoom fine, which is why it always worked when we tested by browsing around first.

The layer now arms at z17, since being in zoom range is what actually drives tile fetching, and the 50 ft gate moved to a stepped textOpacity that's 0 below z19. Visible behavior is unchanged.

Verified on the 4a: cold process, zoomed straight in, numbers drew at the 50 ft scale. Commit is co-authored with ars18.