### PR TITLE
Results: sort chip moves left of the rating filter

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -2169,6 +2169,32 @@ private fun SearchResults(
                             { Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(16.dp)) }
                         } else null,
                     )
+                    // Sort: a menu (Relevance / Rating / Distance). LEFT of the filters like
+                    // Google's results header (user 2026-07-13).
+                    Box {
+                        ElevatedFilterChip(
+                            selected = sortMode > 0,
+                            onClick = { sortMenu = true },
+                            label = {
+                                Text(
+                                    when (sortMode) {
+                                        1 -> stringResource(R.string.mapscreen_sort_rating)
+                                        2 -> stringResource(R.string.mapscreen_sort_distance)
+                                        else -> stringResource(R.string.mapscreen_sort)
+                                    },
+                                )
+                            },
+                            shape = androidx.compose.foundation.shape.CircleShape,
+                            colors = chipColors,
+                            border = null,
+                            trailingIcon = { Icon(Icons.Default.KeyboardArrowDown, contentDescription = null, modifier = Modifier.size(18.dp)) },
+                        )
+                        VelaMenu(expanded = sortMenu, onDismissRequest = { sortMenu = false }) {
+                            item(stringResource(R.string.mapscreen_sort_relevance)) { sortMode = 0; sortMenu = false }
+                            item(stringResource(R.string.mapscreen_sort_rating_item)) { sortMode = 1; sortMenu = false }
+                            item(stringResource(R.string.mapscreen_sort_distance_item)) { sortMode = 2; sortMenu = false }
+                        }
+                    }
                     // Rating floor: a MENU of Google's tiers (3.5+/4.0+/4.5+) — the old fixed
                     // 4.0★ toggle couldn't say what it did or offer another bar.
                     Box {
@@ -2218,31 +2244,6 @@ private fun SearchResults(
                             { Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(16.dp)) }
                         } else null,
                     )
-                    // Sort: a menu (Relevance / Rating / Distance) instead of blind cycling.
-                    Box {
-                        ElevatedFilterChip(
-                            selected = sortMode > 0,
-                            onClick = { sortMenu = true },
-                            label = {
-                                Text(
-                                    when (sortMode) {
-                                        1 -> stringResource(R.string.mapscreen_sort_rating)
-                                        2 -> stringResource(R.string.mapscreen_sort_distance)
-                                        else -> stringResource(R.string.mapscreen_sort)
-                                    },
-                                )
-                            },
-                            shape = androidx.compose.foundation.shape.CircleShape,
-                            colors = chipColors,
-                            border = null,
-                            trailingIcon = { Icon(Icons.Default.KeyboardArrowDown, contentDescription = null, modifier = Modifier.size(18.dp)) },
-                        )
-                        VelaMenu(expanded = sortMenu, onDismissRequest = { sortMenu = false }) {
-                            item(stringResource(R.string.mapscreen_sort_relevance)) { sortMode = 0; sortMenu = false }
-                            item(stringResource(R.string.mapscreen_sort_rating_item)) { sortMode = 1; sortMenu = false }
-                            item(stringResource(R.string.mapscreen_sort_distance_item)) { sortMode = 2; sortMenu = false }
-                        }
-                    }
                 }
                 Divider()
                 } // SheetFold - chips


### PR DESCRIPTION
Small one from device use: the Sort menu sat at the far end of the filter chip row, off screen until you scrolled it. Google leads with sort, so Vela's now sits before Rating (after Open now). Pure reorder, no behavior change.