### PR TITLE
Voice: no stale-prompt burst on late attach + install button in Voice settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,14 @@ Defaults that make the safe path the easy one:
   auditions the nav sample on an EXPLICIT library pick ("Use" button); the download-completion
   (firstEver) and delete-fallback paths pass audition=false - a phone that starts talking on its
   own right after an install reads as a bug (user report). The Test button is the on-demand way.
+- **Voice download shows a distinct "Installing…" after 100% (2026-07-19):** a voice download hits
+  100% and then spends ~15 s unpacking the ~67 MB archive; the map card already flips to
+  `voiceInstalling` ("Installing Vela Voice…"), but the three SETTINGS progress sites (the Voice
+  section install line, the Voice-library reinstall line, and each `VoiceRow`) kept printing
+  "Downloading … 100%" through the unpack and read as a hang (user report). They now switch to
+  `settings_voice_search_installing` ("Installing…") with an indeterminate bar while
+  `state.voiceInstalling`. Any new voice-download progress UI must read `voiceInstalling`, not just
+  `voiceDownloadPct`.
 - **Depart at / Arrive by is confirm-driven (2026-07-11):** a time change re-routes TRANSIT
   ONLY (`setDirectionsTime`) - the keyless drive/walk/bike request has no departure field, so
   refetching it returned identical routes and just flickered the list; the chooser's arrival

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -2125,3 +2125,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   forever. A longer text for a known review now replaces the stored entry, and the More click
   uses the button's class hook so it works in every UI language (the old label match only knew
   English). Device-verified on a busy coffee shop: multi-paragraph reviews end in real sentences.
+- ✅ **No stale voice-prompt burst when a voice attaches late.** If you drove with no voice
+  installed (nav queues prompts with nothing to speak them) and then installed one, the whole
+  backlog used to flush at once, a burst of out-of-order directions. The queue now speaks only
+  the most recent line on attach and is cleared whenever guidance stops, so installing a voice
+  can't trigger a stale replay.
+- ✅ **Install the Vela voice straight from Voice settings.** When no Vela voice is installed, the
+  one-tap install button now sits in the Voice settings section itself, not only inside the Voice
+  library, so you don't have to dig for it.

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -749,9 +749,17 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
             state.voiceDownloadingId?.let { id ->
                 val nm = vm.voiceCatalog().firstOrNull { it.id == id }?.displayName ?: stringResource(R.string.settings_voice_fallback_name)
                 val pct = state.voiceDownloadPct ?: 0f
-                Text(stringResource(R.string.settings_voice_downloading, nm, (pct * 100).toInt()), style = MaterialTheme.typography.bodyMedium)
-                Spacer(Modifier.height(6.dp))
-                LinearProgressIndicator(progress = { pct }, modifier = Modifier.fillMaxWidth())
+                if (state.voiceInstalling) {
+                    // Download reached 100%; now unpacking the ~67 MB archive (~15 s). Show a distinct
+                    // "Installing…" with an indeterminate bar so it doesn't read as a stuck 100% download.
+                    Text(stringResource(R.string.settings_voice_search_installing), style = MaterialTheme.typography.bodyMedium)
+                    Spacer(Modifier.height(6.dp))
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                } else {
+                    Text(stringResource(R.string.settings_voice_downloading, nm, (pct * 100).toInt()), style = MaterialTheme.typography.bodyMedium)
+                    Spacer(Modifier.height(6.dp))
+                    LinearProgressIndicator(progress = { pct }, modifier = Modifier.fillMaxWidth())
+                }
                 Spacer(Modifier.height(12.dp))
             } ?: Spacer(Modifier.height(4.dp))
             // One-tap install of the Vela voice right here when it's missing (user 2026-07-20:
@@ -1497,12 +1505,21 @@ private fun VoiceLibrary(vm: MapViewModel, state: MapUiState) {
     if (velaVoice != null && velaVoiceId !in installed && query.isBlank()) {
         Spacer(Modifier.height(8.dp))
         if (state.voiceDownloadingId == velaVoiceId) {
-            Text(
-                stringResource(R.string.settings_voice_row_downloading, ((state.voiceDownloadPct ?: 0f) * 100).toInt()),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            LinearProgressIndicator(progress = { state.voiceDownloadPct ?: 0f }, modifier = Modifier.fillMaxWidth())
+            if (state.voiceInstalling) {
+                Text(
+                    stringResource(R.string.settings_voice_search_installing),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            } else {
+                Text(
+                    stringResource(R.string.settings_voice_row_downloading, ((state.voiceDownloadPct ?: 0f) * 100).toInt()),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                LinearProgressIndicator(progress = { state.voiceDownloadPct ?: 0f }, modifier = Modifier.fillMaxWidth())
+            }
         } else {
             Button(
                 onClick = { vm.downloadVoice(velaVoiceId) },
@@ -1572,6 +1589,7 @@ private fun VoiceLibrary(vm: MapViewModel, state: MapUiState) {
                         active = v.id == selected,
                         downloading = state.voiceDownloadingId == v.id,
                         downloadPct = if (state.voiceDownloadingId == v.id) state.voiceDownloadPct ?: 0f else 0f,
+                        installing = state.voiceDownloadingId == v.id && state.voiceInstalling,
                         anyDownloading = state.voiceDownloadingId != null,
                         velaVoice = v.id == velaVoiceId,
                         onDownload = { vm.downloadVoice(v.id) },
@@ -1615,6 +1633,7 @@ private fun VoiceRow(
     active: Boolean,
     downloading: Boolean,
     downloadPct: Float,
+    installing: Boolean = false, // download done, unpacking the archive (~15 s) - not a stuck 100%
     anyDownloading: Boolean,
     velaVoice: Boolean = false, // the fleet-default id wears the "Vela voice (Name)" branding
     onDownload: () -> Unit,
@@ -1641,6 +1660,7 @@ private fun VoiceRow(
                 )
             }
             val sub = when {
+                installing -> stringResource(R.string.settings_voice_search_installing)
                 downloading -> stringResource(R.string.settings_voice_row_downloading, (downloadPct * 100).toInt())
                 active -> stringResource(R.string.settings_voice_row_in_use, v.region, gender, v.sizeMb)
                 installed -> stringResource(R.string.settings_voice_row_downloaded, v.region, gender, v.sizeMb)
@@ -1666,5 +1686,8 @@ private fun VoiceRow(
             else -> OutlinedButton(onClick = onDownload, enabled = !anyDownloading, modifier = Modifier.dpadHighlight(androidx.compose.foundation.shape.CircleShape)) { Text(stringResource(R.string.settings_download)) }
         }
     }
-    if (downloading) LinearProgressIndicator(progress = { downloadPct }, modifier = Modifier.fillMaxWidth())
+    if (downloading) {
+        if (installing) LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        else LinearProgressIndicator(progress = { downloadPct }, modifier = Modifier.fillMaxWidth())
+    }
 }

--- a/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsScreen.kt
@@ -754,6 +754,21 @@ fun SettingsScreen(vm: MapViewModel, onBack: () -> Unit, openOffline: Boolean = 
                 LinearProgressIndicator(progress = { pct }, modifier = Modifier.fillMaxWidth())
                 Spacer(Modifier.height(12.dp))
             } ?: Spacer(Modifier.height(4.dp))
+            // One-tap install of the Vela voice right here when it's missing (user 2026-07-20:
+            // don't make me dig into the Voice library for the main voice). Same download the
+            // library offers; hidden while any voice download is in flight (the line above shows it).
+            run {
+                val velaId = vm.defaultVoiceId()
+                val vela = vm.voiceCatalog().firstOrNull { it.id == velaId }
+                if (vela != null && velaId !in state.installedVoiceIds && state.voiceDownloadingId == null) {
+                    Button(
+                        onClick = { vm.downloadVoice(velaId) },
+                        modifier = Modifier.fillMaxWidth().dpadHighlight(RoundedCornerShape(24.dp)),
+                    ) { Text(stringResource(R.string.settings_voice_install_vela, vela.sizeMb)) }
+                    Hint(stringResource(R.string.settings_voice_install_vela_hint))
+                    Spacer(Modifier.height(10.dp))
+                }
+            }
             // Enumerate TTS engines OFF the main thread. PackageManager.queryIntentServices + the
             // per-engine loadLabel is a binder IPC that took >5 s on the flip phone and ANR'd the UI
             // when run in composition (input-dispatch timeout). Load async (cached in VoiceGuide);

--- a/core/src/main/java/app/vela/core/voice/VoiceGuide.kt
+++ b/core/src/main/java/app/vela/core/voice/VoiceGuide.kt
@@ -206,10 +206,7 @@ class VoiceGuide @Inject constructor(
             ready = true // the neural synth loads + queues internally
             working = neural != null
             neural?.warmUp()
-            while (pending.isNotEmpty()) {
-                val (text, interrupt) = pending.removeFirst()
-                speakNow(text, interrupt)
-            }
+            drainPendingLatest()
             return
         }
         useNeural = false
@@ -267,10 +264,19 @@ class VoiceGuide @Inject constructor(
         systemInitFailed = false
         lastSystemLang = null // force setLanguage on the first utterance
         if (!useNeural) { ready = true; working = true } // this system engine is the PRIMARY voice
-        while (pending.isNotEmpty()) {
-            val (text, interrupt) = pending.removeFirst()
-            speakNow(text, interrupt)
-        }
+        drainPendingLatest()
+    }
+
+    /** Speak only the MOST RECENT queued line when a voice (re-)attaches, never the whole backlog.
+     *  Prompts pile into [pending] while nothing can speak them (a drive with no voice installed,
+     *  then the user installs one mid-way or afterward); replaying the entire pile dumps a burst of
+     *  stale, out-of-order instructions all at once (user 2026-07-20: "it automatically started
+     *  speaking... random letters"). Only the latest is still relevant, and the live nav loop
+     *  re-announces the current maneuver anyway. */
+    private fun drainPendingLatest() {
+        val last = pending.lastOrNull()
+        pending.clear()
+        last?.let { (text, interrupt) -> speakNow(text, interrupt) }
     }
 
     /** Pick the highest-quality voice for [lang] that works offline — engines
@@ -411,6 +417,9 @@ class VoiceGuide @Inject constructor(
     fun stop() {
         tts?.stop()
         neural?.stop()
+        // Drop any queued-but-unspoken prompts: once guidance stops (nav end / mute), a backlog is
+        // stale and must not survive to be flushed later when a voice attaches (issue: stale burst).
+        pending.clear()
         releaseAllFocus()
     }
 


### PR DESCRIPTION
Two independent voice fixes found while testing the nav voice for #184.

**1. Stale-prompt burst on late voice attach.** If you navigate with no voice installed, nav prompts pile into `VoiceGuide.pending` (nothing can speak them). When a voice attaches later — e.g. you install one from Settings — the code drained the **entire** backlog at once, so a burst of old, out-of-order directions plays immediately (reported: "it automatically started speaking… random letters"). Fixes:
- `drainPendingLatest()` replaces the two drain sites (neural attach + system `onInit`): speak only the **most recent** queued line, drop the rest. The live nav loop re-announces the current maneuver anyway.
- `stop()` now **clears** `pending`, so an ended drive / mute leaves no queued prompts to flush later.

**2. Install Vela voice from the Voice settings section.** The one-tap "Install Vela voice" button existed only inside the Voice **library** screen. It now also appears in the Voice settings section itself when no Vela voice is installed, so it isn't buried (hidden once installed / while a download is in flight). Mirrors the library's proven install block (`vm.downloadVoice(vm.defaultVoiceId())`).

Verification: `:core` voice unit tests pass, release build clean, device smoke-test (launches, Settings renders, no crash; install button correctly hidden since a voice is installed). The queue fix is verified by inspection — its trigger (a drive-length backlog + a late attach) is hard to script, but the change is small and self-evidently correct.
