### PR TITLE
Search: paginate to 60 results and append nearby matches from the ambient pool

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,7 +17,17 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
-- ✅ **Self-healing crash fallback for broken GPU drivers (2026-07-17, issue #95).** Some budget
+- ✅ **Search goes three pages deep and rescues the place next to you (2026-07-18, user).**
+  Category searches ("restaurants") used to return exactly one page of 20, ranked by Google's
+  keyless web ordering, which is prominence-heavy over the whole visible box - so a modest
+  restaurant the user was standing next to ranked 21+ and never listed. Two fixes: (1) a FULL
+  first page now triggers pages 2 and 3 concurrently (the same !8i offset pagination the web
+  map uses, verified live: each page returns 20 fresh places), one extra round trip for up to
+  60 results; specific-name queries return partial pages and never paginate, costing nothing.
+  (2) matching places from the ambient pool (the tight-span category fan-out that feeds the map
+  dots, which usually already holds the neighbour) are APPENDED to the results, nearest first,
+  deduped against Google's list - never reshuffled into it, since the old distance re-rank
+  experiment proved that floats junk above landmarks. Zero extra network for the merge. Some budget
   tablets' GL drivers (seen on a Samsung tablet's Android 14 update with a Unisoc chip) kill the
   app the instant the map's GL surface initializes - before the user can reach any setting. Vela
   now marks "map initializing" at surface creation and clears it on the first finished render;

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1407,6 +1407,26 @@ class MapViewModel @Inject constructor(
                             }
                         }
                     } else emptyList()
+                    // NEARBY MERGE (user 2026-07-18): even with pagination, Google's keyless
+                    // ranking is prominence-heavy over the whole viewport, so a modest place
+                    // right next to the user can miss every page of a category search. The
+                    // ambient pool (the category fan-out at a tight span) usually already holds
+                    // it - append matching ambient places the search missed, nearest first.
+                    // APPENDED, never reshuffled: the distance re-rank experiment on the dot
+                    // layer taught us not to touch Google's ordering. Zero extra network.
+                    val ambientExtra = if (near != null && !app.vela.core.data.OfflineAddressStore.looksLikeAddress(q)) {
+                        val qn = q.trim().lowercase().trimEnd('s')
+                        if (qn.length < 3) emptyList()
+                        else _state.value.ambientPois
+                            .filter { p ->
+                                val cat = p.category?.lowercase() ?: ""
+                                (cat.isNotEmpty() && (cat.contains(qn) || (cat.length >= 4 && qn.contains(cat)))) ||
+                                    p.name.lowercase().contains(qn)
+                            }
+                            .filterNot { a -> res.places.any { g -> g.name.equals(a.name, ignoreCase = true) && g.location.distanceTo(a.location) < 150.0 } }
+                            .sortedBy { it.location.distanceTo(near) }
+                            .take(20)
+                    } else emptyList()
                     _state.update {
                         // Keep the directions DESTINATION (held in `selected`) while picking an origin/stop —
                         // else typing the origin query wiped the "To" and the panel showed an empty
@@ -1414,7 +1434,7 @@ class MapViewModel @Inject constructor(
                         // A live scrape succeeding is definitive proof we're online — clear a stuck
                         // offline flag (the network callback can miss an event after doze and leave
                         // `offline` latched until relaunch; seen on-device 2026-07-09).
-                        it.copy(results = localAddrs + res.places, selected = if (it.pickingOrigin || it.pickingDest || it.pickingStop) it.selected else null, status = null, searching = false, offline = false)
+                        it.copy(results = localAddrs + res.places + ambientExtra, selected = if (it.pickingOrigin || it.pickingDest || it.pickingStop) it.selected else null, status = null, searching = false, offline = false)
                     }
                 } else {
                     // Online SUCCEEDED but found nothing. Don't leave a blank screen (the "POI list just

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -136,17 +136,20 @@ class GoogleMapsDataSource @Inject constructor(
             }
         }
         val first = page(0)
-        // PAGINATE like the Google app: a page is 20 and a FULL first page means the viewport
-        // holds more. Google's keyless web ranking is prominence-heavy over the whole box, so a
-        // modest place sitting right next to the user ranks 21-60 for a category query - one
-        // page was exactly why "the restaurant right next to me" never made the list (user
-        // 2026-07-18). Pages 2+3 fetch CONCURRENTLY (one extra round trip, not two); either
-        // failing quietly leaves page 1 intact. Specific-name queries return partial pages and
-        // never paginate, so they cost nothing extra.
-        val more = if (first.size >= 18) {
+        // PAGINATE like the Google app: a page is !7iN results (20 today) and a FULL first page
+        // means the viewport holds more. Google's keyless web ranking is prominence-heavy over
+        // the whole box, so a modest place sitting right next to the user ranks 21-60 for a
+        // category query - one page was exactly why "the restaurant right next to me" never made
+        // the list (user 2026-07-18). Pages 2+3 fetch CONCURRENTLY (one extra round trip, not
+        // two); either failing quietly leaves page 1 intact. Specific-name queries return
+        // partial pages and never paginate, so they cost nothing extra. Page size + offsets are
+        // DERIVED from the calibrated template (searchPb is remote-updatable); a recaptured
+        // template without a !7i token skips pagination rather than guessing.
+        val pageSize = SearchPb.pageSize(cal.searchPb)
+        val more = if (pageSize != null && first.size >= pageSize - 2) {
             kotlinx.coroutines.coroutineScope {
-                val p2 = async { runCatching { page(20) }.getOrDefault(emptyList()) }
-                val p3 = async { runCatching { page(40) }.getOrDefault(emptyList()) }
+                val p2 = async { runCatching { page(pageSize) }.getOrDefault(emptyList()) }
+                val p3 = async { runCatching { page(pageSize * 2) }.getOrDefault(emptyList()) }
                 p2.await() + p3.await()
             }
         } else emptyList()

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -111,23 +111,50 @@ class GoogleMapsDataSource @Inject constructor(
         // normally pass the user's location, with a fallback for the rare null.
         val viewport = near ?: DEFAULT_VIEWPORT
         val cal = calibration.current()
-        val pb = SearchPb.build(query, viewport, cal.searchPb, spanMeters)
-        val url = "${cal.searchEndpoint}&q=${query.enc()}&pb=${pb.enc()}".localized()
-        val raw = get(url)
-        // A remote transforms.js can fully re-parse a reshaped response (searchOverride);
-        // otherwise the compiled parser runs. Either way, an optional transformPlaces
-        // hook gets the last word. No hook / any error → pure compiled path.
-        val places = try {
-            jsTransforms.searchOverride(raw)
-                ?: SearchParser.parse(query, GoogleResponse.parse(raw), near, cal.paths).places
-        } catch (e: CalibrationNeededException) {
-            // Capture the exact request that drifted so an opted-in user can hand it
-            // to a dev (no-op unless diagnostics are on).
-            diag.record("drift", "search parse drift: ${e.message}", url)
-            throw e
+        val firstUrl = "${cal.searchEndpoint}&q=${query.enc()}&pb=${SearchPb.build(query, viewport, cal.searchPb, spanMeters).enc()}".localized()
+        suspend fun page(offset: Int): List<Place> {
+            val url = if (offset == 0) {
+                firstUrl
+            } else {
+                "${cal.searchEndpoint}&q=${query.enc()}&pb=${SearchPb.build(query, viewport, cal.searchPb, spanMeters, offset).enc()}".localized()
+            }
+            val raw = get(url)
+            // A remote transforms.js can fully re-parse a reshaped response (searchOverride);
+            // otherwise the compiled parser runs. Either way, an optional transformPlaces
+            // hook gets the last word. No hook / any error → pure compiled path.
+            return try {
+                jsTransforms.searchOverride(raw)
+                    ?: SearchParser.parse(query, GoogleResponse.parse(raw), near, cal.paths).places
+            } catch (e: CalibrationNeededException) {
+                if (offset == 0) {
+                    // Capture the exact request that drifted so an opted-in user can hand it
+                    // to a dev (no-op unless diagnostics are on).
+                    diag.record("drift", "search parse drift: ${e.message}", url)
+                    throw e
+                }
+                emptyList() // a later page drifting must never kill the first page's results
+            }
+        }
+        val first = page(0)
+        // PAGINATE like the Google app: a page is 20 and a FULL first page means the viewport
+        // holds more. Google's keyless web ranking is prominence-heavy over the whole box, so a
+        // modest place sitting right next to the user ranks 21-60 for a category query - one
+        // page was exactly why "the restaurant right next to me" never made the list (user
+        // 2026-07-18). Pages 2+3 fetch CONCURRENTLY (one extra round trip, not two); either
+        // failing quietly leaves page 1 intact. Specific-name queries return partial pages and
+        // never paginate, so they cost nothing extra.
+        val more = if (first.size >= 18) {
+            kotlinx.coroutines.coroutineScope {
+                val p2 = async { runCatching { page(20) }.getOrDefault(emptyList()) }
+                val p3 = async { runCatching { page(40) }.getOrDefault(emptyList()) }
+                p2.await() + p3.await()
+            }
+        } else emptyList()
+        val places = (first + more).distinctBy { p ->
+            p.featureId ?: "${p.name.lowercase()}|${(p.location.lat * 2000).toInt()}|${(p.location.lng * 2000).toInt()}"
         }
         // detail = the exact request URL so an opted-in user's export is replayable.
-        diag.record("search", "\"$query\" near ${near?.lat ?: "?"},${near?.lng ?: "?"} → ${places.size} results", url)
+        diag.record("search", "\"$query\" near ${near?.lat ?: "?"},${near?.lng ?: "?"} → ${places.size} results (page1 ${first.size})", firstUrl)
         // open/closed diagnosis: what status + hours did we actually parse for each result? (compare
         // the status string to the hours to see whether Google's string is wrong or we mis-parse.)
         places.take(6).forEach { p ->

--- a/core/src/main/java/app/vela/core/data/google/SearchPb.kt
+++ b/core/src/main/java/app/vela/core/data/google/SearchPb.kt
@@ -44,8 +44,9 @@ object SearchPb {
         viewport: LatLng,
         template: String = DEFAULT_TEMPLATE,
         spanMeters: Double? = null,
+        offset: Int = 0,
     ): String {
-        val pb = template
+        var pb = template
             .replace("{QUERY}", query.replace('!', ' ').trim())
             .replace("{LNG}", viewport.lng.toString())
             .replace("{LAT}", viewport.lat.toString())
@@ -53,8 +54,14 @@ object SearchPb {
         // zoomed-out search silently kept a city-sized net (user 2026-07-11). When the caller
         // knows its real viewport, stretch the window to it (floored so street-level searches
         // keep the calibrated behaviour; capped so a whole-globe zoom asks something sane).
-        return if (spanMeters != null) {
-            pb.replaceFirst(Regex("!1d[0-9.]+"), "!1d${spanMeters.coerceIn(3_000.0, 500_000.0).toInt()}")
-        } else pb
+        if (spanMeters != null) {
+            pb = pb.replaceFirst(Regex("!1d[0-9.]+"), "!1d${spanMeters.coerceIn(3_000.0, 500_000.0).toInt()}")
+        }
+        // Result offset (!8i) rides directly after the page size (!7i20) - the same pagination
+        // the web map uses. offset 20 = Google's ranks 21-40, and so on.
+        if (offset > 0) {
+            pb = pb.replaceFirst("!7i20", "!7i20!8i$offset")
+        }
+        return pb
     }
 }

--- a/core/src/main/java/app/vela/core/data/google/SearchPb.kt
+++ b/core/src/main/java/app/vela/core/data/google/SearchPb.kt
@@ -57,11 +57,21 @@ object SearchPb {
         if (spanMeters != null) {
             pb = pb.replaceFirst(Regex("!1d[0-9.]+"), "!1d${spanMeters.coerceIn(3_000.0, 500_000.0).toInt()}")
         }
-        // Result offset (!8i) rides directly after the page size (!7i20) - the same pagination
-        // the web map uses. offset 20 = Google's ranks 21-40, and so on.
+        // Result offset (!8i) rides directly after the page-size token (!7iN) - the same
+        // pagination the web map uses. offset 20 = Google's ranks 21-40, and so on. Keyed on the
+        // REGEX, not the literal "!7i20": searchPb is remote-calibratable (calibration.json ships
+        // its own), and a recaptured template with a different page size must not silently kill
+        // pagination (a literal miss would refetch page 1 and dedupe it away, wasted requests).
         if (offset > 0) {
-            pb = pb.replaceFirst("!7i20", "!7i20!8i$offset")
+            pb = pb.replaceFirst(PAGE_SIZE_RX, "\$0!8i$offset")
         }
         return pb
     }
+
+    private val PAGE_SIZE_RX = Regex("!7i\\d+")
+
+    /** The page size the [template] actually requests (the !7iN token), or null when a
+     *  recalibrated template dropped the token - callers should then skip pagination. */
+    fun pageSize(template: String): Int? =
+        PAGE_SIZE_RX.find(template)?.value?.removePrefix("!7i")?.toIntOrNull()
 }


### PR DESCRIPTION
Fixes the report that a category search (restaurants) returned only 20 results and missed a restaurant the user was standing next to.

Why it happened: the keyless search asks for one page of 20, and Google's web ranking for a category query is prominence-weighted across the whole visible box. A modest place beside the user ranks 21 to 60 and never made the single page.

What changes:

- A full first page triggers pages 2 and 3 concurrently, using the same offset pagination the Google web map uses. Verified against live Google: each page returns 20 fresh places. One extra round trip, up to 60 results. Specific-name queries return partial pages and never paginate, so they cost nothing new.
- Places from the ambient pool (the tight-span category fan-out that feeds the map dots, which usually already holds the missing neighbour) that match the query are appended to the results, nearest first, deduped against Google's list. Appended, never merged into Google's ordering: an earlier distance re-rank experiment floated junk above landmarks and was reverted.
- A later page hitting parse drift quietly contributes nothing instead of killing page one.

Tested on a Pixel 4a: category search in a dense town lists well past 20 with the nearby small places present.