### PR TITLE
Departure boards stop listing every bus twice at double-fed stops

### DIFF
--- a/core/src/main/java/app/vela/core/data/transit/Transitous.kt
+++ b/core/src/main/java/app/vela/core/data/transit/Transitous.kt
@@ -178,6 +178,13 @@ object Transitous {
                     tripId = t.tripId,
                 )
             }.sortedBy { it.epochSec ?: Long.MAX_VALUE }
+                // Two agencies (or a parent + its curb twin) can both publish the same physical
+                // stop, and the sibling merge then feeds the same run in twice - every departure
+                // showed doubled (7:25, 7:25, 8:23, 8:23; device-seen 2026-07-13). Same line +
+                // same departure minute is the same bus regardless of which feed copy it rode in
+                // on, so collapse on the epoch (tripIds differ across agency copies - can't key
+                // on those).
+                .distinctBy { it.epochSec }
             StopDepartureLine(
                 label = k.label,
                 mode = modeOf(ts.firstOrNull()?.mode),

--- a/core/src/test/java/app/vela/core/data/transit/TransitousTest.kt
+++ b/core/src/test/java/app/vela/core/data/transit/TransitousTest.kt
@@ -111,6 +111,17 @@ class TransitousTest {
     }
 
     @Test
+    fun `board collapses the same run fed in twice by merged siblings`() {
+        // Two feed copies of the same physical stop (two agencies, or a parent + curb twin)
+        // deliver the same departures with different trip ids; the board must not list 7:25 twice.
+        val a = st("102", "Downtown", "2026-01-01T10:00:00Z").copy(tripId = "ct-1")
+        val b = st("102", "Downtown", "2026-01-01T10:00:00Z").copy(tripId = "et-1")
+        val later = st("102", "Downtown", "2026-01-01T11:00:00Z").copy(tripId = "ct-2")
+        val board = Transitous.buildBoard(listOf(a, b, later), null)!!
+        assertEquals(listOf(2), board.lines.map { it.upcoming.size })
+    }
+
+    @Test
     fun `iso parse and clock text`() {
         val epoch = Transitous.parseIso("2026-01-01T20:26:00Z")!!
         assertEquals(1767299160L, epoch)


### PR DESCRIPTION
Found combing the transit changes: one intersection's board showed every departure twice (7:25, 7:25, 8:23, 8:23, 9:23, 9:23). Some stops exist in the feeds twice, once per agency or as a parent plus its curb twin, and the sibling merge happily pulls stoptimes from both copies of the same physical stop.

Same route + headsign + departure minute is the same bus no matter which feed copy delivered it, so buildBoard now collapses duplicates on the departure epoch within each line. Trip ids can't be the key since each agency copy mints its own. Unit-tested with two feed copies of the same run.