### PR TITLE
Transit stop names take the transit blue per theme

### DIFF
--- a/app/src/main/java/app/vela/ui/map/PoiIcons.kt
+++ b/app/src/main/java/app/vela/ui/map/PoiIcons.kt
@@ -458,6 +458,10 @@ object PoiIcons {
 
     /** The label colour for a category [group] per theme: the icon colour in light, its pastel
      *  tint in dark (Google's own dark-mode treatment — full saturation vanishes on a dark map). */
+    /** Public single-group variant of [labelColor] for layers styled outside this file
+     *  (the canonical GTFS stop labels take the transit category colour per theme). */
+    fun labelColorFor(group: String, dark: Boolean): String = labelColor(group, dark)
+
     private fun labelColor(group: String, dark: Boolean): String {
         val base = GROUPS.first { it.first == group }.third
         return if (dark) lighten(base, 0.55f) else base

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -2200,6 +2200,14 @@ private fun applyMapTheme(style: Style, dark: Boolean) {
         PropertyFactory.textColor(PoiIcons.ambientLabelColor(dark)),
         PropertyFactory.textHaloColor(if (dark) "#11161C" else "#FFFFFF"),
     )
+    // Canonical GTFS stop names take the TRANSIT category colour per theme - blue in light,
+    // its pastel tint in dark, the same grammar every POI label follows. The creation-time
+    // colours in ensureLayers were hardcoded for dark (no theme there) and read as grey with
+    // a navy halo on the light map (issue #71 follow-up, 2026-07-14).
+    (style.getLayer(TRANSIT_STOPS_LAYER) as? SymbolLayer)?.setProperties(
+        PropertyFactory.textColor(PoiIcons.labelColorFor("transit", dark)),
+        PropertyFactory.textHaloColor(if (dark) "#11161C" else "#FFFFFF"),
+    )
     // Search-result labels stay NEUTRAL ink - Google doesn't category-tint result labels the
     // way it tints ambient POI labels (the red pin is the result signal, not the text colour).
     (style.getLayer(MARKERS_LAYER) as? SymbolLayer)?.setProperties(


### PR DESCRIPTION
The canonical GTFS stop labels were styled at layer creation with colors hardcoded for
the dark map, so light mode rendered them grey with a navy halo and they were hard to
read (issue #71 follow-up). They now take the transit category color through the same
grammar every POI label uses: the saturated blue in light mode, its pastel tint in dark,
with the standard per-theme halo.

Fixes the readability regression reported in #71.