### PR TITLE
Bus stop names hide until you're zoomed in close

### DIFF
--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -2001,6 +2001,13 @@ private fun ensureLayers(style: Style) {
                     PropertyFactory.textColor("#7f8ba0"),
                     PropertyFactory.textHaloColor("#0e1626"),
                     PropertyFactory.textHaloWidth(1.1f),
+                    // Google-style: bare badges from z15, NAMES only from z17 (user 2026-07-13) -
+                    // a stop every block meant a wall of grey text at street zoom. Opacity step,
+                    // not a second layer: the label still participates in collision (textOptional
+                    // keeps the icon when a name can't fit), it's just invisible until close.
+                    PropertyFactory.textOpacity(
+                        Expression.step(Expression.zoom(), Expression.literal(0f), Expression.stop(17f, 1f)),
+                    ),
                 )
             },
         )


### PR DESCRIPTION
Stop badges draw from z15, and every badge carried its name, so a dense corridor was a wall of grey stop names at street zoom. Google shows bare badges at that range and only names them once you're close. Same now: badge from z15, name fades in at z17. It's a text opacity step on the existing layer, so collision behavior doesn't change.