### PR TITLE
Board refresh stops polling while the app is backgrounded

### DIFF
--- a/app/src/main/java/app/vela/MainActivity.kt
+++ b/app/src/main/java/app/vela/MainActivity.kt
@@ -62,6 +62,16 @@ class MainActivity : ComponentActivity() {
         handleIntent(intent)
     }
 
+    override fun onStart() {
+        super.onStart()
+        app.vela.ui.AppVisibility.foreground.value = true
+    }
+
+    override fun onStop() {
+        super.onStop()
+        app.vela.ui.AppVisibility.foreground.value = false
+    }
+
     /** Vela registers for `geo:` URIs and Google-Maps web links so it can be the
      *  system maps handler; turn whichever we got into a search or a dropped pin. */
     private fun handleIntent(intent: Intent?) {

--- a/app/src/main/java/app/vela/ui/AppVisibility.kt
+++ b/app/src/main/java/app/vela/ui/AppVisibility.kt
@@ -1,0 +1,11 @@
+package app.vela.ui
+
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/** Whether the app is on screen (MainActivity between onStart/onStop). Periodic work that only
+ *  matters while the user is looking - the 30 s departure-board refresh - gates on this instead
+ *  of polling from the background. Starts true so work launched before the first onStart isn't
+ *  wrongly parked. */
+object AppVisibility {
+    val foreground = MutableStateFlow(true)
+}

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -1376,6 +1377,10 @@ class MapViewModel @Inject constructor(
         boardRefreshJob = viewModelScope.launch {
             while (true) {
                 kotlinx.coroutines.delay(30_000)
+                // Backgrounding with a stop sheet open used to keep this polling every 30 s
+                // (viewModelScope outlives the screen). Park until the app is visible again;
+                // the first tick after coming back refreshes immediately.
+                app.vela.ui.AppVisibility.foreground.first { it }
                 if (_state.value.selected?.id != selId) return@launch
                 val fresh = withContext(Dispatchers.IO) {
                     runCatching { app.vela.core.data.transit.Transitous.board(http, lat, lng) }.getOrNull()


### PR DESCRIPTION
The 30 second departure-board refresh kept running if you backgrounded the app with a stop sheet open, since the view model scope outlives the screen. Small battery and network drip, and pointless load on the community API.

The loop now parks on a foreground flag (flipped in MainActivity onStart/onStop) and resumes on the first tick after the app comes back, refreshing immediately so the board's fresh when you return. Nav's foreground service is unaffected since this only gates the stop-sheet poller.