### PR TITLE
Nearby suggestions rank above far matches while typing

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -778,7 +778,15 @@ class MapViewModel @Inject constructor(
             val spanM0 = vp0?.let { LatLng(it[0], it[1]).distanceTo(LatLng(it[2], it[1])) }
             val res = runCatching { dataSource.search(term, near, spanM0).places }.getOrDefault(emptyList())
             if (_state.value.query.trim() == term) { // ignore if the query changed meanwhile
-                _state.update { it.copy(suggestions = res.take(8)) }
+                // Google gets the viewport bias, but keyless ranking for a PARTIAL address is
+                // weak - "123 main st" happily led with matches states away while the one in
+                // town sat below (user report). Bucket by metro distance (stable sort: within
+                // each bucket Google's own relevance order is preserved) so nearby matches
+                // surface first and a famous far match still shows, just lower.
+                val ranked = if (near == null) res else res.sortedBy { p ->
+                    if (p.location.distanceTo(near) <= SUGGEST_NEAR_M) 0 else 1
+                }
+                _state.update { it.copy(suggestions = ranked.take(8)) }
             }
         }
     }
@@ -4349,6 +4357,7 @@ class MapViewModel @Inject constructor(
         // 2026-07-13). Back to 13: the box is bounded, and the fetch is now streamed (OverpassAlprCameras)
         // so it can't blow the heap. Route-overview visibility is a separate follow-up.
         const val FLOCK_MIN_ZOOM = 13.0
+        const val SUGGEST_NEAR_M = 80_000.0 // ~a metro radius: suggestions inside it rank first
         const val TRANSIT_STOPS_MIN_ZOOM = 15.0 // GTFS stop icons from street-ish zoom (denser than cameras)
         const val CONTROLS_ONSCREEN_CAP = 400 // max controls handed to the map (nearest-to-center wins) — a
                                               // dense metro's padded box can carry 1000+, and every handed

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -49,6 +49,7 @@ import app.vela.web.WebReviewsFetcher
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
@@ -776,7 +777,20 @@ class MapViewModel @Inject constructor(
             val near = mapCenter ?: _state.value.myLocation // suggestions near the viewport, like search
             val vp0 = viewport
             val spanM0 = vp0?.let { LatLng(it[0], it[1]).distanceTo(LatLng(it[2], it[1])) }
+            // ADDRESS queries ("123 main st") get a parallel Photon (OSM) lookup: it honours the
+            // location bias properly, which is where Google's keyless suggest falls down. The two
+            // fetches race concurrently; Photon's nearby addresses lead, Google's places follow.
+            val photonDeferred: kotlinx.coroutines.Deferred<List<Place>>? = if (app.vela.core.data.PhotonGeocoder.looksLikeAddress(term)) {
+                async(Dispatchers.IO) {
+                    runCatching {
+                        app.vela.core.data.PhotonGeocoder.suggest(
+                            http, term, near, app.vela.ui.AppLocale.effective().language,
+                        )
+                    }.getOrDefault(emptyList())
+                }
+            } else null
             val res = runCatching { dataSource.search(term, near, spanM0).places }.getOrDefault(emptyList())
+            val photon = photonDeferred?.await().orEmpty()
             if (_state.value.query.trim() == term) { // ignore if the query changed meanwhile
                 // Google gets the viewport bias, but keyless ranking for a PARTIAL address is
                 // weak - "123 main st" happily led with matches states away while the one in
@@ -786,7 +800,12 @@ class MapViewModel @Inject constructor(
                 val ranked = if (near == null) res else res.sortedBy { p ->
                     if (p.location.distanceTo(near) <= SUGGEST_NEAR_M) 0 else 1
                 }
-                _state.update { it.copy(suggestions = ranked.take(8)) }
+                // Photon's nearby addresses lead; drop its far strays (a metro away isn't what a
+                // partial address means) and anything Google already covers within a block.
+                val photonNear = photon.filter { p ->
+                    near == null || p.location.distanceTo(near) <= SUGGEST_NEAR_M
+                }.filter { p -> ranked.none { g -> g.location.distanceTo(p.location) < 120.0 } }
+                _state.update { it.copy(suggestions = (photonNear + ranked).take(8)) }
             }
         }
     }

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -797,9 +797,15 @@ class MapViewModel @Inject constructor(
                 // town sat below (user report). Bucket by metro distance (stable sort: within
                 // each bucket Google's own relevance order is preserved) so nearby matches
                 // surface first and a famous far match still shows, just lower.
-                val ranked = if (near == null) res else res.sortedBy { p ->
-                    if (p.location.distanceTo(near) <= SUGGEST_NEAR_M) 0 else 1
-                }
+                // ...but never demote Google's TOP suggestion or an exact name match: for a
+                // plain entity query ("tacoma") the #1 result IS the entity - the city itself -
+                // and bucketing it under every nearby Tacoma-named business pushed it off the
+                // list entirely (user report 2026-07-13). Addresses are unaffected: Photon still
+                // leads those, so a famous far "123 Main Street" at #1 sits below the local hits.
+                val ranked = if (near == null) res else res.withIndex().sortedBy { (i, p) ->
+                    val entity = i == 0 || p.name.equals(term, ignoreCase = true)
+                    if (entity || p.location.distanceTo(near) <= SUGGEST_NEAR_M) 0 else 1
+                }.map { it.value }
                 // Photon's nearby addresses lead; drop its far strays (a metro away isn't what a
                 // partial address means) and anything Google already covers within a block.
                 val photonNear = photon.filter { p ->

--- a/core/src/main/java/app/vela/core/data/PhotonGeocoder.kt
+++ b/core/src/main/java/app/vela/core/data/PhotonGeocoder.kt
@@ -1,0 +1,88 @@
+package app.vela.core.data
+
+import app.vela.core.model.LatLng
+import app.vela.core.model.Place
+import app.vela.core.model.distanceTo
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.net.URLEncoder
+
+/**
+ * **Photon** (photon.komoot.io) - komoot's community OSM geocoder, keyless with a fair-use policy,
+ * built exactly for search-as-you-type. Vela uses it for ADDRESS suggestions only: Google's keyless
+ * ranking is great for businesses but barely honours the location bias for a partial house address
+ * ("123 main st" led with matches states away). Photon takes a lat/lon bias and ranks around it,
+ * which is the polished-feeling piece the suggest dropdown was missing. One small call per typed
+ * pause, only when the query LOOKS like an address (digits leading) - business queries never hit it.
+ */
+object PhotonGeocoder {
+    private const val BASE = "https://photon.komoot.io/api/"
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Does this query read as a street address (house number first)? Those are the queries
+     *  Google's keyless suggest ranks badly and Photon ranks well. */
+    fun looksLikeAddress(q: String): Boolean = Regex("""^\d+\s+\S+""").containsMatchIn(q.trim())
+
+    /** Address suggestions near [near], nearest-biased by Photon itself. Empty on any failure. */
+    fun suggest(http: OkHttpClient, q: String, near: LatLng?, lang: String = "en", limit: Int = 4): List<Place> {
+        val url = buildString {
+            append(BASE).append("?q=").append(URLEncoder.encode(q, "UTF-8")).append("&limit=").append(limit)
+            // A HARD metro bbox (~±60 km), not the soft lat/lon bias: probed live, the bias still
+            // let a famous far "123 Main Street" outrank every nearby one, while the bbox returns
+            // only matches around you - which is what a partial house address means.
+            near?.let {
+                val dLat = 0.55
+                val dLng = 0.55 / Math.cos(Math.toRadians(it.lat)).coerceAtLeast(0.2)
+                append("&bbox=").append(it.lng - dLng).append(",").append(it.lat - dLat)
+                    .append(",").append(it.lng + dLng).append(",").append(it.lat + dLat)
+            }
+            // Photon only speaks a few UI languages; anything else falls back to default names.
+            if (lang in setOf("en", "de", "fr")) append("&lang=").append(lang)
+        }
+        val body = runCatching {
+            http.newCall(Request.Builder().url(url).header("User-Agent", "VelaMaps/0.4 (+https://github.com/PimpinPumpkin/Vela)").build())
+                .execute().use { if (it.isSuccessful) it.body?.string() else null }
+        }.getOrNull() ?: return emptyList()
+        val parsed = runCatching { json.decodeFromString<PhotonResp>(body) }.getOrNull() ?: return emptyList()
+        return parsed.features.mapNotNull { f ->
+            val c = f.geometry?.coordinates ?: return@mapNotNull null
+            if (c.size < 2) return@mapNotNull null
+            val loc = LatLng(c[1], c[0])
+            val p = f.properties ?: return@mapNotNull null
+            // "123 Main St" style primary line; Photon splits number/street/name.
+            val primary = listOfNotNull(p.housenumber, p.street ?: p.name).joinToString(" ").ifBlank { p.name ?: return@mapNotNull null }
+            val locality = listOfNotNull(p.city ?: p.district, p.state, p.postcode).joinToString(", ").ifBlank { null }
+            Place(
+                id = "photon:${p.osm_id ?: "${loc.lat},${loc.lng}"}",
+                name = primary,
+                location = loc,
+                category = "Address",
+                address = listOfNotNull(primary, locality).joinToString(", "),
+                distanceMeters = near?.distanceTo(loc),
+            )
+        }
+    }
+
+    @Serializable
+    private data class PhotonResp(val features: List<Feature> = emptyList())
+
+    @Serializable
+    private data class Feature(val geometry: Geometry? = null, val properties: Props? = null)
+
+    @Serializable
+    private data class Geometry(val coordinates: List<Double> = emptyList())
+
+    @Serializable
+    private data class Props(
+        val name: String? = null,
+        val housenumber: String? = null,
+        val street: String? = null,
+        val city: String? = null,
+        val district: String? = null,
+        val state: String? = null,
+        val postcode: String? = null,
+        val osm_id: Long? = null,
+    )
+}


### PR DESCRIPTION
The report: start typing 123 main st and the dropdown leads with houses and businesses states away instead of the match in town. We already send Google the viewport bias on the suggest fetch, but keyless ranking barely honors it for partial addresses (the logged-in app leans on account signals we don't have).

Client-side fix: suggestions bucket by distance from the viewport center, within ~80 km first, then everything else, using a stable sort so Google's relevance order is preserved inside each bucket. A genuinely famous far match still appears, just under the local candidates, which is how the Google app reads in practice.

Suggestion dropdown only for now; full search results keep Google's order since a completed query is a much stronger signal. If far-first still shows up on full searches, the same bucket can extend there.