### PR TITLE
Offline routing graphs now load on Android below 14

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1938,7 +1938,19 @@ architecture note.
   static-inits a JDK-16 `VarHandle` method ART lacks); (2) **override `createWeightingFactory()`** to a
   hand-rolled `SpeedWeighting`+access-block (v11 compiles custom models via **Janino** → JVM bytecode ART
   can't load); (3) **swallow `close()`** (MMAP unmap uses `Unsafe.invokeCleaner`, absent on Android - keep
-  one engine for the process lifetime). **R8:** `consumer-rules.pro` keeps `com.graphhopper.**` + hppc/jts/
+  one engine for the process lifetime). **Three MORE ART gaps, all pre-API-34, all fixed so offline graphs
+  LOAD below Android 14 (contributed by ars18, ported 2026-07-17 - before this, a downloaded graph loaded on
+  API 34+ ONLY; the `:ghprobe` device was on 14 so it was never caught):** (4) the custom model is built
+  PROGRAMMATICALLY via `carModel()` instead of `GHUtility.loadCustomModelFromJar("car.json")` - the jar's
+  loader makes Jackson bean-introspect `Statement` (a Java 17 record), which needs `Class.getRecordComponents`
+  (ART API 34+); record CONSTRUCTORS work everywhere, only the reflection probe is missing. `carModel()` MUST
+  mirror the jar's `car.json` exactly (the CH profile version hashes are keyed on the model) - `GraphHopperRouterTest.carModelMatchesJar` asserts it and fails on any GraphHopper-upgrade drift; (5) profiles are
+  set AFTER `init()` via `hopper.setProfiles`/`chPreparationHandler.setCHProfiles`, never inside the cfg -
+  `init()` force-round-trips every profile's model through Jackson (same record probe); (6) `MMapDataAccess`
+  reads graph segments with the JDK-13 absolute-bulk `ByteBuffer.get/put(int,byte[],int,int)` (ART API 34+),
+  so a **buildSrc artifact transform** (`GraphHopperByteBufferPatch`, ASM) rewrites exactly those 6 call
+  sites in `graphhopper-core-*.jar` to `app.vela.core.util.ByteBufferCompat` (`duplicate()+position()`,
+  API 1, byte-identical). `buildSrc` carries NO AGP dep (AGP there splits the plugin classloaders). **R8:** `consumer-rules.pro` keeps `com.graphhopper.**` + hppc/jts/
   jackson wholesale (GraphHopper resolves a lot reflectively) and `-dontwarn`s the excluded/absent refs - 
   release build is clean (**but +~10 MB APK; tighter keeps / on-demand delivery is a later optimisation**).
   Graphs are built off-device, one per region, and (Phase 1b) downloaded alongside the offline tiles;

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1967,6 +1967,18 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   the English base only; Weblate opens PRs to fill the locales, and untranslated strings fall
   back to English in the meantime.
 
+## Added 2026-07-17 (offline routing on pre-Android-14 devices)
+
+- ✅ **Downloaded routing graphs now load on Android below 14 (API 34).** Three pre-API-34 gaps in
+  the GraphHopper offline engine meant a downloaded graph loaded on API 34+ only, and silently
+  failed everywhere below (never caught because the `:ghprobe` test device was on Android 14):
+  the custom model is now built programmatically instead of via the jar's Jackson record probe
+  (`Class.getRecordComponents` is API 34+), profiles are set after `init()` to skip a second
+  Jackson round-trip, and a build-time ASM transform rewrites `MMapDataAccess`'s JDK-13
+  absolute-bulk `ByteBuffer` calls to an API-1 shim. Offline routing now works down to minSdk 26.
+  Fix contributed by ars18 (vela-dpad fork); a unit test guards the hand-built model against
+  GraphHopper-upgrade drift.
+
 ## Added 2026-07-16 (community QOL batch, issues #169 #170 #171 #172 #173)
 
 - ✅ **Edit the destination from the route picker (issue #170).** Both endpoint rows on the

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,26 @@ plugins {
     alias(libs.plugins.baselineprofile)
 }
 
+// GraphHopper's MMapDataAccess uses JDK-13 absolute-bulk ByteBuffer methods (ART API 34+ only):
+// an artifact transform rewrites those call sites to app.vela.core.util.ByteBufferCompat so
+// offline region graphs load on the API 26-33 devices Vela's minSdk still supports. See
+// buildSrc/src/main/kotlin/GraphHopperByteBufferPatch.kt. The patched calls behave identically
+// on API 34+, so there is no per-device build variance. (Fix contributed by ars18.)
+val bbPatched = Attribute.of("graphhopperByteBufferPatched", Boolean::class.javaObjectType)
+dependencies {
+    attributesSchema { attribute(bbPatched) }
+    artifactTypes.getByName("jar") { attributes.attribute(bbPatched, false) }
+    registerTransform(GraphHopperByteBufferPatch::class.java) {
+        from.attribute(bbPatched, false)
+            .attribute(org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, org.gradle.api.artifacts.type.ArtifactTypeDefinition.JAR_TYPE)
+        to.attribute(bbPatched, true)
+            .attribute(org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, org.gradle.api.artifacts.type.ArtifactTypeDefinition.JAR_TYPE)
+    }
+}
+configurations.configureEach {
+    if (isCanBeResolved) attributes.attribute(bbPatched, true)
+}
+
 android {
     namespace = "app.vela"
     compileSdk = 35

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,15 @@
+// buildSrc exists for ONE thing: the GraphHopper ByteBuffer patch transform (see
+// src/main/kotlin/GraphHopperByteBufferPatch.kt). Plain Gradle + ASM - deliberately NO Android
+// Gradle Plugin dependency here: AGP on the buildSrc classpath splits the plugin classes across
+// classloaders and breaks the root plugins block.
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.ow2.asm:asm:9.7")
+}

--- a/buildSrc/src/main/kotlin/GraphHopperByteBufferPatch.kt
+++ b/buildSrc/src/main/kotlin/GraphHopperByteBufferPatch.kt
@@ -1,0 +1,104 @@
+import org.gradle.api.artifacts.transform.InputArtifact
+import org.gradle.api.artifacts.transform.TransformAction
+import org.gradle.api.artifacts.transform.TransformOutputs
+import org.gradle.api.artifacts.transform.TransformParameters
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.provider.Provider
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+
+/**
+ * Artifact transform that rewrites GraphHopper's JDK-13 absolute-bulk ByteBuffer calls to a
+ * compat shim, so prebuilt region graphs load on Android below API 34.
+ *
+ * GraphHopper 11's MMapDataAccess reads/writes graph segments with
+ * `ByteBuffer.get(int, byte[], int, int)` / `put(int, byte[], int, int)` - added in Java 13,
+ * present on ART only from API 34. On the API 26-33 devices Vela's minSdk still supports, every
+ * offline graph load died with NoSuchMethodError. The only call sites in the whole dependency
+ * tree are the six inside MMapDataAccess (verified by scanning every GraphHopper jar's constant
+ * pool), so this transform patches exactly `graphhopper-core-*.jar`, and inside it exactly
+ * `com/graphhopper/storage/MMapDataAccess.class`: each such call becomes an INVOKESTATIC to
+ * `app.vela.core.util.ByteBufferCompat`, which does the same thing via duplicate()+position()
+ * (API 1, and just as thread-safe - the duplicate carries its own position). Every other jar
+ * passes through untouched.
+ *
+ * (Contributed by ars18 in the vela-dpad fork; ported here so offline routing works on all
+ * supported devices, not just API 34+.)
+ */
+abstract class GraphHopperByteBufferPatch : TransformAction<TransformParameters.None> {
+
+    @get:InputArtifact
+    abstract val inputArtifact: Provider<FileSystemLocation>
+
+    override fun transform(outputs: TransformOutputs) {
+        val input = inputArtifact.get().asFile
+        if (!input.name.startsWith("graphhopper-core-")) {
+            outputs.file(input) // pass through untouched
+            return
+        }
+        val out = outputs.file(input.nameWithoutExtension + "-bbpatched.jar")
+        ZipFile(input).use { zip ->
+            ZipOutputStream(out.outputStream().buffered()).use { zos ->
+                for (entry in zip.entries()) {
+                    val bytes = zip.getInputStream(entry).readBytes()
+                    val patched = if (entry.name == "com/graphhopper/storage/MMapDataAccess.class") {
+                        patchClass(bytes)
+                    } else {
+                        bytes
+                    }
+                    zos.putNextEntry(ZipEntry(entry.name))
+                    zos.write(patched)
+                    zos.closeEntry()
+                }
+            }
+        }
+    }
+
+    private fun patchClass(bytes: ByteArray): ByteArray {
+        val reader = ClassReader(bytes)
+        val writer = ClassWriter(reader, 0) // pure call-site swap: stack shape is unchanged
+        reader.accept(object : ClassVisitor(Opcodes.ASM9, writer) {
+            override fun visitMethod(
+                access: Int,
+                name: String?,
+                descriptor: String?,
+                signature: String?,
+                exceptions: Array<out String>?,
+            ): MethodVisitor {
+                val mv = super.visitMethod(access, name, descriptor, signature, exceptions)
+                return object : MethodVisitor(Opcodes.ASM9, mv) {
+                    override fun visitMethodInsn(
+                        opcode: Int,
+                        owner: String?,
+                        mName: String?,
+                        mDesc: String?,
+                        isInterface: Boolean,
+                    ) {
+                        if (opcode == Opcodes.INVOKEVIRTUAL &&
+                            owner == "java/nio/ByteBuffer" &&
+                            (mName == "get" || mName == "put") &&
+                            mDesc == "(I[BII)Ljava/nio/ByteBuffer;"
+                        ) {
+                            super.visitMethodInsn(
+                                Opcodes.INVOKESTATIC,
+                                "app/vela/core/util/ByteBufferCompat",
+                                mName,
+                                "(Ljava/nio/ByteBuffer;I[BII)Ljava/nio/ByteBuffer;",
+                                false,
+                            )
+                        } else {
+                            super.visitMethodInsn(opcode, owner, mName, mDesc, isInterface)
+                        }
+                    }
+                }
+            }
+        }, 0)
+        return writer.toByteArray()
+    }
+}

--- a/core/src/main/java/app/vela/core/data/GraphHopperRouteEngine.kt
+++ b/core/src/main/java/app/vela/core/data/GraphHopperRouteEngine.kt
@@ -16,7 +16,6 @@ import com.graphhopper.routing.WeightingFactory
 import com.graphhopper.routing.util.EdgeFilter
 import com.graphhopper.routing.weighting.SpeedWeighting
 import com.graphhopper.util.EdgeIteratorState
-import com.graphhopper.util.GHUtility
 import com.graphhopper.util.Instruction
 import org.json.JSONArray
 import java.io.File
@@ -197,11 +196,17 @@ class GraphHopperRouteEngine(private val graphsRoot: File) : RouteEngine {
             putObject("graph.dataaccess", "MMAP") // ART lacks RAMDataAccess's VarHandle method
             putObject("graph.encoded_values", if (v2) ENCODED_VALUES_V2 else ENCODED_VALUES)
             putObject("import.osm.ignored_highways", "") // import-only; required by init() validation
-            val names = if (v2) listOf(PROFILE, PROFILE_AVOID_TOLL, PROFILE_AVOID_MOTORWAY) else listOf(PROFILE)
-            profiles = names.map { Profile(it).setCustomModel(GHUtility.loadCustomModelFromJar("car.json")) }
-            setCHProfiles(names.map { CHProfile(it) }) // prebuilt CH → fast on-device routing
         }
         hopper.init(cfg)
+        // Profiles are set DIRECTLY, never through init(): init() round-trips every profile's
+        // custom model through Jackson (writeValueAsBytes + readValue, GraphHopper.java ~1631),
+        // and bean-introspecting Statement (a Java 17 record) needs Class.getRecordComponents -
+        // which ART only has from API 34. On the API 26-33 devices Vela still supports EVERY graph
+        // load threw before ever touching the graph. The direct setters skip Jackson entirely;
+        // GraphHopper's own javadoc shows this exact pattern for programmatic setup. (ars18.)
+        val names = if (v2) listOf(PROFILE, PROFILE_AVOID_TOLL, PROFILE_AVOID_MOTORWAY) else listOf(PROFILE)
+        hopper.setProfiles(names.map { Profile(it).setCustomModel(carModel()) })
+        hopper.chPreparationHandler.setCHProfiles(names.map { CHProfile(it) }) // prebuilt CH → fast on-device routing
         hopper.importOrLoad()
         return hopper
     }
@@ -257,6 +262,23 @@ class GraphHopperRouteEngine(private val graphsRoot: File) : RouteEngine {
          *  regions), falling through to the next-smallest if that graph can't make the trip. */
         internal fun inBox(s: Double, w: Double, n: Double, e: Double, lat: Double, lng: Double) =
             lat in s..n && lng in w..e
+
+        /** The bundled `car.json` custom model, built PROGRAMMATICALLY - never through Jackson.
+         *  `GHUtility.loadCustomModelFromJar` bean-introspects `Statement`, a Java 17 record, and
+         *  Jackson's record probe needs `Class.getRecordComponents` - which ART only has from API
+         *  34. On the API 26-33 devices Vela still supports EVERY graph load threw before ever
+         *  touching the graph (the introspection runs before any registered deserializer is
+         *  consulted, so a configured mapper doesn't help). Record CONSTRUCTORS work fine on ART;
+         *  only the reflection probe is missing. This mirrors the jar's car.json EXACTLY
+         *  (distance_influence 90; priority: if !car_access multiply_by 0; speed: if true limit_to
+         *  car_average_speed) so the content - and with it the baked per-profile version hashes -
+         *  matches a model parsed from the file (asserted by GraphHopperRouterTest.carModelMatchesJar).
+         *  Keep it in lockstep with the bundled car.json when GraphHopper is upgraded. (ars18.) */
+        internal fun carModel(): com.graphhopper.util.CustomModel =
+            com.graphhopper.util.CustomModel()
+                .setDistanceInfluence(90.0)
+                .addToPriority(com.graphhopper.json.Statement.If("!car_access", com.graphhopper.json.Statement.Op.MULTIPLY, "0"))
+                .addToSpeed(com.graphhopper.json.Statement.If("true", com.graphhopper.json.Statement.Op.LIMIT, "car_average_speed"))
 
         private const val PROFILE = "car"
         private const val PROFILE_AVOID_TOLL = "car_avoid_toll"

--- a/core/src/main/java/app/vela/core/util/ByteBufferCompat.kt
+++ b/core/src/main/java/app/vela/core/util/ByteBufferCompat.kt
@@ -1,0 +1,34 @@
+package app.vela.core.util
+
+import java.nio.ByteBuffer
+
+/**
+ * Pre-API-34 stand-ins for the JDK-13 absolute-bulk ByteBuffer methods. The build's ASM artifact
+ * transform (buildSrc/src/main/kotlin/GraphHopperByteBufferPatch.kt) rewrites GraphHopper's
+ * `ByteBuffer.get(int, byte[], int, int)` / `put(int, byte[], int, int)` call sites to these -
+ * ART only has the real ones from API 34, and MMapDataAccess uses them to read/write graph
+ * segments, so offline graph loading died on every older device.
+ *
+ * duplicate() carries its own position, so like the real absolute methods these never touch the
+ * shared buffer's position - byte-identical semantics, thread-safe, API 1.
+ *
+ * (Contributed by ars18 in the vela-dpad fork.)
+ */
+object ByteBufferCompat {
+
+    @JvmStatic
+    fun get(bb: ByteBuffer, index: Int, dst: ByteArray, offset: Int, length: Int): ByteBuffer {
+        val d = bb.duplicate()
+        d.position(index)
+        d.get(dst, offset, length)
+        return bb
+    }
+
+    @JvmStatic
+    fun put(bb: ByteBuffer, index: Int, src: ByteArray, offset: Int, length: Int): ByteBuffer {
+        val d = bb.duplicate()
+        d.position(index)
+        d.put(src, offset, length)
+        return bb
+    }
+}

--- a/core/src/test/java/app/vela/core/GraphHopperRouterTest.kt
+++ b/core/src/test/java/app/vela/core/GraphHopperRouterTest.kt
@@ -65,6 +65,22 @@ class GraphHopperRouterTest {
         assertEquals("Turn right onto Elm St", GraphHopperRouteEngine.ghPhrase(ManeuverType.TURN_RIGHT, "Elm St", dest = null, exitNo = null))
     }
 
+    /**
+     * The hand-built [GraphHopperRouteEngine.carModel] must stay byte-for-byte equivalent to the
+     * `car.json` shipped inside the GraphHopper jar. The engine builds the model programmatically
+     * (Jackson's record introspection of the jar's copy needs an API-34 reflection method absent on
+     * older ART), and CH profiles are versioned by the model's contents - so any drift between the
+     * two would silently fail every prebuilt-graph load. This test runs on the desktop JVM, where the
+     * jar's own loader works, and fails loudly if a GraphHopper upgrade changes car.json.
+     */
+    @Test fun carModelMatchesJar() {
+        val jar = com.graphhopper.util.GHUtility.loadCustomModelFromJar("car.json")
+        val mine = GraphHopperRouteEngine.carModel()
+        assertEquals(jar.distanceInfluence!!, mine.distanceInfluence!!, 0.0)
+        assertEquals(jar.getPriority().toString(), mine.getPriority().toString())
+        assertEquals(jar.getSpeed().toString(), mine.getSpeed().toString())
+    }
+
     /** Multi-region: a trip routes on the first installed region whose box covers BOTH endpoints. */
     @Test fun regionBoxCoversEndpoints() {
         // the metro metro box [S, W, N, E]


### PR DESCRIPTION
## The bug

Our GraphHopper offline engine could only **load** a downloaded region graph on Android 14 (API 34) and up. On every device below that it failed silently, so offline routing never worked for a large share of the target audience (minSdk is 26; the degoogled / feature-phone crowd skews older). It slipped through because the `:ghprobe` validation device runs Android 14, where all the missing APIs exist.

Diagnosed and fixed by **ars18** in the vela-dpad fork; this ports it upstream with one added test.

## Three pre-API-34 gaps, all fixed

1. **Jackson record introspection.** `GHUtility.loadCustomModelFromJar("car.json")` makes Jackson bean-introspect `Statement`, a Java 17 record. That needs `Class.getRecordComponents`, which ART only has from API 34. Now the model is built programmatically in `carModel()` (record constructors work on every ART).
2. **`init()` Jackson round-trip.** `GraphHopper.init()` re-serializes every profile's custom model (same record probe). Profiles are now set after `init()` via `setProfiles` / `chPreparationHandler.setCHProfiles`, GraphHopper's documented programmatic pattern.
3. **`MMapDataAccess` absolute-bulk `ByteBuffer`.** Graph segments are read with `ByteBuffer.get/put(int, byte[], int, int)`, JDK-13 methods that are API 34+ on ART. A `buildSrc` ASM artifact transform (`GraphHopperByteBufferPatch`) rewrites exactly those 6 call sites in `graphhopper-core-*.jar` to `ByteBufferCompat` (`duplicate() + position()`, API 1, byte-identical semantics).

## Verification

- `:core` router tests pass, including a new **`carModelMatchesJar`** lockstep test that asserts the hand-built `carModel()` equals the jar's `car.json` (the CH profile version hashes are keyed on the model, so drift would silently break every graph load; the test fails on any GraphHopper upgrade that changes car.json).
- Release build succeeds with the new `buildSrc` transform.
- Disassembly of the transformed jar confirms all 6 absolute-bulk calls in `MMapDataAccess` are rewritten to `ByteBufferCompat`; the API-1 single-byte `get/put` calls are untouched.
- No regression on API 34+: the shim behaves identically where the real methods exist, so there is no per-device build variance.

## Not device-verified here

The bug reproduces only below API 34; the local test phone is on Android 14, so it can confirm no-regression but not the sub-34 fix itself. ars18 proved the fix end-to-end on an API-33 phone (offline, wifi + data off): the 135-region catalog lists, a 110 MB v2 graph downloads and routes.