### PR TITLE
Coordinate deep links move the camera to the pin

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1261,7 +1261,15 @@ class MapViewModel @Inject constructor(
                 _state.update { it.copy(query = q, center = near ?: it.center) }
                 runSearch(q, near ?: _state.value.myLocation ?: _state.value.center)
             }
-            near != null -> onMapLongPress(near)
+            near != null -> {
+                // A long-press pin assumes the camera is already there (the user pressed the
+                // screen); a deep link's coordinate is usually far away, so move the camera
+                // too - without this the pin sheet opened while the map stayed put (device
+                // 2026-07-13). Setting center also trips the follow-disarm rule, correctly:
+                // a coordinate link means "look over there".
+                _state.update { it.copy(center = near) }
+                onMapLongPress(near)
+            }
         }
     }
 


### PR DESCRIPTION
geo:lat,lng links (and pasted coordinates that resolve through the same path) opened the
reverse-geocoded pin sheet but left the map wherever it was. The long-press handler the
link reuses never sets the map center, because a real long-press happens on screen where
the camera already is. The deep-link branch now centers on the coordinate before
dropping the pin, which also trips the follow-disarm rule the way a far jump should.