### PR TITLE
D-pad cleanup: parking menu, focus rings, results handle key path

### DIFF
--- a/app/src/main/java/app/vela/ui/VelaMenu.kt
+++ b/app/src/main/java/app/vela/ui/VelaMenu.kt
@@ -22,6 +22,11 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.ui.Alignment
+import androidx.compose.material3.Icon
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -81,12 +86,13 @@ fun VelaMenu(expanded: Boolean, onDismissRequest: () -> Unit, content: @Composab
  *  (auto-focused if it's the first) under D-pad. [onClick] should also dismiss the menu, exactly
  *  as it did for the DropdownMenuItem it replaces. */
 @Composable
-fun VelaMenuScope.item(text: String, onClick: () -> Unit) {
+fun VelaMenuScope.item(text: String, icon: ImageVector? = null, onClick: () -> Unit) {
     if (!dpad) {
         // Explicit themed ink: the popup's default let some items render full black next
         // to the app's softer text (the results Price/Sort menus, user 2026-07-11).
         DropdownMenuItem(
             text = { Text(text, color = MaterialTheme.colorScheme.onSurface) },
+            leadingIcon = icon?.let { { Icon(it, contentDescription = null) } },
             onClick = onClick,
         )
         return
@@ -103,10 +109,8 @@ fun VelaMenuScope.item(text: String, onClick: () -> Unit) {
             }
         }
     }
-    Text(
-        text,
-        style = MaterialTheme.typography.bodyLarge,
-        color = MaterialTheme.colorScheme.onSurface,
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
             .focusRequester(fr)
@@ -124,5 +128,15 @@ fun VelaMenuScope.item(text: String, onClick: () -> Unit) {
             .focusable()
             .pointerInput(Unit) { detectTapGestures { onClick() } }
             .padding(horizontal = 20.dp, vertical = 12.dp),
-    )
+    ) {
+        if (icon != null) {
+            Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.width(12.dp))
+        }
+        Text(
+            text,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
 }

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1430,6 +1430,7 @@ fun MapScreen(
                         .align(Alignment.TopCenter)
                         .statusBarsPadding()
                         .padding(top = 76.dp)
+                        .dpadHighlight(RoundedCornerShape(20.dp))
                         .clickable {
                             vm.saveImportedList()
                             Toast.makeText(context, savedMsg, Toast.LENGTH_SHORT).show()
@@ -1607,42 +1608,31 @@ fun MapScreen(
                         ),
                     )
                     // The parking hub, anchored to the button. Only reachable when a spot is set.
-                    DropdownMenu(expanded = showParkingMenu, onDismissRequest = { showParkingMenu = false }) {
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.map_parking_find)) },
-                            leadingIcon = { Icon(Icons.Default.DirectionsCar, contentDescription = null) },
-                            onClick = { showParkingMenu = false; vm.showParkedCar(parkedCarLabel) },
-                        )
+                    // VelaMenu, not a bare DropdownMenu - the D-pad rule (docs/dpad.md): a popup
+                    // can't be pre-focused, so key-first devices get the auto-focusing chooser.
+                    app.vela.ui.VelaMenu(expanded = showParkingMenu, onDismissRequest = { showParkingMenu = false }) {
+                        item(stringResource(R.string.map_parking_find), Icons.Default.DirectionsCar) {
+                            showParkingMenu = false; vm.showParkedCar(parkedCarLabel)
+                        }
                         // "Move parking here" overwrites the current spot with your live fix; the old
                         // one is not lost - saveParkingSpot archives it to history. Hidden with no fix.
                         if (state.myLocation != null) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.map_parking_move_here)) },
-                                leadingIcon = { Icon(Icons.Default.MyLocation, contentDescription = null) },
-                                onClick = {
-                                    showParkingMenu = false
-                                    val msg = if (vm.saveParkingSpot()) parkingMovedMsg else parkingNoFixMsg
-                                    Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
-                                },
-                            )
+                            item(stringResource(R.string.map_parking_move_here), Icons.Default.MyLocation) {
+                                showParkingMenu = false
+                                val msg = if (vm.saveParkingSpot()) parkingMovedMsg else parkingNoFixMsg
+                                Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                            }
                         }
                         if (state.parkingHistory.size > 1) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.map_parking_earlier)) },
-                                leadingIcon = { Icon(Icons.Default.History, contentDescription = null) },
-                                onClick = { showParkingMenu = false; showParkingHistory = true },
-                            )
+                            item(stringResource(R.string.map_parking_earlier), Icons.Default.History) {
+                                showParkingMenu = false; showParkingHistory = true
+                            }
                         }
-                        Divider()
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.map_parking_clear)) },
-                            leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
-                            onClick = {
-                                showParkingMenu = false
-                                vm.clearParkingSpot()
-                                Toast.makeText(context, parkingClearedMsg, Toast.LENGTH_SHORT).show()
-                            },
-                        )
+                        item(stringResource(R.string.map_parking_clear), Icons.Default.Delete) {
+                            showParkingMenu = false
+                            vm.clearParkingSpot()
+                            Toast.makeText(context, parkingClearedMsg, Toast.LENGTH_SHORT).show()
+                        }
                     }
                 }
             }
@@ -2069,8 +2059,23 @@ private fun SearchResults(
                         )
                     },
             ) {
+                // The handle pill is a real focus stop under D-pad: OK steps the sheet up a
+                // detent (the tap grammar), BACK steps it down as always - the tap/drag gestures
+                // on the Column above have no key path of their own (docs/dpad.md).
                 Box(
-                    Modifier.fillMaxWidth().padding(top = 8.dp, bottom = 2.dp),
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp, bottom = 2.dp)
+                        .dpadHighlight(RoundedCornerShape(6.dp))
+                        .onKeyEvent { ev ->
+                            if ((ev.key == Key.DirectionCenter || ev.key == Key.Enter) && ev.type == KeyEventType.KeyUp) {
+                                if (collapsed) onExpand() else onExpandedChange(!expanded)
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                        .focusable(),
                     contentAlignment = Alignment.Center,
                 ) {
                     Box(

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -627,6 +627,7 @@ fun PlaceSheet(
                     // Minimized: a single tap ANYWHERE on the card pops it back to peek (Google) —
                     // the action pills keep their own taps since inner clickables win their bounds.
                     // Inert (enabled=false) whenever the full body is showing.
+                    .dpadHighlight(RoundedCornerShape(20.dp))
                     .clickable(enabled = minimizedState.value && !singleDetent) { minimizedState.value = false }
                     .padding(start = 20.dp, end = 20.dp, bottom = 20.dp),
             ) {


### PR DESCRIPTION
The static auditor flagged four pre-existing holes. The parking hub was a bare
DropdownMenu, which cannot be pre-focused, so keypad phones opened it with nothing
focused; it is a VelaMenu now, and VelaMenu items grew an optional leading icon so the
conversion keeps its glyphs. The imported-list save pill and the minimized place card's
restore tap get focus rings. The results sheet's handle becomes a real focus stop: OK
steps the sheet up a detent, matching its tap, with BACK stepping down as before.

The auditor reports zero violations after this.