### PR TITLE
Mute turn guidance while off-route

### DIFF
--- a/core/src/main/java/app/vela/core/nav/NavEngine.kt
+++ b/core/src/main/java/app/vela/core/nav/NavEngine.kt
@@ -253,7 +253,14 @@ object NavEngine {
         val redundantContinue =
             (target.type == ManeuverType.CONTINUE || target.type == ManeuverType.STRAIGHT) &&
                 !app.vela.core.model.continueHasGenuineFork(target.lanes)
-        val voiceSilent = isDepart || redundantContinue
+        // MUTE turn guidance while off-route (Google's behaviour): the progress snap still maps
+        // the driver onto the OLD route while a reroute is pending (or failing in a dead spot),
+        // and as the phantom snap drifts past old maneuvers the engine happily announced them -
+        // "turn right onto X" spoken on a street that turn doesn't exist on (the wrong-direction
+        // report, 2026-07-13). "Rerouting" is the only thing worth saying until a route matches
+        // the road under the wheels. Step advance below stays live so progress/back-on-course
+        // bookkeeping is untouched.
+        val voiceSilent = isDepart || redundantContinue || offRoute
 
         // Approach prompts, SPEED-SCALED (Google/OsmAnd scale announcements with speed — the fixed
         // 400 m gave a 75 mph driver 12 s to cross three lanes for an exit). max(fixed, v×T) keeps

--- a/core/src/test/java/app/vela/core/VelaLogicTest.kt
+++ b/core/src/test/java/app/vela/core/VelaLogicTest.kt
@@ -123,6 +123,41 @@ class NavEngineTest {
         assertEquals(1, reroutes)
     }
 
+    /** Off-route mutes turn guidance: while a reroute is pending the progress snap still maps the
+     *  driver onto the OLD route, and the engine used to announce that route's maneuvers as the
+     *  phantom snap drifted past them ("turn right onto X" spoken on a street it doesn't exist
+     *  on). Muted while the latch is up; guidance resumes the moment the driver is back on line. */
+    @Test
+    fun offRouteMutesOldRouteTurnPrompts() {
+        val a = LatLng(37.0000, -122.0000)
+        val mid = LatLng(37.0050, -122.0000)
+        val b = LatLng(37.0100, -122.0000)
+        val route = Route(
+            polyline = listOf(a, mid, b),
+            legs = listOf(
+                RouteLeg(
+                    distanceMeters = 1100.0, durationSeconds = 80.0, durationInTrafficSeconds = null,
+                    maneuvers = listOf(
+                        Maneuver(ManeuverType.DEPART, "Head north", a, 550.0, 40.0),
+                        Maneuver(ManeuverType.TURN_RIGHT, "Turn right onto Oak", mid, 550.0, 40.0),
+                        Maneuver(ManeuverType.ARRIVE, "Arrive", b, 0.0, 0.0),
+                    ),
+                ),
+            ),
+            distanceMeters = 1100.0, durationSeconds = 80.0, durationInTrafficSeconds = null,
+        )
+        // Drive OFF the line (~400 m east) until the off-route latch is up.
+        var state = NavState()
+        repeat(6) { state = NavEngine.update(route, state, LatLng(37.0020, -121.9955)).first }
+        assertTrue("latched off-route", state.offRoute)
+        // Still off-route, the phantom snap drifts into the turn's approach band: stay silent.
+        val (next, muted) = NavEngine.update(route, state, LatLng(37.0037, -121.9955))
+        assertTrue("no old-route turn prompts while off-route", muted.none { it is NavEvent.Speak })
+        // Back ON the line short of the turn: the latch clears and guidance resumes.
+        val (_, resumed) = NavEngine.update(route, next, LatLng(37.0040, -122.0000))
+        assertTrue("guidance resumes once back on the route", resumed.any { it is NavEvent.Speak })
+    }
+
     @Test
     fun offRouteClearsWhenBackOnPath() {
         val route = straightRoute()


### PR DESCRIPTION
Root cause of the wrong-turn report (nav spoke a wrong-direction turn and the route didn't redraw). After a wrong turn there's a window before a reroute is adopted, longer if the fetch fails in a dead spot, where the engine still snaps your progress onto the old route. As that phantom snap drifts past the old route's maneuvers, the approach and turn-now announcements fired for them: a turn called out on a street you're not on. And since no reroute had landed yet, the line on the map was still the old one, which is the other half of the report.

Turn prompts and their haptics are now muted while the off-route latch is up, same as Google: you hear Rerouting and then nothing until a route matches the road you're actually on. Guidance resumes the moment you're back on line (the spoken-band bookkeeping isn't consumed while muted, so the next prompt still fires). Step advance stays live so back-on-course detection is unaffected.

Unit test drives a route off line, drifts the phantom snap into a turn's approach band, asserts silence, then rejoins and asserts guidance resumes.