### PR TITLE
Share to Vela from any app's share sheet

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,6 +85,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!-- Share TO Vela: a Google Maps share link, a URL, or a plain address from any
+                 app's share sheet opens/imports/searches without the copy-paste dance. -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+
             <!-- geo: links from other apps → Vela can be your default maps handler. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/app/vela/MainActivity.kt
+++ b/app/src/main/java/app/vela/MainActivity.kt
@@ -65,8 +65,18 @@ class MainActivity : ComponentActivity() {
     /** Vela registers for `geo:` URIs and Google-Maps web links so it can be the
      *  system maps handler; turn whichever we got into a search or a dropped pin. */
     private fun handleIntent(intent: Intent?) {
-        if (intent?.action != Intent.ACTION_VIEW) return
-        val data = intent.data?.toString() ?: return
-        MapLinkParser.parse(data)?.let { vm.openDeepLink(it) }
+        when (intent?.action) {
+            Intent.ACTION_VIEW -> {
+                val data = intent.data?.toString() ?: return
+                MapLinkParser.parse(data)?.let { vm.openDeepLink(it) }
+            }
+            // Share TO Vela: a Google Maps share link imports without the copy-paste dance, a
+            // geo:/maps URL opens like a deep link, plain text (an address someone texted you)
+            // just searches.
+            Intent.ACTION_SEND -> {
+                val text = intent.getStringExtra(Intent.EXTRA_TEXT) ?: return
+                vm.openSharedText(text)
+            }
+        }
     }
 }

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1253,6 +1253,31 @@ class MapViewModel @Inject constructor(
     /** Handle an external `geo:` / Google-Maps link (Vela as the system maps
      *  handler): a query runs a search biased to any coordinates in the link; a
      *  bare point drops a reverse-geocoded pin there. */
+    /** Text SHARED to Vela (the system share sheet): a Google Maps share link imports like a
+     *  pasted one, a geo:/maps URL opens like a deep link, and anything else - an address, a
+     *  place name - just searches. Share payloads are usually "Check out X! https://..." so the
+     *  link is fished out of the prose first. */
+    fun openSharedText(raw: String) {
+        val token = raw.trim().split(Regex("\\s+")).firstOrNull {
+            MapLinkParser.isShareLink(it) || it.startsWith("http", ignoreCase = true) || it.startsWith("geo:", ignoreCase = true)
+        }
+        when {
+            token != null && MapLinkParser.isShareLink(token) -> {
+                _state.update { it.copy(query = token) }
+                runSearch(token, _state.value.myLocation ?: _state.value.center)
+            }
+            token != null -> {
+                val link = MapLinkParser.parse(token)
+                if (link != null) openDeepLink(link)
+                else runSearch(raw.trim(), _state.value.myLocation ?: _state.value.center)
+            }
+            raw.isNotBlank() -> {
+                _state.update { it.copy(query = raw.trim()) }
+                runSearch(raw.trim(), _state.value.myLocation ?: _state.value.center)
+            }
+        }
+    }
+
     fun openDeepLink(link: MapLink) {
         val near = link.lat?.let { la -> link.lng?.let { ln -> LatLng(la, ln) } }
         val q = link.query


### PR DESCRIPTION
Closes the loop on list imports: instead of copying a maps.app.goo.gl link and pasting it into the search bar, you can now hit share in Google Maps (or a messaging app) and pick Vela. A share link runs the existing list import, a geo: or Google Maps URL opens like a deep link, and plain shared text, say an address someone texted you, just searches.

Share payloads usually wrap the link in prose, so the first URL-ish token gets fished out before deciding which path to take.