### PR TITLE
Quarterly cron rebakes the routing graphs and overlay data

### DIFF
--- a/.github/workflows/quarterly-data-refresh.yml
+++ b/.github/workflows/quarterly-data-refresh.yml
@@ -1,0 +1,47 @@
+# Quarterly rebake of the hosted open-data assets: routing graphs, building footprints,
+# address overlays, and maxspeed overlays. Roads and addresses drift; a scheduled refresh
+# keeps the downloads current without anyone remembering to dispatch eight groups by hand.
+#
+# Each downstream workflow is race-safe on its own (per-region assets + a serialized manifest
+# merge), so this job just fires the dispatches and exits; the builds run on their own clock.
+# Rebakes OVERWRITE the current-generation assets in place (same names, same manifest), so no
+# new generation accumulates - generations only fork when a graph FORMAT changes (the v2
+# story), which is a manual cutover, never this cron.
+#
+# poi-packs has its own monthly cron and is deliberately not here.
+name: Quarterly data refresh
+
+on:
+  schedule:
+    - cron: "0 4 2 1,4,7,10 *" # 04:00 UTC on Jan/Apr/Jul/Oct 2nd
+  workflow_dispatch: {} # manual full refresh whenever needed
+
+permissions:
+  actions: write # gh workflow run
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Routing graphs (all groups, current v2 generation)
+        run: |
+          for g in us canada europe oceania asia south-america central-america africa; do
+            gh workflow run routing-graphs.yml --repo "$REPO" -f group="$g" -f variant=v2
+            sleep 5 # dispatch-api niceness; the workflow's own concurrency group serializes the runs
+          done
+
+      - name: Building overlays (all catalog groups)
+        run: |
+          for g in us world chunk; do
+            gh workflow run building-overlays.yml --repo "$REPO" -f group="$g"
+            sleep 5
+          done
+
+      - name: Address overlays (whole catalog)
+        run: gh workflow run address-overlays.yml --repo "$REPO" -f all=true
+
+      - name: Maxspeed overlays (whole catalog)
+        run: gh workflow run maxspeed-overlays.yml --repo "$REPO" -f all=true


### PR DESCRIPTION
One scheduled workflow, quarterly (Jan/Apr/Jul/Oct 2nd), that dispatches the routing-graphs build for all eight groups with variant=v2 so the current generation updates in place, plus the building-overlay catalog groups and the full address and maxspeed catalogs. Each downstream workflow is already race-safe (per-region assets, serialized manifest merge), so this just fires the dispatches.

Worth saying out loud since we just cleaned up the v1 generation: rebakes overwrite assets under the same names, so this cron never accumulates a new generation. Generations only fork on a format change, which stays a manual cutover.

poi-packs keeps its own monthly cron and isn't touched. There's also a manual dispatch trigger for an off-cycle full refresh.