### PR TITLE
Review and stop counts use real plural forms

### DIFF
--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -174,6 +174,7 @@ import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import app.vela.R
 import androidx.compose.ui.text.SpanStyle
@@ -2343,7 +2344,7 @@ private fun TransitStepRow(s: TransitStep, ink: Color, dim: Color, onWalkDirecti
             s.boardStop?.let { StopLine(it, ink, dim, emphasize = true, delay = s.delayText) }
             val rideLabel = listOfNotNull(
                 s.durationText,
-                s.numStops?.let { stringResource(R.string.place_transit_stops, it) },
+                s.numStops?.let { pluralStringResource(R.plurals.place_transit_stops, it, it) },
             ).joinToString("  ·  ")
             if (s.intermediateStops.isNotEmpty()) {
                 Row(
@@ -2620,7 +2621,7 @@ fun RouteDetailSheet(
             }
             step?.numStops?.let { n ->
                 Text(
-                    stringResource(R.string.place_transit_stops, n),
+                    pluralStringResource(R.plurals.place_transit_stops, n, n),
                     style = MaterialTheme.typography.labelMedium, color = dim,
                     modifier = Modifier.padding(start = 16.dp, bottom = 4.dp),
                 )
@@ -3453,7 +3454,7 @@ private fun ReviewsTab(
                     RatingStars(r)
                     place.reviewCount?.let {
                         Text(
-                            stringResource(R.string.place_review_count, it),
+                            pluralStringResource(R.plurals.place_review_count, it, it),
                             style = MaterialTheme.typography.bodyMedium,
                             color = dim,
                             modifier = Modifier.padding(top = 3.dp),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -232,7 +232,10 @@
     <string name="place_gallery_counter">%1$d / %2$d</string>
     <string name="place_search_reviews">Rezensionen durchsuchen</string>
     <string name="place_sort_reviews">Rezensionen sortieren</string>
-    <string name="place_review_count">%1$d Rezensionen</string>
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="one">%1$d Rezension</item>
+        <item quantity="other">%1$d Rezensionen</item>
+    </plurals>
     <string name="place_all_n_reviews">Alle %1$d Rezensionen · sortieren &amp; suchen</string>
     <string name="place_all_reviews">Alle Rezensionen · sortieren &amp; suchen</string>
     <string name="place_reviews_progress">Rezensionen · %1$d von etwa %2$d</string>
@@ -434,7 +437,10 @@
     <string name="settings_update_checking">Wird geprüft…</string>
     <string name="settings_update_none">Du bist auf der neuesten Version.</string>
     <string name="settings_place_pages">Ortsseiten</string>
-    <string name="place_transit_stops">%1$d Haltestellen</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="one">%1$d Haltestelle</item>
+        <item quantity="other">%1$d Haltestellen</item>
+    </plurals>
     <string name="place_transit_stop_id">Haltestelle %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Tickets &amp; Infos</string>
     <string name="route_detail_unavailable">Liniendetails nicht verfügbar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -232,7 +232,10 @@
     <string name="place_gallery_counter">%1$d / %2$d</string>
     <string name="place_search_reviews">Buscar reseñas</string>
     <string name="place_sort_reviews">Ordenar reseñas</string>
-    <string name="place_review_count">%1$d reseñas</string>
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="one">%1$d reseña</item>
+        <item quantity="other">%1$d reseñas</item>
+    </plurals>
     <string name="place_all_n_reviews">Las %1$d reseñas · ordenar y buscar</string>
     <string name="place_all_reviews">Todas las reseñas · ordenar y buscar</string>
     <string name="place_reviews_progress">Reseñas · %1$d de unos %2$d</string>
@@ -434,7 +437,10 @@
     <string name="settings_update_checking">Comprobando…</string>
     <string name="settings_update_none">Tienes la versión más reciente.</string>
     <string name="settings_place_pages">Páginas de sitios</string>
-    <string name="place_transit_stops">%1$d paradas</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="one">%1$d parada</item>
+        <item quantity="other">%1$d paradas</item>
+    </plurals>
     <string name="place_transit_stop_id">Parada %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Billetes e info</string>
     <string name="route_detail_unavailable">Detalles de la línea no disponibles</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -232,7 +232,10 @@
     <string name="place_gallery_counter">%1$d / %2$d</string>
     <string name="place_search_reviews">Rechercher dans les avis</string>
     <string name="place_sort_reviews">Trier les avis</string>
-    <string name="place_review_count">%1$d avis</string>
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="one">%1$d avis</item>
+        <item quantity="other">%1$d avis</item>
+    </plurals>
     <string name="place_all_n_reviews">Tous les %1$d avis · trier et rechercher</string>
     <string name="place_all_reviews">Tous les avis · trier et rechercher</string>
     <string name="place_reviews_progress">Avis · %1$d sur environ %2$d</string>
@@ -434,7 +437,10 @@
     <string name="settings_update_checking">Vérification…</string>
     <string name="settings_update_none">Tu as la version la plus récente.</string>
     <string name="settings_place_pages">Fiches de lieux</string>
-    <string name="place_transit_stops">%1$d arrêts</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="one">%1$d arrêt</item>
+        <item quantity="other">%1$d arrêts</item>
+    </plurals>
     <string name="place_transit_stop_id">Arrêt %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Billets et infos</string>
     <string name="route_detail_unavailable">Détails de la ligne indisponibles</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -232,7 +232,10 @@
     <string name="place_gallery_counter">%1$d / %2$d</string>
     <string name="place_search_reviews">Cerca nelle recensioni</string>
     <string name="place_sort_reviews">Ordina recensioni</string>
-    <string name="place_review_count">%1$d recensioni</string>
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="one">%1$d recensione</item>
+        <item quantity="other">%1$d recensioni</item>
+    </plurals>
     <string name="place_all_n_reviews">Tutte le %1$d recensioni · ordina e cerca</string>
     <string name="place_all_reviews">Tutte le recensioni · ordina e cerca</string>
     <string name="place_reviews_progress">Recensioni · %1$d di circa %2$d</string>
@@ -434,7 +437,10 @@
     <string name="settings_update_checking">Controllo…</string>
     <string name="settings_update_none">Hai già l\'ultima versione.</string>
     <string name="settings_place_pages">Pagine dei luoghi</string>
-    <string name="place_transit_stops">%1$d fermate</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="one">%1$d fermata</item>
+        <item quantity="other">%1$d fermate</item>
+    </plurals>
     <string name="place_transit_stop_id">Fermata %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Biglietti e info</string>
     <string name="route_detail_unavailable">Dettagli linea non disponibili</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -231,7 +231,11 @@
     <string name="place_gallery_counter">%1$d / %2$d</string>
     <string name="place_search_reviews">חפש בביקורות</string>
     <string name="place_sort_reviews">מיין ביקורות</string>
-    <string name="place_review_count">%1$d ביקורות</string>
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="one">ביקורת אחת</item>
+        <item quantity="two">%1$d ביקורות</item>
+        <item quantity="other">%1$d ביקורות</item>
+    </plurals>
     <string name="place_all_n_reviews">כל %1$d הביקורות · מיון &amp; חיפוש</string>
     <string name="place_all_reviews">כל הביקורות · מיון &amp; חיפוש</string>
     <string name="place_reviews_progress">ביקורות · %1$d מתוך כ-%2$d</string>
@@ -432,7 +436,11 @@
     <string name="settings_update_checking">בודק…</string>
     <string name="settings_update_none">אתה בגרסה העדכנית ביותר.</string>
     <string name="settings_place_pages">עמודי מקומות</string>
-    <string name="place_transit_stops">%1$d תחנות</string>
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="one">תחנה אחת</item>
+        <item quantity="two">%1$d תחנות</item>
+        <item quantity="other">%1$d תחנות</item>
+    </plurals>
     <string name="place_transit_stop_id">תחנה %1$s</string>
     <string name="place_transit_tickets">כרטיסים &amp; מידע</string>
     <string name="route_detail_unavailable">פרטי הקו אינם זמינים</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -247,7 +247,9 @@
     <string name="place_gallery_counter">%1$d / %2$d</string> <!-- format -->
     <string name="place_search_reviews">クチコミを検索</string>
     <string name="place_sort_reviews">クチコミを並べ替え</string>
-    <string name="place_review_count">クチコミ %1$d 件</string> <!-- format -->
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="other">クチコミ %1$d 件</item>
+    </plurals>
     <string name="place_all_n_reviews">クチコミ全 %1$d 件 · 並べ替えと検索</string> <!-- format -->
     <string name="place_all_reviews">すべてのクチコミ · 並べ替えと検索</string>
     <string name="place_reviews_progress">クチコミ · 約 %2$d 件中 %1$d 件</string> <!-- format -->
@@ -455,7 +457,9 @@
     <string name="settings_update_checking">確認しています…</string>
     <string name="settings_update_none">最新バージョンを使用しています。</string>
     <string name="settings_place_pages">場所のページ</string>
-    <string name="place_transit_stops">%1$d 停留所</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="other">%1$d 停留所</item>
+    </plurals>
     <string name="place_transit_stop_id">停留所 %1$s</string> <!-- format -->
     <string name="place_transit_tickets">チケット・運行情報</string>
     <string name="route_detail_unavailable">路線の詳細を取得できません</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -232,7 +232,10 @@
     <string name="place_gallery_counter">%1$d / %2$d</string>
     <string name="place_search_reviews">Recensies zoeken</string>
     <string name="place_sort_reviews">Recensies sorteren</string>
-    <string name="place_review_count">%1$d recensies</string>
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="one">%1$d recensie</item>
+        <item quantity="other">%1$d recensies</item>
+    </plurals>
     <string name="place_all_n_reviews">Alle %1$d recensies · sorteren en zoeken</string>
     <string name="place_all_reviews">Alle recensies · sorteren en zoeken</string>
     <string name="place_reviews_progress">Recensies · %1$d van ongeveer %2$d</string>
@@ -434,7 +437,10 @@
     <string name="settings_update_checking">Controleren…</string>
     <string name="settings_update_none">Je hebt de nieuwste versie.</string>
     <string name="settings_place_pages">Plaatspagina\'s</string>
-    <string name="place_transit_stops">%1$d haltes</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="one">%1$d halte</item>
+        <item quantity="other">%1$d haltes</item>
+    </plurals>
     <string name="place_transit_stop_id">Halte %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Tickets &amp; info</string>
     <string name="route_detail_unavailable">Lijndetails niet beschikbaar</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -232,7 +232,12 @@
     <string name="place_gallery_counter">%1$d / %2$d</string>
     <string name="place_search_reviews">Szukaj w opiniach</string>
     <string name="place_sort_reviews">Sortuj opinie</string>
-    <string name="place_review_count">%1$d opinii</string>
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="one">%1$d opinia</item>
+        <item quantity="few">%1$d opinie</item>
+        <item quantity="many">%1$d opinii</item>
+        <item quantity="other">%1$d opinii</item>
+    </plurals>
     <string name="place_all_n_reviews">Wszystkie %1$d opinii · sortuj i szukaj</string>
     <string name="place_all_reviews">Wszystkie opinie · sortuj i szukaj</string>
     <string name="place_reviews_progress">Opinie · %1$d z około %2$d</string>
@@ -436,7 +441,12 @@
     <string name="settings_update_checking">Sprawdzanie…</string>
     <string name="settings_update_none">Masz najnowszą wersję.</string>
     <string name="settings_place_pages">Strony miejsc</string>
-    <string name="place_transit_stops">%1$d przystanków</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="one">%1$d przystanek</item>
+        <item quantity="few">%1$d przystanki</item>
+        <item quantity="many">%1$d przystanków</item>
+        <item quantity="other">%1$d przystanków</item>
+    </plurals>
     <string name="place_transit_stop_id">Przystanek %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Bilety i informacje</string>
     <string name="route_detail_unavailable">Szczegóły linii niedostępne</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -232,7 +232,10 @@
     <string name="place_gallery_counter">%1$d / %2$d</string>
     <string name="place_search_reviews">Pesquisar avaliações</string>
     <string name="place_sort_reviews">Ordenar avaliações</string>
-    <string name="place_review_count">%1$d avaliações</string>
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="one">%1$d avaliação</item>
+        <item quantity="other">%1$d avaliações</item>
+    </plurals>
     <string name="place_all_n_reviews">Todas as %1$d avaliações · ordenar e pesquisar</string>
     <string name="place_all_reviews">Todas as avaliações · ordenar e pesquisar</string>
     <string name="place_reviews_progress">Avaliações · %1$d de cerca de %2$d</string>
@@ -434,7 +437,10 @@
     <string name="settings_update_checking">Verificando…</string>
     <string name="settings_update_none">Você está na versão mais recente.</string>
     <string name="settings_place_pages">Páginas de locais</string>
-    <string name="place_transit_stops">%1$d paradas</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="one">%1$d parada</item>
+        <item quantity="other">%1$d paradas</item>
+    </plurals>
     <string name="place_transit_stop_id">Parada %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Bilhetes e info</string>
     <string name="route_detail_unavailable">Detalhes da linha indisponíveis</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -232,7 +232,12 @@
     <string name="place_gallery_counter">%1$d / %2$d</string>
     <string name="place_search_reviews">Поиск по отзывам</string>
     <string name="place_sort_reviews">Сортировать отзывы</string>
-    <string name="place_review_count">%1$d отзывов</string>
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="one">%1$d отзыв</item>
+        <item quantity="few">%1$d отзыва</item>
+        <item quantity="many">%1$d отзывов</item>
+        <item quantity="other">%1$d отзыва</item>
+    </plurals>
     <string name="place_all_n_reviews">Все отзывы (%1$d) · сортировка и поиск</string>
     <string name="place_all_reviews">Все отзывы · сортировка и поиск</string>
     <string name="place_reviews_progress">Отзывы · %1$d из примерно %2$d</string>
@@ -436,7 +441,12 @@
     <string name="settings_update_checking">Проверка…</string>
     <string name="settings_update_none">У вас самая новая версия.</string>
     <string name="settings_place_pages">Страницы мест</string>
-    <string name="place_transit_stops">%1$d остановок</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="one">%1$d остановка</item>
+        <item quantity="few">%1$d остановки</item>
+        <item quantity="many">%1$d остановок</item>
+        <item quantity="other">%1$d остановки</item>
+    </plurals>
     <string name="place_transit_stop_id">Остановка %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Билеты и информация</string>
     <string name="route_detail_unavailable">Сведения о маршруте недоступны</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -232,7 +232,10 @@
     <string name="place_gallery_counter">%1$d / %2$d</string>
     <string name="place_search_reviews">Sök recensioner</string>
     <string name="place_sort_reviews">Sortera recensioner</string>
-    <string name="place_review_count">%1$d recensioner</string>
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="one">%1$d recension</item>
+        <item quantity="other">%1$d recensioner</item>
+    </plurals>
     <string name="place_all_n_reviews">Alla %1$d recensioner · sortera &amp;amp; sök</string>
     <string name="place_all_reviews">Alla recensioner · sortera &amp;amp; sök</string>
     <string name="place_reviews_progress">Recensioner · %1$d av cirka %2$d</string>
@@ -434,7 +437,10 @@
     <string name="settings_update_checking">Kontrollerar…</string>
     <string name="settings_update_none">Du har den senaste versionen.</string>
     <string name="settings_place_pages">Platssidor</string>
-    <string name="place_transit_stops">%1$d hållplatser</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="one">%1$d hållplats</item>
+        <item quantity="other">%1$d hållplatser</item>
+    </plurals>
     <string name="place_transit_stop_id">Hållplats %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Biljetter &amp; info</string>
     <string name="route_detail_unavailable">Linjedetaljer ej tillgängliga</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -232,7 +232,12 @@
     <string name="place_gallery_counter">%1$d / %2$d</string>
     <string name="place_search_reviews">Пошук у відгуках</string>
     <string name="place_sort_reviews">Сортувати відгуки</string>
-    <string name="place_review_count">%1$d відгуків</string>
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="one">%1$d відгук</item>
+        <item quantity="few">%1$d відгуки</item>
+        <item quantity="many">%1$d відгуків</item>
+        <item quantity="other">%1$d відгуку</item>
+    </plurals>
     <string name="place_all_n_reviews">Усі %1$d відгуків · сортування й пошук</string>
     <string name="place_all_reviews">Усі відгуки · сортування й пошук</string>
     <string name="place_reviews_progress">Відгуки · %1$d з приблизно %2$d</string>
@@ -436,7 +441,12 @@
     <string name="settings_update_checking">Перевірка…</string>
     <string name="settings_update_none">У вас найновіша версія.</string>
     <string name="settings_place_pages">Сторінки місць</string>
-    <string name="place_transit_stops">%1$d зупинок</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="one">%1$d зупинка</item>
+        <item quantity="few">%1$d зупинки</item>
+        <item quantity="many">%1$d зупинок</item>
+        <item quantity="other">%1$d зупинки</item>
+    </plurals>
     <string name="place_transit_stop_id">Зупинка %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Квитки та інформація</string>
     <string name="route_detail_unavailable">Деталі маршруту недоступні</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -247,7 +247,9 @@
     <string name="place_gallery_counter">%1$d / %2$d</string> <!-- format -->
     <string name="place_search_reviews">搜尋評論</string>
     <string name="place_sort_reviews">排序評論</string>
-    <string name="place_review_count">%1$d 篇評論</string> <!-- format -->
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="other">%1$d 篇評論</item>
+    </plurals>
     <string name="place_all_n_reviews">全部 %1$d 篇評論 · 排序與搜尋</string> <!-- format -->
     <string name="place_all_reviews">所有評論 · 排序與搜尋</string>
     <string name="place_reviews_progress">評論 · %1$d／約 %2$d 篇</string> <!-- format -->
@@ -455,7 +457,9 @@
     <string name="settings_update_checking">檢查中…</string>
     <string name="settings_update_none">你使用的已是最新版本。</string>
     <string name="settings_place_pages">地點頁面</string>
-    <string name="place_transit_stops">%1$d 站</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="other">%1$d 站</item>
+    </plurals>
     <string name="place_transit_stop_id">站牌 %1$s</string> <!-- format -->
     <string name="place_transit_tickets">票券與資訊</string>
     <string name="route_detail_unavailable">無法取得路線詳情</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -247,7 +247,9 @@
     <string name="place_gallery_counter">%1$d / %2$d</string> <!-- format -->
     <string name="place_search_reviews">搜索评价</string>
     <string name="place_sort_reviews">评价排序</string>
-    <string name="place_review_count">%1$d 条评价</string> <!-- format -->
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="other">%1$d 条评价</item>
+    </plurals>
     <string name="place_all_n_reviews">全部 %1$d 条评价 · 排序和搜索</string> <!-- format -->
     <string name="place_all_reviews">全部评价 · 排序和搜索</string>
     <string name="place_reviews_progress">评价 · 已加载 %1$d 条，共约 %2$d 条</string> <!-- format -->
@@ -455,7 +457,9 @@
     <string name="settings_update_checking">正在检查…</string>
     <string name="settings_update_none">已是最新版本。</string>
     <string name="settings_place_pages">地点页面</string>
-    <string name="place_transit_stops">%1$d 站</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="other">%1$d 站</item>
+    </plurals>
     <string name="place_transit_stop_id">站点 %1$s</string> <!-- format -->
     <string name="place_transit_tickets">购票与信息</string>
     <string name="route_detail_unavailable">无法获取线路详情</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,7 +257,10 @@
     <string name="place_gallery_counter">%1$d / %2$d</string> <!-- format -->
     <string name="place_search_reviews">Search reviews</string>
     <string name="place_sort_reviews">Sort reviews</string>
-    <string name="place_review_count">%1$d reviews</string> <!-- format -->
+    <plurals name="place_review_count"> <!-- format -->
+        <item quantity="one">%1$d review</item>
+        <item quantity="other">%1$d reviews</item>
+    </plurals>
     <string name="place_all_n_reviews">All %1$d reviews · sort &amp; search</string> <!-- format -->
     <string name="place_all_reviews">All reviews · sort &amp; search</string>
     <string name="place_reviews_progress">Reviews · %1$d of about %2$d</string> <!-- format -->
@@ -470,7 +473,10 @@
     <string name="settings_update_checking">Checking…</string>
     <string name="settings_update_none">You\'re on the latest version.</string>
     <string name="settings_place_pages">Place pages</string>
-    <string name="place_transit_stops">%1$d stops</string> <!-- format -->
+    <plurals name="place_transit_stops"> <!-- format -->
+        <item quantity="one">%1$d stop</item>
+        <item quantity="other">%1$d stops</item>
+    </plurals>
     <string name="place_transit_stop_id">Stop %1$s</string> <!-- format -->
     <string name="place_transit_tickets">Tickets &amp; info</string>
     <string name="route_detail_unavailable">Route details unavailable</string>


### PR DESCRIPTION
The what-is-this, in one line: Android strings with a %d aren't grammar-aware, so 'reviews' and 'stops' rendered as '1 reviews' and '1 stops' in English and were flat-out wrong in Russian, Ukrainian and Polish, which decline the noun differently for 2-4 vs 5+ (2 отзыва but 5 отзывов).

Both strings are now plurals resources with the forms each of the 15 locales actually needs: one/other for most languages, one/few/many for the Slavic three, one/two/other for Hebrew, and a single form for Japanese and both Chinese variants where nouns don't inflect. Call sites switched to pluralStringResource. The results-count plural was fixed earlier, so this closes out the plurals item from the i18n follow-ups.