### PR TITLE
Search your own history and lists as you type (#180)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1238,6 +1238,15 @@ architecture note.
   MapLibre's 0,0 default, and search/suggest biased to null island. `plausibleBias()` in
   MapViewModel discards any bias point within ~50 km of 0,0 - keep new "near" consumers behind
   it.
+- **Local suggestions (issue #180, 2026-07-19):** `onQueryChange` sets `localSuggestions` from
+  `localMatches()` SYNCHRONOUSLY (recents searches + viewed places + list/saved places, substring
+  match) BEFORE the debounced network fetch - that is why they are instant and the only thing that
+  shows offline. `LocalSuggestion` (kind RECENT_QUERY / RECENT_PLACE / SAVED_PLACE) renders above
+  the network rows in `SearchEntryContent`. Dedup of network vs local is by `nameLocKey` (name +
+  coarse location), NOT feature id - SavedPlace-backed locals carry no id, so an id-only compare
+  double-shows them. Clear `localSuggestions` everywhere `suggestions` clears. The press-hold
+  "save a Google suggestion to a list" half of #180 is NOT built (delete-from-history via the X
+  is); it needs the save-to-list sheet wired to a suggestion long-press.
 
 - **Interface size (2026-07-11):** `UiScale` holder (pref `ui_scale`, chips 90/100/115/130% in
   Settings -> Appearance) applied as a LocalDensity override around VelaRoot's whole tree - all

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1244,9 +1244,15 @@ architecture note.
   shows offline. `LocalSuggestion` (kind RECENT_QUERY / RECENT_PLACE / SAVED_PLACE) renders above
   the network rows in `SearchEntryContent`. Dedup of network vs local is by `nameLocKey` (name +
   coarse location), NOT feature id - SavedPlace-backed locals carry no id, so an id-only compare
-  double-shows them. Clear `localSuggestions` everywhere `suggestions` clears. The press-hold
-  "save a Google suggestion to a list" half of #180 is NOT built (delete-from-history via the X
-  is); it needs the save-to-list sheet wired to a suggestion long-press.
+  double-shows them. Clear `localSuggestions` everywhere `suggestions` clears. **Press-hold / ⋮
+  menu on a suggestion (issue #180, 2026-07-19):** every suggestion row (local AND network) now
+  has a trailing ⋮ overflow plus a long-press (`SuggestionRow` gained `onLongClick` + a `trailing`
+  slot; the row uses `combinedClickable`), both opening a `VelaMenu` via `SuggestionOverflow` -
+  "Save to list" for any place-backed row (reuses PlaceSheet's `SaveToListSheet`, made `internal`)
+  and "Remove from history" for removable rows. The ⋮ is the D-pad key path for the long-press
+  (touch-only), so it stays D-pad-legal. The ⋮ REPLACES the bare X on local rows; the empty-query
+  recents list keeps its own X. Menu open-state is `remember(suggestion)`-keyed so a keystroke
+  that rebuilds the list closes a stranded menu.
 
 - **Interface size (2026-07-11):** `UiScale` holder (pref `ui_scale`, chips 90/100/115/130% in
   Settings -> Appearance) applied as a LocalDensity override around VelaRoot's whole tree - all

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -2125,3 +2125,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   forever. A longer text for a known review now replaces the stored entry, and the More click
   uses the button's class hook so it works in every UI language (the old label match only knew
   English). Device-verified on a busy coffee shop: multi-paragraph reviews end in real sentences.
+- ✅ **Search your own history and lists as you type (issue #180).** As you type, matches from
+  your recent searches, recently-viewed places, and saved lists surface at the top of the
+  suggestions, above Google's, each with an icon that tells them apart (clock for a past search,
+  pin for a place you opened, bookmark for a saved-list place). It is computed on-device, so it
+  is instant and the only thing that shows when you are offline. A network suggestion that
+  duplicates one of your own is dropped (matched by name and location, since saved places carry
+  no Google id). Tapping a place opens it; tapping a past search re-runs it; the X drops a
+  history entry. Looking up one location out of a chain no longer means re-typing the city.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -2131,5 +2131,7 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   pin for a place you opened, bookmark for a saved-list place). It is computed on-device, so it
   is instant and the only thing that shows when you are offline. A network suggestion that
   duplicates one of your own is dropped (matched by name and location, since saved places carry
-  no Google id). Tapping a place opens it; tapping a past search re-runs it; the X drops a
-  history entry. Looking up one location out of a chain no longer means re-typing the city.
+  no Google id). Tapping a place opens it; tapping a past search re-runs it. Press-and-hold any
+  suggestion (or tap its ⋮) to save a place into one of your lists or drop a history row, the same
+  list picker the place sheet uses. Looking up one location out of a chain no longer means
+  re-typing the city.

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -3131,22 +3131,59 @@ private fun SearchEntryContent(
             }
             merged.forEach { entry ->
                 when (entry) {
-                    is RecentPlace -> SuggestionRow(
-                        icon = Icons.Default.Place,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        label = entry.place.name,
-                        // A real place shows its address under the name (Google-style).
-                        sublabel = entry.place.address,
-                        onClick = { onPickRecentPlace(entry.place) },
-                        onRemove = { onRemoveRecentPlace(entry.place.id) },
-                    )
-                    is RecentQuery -> SuggestionRow(
-                        icon = Icons.Default.History,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        label = entry.query,
-                        onClick = { onPickRecent(entry.query) },
-                        onRemove = { onRemoveRecent(entry.query) },
-                    )
+                    is RecentPlace -> {
+                        // Long-press OR the ⋮ opens the same manage menu as the typing view (issue
+                        // #180): save this recent place to a list, or drop it from history. (The
+                        // press-hold was previously only on the typed-suggestion rows, so the entry
+                        // page (where history actually lives) had no long-press. The ⋮ opens the
+                        // menu on a plain tap too, so removal works even where long-press doesn't.)
+                        var menuOpen by remember(entry.place.id) { mutableStateOf(false) }
+                        val p = entry.place.toPlace()
+                        SuggestionRow(
+                            icon = Icons.Default.Place,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            label = entry.place.name,
+                            sublabel = entry.place.address,
+                            onClick = { onPickRecentPlace(entry.place) },
+                            onLongClick = { menuOpen = true },
+                            trailing = {
+                                SuggestionOverflow(
+                                    open = menuOpen,
+                                    onOpenChange = { menuOpen = it },
+                                    place = p,
+                                    removable = true,
+                                    lists = lists,
+                                    onRemove = { onRemoveRecentPlace(entry.place.id) },
+                                    onAddToList = { id -> onAddToList(p, id) },
+                                    onRemoveFromList = { id -> onRemoveFromList(p, id) },
+                                    onCreateWith = { name -> onCreateListWith(p, name) },
+                                )
+                            },
+                        )
+                    }
+                    is RecentQuery -> {
+                        var menuOpen by remember(entry.query) { mutableStateOf(false) }
+                        SuggestionRow(
+                            icon = Icons.Default.History,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            label = entry.query,
+                            onClick = { onPickRecent(entry.query) },
+                            onLongClick = { menuOpen = true },
+                            trailing = {
+                                SuggestionOverflow(
+                                    open = menuOpen,
+                                    onOpenChange = { menuOpen = it },
+                                    place = null, // a typed query, not a place: only "remove from history"
+                                    removable = true,
+                                    lists = lists,
+                                    onRemove = { onRemoveRecent(entry.query) },
+                                    onAddToList = {},
+                                    onRemoveFromList = {},
+                                    onCreateWith = {},
+                                )
+                            },
+                        )
+                    }
                 }
                 Divider()
             }

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import android.widget.Toast
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
@@ -1291,6 +1292,10 @@ fun MapScreen(
                                 vm.pickLocalSuggestion(it)
                             },
                             onRemoveLocal = vm::removeLocalSuggestion,
+                            lists = state.lists,
+                            onAddToList = { place, listId -> vm.addPlaceToList(listId, place) },
+                            onRemoveFromList = { place, listId -> vm.removePlaceFromList(listId, place) },
+                            onCreateListWith = { place, name -> vm.addPlaceToList(vm.createList(name), place) },
                             saved = state.saved,
                             recents = state.recents,
                             recentPlaces = state.recentPlaces,
@@ -2972,6 +2977,10 @@ private fun SearchEntryContent(
     localSuggestions: List<app.vela.ui.map.LocalSuggestion>,
     onPickLocal: (app.vela.ui.map.LocalSuggestion) -> Unit,
     onRemoveLocal: (app.vela.ui.map.LocalSuggestion) -> Unit,
+    lists: List<app.vela.core.model.PlaceList> = emptyList(),
+    onAddToList: (Place, String) -> Unit = { _, _ -> },
+    onRemoveFromList: (Place, String) -> Unit = { _, _ -> },
+    onCreateListWith: (Place, String) -> Unit = { _, _ -> },
     saved: List<SavedPlace>,
     recents: List<RecentQuery>,
     recentPlaces: List<RecentPlace>,
@@ -3007,6 +3016,10 @@ private fun SearchEntryContent(
             if (assigning != null) AssignBanner(assigning, onCancelAssign)
             if (pickingStop) PickStopBanner(onCancelPickStop)
             localSuggestions.forEach { s ->
+                // Menu state is keyed on the suggestion so a keystroke that rebuilds the list
+                // closes any open menu instead of leaving it stranded on a different row.
+                var menuOpen by remember(s) { mutableStateOf(false) }
+                val place = s.place
                 SuggestionRow(
                     icon = when (s.kind) {
                         app.vela.ui.map.LocalSuggestion.Kind.RECENT_QUERY -> Icons.Default.History
@@ -3017,17 +3030,45 @@ private fun SearchEntryContent(
                     label = s.label,
                     sublabel = s.sublabel,
                     onClick = { onPickLocal(s) },
-                    onRemove = if (s.removable) ({ onRemoveLocal(s) }) else null,
+                    onLongClick = { menuOpen = true },
+                    trailing = {
+                        SuggestionOverflow(
+                            open = menuOpen,
+                            onOpenChange = { menuOpen = it },
+                            place = place,
+                            removable = s.removable,
+                            lists = lists,
+                            onRemove = { onRemoveLocal(s) },
+                            onAddToList = { id -> place?.let { onAddToList(it, id) } },
+                            onRemoveFromList = { id -> place?.let { onRemoveFromList(it, id) } },
+                            onCreateWith = { name -> place?.let { onCreateListWith(it, name) } },
+                        )
+                    },
                 )
                 Divider()
             }
             suggestions.forEach { p ->
+                var menuOpen by remember(p.id) { mutableStateOf(false) }
                 SuggestionRow(
                     icon = Icons.Default.Search,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     label = p.name,
                     sublabel = p.address ?: p.category,
                     onClick = { onPickSuggestion(p) },
+                    onLongClick = { menuOpen = true },
+                    trailing = {
+                        SuggestionOverflow(
+                            open = menuOpen,
+                            onOpenChange = { menuOpen = it },
+                            place = p,
+                            removable = false,
+                            lists = lists,
+                            onRemove = {},
+                            onAddToList = { id -> onAddToList(p, id) },
+                            onRemoveFromList = { id -> onRemoveFromList(p, id) },
+                            onCreateWith = { name -> onCreateListWith(p, name) },
+                        )
+                    },
                 )
                 Divider()
             }
@@ -3301,6 +3342,10 @@ private fun SectionLabel(text: String) {
     )
 }
 
+// combinedClickable powers the press-hold on suggestion rows (issue #180). The row still
+// clicks on tap / D-pad centre; long-press (touch) opens the same menu the trailing ⋮ opens,
+// so D-pad keeps a key path via the button.
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 private fun SuggestionRow(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
@@ -3309,9 +3354,14 @@ private fun SuggestionRow(
     onClick: () -> Unit,
     sublabel: String? = null,
     onRemove: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
+    trailing: (@Composable () -> Unit)? = null,
 ) {
+    val hasTrailing = onRemove != null || trailing != null
     Row(
-        Modifier.fillMaxWidth().dpadHighlight(RoundedCornerShape(6.dp)).clickable(onClick = onClick).padding(horizontal = 16.dp, vertical = 12.dp),
+        Modifier.fillMaxWidth().dpadHighlight(RoundedCornerShape(6.dp))
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(icon, contentDescription = null, modifier = Modifier.padding(end = 12.dp), tint = tint)
@@ -3322,7 +3372,7 @@ private fun SuggestionRow(
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                modifier = if (onRemove != null) Modifier.weight(1f) else Modifier,
+                modifier = if (hasTrailing) Modifier.weight(1f) else Modifier,
             )
         } else {
             Column(Modifier.weight(1f)) {
@@ -3342,9 +3392,11 @@ private fun SuggestionRow(
                 )
             }
         }
-        // Per-row remove (the X on recents). Its own focus stop with a visible ring, so a D-pad
-        // walk can reach it after the row itself.
-        if (onRemove != null) {
+        // A trailing slot (the ⋮ overflow + its menu) wins over the bare X when provided; both
+        // are their own D-pad focus stops with a ring, reached after the row itself.
+        if (trailing != null) {
+            trailing()
+        } else if (onRemove != null) {
             // Same circle language as the sheet headers, sized down for a list row.
             app.vela.ui.place.HeaderCircleButton(
                 Icons.Default.Close,
@@ -3354,6 +3406,49 @@ private fun SuggestionRow(
                 size = 32.dp,
             ) { onRemove() }
         }
+    }
+}
+
+/** The ⋮ overflow + its context menu for a search-suggestion row (issue #180): save a place
+ *  to a list, or drop a history row. Opened by the ⋮ button (D-pad + touch) or a row long-press.
+ *  [place] null = a bare query row (save-to-list hidden); [removable] false = not from history
+ *  (remove hidden). Reuses the place sheet's list picker so the checkmark/create flow matches. */
+@Composable
+private fun SuggestionOverflow(
+    open: Boolean,
+    onOpenChange: (Boolean) -> Unit,
+    place: Place?,
+    removable: Boolean,
+    lists: List<app.vela.core.model.PlaceList>,
+    onRemove: () -> Unit,
+    onAddToList: (String) -> Unit,
+    onRemoveFromList: (String) -> Unit,
+    onCreateWith: (String) -> Unit,
+) {
+    var showSave by remember { mutableStateOf(false) }
+    Box {
+        IconButton(onClick = { onOpenChange(true) }) {
+            Icon(
+                Icons.Default.MoreVert,
+                contentDescription = stringResource(R.string.mapscreen_suggestion_options),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        VelaMenu(expanded = open, onDismissRequest = { onOpenChange(false) }) {
+            if (place != null) item(stringResource(R.string.place_save_to_list)) { onOpenChange(false); showSave = true }
+            if (removable) item(stringResource(R.string.mapscreen_remove_from_history)) { onOpenChange(false); onRemove() }
+        }
+    }
+    if (showSave && place != null) {
+        val containing = lists.filter { l -> l.places.any { it.matches(place.id, place.featureId) } }
+            .mapTo(HashSet()) { it.id }
+        app.vela.ui.place.SaveToListSheet(
+            lists = lists,
+            containingIds = containing,
+            onToggle = { id, add -> if (add) onAddToList(id) else onRemoveFromList(id) },
+            onCreateWith = { name -> onCreateWith(name) },
+            onDismiss = { showSave = false },
+        )
     }
 }
 

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1285,6 +1285,12 @@ fun MapScreen(
                                 ((state.pickingOrigin || state.pickingDest || state.pickingStop) && state.query.isBlank())
                             ) -> SearchEntryContent(
                             suggestions = state.suggestions,
+                            localSuggestions = state.localSuggestions,
+                            onPickLocal = {
+                                focusManager.clearFocus()
+                                vm.pickLocalSuggestion(it)
+                            },
+                            onRemoveLocal = vm::removeLocalSuggestion,
                             saved = state.saved,
                             recents = state.recents,
                             recentPlaces = state.recentPlaces,
@@ -2963,6 +2969,9 @@ private fun ChooseOnMapOverlay(
 @Composable
 private fun SearchEntryContent(
     suggestions: List<Place>,
+    localSuggestions: List<app.vela.ui.map.LocalSuggestion>,
+    onPickLocal: (app.vela.ui.map.LocalSuggestion) -> Unit,
+    onRemoveLocal: (app.vela.ui.map.LocalSuggestion) -> Unit,
     saved: List<SavedPlace>,
     recents: List<RecentQuery>,
     recentPlaces: List<RecentPlace>,
@@ -2989,14 +2998,29 @@ private fun SearchEntryContent(
     onPinSavedAs: (SavedPlace, ShortcutKind) -> Unit,
     onRemoveSaved: (SavedPlace) -> Unit,
 ) {
-    // While typing, live place suggestions take over the page (Google-style);
-    // with an empty box it's the Home/Work + saved + recents shortlist.
-    if (suggestions.isNotEmpty()) {
+    // While typing, live place suggestions take over the page (Google-style). The user's OWN
+    // history + list matches (issue #180) lead, instant and offline, then the network results.
+    if (localSuggestions.isNotEmpty() || suggestions.isNotEmpty()) {
         Column(
             Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(top = 8.dp),
         ) {
             if (assigning != null) AssignBanner(assigning, onCancelAssign)
             if (pickingStop) PickStopBanner(onCancelPickStop)
+            localSuggestions.forEach { s ->
+                SuggestionRow(
+                    icon = when (s.kind) {
+                        app.vela.ui.map.LocalSuggestion.Kind.RECENT_QUERY -> Icons.Default.History
+                        app.vela.ui.map.LocalSuggestion.Kind.RECENT_PLACE -> Icons.Default.Place
+                        app.vela.ui.map.LocalSuggestion.Kind.SAVED_PLACE -> Icons.Default.Bookmark
+                    },
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    label = s.label,
+                    sublabel = s.sublabel,
+                    onClick = { onPickLocal(s) },
+                    onRemove = if (s.removable) ({ onRemoveLocal(s) }) else null,
+                )
+                Divider()
+            }
             suggestions.forEach { p ->
                 SuggestionRow(
                     icon = Icons.Default.Search,

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -80,6 +80,21 @@ data class TransitNavState(
     val isLastStep: Boolean get() = stepIndex >= itinerary.steps.lastIndex
 }
 
+/** A match found in the user's OWN data (issue #180) as they type, surfaced above the network
+ *  suggestions, instantly and offline. A recent QUERY re-runs the search; anything place-backed
+ *  ([place] non-null: a saved-list place, a saved shortcut, or a recently-viewed place) opens
+ *  that place directly. [removable] rows carry the X to drop them from history. */
+data class LocalSuggestion(
+    val kind: Kind,
+    val label: String,
+    val sublabel: String?,
+    val place: Place? = null,
+    val query: String? = null,
+    val removable: Boolean = false,
+) {
+    enum class Kind { RECENT_QUERY, RECENT_PLACE, SAVED_PLACE }
+}
+
 data class MapUiState(
     val center: LatLng? = null,
     // Camera zoom requested by a deep link (geo:...?z=17); one-shot - any ordinary selection
@@ -124,6 +139,9 @@ data class MapUiState(
     // OSM icons back in instead of leaving the outskirts iconless (user 2026-07-10).
     val ambientCoversView: Boolean = false,
     val suggestions: List<Place> = emptyList(),
+    // Matches from the user's OWN recents + lists (issue #180), shown above the network suggestions
+    // as they type, instant and offline.
+    val localSuggestions: List<LocalSuggestion> = emptyList(),
     val selected: Place? = null,
     val placesHere: List<Place> = emptyList(), // other Google listings at the selected spot
     val reviews: List<Review> = emptyList(),
@@ -950,9 +968,13 @@ class MapViewModel @Inject constructor(
         suggestJob?.cancel()
         val term = q.trim()
         if (term.length < 2) {
-            _state.update { it.copy(suggestions = emptyList()) }
+            _state.update { it.copy(suggestions = emptyList(), localSuggestions = emptyList()) }
             return
         }
+        // Match the user's OWN history + lists FIRST, synchronous, no network, so these land
+        // instantly (and are the only thing that shows offline). Independent of the debounced
+        // Google fetch below, which appends behind them.
+        _state.update { it.copy(localSuggestions = localMatches(term)) }
         suggestJob = viewModelScope.launch {
             delay(320) // only fire once typing pauses
             val near = plausibleBias(mapCenter) ?: plausibleBias(_state.value.myLocation) // suggestions near the viewport, like search
@@ -1013,8 +1035,81 @@ class MapViewModel @Inject constructor(
                     .filter { p -> near == null || p.location.distanceTo(near) <= SUGGEST_NEAR_M }
                     .filter { p -> !coveredByGoogle(p) }
                     .distinctBy { "${(it.location.lat * 2e4).toInt()},${(it.location.lng * 2e4).toInt()}" }
-                _state.update { it.copy(suggestions = (addrLead + ranked).take(8)) }
+                // Drop any network suggestion the user's OWN data already surfaced above, so a
+                // saved/recent place doesn't appear twice. Match on BOTH keys: recents/saved
+                // usually lack a feature id (they're SavedPlace-backed), so a feature-id-only
+                // compare misses them - name + coarse location catches those.
+                val localPlaces = _state.value.localSuggestions.mapNotNull { it.place }
+                val localNameLoc = localPlaces.map { nameLocKey(it) }.toHashSet()
+                val localFids = localPlaces.mapNotNull { it.featureId }.toHashSet()
+                val deduped = (addrLead + ranked).filterNot {
+                    nameLocKey(it) in localNameLoc || (it.featureId != null && it.featureId in localFids)
+                }
+                _state.update { it.copy(suggestions = deduped.take(8)) }
             }
+        }
+    }
+
+    private fun placeKey(p: Place): String =
+        p.featureId ?: nameLocKey(p)
+
+    /** Feature-id-independent identity: lowercased name + ~5 m rounded location. The dedup key
+     *  that works for SavedPlace-backed local suggestions, which carry no feature id. */
+    private fun nameLocKey(p: Place): String =
+        "${p.name.lowercase()}|${(p.location.lat * 2e4).toInt()},${(p.location.lng * 2e4).toInt()}"
+
+    /** Substring-match the typed [term] against the user's recents (searches + viewed places) and
+     *  saved lists (issue #180): no network, so it's instant and works offline. Recent SEARCHES
+     *  lead (that's what "search your history" most means), then places, deduped and capped so the
+     *  network suggestions still get room below. */
+    private fun localMatches(term: String): List<LocalSuggestion> {
+        val t = term.lowercase()
+        val out = ArrayList<LocalSuggestion>()
+
+        // Recent SEARCHES containing the term (skip an exact echo of what's being typed).
+        recentStore.recent().asSequence()
+            .filter { it.query.lowercase().contains(t) && !it.query.equals(term, ignoreCase = true) }
+            .take(3)
+            .forEach { out.add(LocalSuggestion(LocalSuggestion.Kind.RECENT_QUERY, it.query, null, query = it.query, removable = true)) }
+
+        // Places from the user's own data, deduped across sources by stable key.
+        val seen = HashSet<String>()
+        fun addPlace(kind: LocalSuggestion.Kind, p: Place, removable: Boolean) {
+            if (!p.name.lowercase().contains(t) && p.address?.lowercase()?.contains(t) != true) return
+            if (!seen.add(placeKey(p))) return
+            out.add(LocalSuggestion(kind, p.name, p.address, place = p, removable = removable))
+        }
+        // Recently-VIEWED places (history) first, then saved-list places, then the saved shortlist.
+        _state.value.recentPlaces.forEach { addPlace(LocalSuggestion.Kind.RECENT_PLACE, it.place.toPlace(), removable = true) }
+        listStore.lists().flatMap { it.places }.forEach { addPlace(LocalSuggestion.Kind.SAVED_PLACE, it.toPlace(), removable = false) }
+        savedStore.saved().forEach { addPlace(LocalSuggestion.Kind.SAVED_PLACE, it.toPlace(), removable = false) }
+
+        return out.take(6)
+    }
+
+    /** Open (place-backed) or re-run (recent query) a local suggestion tapped in the search page. */
+    fun pickLocalSuggestion(s: LocalSuggestion) {
+        when {
+            s.place != null -> selectPlace(s.place)
+            s.query != null -> searchRecent(s.query)
+        }
+    }
+
+    /** Drop a local suggestion from history via its X (recent search or recently-viewed place);
+     *  saved-list rows aren't removable here. Refreshes the live local matches for the current query. */
+    fun removeLocalSuggestion(s: LocalSuggestion) {
+        when (s.kind) {
+            LocalSuggestion.Kind.RECENT_QUERY -> s.query?.let { recentStore.remove(it) }
+            LocalSuggestion.Kind.RECENT_PLACE -> s.place?.let { recentPlaceStore.remove(it.id) }
+            LocalSuggestion.Kind.SAVED_PLACE -> return
+        }
+        val term = _state.value.query.trim()
+        _state.update {
+            it.copy(
+                recents = recentStore.recent(),
+                recentPlaces = recentPlaceStore.recent(),
+                localSuggestions = if (term.length >= 2) localMatches(term) else emptyList(),
+            )
         }
     }
 
@@ -1027,7 +1122,7 @@ class MapViewModel @Inject constructor(
         if (backToTrip != null) {
             _state.update {
                 it.copy(
-                    query = "", results = emptyList(), suggestions = emptyList(),
+                    query = "", results = emptyList(), suggestions = emptyList(), localSuggestions = emptyList(),
                     selected = backToTrip, alongRouteDest = null, directionsOpen = true,
                     resultsCollapsed = false, showSearchThisArea = false,
                 )
@@ -1036,7 +1131,7 @@ class MapViewModel @Inject constructor(
         }
         _state.update {
             it.copy(
-                query = "", results = emptyList(), suggestions = emptyList(), selected = null,
+                query = "", results = emptyList(), suggestions = emptyList(), localSuggestions = emptyList(), selected = null,
                 resultsCollapsed = false, showSearchThisArea = false, openListId = null, pendingImport = null,
             )
         }
@@ -1159,7 +1254,7 @@ class MapViewModel @Inject constructor(
         shortcutStore.set(kind, sp)
         _state.update {
             it.copy(
-                assigningShortcut = null, selected = null, suggestions = emptyList(),
+                assigningShortcut = null, selected = null, suggestions = emptyList(), localSuggestions = emptyList(),
                 results = emptyList(), query = "",
                 home = shortcutStore.get(ShortcutKind.HOME), work = shortcutStore.get(ShortcutKind.WORK),
                 status = appContext.getString(R.string.mapvm_shortcut_set, kind.label, sp.name),
@@ -1337,7 +1432,7 @@ class MapViewModel @Inject constructor(
         MapLinkParser.parseBareCoordinate(q)?.let { link ->
             val at = LatLng(link.lat!!, link.lng!!)
             recentStore.add(q)
-            _state.update { it.copy(recents = recentStore.recent(), suggestions = emptyList(), searching = false, center = at) }
+            _state.update { it.copy(recents = recentStore.recent(), suggestions = emptyList(), localSuggestions = emptyList(), searching = false, center = at) }
             onMapLongPress(at)
             return
         }
@@ -1363,7 +1458,7 @@ class MapViewModel @Inject constructor(
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
             // A fresh typed search leaves any along-route browse: picks open places normally again.
-            _state.update { it.copy(searching = true, suggestions = emptyList(), showSearchThisArea = false, resultsCollapsed = false, alongRouteDest = null) }
+            _state.update { it.copy(searching = true, suggestions = emptyList(), localSuggestions = emptyList(), showSearchThisArea = false, resultsCollapsed = false, alongRouteDest = null) }
             // A pasted Google Maps SHARE LINK: try the shared-list import (issue #1). The link
             // resolves keylessly to the list's places, each carrying the owner's note; they land
             // as results (title in the bar) and each is savable/openable like any search hit.
@@ -1526,7 +1621,7 @@ class MapViewModel @Inject constructor(
         searchJob = viewModelScope.launch {
             _state.update {
                 it.copy(
-                    query = query, searching = true, directionsOpen = false, suggestions = emptyList(),
+                    query = query, searching = true, directionsOpen = false, suggestions = emptyList(), localSuggestions = emptyList(),
                     resultsCollapsed = false, recents = recentStore.recent(),
                     // Stash the trip's destination: browsing stop candidates must not lose the trip.
                     // While this is set, picking a result ADDS IT AS A STOP and returns to the panel.
@@ -1636,7 +1731,7 @@ class MapViewModel @Inject constructor(
         routeJob?.cancel() // a directions fetch in flight must not resurrect the stale panel
         _state.update {
             it.copy(
-                selected = withListNote(p), center = p.location, centerZoom = null, reviews = emptyList(), suggestions = emptyList(),
+                selected = withListNote(p), center = p.location, centerZoom = null, reviews = emptyList(), suggestions = emptyList(), localSuggestions = emptyList(),
                 placesHere = othersAt(p, it.results), loadingDetails = false, photosLoading = false,
                 // Picking a NEW place while a route chooser is open closes it: the chooser
                 // belonged to the previous destination and kept covering the fresh place
@@ -2979,7 +3074,7 @@ class MapViewModel @Inject constructor(
     /** Tapped the directions "From" row → the next search pick becomes the origin
      *  (not a destination). The UI opens the search overlay; [setDirectionsOrigin] or
      *  [cancelPickOrigin] ends the mode. */
-    fun beginPickOrigin() = _state.update { it.copy(pickingOrigin = true, pickingDest = false, query = "", suggestions = emptyList()) }
+    fun beginPickOrigin() = _state.update { it.copy(pickingOrigin = true, pickingDest = false, query = "", suggestions = emptyList(), localSuggestions = emptyList()) }
 
     fun cancelPickOrigin() = _state.update { it.copy(pickingOrigin = false, pickingDest = false) }
 
@@ -2988,7 +3083,7 @@ class MapViewModel @Inject constructor(
      *  backing out and retyping lost the custom origin). [setDirectionsDestination] or
      *  [cancelPickDestination] ends the mode. */
     fun beginPickDestination() = _state.update {
-        it.copy(pickingDest = true, pickingOrigin = false, pickingStop = false, query = "", suggestions = emptyList())
+        it.copy(pickingDest = true, pickingOrigin = false, pickingStop = false, query = "", suggestions = emptyList(), localSuggestions = emptyList())
     }
 
     fun cancelPickDestination() = _state.update { it.copy(pickingDest = false) }
@@ -3001,7 +3096,7 @@ class MapViewModel @Inject constructor(
         _state.update {
             it.copy(
                 selected = withListNote(p), pickingDest = false, pickOnMap = null,
-                directionsOpen = true, results = emptyList(), query = "", suggestions = emptyList(),
+                directionsOpen = true, results = emptyList(), query = "", suggestions = emptyList(), localSuggestions = emptyList(),
                 reviews = emptyList(), reviewsLoading = false, reviewsFound = 0, photosLoading = false,
                 loadingDetails = false, placesHere = emptyList(),
                 stopDepartures = null, stopDeparturesLoading = false, stopDeparturesFor = null,
@@ -3050,7 +3145,7 @@ class MapViewModel @Inject constructor(
 
     /** Tapped "Add stop" → the next search pick becomes an intermediate stop (multi-stop routing).
      *  [addStop]/[cancelPickStop] ends the mode. */
-    fun beginPickStop() = _state.update { it.copy(pickingStop = true, pickingDest = false, editingStops = false, query = "", suggestions = emptyList()) }
+    fun beginPickStop() = _state.update { it.copy(pickingStop = true, pickingDest = false, editingStops = false, query = "", suggestions = emptyList(), localSuggestions = emptyList()) }
 
     /** The dedicated stops editor (reorder / remove / add in one sheet, one reroute on Done). */
     fun openStopsEditor() = _state.update { it.copy(editingStops = true) }
@@ -3077,7 +3172,7 @@ class MapViewModel @Inject constructor(
         _state.update {
             it.copy(
                 directionsWaypoints = it.directionsWaypoints + p,
-                results = emptyList(), query = "", suggestions = emptyList(),
+                results = emptyList(), query = "", suggestions = emptyList(), localSuggestions = emptyList(),
                 selected = null, alongRouteDest = null, resultsCollapsed = false,
             )
         }

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -1211,9 +1211,10 @@ internal suspend fun androidx.compose.ui.input.pointer.PointerInputScope.sheetDr
     )
 }
 
-/** "Save to list" — check the lists this place belongs to; create a new one inline. */
+/** "Save to list": check the lists this place belongs to; create a new one inline.
+ *  internal so the search-suggestion overflow menu (MapScreen, issue #180) reuses it. */
 @Composable
-private fun SaveToListSheet(
+internal fun SaveToListSheet(
     lists: List<app.vela.core.model.PlaceList>,
     containingIds: Set<String>,
     onToggle: (listId: String, add: Boolean) -> Unit,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -380,6 +380,8 @@
     <string name="mapscreen_edit_shortcut">Edit %1$s</string> <!-- format -->
     <string name="mapscreen_menu_change">Change</string>
     <string name="mapscreen_menu_remove">Remove</string>
+    <string name="mapscreen_remove_from_history">Remove from history</string>
+    <string name="mapscreen_suggestion_options">Suggestion options</string>
     <string name="mapscreen_saved_place_options">Saved place options</string>
     <string name="mapscreen_set_as_home">Set as Home</string>
     <string name="mapscreen_set_as_work">Set as Work</string>

--- a/core/src/main/java/app/vela/core/model/SavedPlace.kt
+++ b/core/src/main/java/app/vela/core/model/SavedPlace.kt
@@ -15,6 +15,8 @@ data class SavedPlace(
 ) {
     val location: LatLng get() = LatLng(lat, lng)
 
+    fun toPlace(): Place = Place(id = id, name = name, location = location, address = address)
+
     companion object {
         fun of(p: Place) = SavedPlace(p.id, p.name, p.location.lat, p.location.lng, p.address)
     }


### PR DESCRIPTION
Closes #180.

**Two parts, both implemented:**

**1. Search your own data as you type.** Matches from your recent searches, recently-viewed places, and saved lists land at the top of the suggestions, above Google's, each with an icon (clock / pin / bookmark). Computed on-device in `onQueryChange` before the debounced network fetch, so it's instant and the only thing that shows offline. A network suggestion that duplicates one of your own is dropped, matched by name + coarse location (saved places carry no Google id). Device-verified: "Dutch" surfaces the saved Dutch Bros at the top, suppresses Google's duplicate, keeps a different-town Dutch Bros, and tapping opens the place.

**2. Press-hold / overflow to manage a suggestion.** Every suggestion row gains a ⋮ overflow (and a touch long-press) that opens a small menu: **save the place to a list** (reusing the place sheet's list picker + inline "create list"), or **remove a history row**. A bare query row shows only remove; a saved-list place shows only save/manage; D-pad reaches the ⋮ as its own focus stop. This is the "would rock" half of the request — it makes Vela do something Google Maps doesn't.

Rebased onto current `main`; branch em-dash-clean; unit tests + release build green.

_Note: the ⋮ overflow menu couldn't be fully exercised via automation this session (adb drops rapid keystrokes into the Compose search field, so the filtered view is hard to script), but the base list renders correctly on-device, the menu is a standard DropdownMenu reusing the verified place-sheet list picker, and it compiles + unit-tests clean. Worth a manual tap-through before merge._
