### PR TITLE
Auto-fallback to TextureView rendering when a GPU driver kills the map at init

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -25,8 +25,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   rendering (a different graphics path that avoids most of these driver bugs, slightly slower)
   and the app just works from then on. Zero configuration, cannot misfire on healthy devices (a
   successful render resets the counter), and Settings → Developer → Compatibility rendering is
-  the manual override in both directions. Verified on-device: two simulated init deaths flip the
-  fallback on, the map renders fully through it, and the toggle restores normal rendering.
+  the manual override in both directions. Known-fragile chips skip even the two crashes: Unisoc
+  devices (the reported tablet's family, identified from the hardware string) default straight
+  into compatibility rendering on their first launch, with the crash sentinel kept as the net
+  for bad drivers not on the list. Verified on-device: two simulated init deaths flip the
+  fallback on, the map renders fully through it, and the toggle restores normal rendering; a
+  Pixel stays on the normal path untouched.
 - ✅ **Browsed areas keep their Google-quality places for weeks, online or offline (2026-07-17,
   user).** The ambient POI layer's disk cache grew into a durable store: the newest 32 browsed
   areas (up to 200 places each, about 1 MB total) persist for 14 days, paint instantly on a cold

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,16 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **Self-healing crash fallback for broken GPU drivers (2026-07-17, issue #95).** Some budget
+  tablets' GL drivers (seen on a Samsung tablet's Android 14 update with a Unisoc chip) kill the
+  app the instant the map's GL surface initializes - before the user can reach any setting. Vela
+  now marks "map initializing" at surface creation and clears it on the first finished render;
+  two consecutive launches dying inside that window automatically switch the map to TextureView
+  rendering (a different graphics path that avoids most of these driver bugs, slightly slower)
+  and the app just works from then on. Zero configuration, cannot misfire on healthy devices (a
+  successful render resets the counter), and Settings → Developer → Compatibility rendering is
+  the manual override in both directions. Verified on-device: two simulated init deaths flip the
+  fallback on, the map renders fully through it, and the toggle restores normal rendering.
 - ✅ **Browsed areas keep their Google-quality places for weeks, online or offline (2026-07-17,
   user).** The ambient POI layer's disk cache grew into a durable store: the newest 32 browsed
   areas (up to 200 places each, about 1 MB total) persist for 14 days, paint instantly on a cold

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -505,7 +505,7 @@ fun VelaMapView(
         }
         prefs.edit().putBoolean("map_init_inflight", true).apply()
         val opts = org.maplibre.android.maps.MapLibreMapOptions.createFromAttributes(context)
-            .textureMode(prefs.getBoolean("texture_render", false))
+            .textureMode(prefs.getBoolean("texture_render", fragileGpuDefault()))
         MapView(context, opts).apply {
             onCreate(null)
             isFocusable = false
@@ -3752,6 +3752,21 @@ private fun applyMapTheme(style: Style, dark: Boolean) {
         "tunnel_major_rail_hatching", "tunnel_transit_rail_hatching",
     ).forEach { style.getLayer(it)?.setProperties(PropertyFactory.visibility(Property.NONE)) }
 }
+
+/** Known-fragile GPU stacks start in compatibility (TextureView) rendering from the FIRST
+ *  launch - no crashes needed to learn. Unisoc-built devices identify themselves in
+ *  Build.HARDWARE ("ums*" for the ums512/T618 class, "sp98*" for older Spreadtrum) and pair
+ *  budget Mali GPUs with drivers documented to crash GL apps on Android 14 (libGLES_mali.so
+ *  faults; issue #95's tablet is a ums512). This only sets the DEFAULT - an explicit
+ *  Developer-toggle choice (the "texture_render" pref) beats it either way, and the two-crash
+ *  sentinel in VelaMapView remains the generic net for bad drivers not on this list. */
+internal fun fragileGpuDefault(): Boolean =
+    android.os.Build.HARDWARE.startsWith("ums") ||
+        android.os.Build.HARDWARE.startsWith("sp98") ||
+        (
+            android.os.Build.VERSION.SDK_INT >= 31 &&
+                android.os.Build.SOC_MANUFACTURER.contains("unisoc", ignoreCase = true)
+            )
 
 /** Google-style 3D building geometry, shared by all four palettes. Extrusions start a zoom level
  *  AFTER the flat footprints (z17 vs 16): at ~500ft Manhattan towers leaned over and BURIED the

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -486,7 +486,27 @@ fun VelaMapView(
     // surface child) non-focusable, unconditionally: touch gestures don't need view focus,
     // so nothing is lost, and key events now flow to the Compose focus system.
     val mapView = remember {
-        MapView(context).apply {
+        // GPU-driver crash fallback (issue #95): some budget tablets' GL drivers (Samsung's
+        // Android 14 update on Unisoc/Mali chips) kill the process the instant the map's GL
+        // surface initializes - before the user can reach any setting. Sentinel: mark
+        // "initializing" here, clear it on the first finished render (the didBecomeIdle
+        // listener). Two consecutive launches dying mid-init flip the map to TEXTUREVIEW
+        // rendering (`texture_render`) - a different EGL path that dodges most of these driver
+        // bugs at a small perf cost - and the flag sticks until the Developer toggle clears it.
+        // A healthy device clears the sentinel every launch and never accumulates a count.
+        val prefs = context.getSharedPreferences("vela_settings", android.content.Context.MODE_PRIVATE)
+        if (prefs.getBoolean("map_init_inflight", false)) {
+            val n = prefs.getInt("map_init_crashes", 0) + 1
+            if (n >= 2) {
+                prefs.edit().putBoolean("texture_render", true).putInt("map_init_crashes", 0).apply()
+            } else {
+                prefs.edit().putInt("map_init_crashes", n).apply()
+            }
+        }
+        prefs.edit().putBoolean("map_init_inflight", true).apply()
+        val opts = org.maplibre.android.maps.MapLibreMapOptions.createFromAttributes(context)
+            .textureMode(prefs.getBoolean("texture_render", false))
+        MapView(context, opts).apply {
             onCreate(null)
             isFocusable = false
             isFocusableInTouchMode = false
@@ -1948,6 +1968,13 @@ fun VelaMapView(
                 // gate's REVEAL path - before the first finished render a "sparse" verdict is just
                 // unloaded tiles, and revealing on it is the arrival flash.
                 mv.addOnDidBecomeIdleListener {
+                    // First finished render = the GL surface survived init: clear the crash
+                    // sentinel and decay the counter (texture_render itself is untouched, so an
+                    // engaged fallback keeps carrying the device on future launches).
+                    val prefs = context.getSharedPreferences("vela_settings", android.content.Context.MODE_PRIVATE)
+                    if (prefs.getBoolean("map_init_inflight", false)) {
+                        prefs.edit().putBoolean("map_init_inflight", false).putInt("map_init_crashes", 0).apply()
+                    }
                     ovlRenderSettled[0] = true
                     ovlDirty[0] = true
                     runOvlGate()

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -1079,7 +1079,7 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 // Compatibility rendering: TextureView instead of SurfaceView for the map's GL
                 // surface. Auto-enabled by the crash sentinel when a device's driver kills the
                 // map at init (issue #95); this row is the manual override either way.
-                var textureRender by remember { mutableStateOf(prefs.getBoolean("texture_render", false)) }
+                var textureRender by remember { mutableStateOf(prefs.getBoolean("texture_render", app.vela.ui.map.fragileGpuDefault())) }
                 ToggleRow(stringResource(R.string.settings_texture_render), textureRender) {
                     textureRender = it
                     prefs.edit().putBoolean("texture_render", it).apply()

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -1076,6 +1076,15 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 Hint(stringResource(R.string.settings_demo_drive_hint))
                 ToggleRow(stringResource(R.string.settings_building_debug), app.vela.ui.BuildingDebug.on.value) { app.vela.ui.BuildingDebug.set(context, it) }
                 Hint(stringResource(R.string.settings_building_debug_hint))
+                // Compatibility rendering: TextureView instead of SurfaceView for the map's GL
+                // surface. Auto-enabled by the crash sentinel when a device's driver kills the
+                // map at init (issue #95); this row is the manual override either way.
+                var textureRender by remember { mutableStateOf(prefs.getBoolean("texture_render", false)) }
+                ToggleRow(stringResource(R.string.settings_texture_render), textureRender) {
+                    textureRender = it
+                    prefs.edit().putBoolean("texture_render", it).apply()
+                }
+                Hint(stringResource(R.string.settings_texture_render_hint))
                 // Simulated location — pretend to be at the current map centre (demos/screenshots
                 // without leaking where you actually are). Reactive holder reflects the state.
                 ToggleRow(stringResource(R.string.settings_sim_location), app.vela.ui.SimLocation.on) { on -> if (on) vm.simulateLocationHere() else vm.stopSimulateLocation() }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,8 @@
     <string name="settings_building_overlay_hint">Draws building shapes in suburbs where the map is missing them. Auto-skipped in dense areas that already have them. Turn off to render no extra buildings.</string>
     <string name="settings_building_debug">Building overlay debug</string>
     <string name="settings_building_debug_hint">Shows a small badge on the map reporting the fill-buildings state (off / none here / hidden / drawing). Testing aid; turn off for normal use.</string>
+    <string name="settings_texture_render">Compatibility rendering</string>
+    <string name="settings_texture_render_hint">Draws the map through a compatibility path that avoids some devices\' graphics driver bugs. Turns itself on if the map crashed the app at startup. Slightly slower; needs an app restart to apply.</string>
     <string name="settings_show_reviews">Show reviews</string>
     <string name="settings_show_reviews_hint">Off = place pages show no reviews, and Vela never fetches them.</string>
     <string name="settings_load_photos">Load photos</string>


### PR DESCRIPTION
Fixes the issue #95 class of crash: some budget tablets' GL drivers (reported on a Samsung tablet's Android 14 update with a Unisoc chip and Mali GPU) kill the app the instant the map's GL surface initializes, before the user can reach any setting.

How it works:

- A sentinel pref marks map init in progress at surface creation and clears on the first finished render
- Two consecutive launches dying inside that window flip the map to TextureView rendering permanently for that device. TextureView takes a different EGL path that sidesteps most of these driver bugs, at a small performance cost
- A successful render resets the counter, so healthy devices can never accumulate one (a user swiping the app away during first load twice in a row is the worst-case false positive, and the only consequence is slightly slower rendering they can undo)
- Settings, Developer, Compatibility rendering is the manual override in both directions

Verified on a Pixel 4a: two simulated init deaths engage the fallback, the map renders fully through TextureView, and the toggle restores normal rendering.