### PR TITLE
Deep links fly the camera to the point

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -726,6 +726,7 @@ fun MapScreen(
             compassHeading = state.compassHeading,
             locationStale = state.myLocationStale,
             cameraTarget = state.center,
+            cameraTargetZoom = state.centerZoom,
             recenterTick = state.recenterTick,
             cameraBottomInsetPx = cameraBottomInset,
             routePolyline = state.activeRoute?.polyline ?: emptyList(),

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1261,7 +1261,13 @@ class MapViewModel @Inject constructor(
                 _state.update { it.copy(query = q, center = near ?: it.center) }
                 runSearch(q, near ?: _state.value.myLocation ?: _state.value.center)
             }
-            near != null -> onMapLongPress(near)
+            near != null -> {
+                onMapLongPress(near)
+                // A long-press is always at an on-screen point, so it never moves the camera. A
+                // deep link's point can be anywhere: fly there too, or the sheet opens for a place
+                // the map isn't showing (the camera stayed home on every geo: URI, cold or warm).
+                _state.update { it.copy(center = near) }
+            }
         }
     }
 

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -79,6 +79,9 @@ data class TransitNavState(
 
 data class MapUiState(
     val center: LatLng? = null,
+    // Camera zoom requested by a deep link (geo:...?z=17); one-shot - any ordinary selection
+    // (place tap, long-press, search) clears it back to the default framing zooms.
+    val centerZoom: Double? = null,
     val recenterTick: Int = 0, // bumped per recenter tap so the map force-moves even if "centered"
     val myLocation: LatLng? = null,
     val myBearing: Float? = null,
@@ -1258,15 +1261,16 @@ class MapViewModel @Inject constructor(
         val q = link.query
         when {
             !q.isNullOrBlank() -> {
-                _state.update { it.copy(query = q, center = near ?: it.center) }
+                _state.update { it.copy(query = q, center = near ?: it.center, centerZoom = link.zoom) }
                 runSearch(q, near ?: _state.value.myLocation ?: _state.value.center)
             }
             near != null -> {
                 onMapLongPress(near)
                 // A long-press is always at an on-screen point, so it never moves the camera. A
-                // deep link's point can be anywhere: fly there too, or the sheet opens for a place
-                // the map isn't showing (the camera stayed home on every geo: URI, cold or warm).
-                _state.update { it.copy(center = near) }
+                // deep link's point can be anywhere: fly there too (honouring its z= when given),
+                // or the sheet opens for a place the map isn't showing (the camera stayed home on
+                // every geo: URI, cold or warm).
+                _state.update { it.copy(center = near, centerZoom = link.zoom) }
             }
         }
     }
@@ -1290,7 +1294,7 @@ class MapViewModel @Inject constructor(
         routeJob?.cancel() // a directions fetch in flight must not resurrect the stale panel
         _state.update {
             it.copy(
-                selected = withListNote(p), center = p.location, reviews = emptyList(), suggestions = emptyList(),
+                selected = withListNote(p), center = p.location, centerZoom = null, reviews = emptyList(), suggestions = emptyList(),
                 placesHere = othersAt(p, it.results), loadingDetails = false, photosLoading = false,
                 // Picking a NEW place while a route chooser is open closes it: the chooser
                 // belonged to the previous destination and kept covering the fresh place

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -198,6 +198,7 @@ fun VelaMapView(
     compassHeading: Float? = null, // device facing (sensor); points the browse cone when stopped
     locationStale: Boolean = false,
     cameraTarget: LatLng?,
+    cameraTargetZoom: Double? = null, // deep-link z= override for the target fly (null = default framing)
     recenterTick: Int = 0, // bumped on each recenter tap → force a move even if already "centered"
     cameraBottomInsetPx: Int = 0,
     routePolyline: List<LatLng>,
@@ -1504,8 +1505,8 @@ fun VelaMapView(
                 if (target != null && target != lastCameraTarget) {
                     lastCameraTarget = target
                     // Zoom in closer when a place sheet is up (focusing a single pin),
-                    // looser for a plain recenter.
-                    val zoom = if (cameraBottomInsetPx > 0) 16.5 else 14.5
+                    // looser for a plain recenter - unless a deep link asked for its own zoom.
+                    val zoom = cameraTargetZoom ?: if (cameraBottomInsetPx > 0) 16.5 else 14.5
                     map.animateCamera(
                         CameraUpdateFactory.newLatLngZoom(MLLatLng(target.lat, target.lng), zoom),
                     )

--- a/core/src/main/java/app/vela/core/data/MapLinkParser.kt
+++ b/core/src/main/java/app/vela/core/data/MapLinkParser.kt
@@ -2,8 +2,9 @@ package app.vela.core.data
 
 import java.net.URLDecoder
 
-/** A target extracted from an external `geo:` URI or Google-Maps web link. */
-data class MapLink(val query: String? = null, val lat: Double? = null, val lng: Double? = null) {
+/** A target extracted from an external `geo:` URI or Google-Maps web link. [zoom] is the
+ *  caller's requested camera zoom (`geo:...?z=17`, `/@lat,lng,15z`) when it carried one. */
+data class MapLink(val query: String? = null, val lat: Double? = null, val lng: Double? = null, val zoom: Double? = null) {
     val hasTarget: Boolean get() = !query.isNullOrBlank() || (lat != null && lng != null)
 }
 
@@ -60,6 +61,8 @@ object MapLinkParser {
         var lat = COORD.find(coordPart)?.groupValues?.get(1)?.toDoubleOrNull()
         var lng = COORD.find(coordPart)?.groupValues?.get(2)?.toDoubleOrNull()
         if (lat == 0.0 && lng == 0.0) { lat = null; lng = null } // 0,0 = "no point, see ?q"
+        // RFC-style zoom: geo:lat,lng?z=17 (1..21). Honoured for the camera; junk is ignored.
+        val zoom = queryParam(raw, "z")?.toDoubleOrNull()?.takeIf { it in 1.0..21.0 }
 
         val q = queryParam(raw, "q")?.let { decode(it) }
         if (!q.isNullOrBlank()) {
@@ -67,26 +70,29 @@ object MapLinkParser {
             val label = Regex("""\(([^)]+)\)""").find(q)?.groupValues?.get(1)
             val qc = COORD.find(q)
             if (qc != null && lat == null) {
-                return MapLink(query = label, lat = qc.groupValues[1].toDoubleOrNull(), lng = qc.groupValues[2].toDoubleOrNull())
+                return MapLink(query = label, lat = qc.groupValues[1].toDoubleOrNull(), lng = qc.groupValues[2].toDoubleOrNull(), zoom = zoom)
             }
             val text = label ?: q.takeUnless { COORD.matches(it.trim()) }
-            return MapLink(query = text, lat = lat, lng = lng)
+            return MapLink(query = text, lat = lat, lng = lng, zoom = zoom)
         }
-        return MapLink(lat = lat, lng = lng)
+        return MapLink(lat = lat, lng = lng, zoom = zoom)
     }
 
     private fun parseMaps(raw: String): MapLink {
         val lat = AT.find(raw)?.groupValues?.get(1)?.toDoubleOrNull()
         val lng = AT.find(raw)?.groupValues?.get(2)?.toDoubleOrNull()
+        // Google web links carry zoom after the @coords: /@38.5,-121.7,15z (sometimes fractional).
+        val zoom = Regex("""@-?\d{1,3}\.\d+,-?\d{1,3}\.\d+,(\d+(?:\.\d+)?)z""")
+            .find(raw)?.groupValues?.get(1)?.toDoubleOrNull()?.takeIf { it in 1.0..21.0 }
         val place = Regex("""/place/([^/@?]+)""").find(raw)?.groupValues?.get(1)
         val search = Regex("""/search/([^/@?]+)""").find(raw)?.groupValues?.get(1)
         val q = queryParam(raw, "q") ?: queryParam(raw, "query")
         val query = (place ?: search ?: q)?.let { decode(it.replace('+', ' ')) }?.takeIf { it.isNotBlank() }
         // A query that's really coordinates → treat as a point.
         query?.trim()?.let { COORD.matchEntire(it) }?.let {
-            return MapLink(lat = it.groupValues[1].toDoubleOrNull(), lng = it.groupValues[2].toDoubleOrNull())
+            return MapLink(lat = it.groupValues[1].toDoubleOrNull(), lng = it.groupValues[2].toDoubleOrNull(), zoom = zoom)
         }
-        return MapLink(query = query, lat = lat, lng = lng)
+        return MapLink(query = query, lat = lat, lng = lng, zoom = zoom)
     }
 
     private fun queryParam(raw: String, key: String): String? {

--- a/core/src/test/java/app/vela/core/MapLinkParserTest.kt
+++ b/core/src/test/java/app/vela/core/MapLinkParserTest.kt
@@ -15,6 +15,17 @@ class MapLinkParserTest {
         assertNull(l.query)
     }
 
+    @Test fun geoZoomIsHonoured() {
+        val l = MapLinkParser.parse("geo:38.5449,-121.7405?z=17")!!
+        assertEquals(17.0, l.zoom!!, 1e-6)
+        // Junk/out-of-range zooms are dropped, never crash.
+        assertNull(MapLinkParser.parse("geo:38.5449,-121.7405?z=potato")!!.zoom)
+        assertNull(MapLinkParser.parse("geo:38.5449,-121.7405?z=99")!!.zoom)
+        // Google web links carry it after the @coords.
+        val g = MapLinkParser.parse("https://www.google.com/maps/place/Foo/@38.5,-121.7,15z")!!
+        assertEquals(15.0, g.zoom!!, 1e-6)
+    }
+
     @Test fun geoZeroWithQueryIsSearch() {
         val l = MapLinkParser.parse("geo:0,0?q=Temple%20Coffee")!!
         assertEquals("Temple Coffee", l.query)


### PR DESCRIPTION
Opening a geo: URI with bare coordinates (another app's open-in-maps button, a shared coordinate link) dropped the pin and opened its sheet but never moved the camera, cold launch or warm. The pin path reuses the long-press handler, and a real long-press is always at an on-screen point, so nothing ever set the camera center.

The deep-link path now sets center too, so the map actually shows the place. The existing far-jump rule drops follow-me on the way, same as a recents pick.

Verified on the 4a both ways: a cold launch straight from a geo: URI opens on the target with the sheet up, and a warm intent flies there from wherever the map was.