### PR TITLE
Departure-board parse anchors are remotely repairable

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1346,6 +1346,7 @@ class MapViewModel @Inject constructor(
         val cal = calibration.current()
         app.vela.core.data.google.parse.SearchParser.remoteClosedWords = cal.statusClosedWords
         app.vela.core.data.google.parse.SearchParser.remoteOpenWords = cal.statusOpenWords
+        app.vela.core.data.google.parse.StopDeparturesParser.remoteIndices = cal.stopBoardIndices
         TRANSIT_CAT = cal.transitCategoryWords?.takeIf { it.isNotEmpty() }?.let { words ->
             runCatching { Regex(words.joinToString("|"), RegexOption.IGNORE_CASE) }.getOrNull()
         } ?: TRANSIT_CAT_COMPILED

--- a/core/src/main/java/app/vela/core/config/Calibration.kt
+++ b/core/src/main/java/app/vela/core/config/Calibration.kt
@@ -68,6 +68,12 @@ data class Calibration(
     // Alternation terms for the transit-category gate (each becomes part of one case-insensitive
     // regex; plain words or small regex fragments both work).
     val transitCategoryWords: List<String>? = null,
+    // Positional anchors of the Google-page departure-board parse (the transit fallback where
+    // Transitous has no coverage) - the ONE scrape that had no remote-repair handle. Keys the
+    // parser reads: "node" (the transit node's index in the place array, compiled 62), "groups",
+    // "entries", "name". Null/missing keys = compiled defaults; the parser's shape search still
+    // runs after the anchor, so this only needs pushing when BOTH drift.
+    val stopBoardIndices: Map<String, Int>? = null,
     // Categories the transit gate must REJECT even when a word above matches - "Gas station"
     // contains "station", and boards now fetch by proximity, so a fuel stop next to a bus stop
     // showed that stop's departures (device report 2026-07-13). Multilingual like the gate itself.

--- a/core/src/main/java/app/vela/core/data/google/parse/StopDeparturesParser.kt
+++ b/core/src/main/java/app/vela/core/data/google/parse/StopDeparturesParser.kt
@@ -41,6 +41,13 @@ object StopDeparturesParser {
 
     private const val TRANSIT_NODE_INDEX = 62
 
+    /** Positional anchors, remotely repairable via the signed calibration bundle
+     *  (Calibration.stopBoardIndices, adopted at config load). Null = compiled defaults.
+     *  The shape searches (findTransitNode's scan, findBadge, collectDepartures) still run
+     *  after these anchors, so a push is only needed when both the index AND shape drift. */
+    @Volatile var remoteIndices: Map<String, Int>? = null
+    private fun idx(key: String, def: Int) = remoteIndices?.get(key) ?: def
+
     /** Parse a raw `)]}'`-guarded place body (what the WebView reads out of
      *  `APP_INITIALIZATION_STATE`). Returns null for a place that isn't a transit stop. */
     fun parse(body: String): StopDepartures? = parse(GoogleResponse.parse(body))
@@ -48,7 +55,7 @@ object StopDeparturesParser {
     fun parse(root: JsonElement): StopDepartures? {
         val place = root.at(6) ?: return null
         val transit = findTransitNode(place) ?: return null
-        val groups = transit.at(1).arr() ?: return null
+        val groups = transit.at(idx("groups", 1)).arr() ?: return null
         // Two layouts show up: a station/subway groups entries by LINE -> DIRECTION -> departures,
         // while a busy bus stop lists each upcoming departure FLAT, every one tagged with its own
         // route badge (the "14R" pill). Rather than assume one shape, walk each group's entries,
@@ -57,7 +64,7 @@ object StopDeparturesParser {
         val merged = LinkedHashMap<String, MutableLine>()
         for (group in groups) {
             val mode = modeFor(group.at(1).str(), group)
-            val entries = group.at(2).arr() ?: continue
+            val entries = group.at(idx("entries", 2)).arr() ?: continue
             for (entry in entries) {
                 for ((headsign, node) in directionsOf(entry)) {
                     val deps = collectDepartures(node)
@@ -80,7 +87,7 @@ object StopDeparturesParser {
             .sortedBy { it.upcoming.firstOrNull()?.epochSec ?: Long.MAX_VALUE }
             .take(MAX_LINES)
         if (lines.isEmpty()) throw CalibrationNeededException("stop departures: 0 lines after grouping")
-        return StopDepartures(stationName = transit.at(0).str()?.takeIf { it.isNotBlank() }, lines = lines)
+        return StopDepartures(stationName = transit.at(idx("name", 0)).str()?.takeIf { it.isNotBlank() }, lines = lines)
     }
 
     /** Accumulates all departures seen for one (route, direction) across the flat entry list. */
@@ -162,7 +169,7 @@ object StopDeparturesParser {
     /** The transit-services node hangs off the place at [TRANSIT_NODE_INDEX]; if that field
      *  has shifted, fall back to the first place child whose subtree holds a departure tuple. */
     private fun findTransitNode(place: JsonElement): JsonElement? {
-        place.at(TRANSIT_NODE_INDEX)?.let { if (hasTimeTuple(it, 0)) return it }
+        place.at(idx("node", TRANSIT_NODE_INDEX))?.let { if (hasTimeTuple(it, 0)) return it }
         return place.arr()?.firstOrNull { hasTimeTuple(it, 0) }
     }
 

--- a/core/src/test/java/app/vela/core/data/google/parse/StopDeparturesParserTest.kt
+++ b/core/src/test/java/app/vela/core/data/google/parse/StopDeparturesParserTest.kt
@@ -124,6 +124,24 @@ class StopDeparturesParserTest {
         assertNull(StopDeparturesParser.parse(")]}'\n$root"))
     }
 
+    /** The remote-repair handle: a pushed calibration can re-point the parse's positional
+     *  anchors without an app release. Move the transit node to a WRONG index AND make the
+     *  shape scan useless by overriding only the node anchor - the override must find it. */
+    @Test
+    fun `remote indices re-point the transit node anchor`() {
+        try {
+            // Transit node parked at place[30] instead of 62.
+            val place = "[" + "null,".repeat(30) + transit + "]"
+            val root = ")]}'\n[null,null,null,null,null,null,$place]"
+            StopDeparturesParser.remoteIndices = mapOf("node" to 30)
+            val d = StopDeparturesParser.parse(root)!!
+            assertEquals("Times Sq-42 St", d.stationName)
+            assertEquals(2, d.lines.size)
+        } finally {
+            StopDeparturesParser.remoteIndices = null
+        }
+    }
+
     @Test
     fun `finds the transit node even if its field index shifts`() {
         // put the transit node at a different place index; the shape-search fallback must find it


### PR DESCRIPTION
Closes the last remote-repair gap: the Google-page departure board (the transit fallback where the open feeds have no coverage) had its positional anchors compiled in, so drift there meant an app release while every other parser heals over the signed calibration channel.

Calibration grows a stopBoardIndices map (keys: node, groups, entries, name) that the parser consults before its compiled defaults, adopted at config load alongside the keyword tables. The existing shape searches still run after the anchors, so a push is only needed if Google moves both the index and the shape. calibration.json doesn't change until drift actually happens; old installs ignore the unknown field as usual.

Unit test parks the transit node at a wrong index and re-points the anchor through the override.