### PR TITLE
Romanized street names for offline routing (#184)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1115,9 +1115,19 @@ Defaults that make the safe path the easy one:
   **REAL romanized names beat ICU (2026-07-19, tiles phase):** ICU on an abjad like Hebrew is a vowel-less
   skeleton ("רחוב הרצל"->"rhwb hrzl"), unpronounceable. Real names are DATA: the OpenMapTiles
   basemap carries `name:en`/`name:latin` per road. `VelaMapView`'s existing nav-label pass
-  (querySourceFeatures over `transportation_name`, once per 400 m quantum) also records `localName ->
-  latinAliasOf(feature)` and reports it via `onNavRoadLatin` -> `MapViewModel.onNavRoadLatin` ->
-  `MapUiState.roadNameLatin` + `VoiceGuide.roadNameLatin`, growing as tiles load, reset on nav end.
+  (querySourceFeatures over `transportation_name`) also records `localName -> latinAliasOf(feature)`
+  and reports it via `onNavRoadLatin` -> `MapViewModel.onNavRoadLatin` -> `MapUiState.roadNameLatin` +
+  `VoiceGuide.roadNameLatin`, growing as tiles load, reset on nav end. **The dict query is WARMUP-paced,
+  NOT the per-400 m quantum the label pass uses:** a drive STARTS with only the route-overview (low-zoom)
+  tiles loaded, which carry ONLY major road names (device-proven: dict=19 major roads at nav start), so the
+  first turn onto a minor road spoke the ICU skeleton. The loop now re-queries the dict every 2 s tick WHILE
+  it is still growing (`dictStaleTicks < 3`, reset on each quantum), so a local road's real name lands within
+  a couple seconds of its nav-zoom tile loading (device-proven: dict jumped 19 -> 404 as local streets
+  resolved to real romanized names with vowels, not the consonant skeleton, on both the banner and the
+  voice). The expensive crossing geometry stays per-quantum, so this never puts a heavy pass on the
+  every-frame path. NB the very FIRST "Starting
+  navigation" opener still fires at dict=0 (before any tiles load) so its road can skeleton once; the banner
+  heals as the dict fills.
   `SpokenScript.forVoice(text, lang, dict)` swaps a known local name for its real Latin form FIRST, ICU only
   for the rest; `SpokenScript.forDisplay(text, uiLang, dict)` does the same for the banner + steps but with
   NO ICU fallback (a skeleton on a sign reads broken - why the earlier ICU display romanization was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1125,9 +1125,13 @@ Defaults that make the safe path the easy one:
   a couple seconds of its nav-zoom tile loading (device-proven: dict jumped 19 -> 404 as local streets
   resolved to real romanized names with vowels, not the consonant skeleton, on both the banner and the
   voice). The expensive crossing geometry stays per-quantum, so this never puts a heavy pass on the
-  every-frame path. NB the very FIRST "Starting
-  navigation" opener still fires at dict=0 (before any tiles load) so its road can skeleton once; the banner
-  heals as the dict fills.
+  every-frame path. The nav-start OPENER ("Starting navigation. Head ... on <road>") is spoken via
+  `VoiceGuide.speakOpener` (not `speak`): it HOLDS the opener up to `OPENER_MAX_WAIT_MS` (2.5 s), retrying
+  every 200 ms until the road it names is covered by `roadNameLatin` (or the text has no foreign run), then
+  speaks - the drive begins before nav-zoom tiles load, so speaking at T=0 read the ICU skeleton; the wait
+  lets the dict fill so the opener says the real name (device-proven: opener spoke the real romanized road,
+  not the skeleton, once the dict reached ~400). `stop()` bumps `openerToken` to cancel a still-waiting
+  opener. An English opener never waits (hasForeignRun false).
   `SpokenScript.forVoice(text, lang, dict)` swaps a known local name for its real Latin form FIRST, ICU only
   for the rest; `SpokenScript.forDisplay(text, uiLang, dict)` does the same for the banner + steps but with
   NO ICU fallback (a skeleton on a sign reads broken - why the earlier ICU display romanization was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1132,6 +1132,16 @@ Defaults that make the safe path the easy one:
   lets the dict fill so the opener says the real name (device-proven: opener spoke the real romanized road,
   not the skeleton, once the dict reached ~400). `stop()` bumps `openerToken` to cancel a still-waiting
   opener. An English opener never waits (hasForeignRun false).
+  **On-MAP labels romanize too (2026-07-19):** the maneuver banner/voice were romanized, but the nav
+  road-name BUBBLES (`ensureNavRoadLabels`, `textField(get("name"))`) and the browse basemap street
+  labels (`highway-name-*` in all four `applyLight`/`applyDark`/classic palette fns) still drew the
+  local script (user: "why are the street name bubbles in jew still when we have english set"). Both now
+  use `roadLabelTextField()` = `coalesce(get("name:en"), get("name:latin"), get("name"))` for a
+  Latin-script UI (gate `uiWantsLatinLabels()` / `NON_LATIN_UI_LANGS`; a Hebrew/Russian/etc UI keeps the
+  local `name`). Same name:latin tile data as the voice/banner, so labels + guidance agree. The nav-bubble
+  filter still matches on the canonical `name` (Hebrew) - display latin, filter on name. NB the search-result
+  markers + transit-stop labels stay on `name` (those are place-name DATA, not streets - a Hebrew business
+  keeps its Hebrew name like Google).
   `SpokenScript.forVoice(text, lang, dict)` swaps a known local name for its real Latin form FIRST, ICU only
   for the rest; `SpokenScript.forDisplay(text, uiLang, dict)` does the same for the banner + steps but with
   NO ICU fallback (a skeleton on a sign reads broken - why the earlier ICU display romanization was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1098,7 +1098,14 @@ Defaults that make the safe path the easy one:
   voice must actually speak that language** - `VoiceGuide` guards on `NeuralSynth.voiceLanguage` and, on a
   mismatch, falls back to a system TTS in the target language (or stays silent + fires a "get a matching voice"
   hint) rather than reading, e.g., Russian nav text through the English Piper model (see the voice bullet under
-  Degoogled constraints). (2) **UI chrome** - 
+  Degoogled constraints). **Foreign NAME romanizing (issue #184, 2026-07-20):** a road NAME can be in a
+  different script than the guidance language (Hebrew name inside English guidance), and a single-language
+  voice drops those glyphs. `SpokenScript.forVoice(text, voiceLang)` romanizes the foreign-script runs to
+  Latin (android.icu `Any-Latin; Latin-ASCII`) ONLY for a Latin-script voice, applied around `forSpeech()`
+  in BOTH speak paths; SPOKEN string only, the banner keeps the local script. CJK is excluded on purpose
+  (ICU reads Han as Chinese pinyin, "明治通り"->"ming zhitongri" not "Meiji-dori") so kanji/kana are left to
+  the native CJK voices. Logic is unit-tested with an injected romanizer (android.icu is JVM-stubbed in
+  unit tests); real ICU output validated via `uconv` (same libicu). (2) **UI chrome** - 
   all ~330 user-facing `:app` strings live in `res/values/strings.xml` (English) + `res/values-<lang>/` for
   the 14 translated languages (fr de es it pt nl ru pl sv uk iw + zh zh-rTW ja; CJK added 2026-07-11, Hebrew 2026-07-13),
   referenced via `stringResource`/`getString`. **CJK notes (2026-07-11):** Chinese ships as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1112,6 +1112,20 @@ Defaults that make the safe path the easy one:
   CJK/Cyrillic voice reading romanized Latin is rough (their G2P is not built for Latin), but audible beats
   dropped; the clean win is the DISPLAY side (name:latin), pending. Logic is unit-tested with an injected
   romanizer (android.icu is JVM-stubbed in unit tests); real ICU output validated via `uconv` (same libicu).
+  **REAL romanized names beat ICU (2026-07-19, tiles phase):** ICU on an abjad like Hebrew is a vowel-less
+  skeleton ("רחוב הרצל"->"rhwb hrzl"), unpronounceable. Real names are DATA: the OpenMapTiles
+  basemap carries `name:en`/`name:latin` per road. `VelaMapView`'s existing nav-label pass
+  (querySourceFeatures over `transportation_name`, once per 400 m quantum) also records `localName ->
+  latinAliasOf(feature)` and reports it via `onNavRoadLatin` -> `MapViewModel.onNavRoadLatin` ->
+  `MapUiState.roadNameLatin` + `VoiceGuide.roadNameLatin`, growing as tiles load, reset on nav end.
+  `SpokenScript.forVoice(text, lang, dict)` swaps a known local name for its real Latin form FIRST, ICU only
+  for the rest; `SpokenScript.forDisplay(text, uiLang, dict)` does the same for the banner + steps but with
+  NO ICU fallback (a skeleton on a sign reads broken - why the earlier ICU display romanization was
+  reverted; an unmapped name keeps local script). Both gate on the UI/voice's own script (a Hebrew UI keeps
+  Hebrew). Works ONLINE and in a downloaded map AREA (both carry name:latin tiles); the gap is offline nav
+  across a state where only the routing GRAPH is downloaded - needs name:en baked into the graph at build
+  time (phase 2, a 135-region rebake, NOT built). Quality tracks OSM name:en coverage (Israel well-tagged ->
+  real names; sparse areas keep local script on display / ICU by voice), same as Google.
   (2) **UI chrome** - 
   all ~330 user-facing `:app` strings live in `res/values/strings.xml` (English) + `res/values-<lang>/` for
   the 14 translated languages (fr de es it pt nl ru pl sv uk iw + zh zh-rTW ja; CJK added 2026-07-11, Hebrew 2026-07-13),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1146,10 +1146,24 @@ Defaults that make the safe path the easy one:
   for the rest; `SpokenScript.forDisplay(text, uiLang, dict)` does the same for the banner + steps but with
   NO ICU fallback (a skeleton on a sign reads broken - why the earlier ICU display romanization was
   reverted; an unmapped name keeps local script). Both gate on the UI/voice's own script (a Hebrew UI keeps
-  Hebrew). Works ONLINE and in a downloaded map AREA (both carry name:latin tiles); the gap is offline nav
-  across a state where only the routing GRAPH is downloaded - needs name:en baked into the graph at build
-  time (phase 2, a 135-region rebake, NOT built). Quality tracks OSM name:en coverage (Israel well-tagged ->
-  real names; sparse areas keep local script on display / ICU by voice), same as Google.
+  Hebrew). Works ONLINE and in a downloaded map AREA (both carry name:latin tiles). Quality tracks OSM
+  name:en coverage (Israel well-tagged -> real names; sparse areas keep local script on display / ICU by
+  voice), same as Google.
+  **OFFLINE across a whole state = a ROMANIZED-NAME SIDECAR next to the routing graph (2026-07-19,
+  branch offline-roadnames; chosen over baking into the GraphHopper graph, which GraphHopper can't do
+  natively without version-locked internals + a full re-download):** `scripts/roadnames_build.py` extracts
+  `<local>\t<English>` for every road with name:en/name:latin from the region PBF (name:en wins; validated
+  Latin-script, != local); `scripts/build-routing-region.sh` gzips it to `<id>-names.tsv.gz`, uploads it
+  beside the graph on the `routing-graphs` release, and adds `namesUrl`/`namesSizeKb` to the manifest
+  entry (merge script carries extra fields as-is; old apps ignore them). App: `RoutingGraphStore.download`
+  pulls the sidecar into `graphs/<id>/names.tsv.gz` (best-effort, never fails the graph); `roadNames()`
+  merges all installed regions' sidecars; `MapViewModel.offlineRoadNames` loads it at init / after a
+  region download or delete and is the BASE for `roadNameLatin` (voice + state) that the online tiles
+  merge ON TOP of, reset to on nav-end. So the graph is UNCHANGED (additive, existing downloads keep
+  working, users grab a small extra file, not a new graph). Memory note: the merged map is held in
+  memory while installed - a whole COUNTRY download could be tens of MB; per-route region loading is a
+  future optimization. **The sidecars only exist after a `routing-graphs.yml` rebake is dispatched** (the
+  bake is user-triggered; until then offline nav keeps the local script / ICU).
   (2) **UI chrome** - 
   all ~330 user-facing `:app` strings live in `res/values/strings.xml` (English) + `res/values-<lang>/` for
   the 14 translated languages (fr de es it pt nl ru pl sv uk iw + zh zh-rTW ja; CJK added 2026-07-11, Hebrew 2026-07-13),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1100,12 +1100,19 @@ Defaults that make the safe path the easy one:
   hint) rather than reading, e.g., Russian nav text through the English Piper model (see the voice bullet under
   Degoogled constraints). **Foreign NAME romanizing (issue #184, 2026-07-20):** a road NAME can be in a
   different script than the guidance language (Hebrew name inside English guidance), and a single-language
-  voice drops those glyphs. `SpokenScript.forVoice(text, voiceLang)` romanizes the foreign-script runs to
-  Latin (android.icu `Any-Latin; Latin-ASCII`) ONLY for a Latin-script voice, applied around `forSpeech()`
-  in BOTH speak paths; SPOKEN string only, the banner keeps the local script. CJK is excluded on purpose
-  (ICU reads Han as Chinese pinyin, "明治通り"->"ming zhitongri" not "Meiji-dori") so kanji/kana are left to
-  the native CJK voices. Logic is unit-tested with an injected romanizer (android.icu is JVM-stubbed in
-  unit tests); real ICU output validated via `uconv` (same libicu). (2) **UI chrome** - 
+  voice drops those glyphs. `SpokenScript.forVoice(text, voiceLang)` romanizes to Latin (android.icu
+  `Any-Latin; Latin-ASCII`) any run in a script the SPEAKING voice can't read, applied around `forSpeech()`
+  in BOTH speak paths; SPOKEN string only, the banner keeps the local script. **Latin is the universal
+  fallback for EVERY voice, not just Latin-script ones (un-scoped 2026-07-19, user: a Chinese driver in
+  Israel wants Latin, not dropped Hebrew - that is what Google does):** each voice keeps only its OWN
+  native script (`VOICE_SCRIPT` maps he/ar/ru/el/th/hi/ko/zh/ja to their script; everything else = Latin),
+  so a Russian voice keeps Cyrillic but romanizes Hebrew, and a Chinese voice keeps Han but romanizes
+  Hebrew/Cyrillic. CJK Han/kana are the ONE exception - never romanized for any voice (ICU reads Han as
+  Chinese pinyin, "明治通り"->"ming zhitongri" not "Meiji-dori"), left to the native CJK voices. NB a
+  CJK/Cyrillic voice reading romanized Latin is rough (their G2P is not built for Latin), but audible beats
+  dropped; the clean win is the DISPLAY side (name:latin), pending. Logic is unit-tested with an injected
+  romanizer (android.icu is JVM-stubbed in unit tests); real ICU output validated via `uconv` (same libicu).
+  (2) **UI chrome** - 
   all ~330 user-facing `:app` strings live in `res/values/strings.xml` (English) + `res/values-<lang>/` for
   the 14 translated languages (fr de es it pt nl ru pl sv uk iw + zh zh-rTW ja; CJK added 2026-07-11, Hebrew 2026-07-13),
   referenced via `stringResource`/`getString`. **CJK notes (2026-07-11):** Chinese ships as

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -2125,3 +2125,13 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   forever. A longer text for a known review now replaces the stored entry, and the More click
   uses the button's class hook so it works in every UI language (the old label match only knew
   English). Device-verified on a busy coffee shop: multi-paragraph reviews end in real sentences.
+- ✅ **Foreign street names are spoken, not skipped (issue #184).** When guidance is in one language
+  but a road name is in another script (Hebrew "רחוב הרצל" while you drive with the English voice),
+  the name used to vanish, because a single-language voice has no phonemes for those glyphs and
+  drops them. The spoken string now romanizes foreign-script name runs into the voice's alphabet
+  (ICU, built into Android), the way Google reads "onto Rehov Herzl", while the on-screen banner
+  keeps the real local-script name that matches the street sign. It only touches the runs the voice
+  can't say (existing Latin text and its accents are left alone) and only for Latin-script voices (a
+  Hebrew or Russian voice reads its own script natively). CJK is deliberately left to the native
+  Japanese/Chinese voices, since ICU mis-reads kanji as Chinese pinyin; a proper kanji-to-romaji
+  step is a possible follow-up.

--- a/app/src/main/java/app/vela/offline/RoutingGraphStore.kt
+++ b/app/src/main/java/app/vela/offline/RoutingGraphStore.kt
@@ -30,6 +30,11 @@ data class RoutingRegion(
     val deltaUrl: String? = null,           // row-level delta from [deltaFromRev] to [rev], if published
     val deltaFromRev: Int = 0,
     val deltaSizeMb: Int = 0,
+    // Romanized road-name sidecar (issue #184): a gzipped `<local>\t<English>` TSV built from the
+    // region's OSM name:en/name:latin, downloaded next to the graph so OFFLINE guidance can say/show
+    // the real romanized street name. Null on graphs baked before this existed (they just skip it).
+    val namesUrl: String? = null,
+    val namesSizeKb: Int = 0,
 )
 
 /**
@@ -65,6 +70,26 @@ class RoutingGraphStore @Inject constructor(
     fun installedIds(): Set<String> =
         readIndex().keys.filter { File(File(graphsRoot, it), "properties").exists() }.toSet()
 
+    /** The merged romanized road-name map (local name -> English/Latin) across ALL installed regions'
+     *  sidecars (issue #184), so offline turn-by-turn can say/show the real name. Empty when no region
+     *  has a names sidecar (older graphs, or none downloaded). Read off the IO thread - a state's file
+     *  is a few hundred KB gzipped / ~1-2 M entries decompressed. */
+    fun roadNames(): Map<String, String> = withGraphNamesFiles { files ->
+        val out = HashMap<String, String>()
+        for (f in files) runCatching {
+            java.util.zip.GZIPInputStream(f.inputStream()).bufferedReader().useLines { lines ->
+                for (line in lines) {
+                    val tab = line.indexOf('\t')
+                    if (tab > 0) out[line.substring(0, tab)] = line.substring(tab + 1)
+                }
+            }
+        }
+        out
+    }
+
+    private inline fun <T> withGraphNamesFiles(block: (List<File>) -> T): T =
+        block(installedIds().map { File(File(graphsRoot, it), "names.tsv.gz") }.filter { it.exists() })
+
     /** Fetch the catalog of available region graphs from [manifestUrl]. */
     suspend fun manifest(manifestUrl: String): List<RoutingRegion> = withContext(Dispatchers.IO) {
         runCatching {
@@ -77,6 +102,8 @@ class RoutingGraphStore @Inject constructor(
                 RoutingRegion(
                     o.getString("id"), o.getString("name"), o.getString("url"), o.optInt("sizeMb"),
                     b.getDouble(0), b.getDouble(1), b.getDouble(2), b.getDouble(3),
+                    namesUrl = o.optString("namesUrl").ifBlank { null },
+                    namesSizeKb = o.optInt("namesSizeKb"),
                 )
             }
         }.getOrDefault(emptyList())
@@ -109,6 +136,15 @@ class RoutingGraphStore @Inject constructor(
             dir.deleteRecursively()
             check(tmp.renameTo(dir)) { "could not install graph (rename failed)" }
             synchronized(indexLock) { writeIndex(readIndex() + (region.id to doubleArrayOf(region.s, region.w, region.n, region.e))) }
+            // Best-effort: pull the romanized road-name sidecar alongside the graph (issue #184). A
+            // failure here NEVER fails the graph install - offline nav just falls back to the local name.
+            region.namesUrl?.let { nu ->
+                runCatching {
+                    downloadHttp.newCall(Request.Builder().url(nu).build()).execute().use { r ->
+                        if (r.isSuccessful) File(dir, "names.tsv.gz").outputStream().use { out -> r.body!!.byteStream().copyTo(out) }
+                    }
+                }
+            }
             onProgress(100)
             true
         }.getOrElse { tmp.deleteRecursively(); false }

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -858,6 +858,7 @@ fun MapScreen(
             navDriveMode = state.travelMode == app.vela.core.model.TravelMode.DRIVE,
             navLabelExclude = navLabelExclude,
             navUpcomingRoads = navUpcomingRoads,
+            onNavRoadLatin = { vm.onNavRoadLatin(it) },
             // Follow yields to a manual pan AND to step preview: the per-frame follow ticker used
             // to keep re-pointing the camera at the puck while a banner swipe was trying to fly to
             // the previewed turn - the two fought at 60 fps (user 2026-07-14). The puck itself
@@ -1121,9 +1122,16 @@ fun MapScreen(
             val shownIdx = (state.previewStepIndex ?: liveStep).coerceIn(0, mans?.lastIndex ?: 0)
             val shown = mans?.getOrNull(shownIdx)
             val next = mans?.getOrNull(shownIdx + 1)
+            // Show the real romanized road name where the basemap gave us one (issue #184): swap the
+            // local-script name in the instruction for its Latin form. No ICU fallback here - a name we
+            // have no real romanization for keeps its local script (a skeleton on a sign reads broken).
+            val navUiLang = app.vela.ui.AppLocale.effective().language
+            fun navRomanize(s: String): String =
+                if (s.isEmpty() || state.roadNameLatin.isEmpty()) s
+                else app.vela.core.voice.SpokenScript.forDisplay(s, navUiLang, state.roadNameLatin)
             ManeuverBanner(
                 offRoute = state.nav.offRoute,
-                text = if (previewing) (shown?.instruction.orEmpty()) else state.maneuverText,
+                text = navRomanize(if (previewing) (shown?.instruction.orEmpty()) else state.maneuverText),
                 // The headline distance is the APPROACH to the shown maneuver. A maneuver's own
                 // distanceMeters is the travel AFTER it (Route.kt convention) — showing it here
                 // put the leg-after on the previewed step's headline ("3.1 mi — Turn right onto
@@ -1138,7 +1146,7 @@ fun MapScreen(
                 ref = shown?.ref,
                 laneHint = shown?.laneHint,
                 lanes = shown?.lanes.orEmpty(),
-                nextText = next?.instruction,
+                nextText = next?.instruction?.let { navRomanize(it) },
                 nextType = next?.type,
                 nextRef = next?.ref,
                 // The road being driven = the one entered by the LIVE maneuver last passed
@@ -1558,6 +1566,8 @@ fun MapScreen(
                 currentStep = if (state.navigating) state.nav.stepIndex else null,
                 onStep = vm::previewStep,
                 onClose = vm::closeSteps,
+                roadLatin = state.roadNameLatin,
+                uiLang = app.vela.ui.AppLocale.effective().language,
                 // Arrive-row destination lines: the live nav state while navigating; pre-nav (the
                 // Steps preview from the directions panel) the selected place, unless the trip is
                 // reversed (the destination is you, so a place line would be wrong).

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -336,6 +336,22 @@ class MapViewModel @Inject constructor(
     private var limitJob: Job? = null // single-flight the off-thread maxspeed snap
     private val noticePrefs = appContext.getSharedPreferences("vela_notices", Context.MODE_PRIVATE)
 
+    // Romanized road names from any downloaded routing regions' sidecars (issue #184): the BASE for
+    // roadNameLatin so OFFLINE turn-by-turn says/shows real street names (there are no map tiles to
+    // read name:latin from offline). The online tile path merges on top of this; nav-end resets to it.
+    @Volatile private var offlineRoadNames: Map<String, String> = emptyMap()
+
+    /** (Re)load the downloaded regions' romanized road-name sidecars and push them to the voice + state
+     *  as the roadNameLatin base. Call off the main thread (reads/gunzips the region files). */
+    private suspend fun refreshOfflineRoadNames() {
+        val loaded = withContext(Dispatchers.IO) { routingGraphStore.roadNames() }
+        offlineRoadNames = loaded
+        if (loaded.isNotEmpty()) {
+            voice.roadNameLatin = loaded
+            _state.update { if (it.roadNameLatin.isEmpty()) it.copy(roadNameLatin = loaded) else it }
+        }
+    }
+
     init {
         loadAmbientCacheFromDisk() // ambient LRU survives restarts (paint-then-refine)
         // Privacy toggle (Settings -> Data & privacy): periodic in-drive traffic re-checks send
@@ -352,6 +368,7 @@ class MapViewModel @Inject constructor(
         // trip answers "what did it say", "was it actually dropping frames" and "what did the
         // drive cost" by itself.
         voice.onSpoken = { tripStore.note("S", it) }
+        viewModelScope.launch { refreshOfflineRoadNames() } // offline romanized road names (issue #184)
         viewModelScope.launch {
             var beat = 0
             while (true) {
@@ -3579,10 +3596,12 @@ class MapViewModel @Inject constructor(
                 // drive used to leave the blue line drawn on the bare map (user 2026-07-14).
                 activeRoute = null, routes = emptyList(), directionsOpen = false,
                 directionsWaypoints = emptyList(), flockOnRoute = emptyList(),
-                roadNameLatin = emptyMap(), // next drive re-resolves from its own tiles (issue #184)
+                // Reset to the OFFLINE base (not empty): the next drive re-resolves from its own tiles ON
+                // TOP of the downloaded regions' names, so an offline drive still speaks real names (issue #184).
+                roadNameLatin = offlineRoadNames,
             )
         }
-        voice.roadNameLatin = emptyMap()
+        voice.roadNameLatin = offlineRoadNames
     }
 
     /** Reset the speed-limit badge + its throttle state (shared by nav-stop and replay-teardown so the
@@ -5135,7 +5154,7 @@ class MapViewModel @Inject constructor(
                 it.copy(routingDownloadingId = null, routingInstalledIds = routingGraphStore.installedIds())
             }
             showStatus(if (ok) appContext.getString(R.string.mapvm_offline_routing_ready, region.name) else appContext.getString(R.string.mapvm_offline_routing_failed))
-            if (ok) downloadPoiPack(region)
+            if (ok) { refreshOfflineRoadNames(); downloadPoiPack(region) } // pick up the new region's romanized road names (issue #184)
             else _state.update { it.copy(regionDownloadName = null) }
         }
     }
@@ -5193,6 +5212,7 @@ class MapViewModel @Inject constructor(
         _state.update {
             it.copy(routingInstalledIds = routingGraphStore.installedIds(), poiPackInstalledIds = poiPackStore.installedIds())
         }
+        viewModelScope.launch { refreshOfflineRoadNames() } // drop the removed region's road names (issue #184)
         showStatus(appContext.getString(R.string.mapvm_offline_routing_removed))
     }
 

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -203,6 +203,9 @@ data class MapUiState(
     val demoDriving: Boolean = false,          // replaying is a Settings→demo synthetic drive (not a recorded trip) — nav chrome only, no "Stop replay" pill
     val arrived: Boolean = false,
     val nav: NavState = NavState(),
+    // Foreign road name -> its basemap Latin name (issue #184), grown from map tiles as the drive
+    // proceeds; the banner/steps show the real romanized name where we have one. Empty otherwise.
+    val roadNameLatin: Map<String, String> = emptyMap(),
     val maneuverText: String = "",
     val fasterRoute: Route? = null,
     val fasterSavingSeconds: Double = 0.0,
@@ -3576,8 +3579,10 @@ class MapViewModel @Inject constructor(
                 // drive used to leave the blue line drawn on the bare map (user 2026-07-14).
                 activeRoute = null, routes = emptyList(), directionsOpen = false,
                 directionsWaypoints = emptyList(), flockOnRoute = emptyList(),
+                roadNameLatin = emptyMap(), // next drive re-resolves from its own tiles (issue #184)
             )
         }
+        voice.roadNameLatin = emptyMap()
     }
 
     /** Reset the speed-limit badge + its throttle state (shared by nav-stop and replay-teardown so the
@@ -3611,6 +3616,19 @@ class MapViewModel @Inject constructor(
 
     /** The in-nav compass button: toggle the follow camera between heading-up and north-up. */
     fun toggleNavNorthUp() = _state.update { it.copy(navNorthUp = !it.navNorthUp) }
+
+    /** VelaMapView reports romanized road names (local -> basemap Latin) as nav tiles load (issue
+     *  #184). Merge them into state (banner/steps consult it) and hand the full map to VoiceGuide so
+     *  guidance SAYS "Rehov Herzl" instead of the ICU skeleton. Only grows during a drive;
+     *  reset on nav end. */
+    fun onNavRoadLatin(map: Map<String, String>) {
+        if (map.isEmpty()) return
+        val merged = if (_state.value.roadNameLatin.isEmpty()) map
+        else _state.value.roadNameLatin + map
+        if (merged.size == _state.value.roadNameLatin.size) return
+        voice.roadNameLatin = merged
+        _state.update { it.copy(roadNameLatin = merged) }
+    }
 
     /** Mute / unmute spoken guidance (the in-nav speaker button). Persisted. */
     fun toggleVoice() = setSpokenDirections(voice.muted)

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -308,6 +308,10 @@ fun VelaMapView(
     navDriveMode: Boolean = false, // navigating a DRIVE route -> the aggressive car-mode declutter
     navLabelExclude: List<String> = emptyList(), // roads already DRIVEN: never bubble-label the road you're ON
     navUpcomingRoads: List<String> = emptyList(), // the next turns' target roads: always bubble-labelled
+    // Foreign-name romanizing (issue #184): as nav road tiles load, report each road's local name ->
+    // its basemap name:latin, so guidance can SAY/SHOW the real romanized name instead of the ICU
+    // consonant skeleton. Accumulates across the drive; called only when the map grows.
+    onNavRoadLatin: (Map<String, String>) -> Unit = {},
     navFollowing: Boolean = true,
     navNorthUp: Boolean = false,
     // Free-drive follow (no route open): when true the camera tracks the live fix north-up and
@@ -572,6 +576,7 @@ fun VelaMapView(
     // leaves the previous filter alone; an empty CROSSER set legitimately hides the tier.
     val labelExcludeHolder = rememberUpdatedState(navLabelExclude)
     val upcomingRoadsHolder = rememberUpdatedState(navUpcomingRoads)
+    val navRoadLatinHolder = rememberUpdatedState(onNavRoadLatin)
     LaunchedEffect(navMode, routePolyline, styleRef) {
         val style = styleRef ?: return@LaunchedEffect
         if (!navMode || routePolyline.size < 2) return@LaunchedEffect
@@ -586,6 +591,9 @@ fun VelaMapView(
         // and the query carries a class filter so far fewer features are materialized at all.
         var lastQuantum = Long.MIN_VALUE
         var lastUpcoming: List<String>? = null
+        // Accumulate local-name -> basemap Latin name across the whole drive (issue #184). Grows as
+        // tiles for upcoming roads load; emitted to the VM (voice + banner) only when it gains entries.
+        val latinAcc = HashMap<String, String>()
         val classFilter = Expression.match(
             Expression.get("class"), Expression.literal(false),
             *(NAV_LABEL_MAJOR_CLASSES + NAV_LABEL_SLOW_CLASSES).map { Expression.stop(it, true) }.toTypedArray(),
@@ -614,11 +622,16 @@ fun VelaMapView(
                     if (window.size >= 2) {
                         val exclude = labelExcludeHolder.value
                         val upcoming = upcomingRoadsHolder.value
+                        val latinBefore = latinAcc.size
                         val crossers = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
                             val out = LinkedHashSet<String>()
                             for (f in feats) {
                                 val name = runCatching { f.getStringProperty("name") }.getOrNull() ?: continue
-                                if (name.isBlank() || name in out || name in exclude) continue
+                                if (name.isBlank()) continue
+                                // Record this road's romanized name once (issue #184) - all named roads,
+                                // not just crossers, so an upcoming turn target is captured when its tile loads.
+                                if (name !in latinAcc) latinAliasOf(f, name)?.let { latinAcc[name] = it }
+                                if (name in out || name in exclude) continue
                                 val geom = f.geometry() ?: continue
                                 val lines: List<List<org.maplibre.geojson.Point>> = when (geom) {
                                     is org.maplibre.geojson.LineString -> listOf(geom.coordinates())
@@ -645,6 +658,8 @@ fun VelaMapView(
                                     ?.setFilter(navLabelFilter(NAV_LABEL_SLOW_CLASSES, exclude, names))
                             }
                         }
+                        // Push any newly-resolved romanized names up to the VM (voice + banner).
+                        if (latinAcc.size != latinBefore) navRoadLatinHolder.value(HashMap(latinAcc))
                         // Mark the quantum done only after a usable pass, so an early empty
                         // query (tiles still loading) retries on the next tick.
                         lastQuantum = quantum
@@ -3411,6 +3426,23 @@ private fun crossesWindow(line: List<Pair<Double, Double>>, window: List<LatLng>
         }
     }
     return false
+}
+
+/** The basemap's romanized alias for a road [name] (issue #184): its name:en (a real English name),
+ *  else name:latin (which OpenMapTiles fills from name:en where OSM has one, otherwise a
+ *  transliteration). Returned only when it is a genuinely Latin-script string that differs from the
+ *  local name, so we never store another non-Latin alias as if it were romanized. */
+private fun latinAliasOf(f: org.maplibre.geojson.Feature, name: String): String? {
+    for (key in arrayOf("name:en", "name:latin")) {
+        val v = runCatching { f.getStringProperty(key) }.getOrNull()
+        if (v.isNullOrBlank() || v == name) continue
+        val hasLatinLetter = v.any { it in 'a'..'z' || it in 'A'..'Z' }
+        val noForeignLetter = v.none {
+            Character.isLetter(it) && Character.UnicodeScript.of(it.code) != Character.UnicodeScript.LATIN
+        }
+        if (hasLatinLetter && noForeignLetter) return v
+    }
+    return null
 }
 
 private fun ensureNavRoadLabels(style: Style, on: Boolean, dark: Boolean, density: Float, exclude: List<String>) {

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -3461,10 +3461,30 @@ private fun latinAliasOf(f: org.maplibre.geojson.Feature, name: String): String?
     return null
 }
 
+// UI languages whose own script is NOT Latin - a user reading in one of these keeps map labels in the
+// local script (a Hebrew UI shows Hebrew street names); everyone else gets the romanized name (issue
+// #184: an English user in Israel wants "Sderot ..." on the map bubbles, not Hebrew). Mirrors the
+// voice/banner rule (SpokenScript).
+private val NON_LATIN_UI_LANGS =
+    setOf("he", "iw", "ar", "fa", "ur", "ru", "uk", "bg", "sr", "mk", "el", "zh", "ja", "ko", "th", "hi")
+
+private fun uiWantsLatinLabels(): Boolean =
+    app.vela.ui.AppLocale.effective().language.lowercase() !in NON_LATIN_UI_LANGS
+
+/** The textField expression for a road-name label: the real Latin name (name:en, else the basemap's
+ *  name:latin) for a Latin-script UI, falling back to the local `name`; the plain local `name` for a
+ *  user who reads a non-Latin script. Same name:latin data the nav voice/banner use. */
+private fun roadLabelTextField(): Expression =
+    if (uiWantsLatinLabels()) {
+        Expression.coalesce(Expression.get("name:en"), Expression.get("name:latin"), Expression.get("name"))
+    } else {
+        Expression.get("name")
+    }
+
 private fun ensureNavRoadLabels(style: Style, on: Boolean, dark: Boolean, density: Float, exclude: List<String>) {
     // Cheap self-gate so callers can invoke per recomposition (audit-3e rule: no per-frame JNI
     // probes) - a change in theme, nav state or the route's own road list re-runs it.
-    val key = listOf(on, dark, exclude)
+    val key = listOf(on, dark, exclude, uiWantsLatinLabels())
     if (key == lastNavLabelKey) return
     lastNavLabelKey = key
     val ids = listOf(NAV_ROADLABEL_LAYER, NAV_ROADLABEL_MINOR_LAYER)
@@ -3505,7 +3525,7 @@ private fun ensureNavRoadLabels(style: Style, on: Boolean, dark: Boolean, densit
                 SymbolLayer(id, "openmaptiles").withSourceLayer("transportation_name")
                     .withFilter(filter)
                     .withProperties(
-                        PropertyFactory.textField(Expression.get("name")),
+                        PropertyFactory.textField(roadLabelTextField()),
                         PropertyFactory.textFont(arrayOf("Noto Sans Regular")),
                         PropertyFactory.textSize(12.5f),
                         PropertyFactory.symbolPlacement(Property.SYMBOL_PLACEMENT_LINE_CENTER),
@@ -3883,6 +3903,7 @@ internal fun applyLight(style: Style) {
     // and the BOLD font stack - Google boldens street names on the map (user 2026-07-11).
     listOf("highway-name-path", "highway-name-minor", "highway-name-major").forEach {
         style.getLayer(it)?.setProperties(
+            PropertyFactory.textField(roadLabelTextField()), // romanize for a Latin-script UI (issue #184)
             PropertyFactory.textFont(arrayOf("Noto Sans Bold")),
             PropertyFactory.textHaloColor("#ffffff"),
             PropertyFactory.textHaloWidth(1.9f),
@@ -4055,7 +4076,10 @@ internal fun applyDark(style: Style) {
     // Street names in BOLD (Google boldens them; user 2026-07-11) - a dedicated pass AFTER the
     // blanket loop so only the road-name layers get the Bold stack, not every label.
     listOf("highway-name-path", "highway-name-minor", "highway-name-major").forEach {
-        style.getLayer(it)?.setProperties(PropertyFactory.textFont(arrayOf("Noto Sans Bold")))
+        style.getLayer(it)?.setProperties(
+            PropertyFactory.textField(roadLabelTextField()), // romanize for a Latin-script UI (issue #184)
+            PropertyFactory.textFont(arrayOf("Noto Sans Bold")),
+        )
     }
     // Drop the wetland fern-hatch + pedestrian-plaza patterns (flat, like Google dark).
     style.getLayer("vela-wetland")?.setProperties(PropertyFactory.fillColor("#0d3847"), PropertyFactory.fillOpacity(0.9f))
@@ -4087,6 +4111,7 @@ internal fun applyDark(style: Style) {
 internal fun applyClassicLight(style: Style) {
     listOf("highway-name-path", "highway-name-minor", "highway-name-major").forEach {
         style.getLayer(it)?.setProperties(
+            PropertyFactory.textField(roadLabelTextField()), // romanize for a Latin-script UI (issue #184)
             PropertyFactory.textFont(arrayOf("Noto Sans Bold")),
             PropertyFactory.textHaloColor("#ffffff"),
             PropertyFactory.textHaloWidth(1.9f),
@@ -4211,7 +4236,10 @@ internal fun applyClassicDark(style: Style) {
     }
     // Street names bold, same rule as every other palette pass.
     listOf("highway-name-path", "highway-name-minor", "highway-name-major").forEach {
-        style.getLayer(it)?.setProperties(PropertyFactory.textFont(arrayOf("Noto Sans Bold")))
+        style.getLayer(it)?.setProperties(
+            PropertyFactory.textField(roadLabelTextField()), // romanize for a Latin-script UI (issue #184)
+            PropertyFactory.textFont(arrayOf("Noto Sans Bold")),
+        )
     }
     style.getLayer("vela-wetland")?.setProperties(PropertyFactory.fillColor("#26403c"), PropertyFactory.fillOpacity(0.9f))
     style.getLayer("vela-plaza")?.setProperties(PropertyFactory.fillColor("#31363f"))

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -598,72 +598,88 @@ fun VelaMapView(
             Expression.get("class"), Expression.literal(false),
             *(NAV_LABEL_MAJOR_CLASSES + NAV_LABEL_SLOW_CLASSES).map { Expression.stop(it, true) }.toTypedArray(),
         )
+        // While the romanized-name dict is still GROWING (an area's higher-zoom tiles loading in), we
+        // re-query every 2 s tick; once it settles (STALE_TICKS with no new name) we stop until the
+        // next quantum. This resolves a local road's real name within a couple seconds of its
+        // nav-zoom tile loading instead of waiting a full 400 m - the route-overview tile that is
+        // loaded when a drive STARTS carries only major road names, so the first turn onto a minor
+        // road would otherwise speak the ICU skeleton (issue #184). The expensive crossing geometry
+        // stays per-quantum, so this never puts a heavy pass on the every-frame path.
+        var dictStaleTicks = 0
         while (true) {
             val quantum = (navPuck.progressM / 400.0).toLong()
             val upcomingNow = upcomingRoadsHolder.value
-            if (quantum == lastQuantum && upcomingNow == lastUpcoming) {
-                kotlinx.coroutines.delay(2_000)
-                continue
-            }
-            val src = style.getSource("openmaptiles") as? VectorSource
-            if (src != null) {
-                val feats = runCatching {
+            val quantumChanged = quantum != lastQuantum || upcomingNow != lastUpcoming
+            if (quantumChanged) dictStaleTicks = 0 // new area: re-warm the dict as its tiles land
+            if (quantumChanged || dictStaleTicks < 3) {
+                val src = style.getSource("openmaptiles") as? VectorSource
+                val feats = if (src != null) runCatching {
                     src.querySourceFeatures(arrayOf("transportation_name"), classFilter)
-                }.getOrNull().orEmpty()
+                }.getOrNull().orEmpty() else emptyList()
                 if (feats.isNotEmpty()) {
-                    // Window of route geometry around the current QUANTUM (not the live puck, so
-                    // the include set is byte-stable between quanta): a little behind, ~2 km ahead.
-                    val fromM = quantum * 400.0 - 200.0
-                    val toM = quantum * 400.0 + 2200.0
-                    val window = ArrayList<LatLng>()
-                    for (k in routePolyline.indices) {
-                        if (routeCum[k] in fromM..toM) window.add(routePolyline[k])
+                    // DICT (cheap: two string props per feature): capture each named road's romanized
+                    // alias once. Runs every qualifying tick so names resolve as tiles load.
+                    val latinBefore = latinAcc.size
+                    for (f in feats) {
+                        val name = runCatching { f.getStringProperty("name") }.getOrNull() ?: continue
+                        if (name.isBlank() || name in latinAcc) continue
+                        latinAliasOf(f, name)?.let { latinAcc[name] = it }
                     }
-                    if (window.size >= 2) {
-                        val exclude = labelExcludeHolder.value
-                        val upcoming = upcomingRoadsHolder.value
-                        val latinBefore = latinAcc.size
-                        val crossers = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
-                            val out = LinkedHashSet<String>()
-                            for (f in feats) {
-                                val name = runCatching { f.getStringProperty("name") }.getOrNull() ?: continue
-                                if (name.isBlank()) continue
-                                // Record this road's romanized name once (issue #184) - all named roads,
-                                // not just crossers, so an upcoming turn target is captured when its tile loads.
-                                if (name !in latinAcc) latinAliasOf(f, name)?.let { latinAcc[name] = it }
-                                if (name in out || name in exclude) continue
-                                val geom = f.geometry() ?: continue
-                                val lines: List<List<org.maplibre.geojson.Point>> = when (geom) {
-                                    is org.maplibre.geojson.LineString -> listOf(geom.coordinates())
-                                    is org.maplibre.geojson.MultiLineString -> geom.coordinates()
-                                    else -> emptyList()
-                                }
-                                val hit = lines.any { pts ->
-                                    crossesWindow(pts.map { it.longitude() to it.latitude() }, window)
-                                }
-                                if (hit) { out.add(name); if (out.size >= 60) break }
-                            }
-                            out.toList()
+                    if (latinAcc.size != latinBefore) {
+                        navRoadLatinHolder.value(HashMap(latinAcc))
+                        dictStaleTicks = 0
+                    } else {
+                        dictStaleTicks++
+                    }
+                    // LABEL crossing + setFilter (the expensive geometry pass): only per quantum.
+                    if (quantumChanged) {
+                        // Window of route geometry around the current QUANTUM (not the live puck, so
+                        // the include set is byte-stable between quanta): a little behind, ~2 km ahead.
+                        val fromM = quantum * 400.0 - 200.0
+                        val toM = quantum * 400.0 + 2200.0
+                        val window = ArrayList<LatLng>()
+                        for (k in routePolyline.indices) {
+                            if (routeCum[k] in fromM..toM) window.add(routePolyline[k])
                         }
-                        // The next turns' target roads always get their bubble: a turn target
-                        // meets the route at a shared vertex, which the proper-crossing test
-                        // can miss (T-junctions especially).
-                        val names = (upcoming + crossers).filter { it !in exclude }.distinct()
-                        if (names != lastApplied) {
-                            lastApplied = names
-                            runCatching {
-                                (style.getLayer(NAV_ROADLABEL_LAYER) as? SymbolLayer)
-                                    ?.setFilter(navLabelFilter(NAV_LABEL_MAJOR_CLASSES, exclude, names))
-                                (style.getLayer(NAV_ROADLABEL_MINOR_LAYER) as? SymbolLayer)
-                                    ?.setFilter(navLabelFilter(NAV_LABEL_SLOW_CLASSES, exclude, names))
+                        if (window.size >= 2) {
+                            val exclude = labelExcludeHolder.value
+                            val upcoming = upcomingRoadsHolder.value
+                            val crossers = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
+                                val out = LinkedHashSet<String>()
+                                for (f in feats) {
+                                    val name = runCatching { f.getStringProperty("name") }.getOrNull() ?: continue
+                                    if (name.isBlank() || name in out || name in exclude) continue
+                                    val geom = f.geometry() ?: continue
+                                    val lines: List<List<org.maplibre.geojson.Point>> = when (geom) {
+                                        is org.maplibre.geojson.LineString -> listOf(geom.coordinates())
+                                        is org.maplibre.geojson.MultiLineString -> geom.coordinates()
+                                        else -> emptyList()
+                                    }
+                                    val hit = lines.any { pts ->
+                                        crossesWindow(pts.map { it.longitude() to it.latitude() }, window)
+                                    }
+                                    if (hit) { out.add(name); if (out.size >= 60) break }
+                                }
+                                out.toList()
                             }
+                            // The next turns' target roads always get their bubble: a turn target
+                            // meets the route at a shared vertex, which the proper-crossing test
+                            // can miss (T-junctions especially).
+                            val names = (upcoming + crossers).filter { it !in exclude }.distinct()
+                            if (names != lastApplied) {
+                                lastApplied = names
+                                runCatching {
+                                    (style.getLayer(NAV_ROADLABEL_LAYER) as? SymbolLayer)
+                                        ?.setFilter(navLabelFilter(NAV_LABEL_MAJOR_CLASSES, exclude, names))
+                                    (style.getLayer(NAV_ROADLABEL_MINOR_LAYER) as? SymbolLayer)
+                                        ?.setFilter(navLabelFilter(NAV_LABEL_SLOW_CLASSES, exclude, names))
+                                }
+                            }
+                            // Mark the quantum done only after a usable pass, so an early empty
+                            // query (tiles still loading) retries on the next tick.
+                            lastQuantum = quantum
+                            lastUpcoming = upcomingNow
                         }
-                        // Push any newly-resolved romanized names up to the VM (voice + banner).
-                        if (latinAcc.size != latinBefore) navRoadLatinHolder.value(HashMap(latinAcc))
-                        // Mark the quantum done only after a usable pass, so an early empty
-                        // query (tiles still loading) retries on the next tick.
-                        lastQuantum = quantum
-                        lastUpcoming = upcomingNow
                     }
                 }
             }

--- a/app/src/main/java/app/vela/ui/nav/StepsSheet.kt
+++ b/app/src/main/java/app/vela/ui/nav/StepsSheet.kt
@@ -106,8 +106,15 @@ fun StepsSheet(
     // routing can have only a street, an address, or nothing but the tapped coordinates).
     destName: String? = null,
     destAddress: String? = null,
+    // Real romanized road names (local -> basemap Latin) + the UI language, so foreign street names
+    // in the step list show in Latin where we have a real romanization (issue #184). Empty = unchanged.
+    roadLatin: Map<String, String> = emptyMap(),
+    uiLang: String = "",
     modifier: Modifier = Modifier,
 ) {
+    fun romanize(s: String): String =
+        if (s.isEmpty() || roadLatin.isEmpty()) s
+        else app.vela.core.voice.SpokenScript.forDisplay(s, uiLang, roadLatin)
     val dark = isAppInDarkTheme()
     val ink = SheetPalette.ink(dark)
     val dim = SheetPalette.dim(dark)
@@ -236,7 +243,7 @@ fun StepsSheet(
                         Column(Modifier.weight(1f)) {
                             val continueLabel = stringResource(R.string.steps_continue)
                             Text(
-                                m.instruction.ifEmpty { continueLabel },
+                                m.instruction.ifEmpty { continueLabel }.let { romanize(it) },
                                 style = MaterialTheme.typography.bodyLarge,
                                 fontWeight = if (active) FontWeight.Bold else FontWeight.Normal,
                                 color = ink,
@@ -266,7 +273,7 @@ fun StepsSheet(
                             // there's no name/address at all (it's then the only locator we have).
                             if (m.type != ManeuverType.ARRIVE || (destName.isNullOrBlank() && destAddress.isNullOrBlank())) {
                                 m.road?.let {
-                                    Text(it, style = MaterialTheme.typography.bodySmall, color = dim)
+                                    Text(romanize(it), style = MaterialTheme.typography.bodySmall, color = dim)
                                 }
                             }
                             if (m.lanes.isNotEmpty()) {

--- a/core/src/main/java/app/vela/core/nav/NavSession.kt
+++ b/core/src/main/java/app/vela/core/nav/NavSession.kt
@@ -198,7 +198,10 @@ class NavSession @Inject constructor(
             destinationAddress = destinationAddress,
             tripDistanceMeters = route.distanceMeters,
         )
-        voice.speak(app.vela.core.i18n.NavStringsRegistry.current().startNav(first))
+        // speakOpener (not speak): briefly hold the opener until the first road's real romanized name
+        // has loaded from the map tiles, so a foreign street isn't read as an ICU skeleton at T=0 while
+        // the nav-zoom tiles are still loading (issue #184). Falls through to speaking after a short cap.
+        voice.speakOpener(app.vela.core.i18n.NavStringsRegistry.current().startNav(first))
         diag.record(
             "nav",
             "start → ${destinationLabel.ifBlank { "destination" }} " +

--- a/core/src/main/java/app/vela/core/voice/SpokenScript.kt
+++ b/core/src/main/java/app/vela/core/voice/SpokenScript.kt
@@ -60,6 +60,41 @@ object SpokenScript {
         }
     }
 
+    /** Romanize for speech using REAL romanized names from [dict] (local name -> Latin, e.g. the
+     *  basemap's name:latin) where we have them, then ICU for any foreign run still left. The dict
+     *  wins because it carries proper vowels ("Rehov Herzl") where rule-based ICU only has the
+     *  consonant skeleton ("rhwb hrzl"). */
+    fun forVoice(text: String, voiceLang: String?, dict: Map<String, String>): String =
+        forVoice(applyDict(text, voiceLang, dict), voiceLang)
+
+    /** Testable core of the dict path: the ICU fallback is injected as [romanize] (android.icu is
+     *  JVM-stubbed in unit tests), so the dict-then-ICU precedence can be asserted. */
+    internal fun forVoice(text: String, voiceLang: String?, dict: Map<String, String>, romanize: (String) -> String): String =
+        forVoice(applyDict(text, voiceLang, dict), voiceLang, romanize)
+
+    /** DISPLAY romanization for the banner/steps: swap known local names for their real Latin form
+     *  from [dict], but NEVER fall back to ICU - a vowel-less skeleton on a street sign reads as
+     *  broken (why display romanization was reverted before), so a name with no real romanization
+     *  keeps its local script, which is what the actual sign shows. */
+    fun forDisplay(text: String, uiLang: String?, dict: Map<String, String>): String =
+        applyDict(text, uiLang, dict)
+
+    /** Replace each local name in [text] with its [dict] Latin form, but only names in a script that
+     *  [lang] can't read (so a Hebrew UI/voice keeps Hebrew). Longest names first so an overlapping
+     *  shorter name can't pre-empt a longer one. */
+    private fun applyDict(text: String, lang: String?, dict: Map<String, String>): String {
+        if (dict.isEmpty()) return text
+        val code = lang?.lowercase()?.substringBefore('-')?.substringBefore('_')
+        val voiceScript = VOICE_SCRIPT[code] ?: Character.UnicodeScript.LATIN
+        var s = text
+        for ((local, latin) in dict.entries.sortedByDescending { it.key.length }) {
+            if (local.isBlank() || latin.isBlank() || local == latin) continue
+            if (local.none { needsRomanizing(it, voiceScript) }) continue // reads this script itself
+            if (s.contains(local)) s = s.replace(local, latin)
+        }
+        return s
+    }
+
     /** Testable core: the ICU call is injected as [romanize] so the run-splitting, voice gating and
      *  CJK/Latin preservation can be unit-tested on the JVM (android.icu is unavailable there). */
     internal fun forVoice(text: String, voiceLang: String?, romanize: (String) -> String): String {

--- a/core/src/main/java/app/vela/core/voice/SpokenScript.kt
+++ b/core/src/main/java/app/vela/core/voice/SpokenScript.kt
@@ -10,24 +10,40 @@ import android.icu.text.Transliterator
  * from the map in its local script (Hebrew "רחוב הרצל"). A single-language Piper/English voice has no
  * phonemes for those glyphs, so it drops the name entirely, exactly the words the driver needs.
  *
- * This transliterates only the FOREIGN-letter runs to Latin (ICU "Any-Latin; Latin-ASCII"), leaving
- * existing Latin text, its accents, digits and punctuation untouched, so a French "Rue de Rivoli" or
- * an English "5th Ave" is never mangled. It runs on the spoken string ONLY; the on-screen banner
- * keeps the real local-script name (that is what matches the street sign).
+ * This transliterates only the runs a given voice CAN'T pronounce to Latin (ICU
+ * "Any-Latin; Latin-ASCII"), leaving existing Latin text, its accents, digits and punctuation
+ * untouched, so a French "Rue de Rivoli" or an English "5th Ave" is never mangled. It runs on the
+ * spoken string ONLY; the on-screen banner keeps the real local-script name (that is what matches
+ * the street sign).
  *
- * Scope: applied only when the speaking voice is Latin-script (a Hebrew/Russian/Greek voice
- * pronounces its own script natively, so it is skipped). CJK ideographs and kana are deliberately
- * NOT romanized: ICU reads Han as Chinese pinyin ("明治通り" becomes "ming zhitongri", not
- * "Meiji-dori"), a confidently-wrong reading. Those are left to the native CJK voices Vela ships;
- * a proper kanji->romaji step is a possible follow-up.
+ * Scope: Latin is the universal fallback the way Google romanizes foreign signs for EVERY user, not
+ * just Latin-script ones (user 2026-07-19: a Chinese driver in Israel would rather hear the streets
+ * in Latin letters than have the Hebrew dropped). So a run is romanized whenever it is in a script
+ * the SPEAKING voice can't read: a Hebrew run is romanized for an English, Russian or Chinese voice
+ * alike; a Russian voice keeps Cyrillic (its own script) but still romanizes Hebrew. Only the voice's
+ * OWN script is left in place. CJK ideographs and kana are the one exception, NEVER romanized for any
+ * voice: ICU reads Han as Chinese pinyin ("明治通り" becomes "ming zhitongri", not "Meiji-dori"), a
+ * confidently-wrong reading, so kanji/kana are left to the native CJK voices Vela ships.
  */
 object SpokenScript {
 
-    /** Voice languages whose own script is NOT Latin: they read their native script directly, so we
-     *  never romanize for them. (Anything not here is treated as Latin-script and triggers romanizing
-     *  of foreign runs.) Legacy "iw" kept alongside "he" for Hebrew, same as the status tables. */
-    private val NON_LATIN_VOICE_LANGS =
-        setOf("he", "iw", "ar", "fa", "ur", "ru", "uk", "bg", "sr", "mk", "el", "zh", "ja", "ko", "th", "hi")
+    /** A voice language's own script (the one it pronounces natively, so we never romanize it). Any
+     *  language not listed reads Latin, which is also the fallback ICU romanizes everything else into.
+     *  Legacy "iw" kept alongside "he" for Hebrew, same as the status tables. */
+    private val VOICE_SCRIPT: Map<String, Character.UnicodeScript> = mapOf(
+        "he" to Character.UnicodeScript.HEBREW, "iw" to Character.UnicodeScript.HEBREW,
+        "ar" to Character.UnicodeScript.ARABIC, "fa" to Character.UnicodeScript.ARABIC,
+        "ur" to Character.UnicodeScript.ARABIC,
+        "ru" to Character.UnicodeScript.CYRILLIC, "uk" to Character.UnicodeScript.CYRILLIC,
+        "bg" to Character.UnicodeScript.CYRILLIC, "sr" to Character.UnicodeScript.CYRILLIC,
+        "mk" to Character.UnicodeScript.CYRILLIC,
+        "el" to Character.UnicodeScript.GREEK,
+        "th" to Character.UnicodeScript.THAI,
+        "hi" to Character.UnicodeScript.DEVANAGARI,
+        "ko" to Character.UnicodeScript.HANGUL,
+        // zh/ja read Han (kana is always left alone below), so their own script is HAN.
+        "zh" to Character.UnicodeScript.HAN, "ja" to Character.UnicodeScript.HAN,
+    )
 
     // Transliterator instances are not thread-safe; nav prompts fire ~once per maneuver on the main
     // thread, so a lazily-built, synchronized single instance is plenty (and avoids per-call setup).
@@ -35,8 +51,8 @@ object SpokenScript {
         runCatching { Transliterator.getInstance("Any-Latin; Latin-ASCII") }.getOrNull()
     }
 
-    /** Romanize foreign-script runs of [text] iff [voiceLang] is a Latin-script voice. No-op (returns
-     *  [text] unchanged) for a non-Latin voice, an all-Latin string, or if ICU is unavailable. */
+    /** Romanize the runs of [text] that the [voiceLang] voice can't pronounce. No-op (returns [text]
+     *  unchanged) when every run is in the voice's own script or Latin, or if ICU is unavailable. */
     fun forVoice(text: String, voiceLang: String?): String {
         val tl = latinizer ?: return text
         return forVoice(text, voiceLang) { run ->
@@ -48,16 +64,16 @@ object SpokenScript {
      *  CJK/Latin preservation can be unit-tested on the JVM (android.icu is unavailable there). */
     internal fun forVoice(text: String, voiceLang: String?, romanize: (String) -> String): String {
         val lang = voiceLang?.lowercase()?.substringBefore('-')?.substringBefore('_')
-        if (lang != null && lang in NON_LATIN_VOICE_LANGS) return text
-        if (text.none { needsRomanizing(it) }) return text
+        val voiceScript = VOICE_SCRIPT[lang] ?: Character.UnicodeScript.LATIN
+        if (text.none { needsRomanizing(it, voiceScript) }) return text
 
         val out = StringBuilder(text.length)
         var i = 0
         val n = text.length
         while (i < n) {
-            if (needsRomanizing(text[i])) {
+            if (needsRomanizing(text[i], voiceScript)) {
                 val start = i
-                while (i < n && needsRomanizing(text[i])) i++
+                while (i < n && needsRomanizing(text[i], voiceScript)) i++
                 out.append(romanize(text.substring(start, i)))
             } else {
                 out.append(text[i])
@@ -67,11 +83,14 @@ object SpokenScript {
         return out.toString()
     }
 
-    /** A character that a Latin voice can't pronounce and ICU can romanize well: a letter whose script
-     *  is neither Latin nor a CJK ideograph/kana (those ICU mis-reads, see the class note). */
-    private fun needsRomanizing(c: Char): Boolean {
+    /** A letter the [voiceScript] voice can't pronounce and ICU can romanize well: its script is
+     *  neither the voice's own, nor Latin, nor a CJK ideograph/kana (those ICU mis-reads as pinyin,
+     *  so they are left to a native CJK voice regardless of who is speaking; see the class note). */
+    private fun needsRomanizing(c: Char, voiceScript: Character.UnicodeScript): Boolean {
         if (!Character.isLetter(c)) return false
-        return when (Character.UnicodeScript.of(c.code)) {
+        val script = Character.UnicodeScript.of(c.code)
+        if (script == voiceScript) return false // the voice reads its own script natively
+        return when (script) {
             Character.UnicodeScript.LATIN,
             Character.UnicodeScript.COMMON,
             Character.UnicodeScript.INHERITED,

--- a/core/src/main/java/app/vela/core/voice/SpokenScript.kt
+++ b/core/src/main/java/app/vela/core/voice/SpokenScript.kt
@@ -1,0 +1,85 @@
+package app.vela.core.voice
+
+import android.icu.text.Transliterator
+
+/**
+ * Romanize foreign-script names in a SPOKEN nav string so a Latin-script voice can actually say
+ * them, the way Google reads "Turn onto Rehov Herzl" for an English driver in Israel (issue #184).
+ *
+ * The problem: nav guidance is generated in the app language (say English), but the road NAME comes
+ * from the map in its local script (Hebrew "רחוב הרצל"). A single-language Piper/English voice has no
+ * phonemes for those glyphs, so it drops the name entirely, exactly the words the driver needs.
+ *
+ * This transliterates only the FOREIGN-letter runs to Latin (ICU "Any-Latin; Latin-ASCII"), leaving
+ * existing Latin text, its accents, digits and punctuation untouched, so a French "Rue de Rivoli" or
+ * an English "5th Ave" is never mangled. It runs on the spoken string ONLY; the on-screen banner
+ * keeps the real local-script name (that is what matches the street sign).
+ *
+ * Scope: applied only when the speaking voice is Latin-script (a Hebrew/Russian/Greek voice
+ * pronounces its own script natively, so it is skipped). CJK ideographs and kana are deliberately
+ * NOT romanized: ICU reads Han as Chinese pinyin ("明治通り" becomes "ming zhitongri", not
+ * "Meiji-dori"), a confidently-wrong reading. Those are left to the native CJK voices Vela ships;
+ * a proper kanji->romaji step is a possible follow-up.
+ */
+object SpokenScript {
+
+    /** Voice languages whose own script is NOT Latin: they read their native script directly, so we
+     *  never romanize for them. (Anything not here is treated as Latin-script and triggers romanizing
+     *  of foreign runs.) Legacy "iw" kept alongside "he" for Hebrew, same as the status tables. */
+    private val NON_LATIN_VOICE_LANGS =
+        setOf("he", "iw", "ar", "fa", "ur", "ru", "uk", "bg", "sr", "mk", "el", "zh", "ja", "ko", "th", "hi")
+
+    // Transliterator instances are not thread-safe; nav prompts fire ~once per maneuver on the main
+    // thread, so a lazily-built, synchronized single instance is plenty (and avoids per-call setup).
+    private val latinizer: Transliterator? by lazy {
+        runCatching { Transliterator.getInstance("Any-Latin; Latin-ASCII") }.getOrNull()
+    }
+
+    /** Romanize foreign-script runs of [text] iff [voiceLang] is a Latin-script voice. No-op (returns
+     *  [text] unchanged) for a non-Latin voice, an all-Latin string, or if ICU is unavailable. */
+    fun forVoice(text: String, voiceLang: String?): String {
+        val tl = latinizer ?: return text
+        return forVoice(text, voiceLang) { run ->
+            synchronized(tl) { runCatching { tl.transliterate(run) }.getOrDefault(run) }
+        }
+    }
+
+    /** Testable core: the ICU call is injected as [romanize] so the run-splitting, voice gating and
+     *  CJK/Latin preservation can be unit-tested on the JVM (android.icu is unavailable there). */
+    internal fun forVoice(text: String, voiceLang: String?, romanize: (String) -> String): String {
+        val lang = voiceLang?.lowercase()?.substringBefore('-')?.substringBefore('_')
+        if (lang != null && lang in NON_LATIN_VOICE_LANGS) return text
+        if (text.none { needsRomanizing(it) }) return text
+
+        val out = StringBuilder(text.length)
+        var i = 0
+        val n = text.length
+        while (i < n) {
+            if (needsRomanizing(text[i])) {
+                val start = i
+                while (i < n && needsRomanizing(text[i])) i++
+                out.append(romanize(text.substring(start, i)))
+            } else {
+                out.append(text[i])
+                i++
+            }
+        }
+        return out.toString()
+    }
+
+    /** A character that a Latin voice can't pronounce and ICU can romanize well: a letter whose script
+     *  is neither Latin nor a CJK ideograph/kana (those ICU mis-reads, see the class note). */
+    private fun needsRomanizing(c: Char): Boolean {
+        if (!Character.isLetter(c)) return false
+        return when (Character.UnicodeScript.of(c.code)) {
+            Character.UnicodeScript.LATIN,
+            Character.UnicodeScript.COMMON,
+            Character.UnicodeScript.INHERITED,
+            Character.UnicodeScript.HAN,
+            Character.UnicodeScript.HIRAGANA,
+            Character.UnicodeScript.KATAKANA,
+            -> false
+            else -> true
+        }
+    }
+}

--- a/core/src/main/java/app/vela/core/voice/VoiceGuide.kt
+++ b/core/src/main/java/app/vela/core/voice/VoiceGuide.kt
@@ -347,7 +347,9 @@ class VoiceGuide @Inject constructor(
             // utterance's own onDone is still in flight and a reset would double-count it,
             // abandoning focus while the interrupting prompt speaks.
             acquireFocus()
-            n.speak(forSpeech(text), interrupt) { releaseFocus() }
+            // Romanize any foreign-script name for this (Latin) neural voice so it isn't dropped
+            // (issue #184); the on-screen banner keeps the real local-script name.
+            n.speak(forSpeech(SpokenScript.forVoice(text, n.voiceLanguage ?: t)), interrupt) { releaseFocus() }
             return
         }
         speakViaSystem(text, interrupt, t)
@@ -381,7 +383,9 @@ class VoiceGuide @Inject constructor(
         // decrement, so just acquire for the new utterance.
         acquireFocus()
         val mode = if (interrupt) TextToSpeech.QUEUE_FLUSH else TextToSpeech.QUEUE_ADD
-        val result = engine.speak(forSpeech(text), mode, null, "vela-${text.hashCode()}")
+        // Same foreign-name romanizing as the neural path (issue #184): the system voice for [t]
+        // is Latin-script for the Latin languages, so a foreign road name would otherwise be lost.
+        val result = engine.speak(forSpeech(SpokenScript.forVoice(text, t)), mode, null, "vela-${text.hashCode()}")
         if (result == TextToSpeech.ERROR) {
             // The utterance was never enqueued, so NONE of the onDone/onStop/onError callbacks that
             // release focus will ever fire for it — roll back the acquire here or music stays ducked

--- a/core/src/main/java/app/vela/core/voice/VoiceGuide.kt
+++ b/core/src/main/java/app/vela/core/voice/VoiceGuide.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
+import android.os.SystemClock
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import androidx.core.content.getSystemService
@@ -329,6 +330,11 @@ class VoiceGuide @Inject constructor(
      *  foreign street; empty by default so nothing changes without it (issue #184). */
     @Volatile var roadNameLatin: Map<String, String> = emptyMap()
 
+    // Bumped by stop()/a new opener so a deferred nav-start opener (see speakOpener) that is still
+    // waiting for its road name to romanize gets cancelled instead of speaking into a dead session.
+    @Volatile private var openerToken = 0
+    private val OPENER_MAX_WAIT_MS = 2500L // cap the nav-start opener's wait for its romanized road name
+
     fun speak(text: String, interrupt: Boolean = false, ignoreMute: Boolean = false) {
         if (muted && !ignoreMute) return
         runCatching { onSpoken?.invoke(text) }
@@ -337,6 +343,29 @@ class VoiceGuide @Inject constructor(
             return
         }
         speakNow(text, interrupt)
+    }
+
+    /** Speak the nav-START opener ("Starting navigation. Head ... on <road>"), but hold it briefly if
+     *  its road name is still in a foreign script we have no real romanization for yet (issue #184). A
+     *  drive begins before the nav-zoom tiles load, so speaking immediately reads the ICU skeleton
+     *  ("rhwb hrzl"); waiting a beat lets [roadNameLatin] fill so the opener says the real name ("Rehov Herzl").
+     *  Retries every 200 ms up to [OPENER_MAX_WAIT_MS], then speaks whatever we have (never silent).
+     *  An all-Latin opener, or one whose road is already covered, speaks instantly. */
+    fun speakOpener(text: String) {
+        val token = ++openerToken
+        val deadline = SystemClock.elapsedRealtime() + OPENER_MAX_WAIT_MS
+        fun attempt() {
+            if (token != openerToken) return // a newer start / a stop superseded this opener
+            val covered = roadNameLatin.keys.any { it.isNotEmpty() && text.contains(it) }
+            val ready = covered || !hasForeignRun(text) || SystemClock.elapsedRealtime() >= deadline
+            if (ready) speak(text) else focusHandler.postDelayed(::attempt, 200)
+        }
+        attempt()
+    }
+
+    /** True if [text] has a letter in a script other than Latin (so an English opener never waits). */
+    private fun hasForeignRun(text: String): Boolean = text.any {
+        Character.isLetter(it) && Character.UnicodeScript.of(it.code) != Character.UnicodeScript.LATIN
     }
 
     private fun speakNow(text: String, interrupt: Boolean) {
@@ -418,6 +447,7 @@ class VoiceGuide @Inject constructor(
         app.vela.core.i18n.NavStringsRegistry.current().expandForSpeech(text)
 
     fun stop() {
+        openerToken++ // cancel any deferred nav-start opener still waiting for its road name
         tts?.stop()
         neural?.stop()
         releaseAllFocus()

--- a/core/src/main/java/app/vela/core/voice/VoiceGuide.kt
+++ b/core/src/main/java/app/vela/core/voice/VoiceGuide.kt
@@ -324,6 +324,11 @@ class VoiceGuide @Inject constructor(
      *  this so a shared drive shows what was said, verbatim, at what time. Set by `:app`. */
     var onSpoken: ((String) -> Unit)? = null
 
+    /** Real romanized road names (local name -> Latin, from the basemap's name:latin), set by `:app`
+     *  as nav tiles load. Used to speak "Rehov Herzl" instead of the ICU skeleton "rhwb hrzl" for a
+     *  foreign street; empty by default so nothing changes without it (issue #184). */
+    @Volatile var roadNameLatin: Map<String, String> = emptyMap()
+
     fun speak(text: String, interrupt: Boolean = false, ignoreMute: Boolean = false) {
         if (muted && !ignoreMute) return
         runCatching { onSpoken?.invoke(text) }
@@ -349,7 +354,7 @@ class VoiceGuide @Inject constructor(
             acquireFocus()
             // Romanize any foreign-script name for this (Latin) neural voice so it isn't dropped
             // (issue #184); the on-screen banner keeps the real local-script name.
-            n.speak(forSpeech(SpokenScript.forVoice(text, n.voiceLanguage ?: t)), interrupt) { releaseFocus() }
+            n.speak(forSpeech(SpokenScript.forVoice(text, n.voiceLanguage ?: t, roadNameLatin)), interrupt) { releaseFocus() }
             return
         }
         speakViaSystem(text, interrupt, t)
@@ -385,7 +390,7 @@ class VoiceGuide @Inject constructor(
         val mode = if (interrupt) TextToSpeech.QUEUE_FLUSH else TextToSpeech.QUEUE_ADD
         // Same foreign-name romanizing as the neural path (issue #184): the system voice for [t]
         // is Latin-script for the Latin languages, so a foreign road name would otherwise be lost.
-        val result = engine.speak(forSpeech(SpokenScript.forVoice(text, t)), mode, null, "vela-${text.hashCode()}")
+        val result = engine.speak(forSpeech(SpokenScript.forVoice(text, t, roadNameLatin)), mode, null, "vela-${text.hashCode()}")
         if (result == TextToSpeech.ERROR) {
             // The utterance was never enqueued, so NONE of the onDone/onStop/onError callbacks that
             // release focus will ever fire for it — roll back the acquire here or music stays ducked

--- a/core/src/test/java/app/vela/core/voice/SpokenScriptTest.kt
+++ b/core/src/test/java/app/vela/core/voice/SpokenScriptTest.kt
@@ -63,4 +63,25 @@ class SpokenScriptTest {
     @Test fun `separators between foreign words pass through`() {
         assertEquals("<שדרות>, <בן> <גוריון>", tag("שדרות, בן גוריון", "en"))
     }
+
+    // --- Real romanized names from the basemap (dict) ---
+    private val dict = mapOf("רחוב הרצל" to "Rehov Herzl")
+
+    @Test fun `voice uses the real name from the dict, ICU only for the rest`() {
+        // The dict name speaks properly; an unmapped foreign name still falls back to ICU (tagged).
+        assertEquals(
+            "Turn onto Rehov Herzl then <דיזנגוף>",
+            SpokenScript.forVoice("Turn onto רחוב הרצל then דיזנגוף", "en", dict) { "<$it>" },
+        )
+    }
+
+    @Test fun `display uses the real name but keeps local script when the dict has none`() {
+        // No ICU on display: an unmapped name stays in Hebrew (a skeleton on a sign reads broken).
+        assertEquals("Turn onto Rehov Herzl", SpokenScript.forDisplay("Turn onto רחוב הרצל", "en", dict))
+        assertEquals("Turn onto דיזנגוף", SpokenScript.forDisplay("Turn onto דיזנגוף", "en", dict))
+    }
+
+    @Test fun `a hebrew UI keeps hebrew even when the dict has a latin name`() {
+        assertEquals("פנה אל רחוב הרצל", SpokenScript.forDisplay("פנה אל רחוב הרצל", "he", dict))
+    }
 }

--- a/core/src/test/java/app/vela/core/voice/SpokenScriptTest.kt
+++ b/core/src/test/java/app/vela/core/voice/SpokenScriptTest.kt
@@ -1,0 +1,56 @@
+package app.vela.core.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The run-splitting, voice gating and CJK/Latin preservation of [SpokenScript] (issue #184). The
+ * real ICU romanization is Android-only, so it is injected here as a tag so we can assert exactly
+ * which substrings would be sent to it, and that everything else is passed through untouched. Runs
+ * break at spaces/punctuation, so a multi-word foreign name tags per word - the real ICU output is
+ * identical either way ("רחוב"+" "+"הרצל" romanizes to the same string as the whole phrase).
+ */
+class SpokenScriptTest {
+
+    // Wrap each romanized run in <> so the test can see precisely what was handed to ICU.
+    private fun tag(text: String, voiceLang: String?) =
+        SpokenScript.forVoice(text, voiceLang) { "<$it>" }
+
+    @Test fun `latin voice romanizes a hebrew name and keeps the english around it`() {
+        assertEquals("Turn right onto <רחוב> <הרצל>", tag("Turn right onto רחוב הרצל", "en"))
+    }
+
+    @Test fun `a hebrew or other non-latin voice is never romanized`() {
+        val heb = "פנה ימינה לרחוב הרצל"
+        assertEquals(heb, tag(heb, "he"))
+        assertEquals(heb, tag(heb, "iw"))
+        assertEquals("Поверните на Тверскую", tag("Поверните на Тверскую", "ru"))
+    }
+
+    @Test fun `pure english is returned unchanged - ICU never invoked`() {
+        assertEquals("Turn right onto 5th Ave", tag("Turn right onto 5th Ave", "en"))
+    }
+
+    @Test fun `french accents survive - only the foreign run is touched`() {
+        assertEquals("onto Champs-Élysées", tag("onto Champs-Élysées", "fr"))
+        assertEquals("onto Champs then <דיזנגוף>", tag("onto Champs then דיזנגוף", "en"))
+    }
+
+    @Test fun `CJK is left for native voices, not mis-romanized`() {
+        assertEquals("Turn onto 明治通り", tag("Turn onto 明治通り", "en"))
+    }
+
+    @Test fun `greek and cyrillic runs romanize under a latin voice`() {
+        assertEquals("onto <Λεωφόρος> <Κηφισίας>", tag("onto Λεωφόρος Κηφισίας", "en"))
+        assertEquals("onto <Тверская> <улица>", tag("onto Тверская улица", "de"))
+    }
+
+    @Test fun `region-tagged voice code is handled`() {
+        assertEquals("onto <רחוב>", tag("onto רחוב", "en-US"))
+        assertEquals("onto רחוב", tag("onto רחוב", "he-IL"))
+    }
+
+    @Test fun `separators between foreign words pass through`() {
+        assertEquals("<שדרות>, <בן> <גוריון>", tag("שדרות, בן גוריון", "en"))
+    }
+}

--- a/core/src/test/java/app/vela/core/voice/SpokenScriptTest.kt
+++ b/core/src/test/java/app/vela/core/voice/SpokenScriptTest.kt
@@ -20,11 +20,21 @@ class SpokenScriptTest {
         assertEquals("Turn right onto <רחוב> <הרצל>", tag("Turn right onto רחוב הרצל", "en"))
     }
 
-    @Test fun `a hebrew or other non-latin voice is never romanized`() {
+    @Test fun `a voice keeps its OWN script but romanizes scripts it cannot read`() {
+        // Own-script text is left alone: a Hebrew voice reads Hebrew, a Russian voice reads Cyrillic.
         val heb = "פנה ימינה לרחוב הרצל"
         assertEquals(heb, tag(heb, "he"))
         assertEquals(heb, tag(heb, "iw"))
         assertEquals("Поверните на Тверскую", tag("Поверните на Тверскую", "ru"))
+        // But a foreign script IS romanized even for a non-Latin voice - Latin is the universal
+        // fallback (a Chinese/Russian driver in Israel gets Latin, not dropped Hebrew). issue #184.
+        assertEquals("onto <רחוב> <הרצל>", tag("onto רחוב הרצל", "zh"))
+        assertEquals("на <רחוב>", tag("на רחוב", "ru")) // Cyrillic kept, Hebrew romanized
+    }
+
+    @Test fun `a chinese voice keeps Han but romanizes hebrew in the same string`() {
+        // Han is never romanized (would become pinyin), so a zh voice reads it; the Hebrew is Latinized.
+        assertEquals("往 明治通り <רחוב>", tag("往 明治通り רחוב", "zh"))
     }
 
     @Test fun `pure english is returned unchanged - ICU never invoked`() {

--- a/scripts/build-routing-region.sh
+++ b/scripts/build-routing-region.sh
@@ -29,6 +29,24 @@ echo "→ building CH graph"
 ( cd "$WORK/graph" && zip -qr "$WORK/$ID$SUFFIX.zip" . )
 SIZE=$(( ( $(stat -f%z "$WORK/$ID$SUFFIX.zip" 2>/dev/null || stat -c%s "$WORK/$ID$SUFFIX.zip") + 1048575 ) / 1048576 ))
 
+# ROMANIZED road-name sidecar (issue #184): a gzipped TSV `<local name>\t<English name>` for every
+# road that carries a name:en / name:latin, so OFFLINE turn-by-turn can say/show the real romanized
+# name (the online path reads the same data off the map tiles; a downloaded graph has no tiles). The
+# graph itself is unchanged, so this is additive - old installs keep working and just grab this small
+# extra file. Best-effort: a failure here still publishes the graph, just without names.
+NAMES_ASSET="$ID$SUFFIX-names.tsv.gz"
+NAMES_URL=""
+if osmium tags-filter "$WORK/region.osm.pbf" w/name:en w/name:latin -o "$WORK/named.osm.pbf" 2>/dev/null \
+   && osmium export "$WORK/named.osm.pbf" -f geojsonseq --keep-tags name,name:en,name:latin -o - 2>/dev/null \
+        | python3 "$ROOT/scripts/roadnames_build.py" "$WORK/$NAMES_ASSET" \
+   && [ -s "$WORK/$NAMES_ASSET" ]; then
+  NAMES_KB=$(( ( $(stat -f%z "$WORK/$NAMES_ASSET" 2>/dev/null || stat -c%s "$WORK/$NAMES_ASSET") + 1023 ) / 1024 ))
+  NAMES_URL="https://github.com/$REPO/releases/download/$TAG/$NAMES_ASSET"
+  echo "→ road names: ${NAMES_KB} KB"
+else
+  echo "→ road-name sidecar skipped (extraction failed or empty)"
+fi
+
 # bbox [S,W,N,E] from the extract's HEADER box (the declared region) — NOT data.bbox, whose node
 # extent gets blown up by outlier nodes (a stray ferry/error node sends it to Alaska). osmium prints
 # (minlon,minlat,maxlon,maxlat).
@@ -43,10 +61,14 @@ gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1 || \
     --notes "Prebuilt GraphHopper CH graphs for Vela offline routing. Data assets, not a code release."
 
 gh release upload "$TAG" "$WORK/$ID$SUFFIX.zip" --clobber --repo "$REPO"
+[ -n "$NAMES_URL" ] && gh release upload "$TAG" "$WORK/$NAMES_ASSET" --clobber --repo "$REPO"
 
-# this region's manifest entry
+# this region's manifest entry (namesUrl/namesSizeKb only when the sidecar was built - old apps ignore
+# the extra fields, new apps download it alongside the graph)
 ENTRY="$(jq -nc --arg id "$ID" --arg name "$NAME" --arg url "$ASSET_URL" --argjson size "$SIZE" --argjson bbox "$BBOX" \
-  '{id:$id,name:$name,url:$url,sizeMb:$size,bbox:$bbox}')"
+  --arg namesUrl "$NAMES_URL" --argjson namesKb "${NAMES_KB:-0}" \
+  '{id:$id,name:$name,url:$url,sizeMb:$size,bbox:$bbox}
+   + (if $namesUrl != "" then {namesUrl:$namesUrl, namesSizeKb:$namesKb} else {} end)')"
 
 # MANIFEST_MODE=emit (CI matrix): just drop the entry to $ENTRY_OUT and stop — the manifest merge is
 # centralised in one job (scripts/merge-routing-manifest.sh) so parallel region builds can't clobber it.

--- a/scripts/build-routing-region.sh
+++ b/scripts/build-routing-region.sh
@@ -36,10 +36,9 @@ SIZE=$(( ( $(stat -f%z "$WORK/$ID$SUFFIX.zip" 2>/dev/null || stat -c%s "$WORK/$I
 # extra file. Best-effort: a failure here still publishes the graph, just without names.
 NAMES_ASSET="$ID$SUFFIX-names.tsv.gz"
 NAMES_URL=""
-if osmium tags-filter "$WORK/region.osm.pbf" w/name:en w/name:latin -o "$WORK/named.osm.pbf" 2>/dev/null \
-   && osmium export "$WORK/named.osm.pbf" -f geojsonseq --keep-tags name,name:en,name:latin -o - 2>/dev/null \
-        | python3 "$ROOT/scripts/roadnames_build.py" "$WORK/$NAMES_ASSET" \
-   && [ -s "$WORK/$NAMES_ASSET" ]; then
+if osmium tags-filter "$WORK/region.osm.pbf" w/name:en w/name:latin -o "$WORK/named.osm.pbf" \
+   && osmium export "$WORK/named.osm.pbf" -f geojsonseq -o - \
+        | python3 "$ROOT/scripts/roadnames_build.py" "$WORK/$NAMES_ASSET"; then
   NAMES_KB=$(( ( $(stat -f%z "$WORK/$NAMES_ASSET" 2>/dev/null || stat -c%s "$WORK/$NAMES_ASSET") + 1023 ) / 1024 ))
   NAMES_URL="https://github.com/$REPO/releases/download/$TAG/$NAMES_ASSET"
   echo "→ road names: ${NAMES_KB} KB"

--- a/scripts/roadnames_build.py
+++ b/scripts/roadnames_build.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Build a region's offline road-name map: local road name -> its Latin/English name.
+
+Reads an osmium GeoJSONSeq stream on stdin (one road way per line, exported with the
+name / name:en / name:latin tags) and writes a gzipped TSV `<local>\t<english>` to the
+output path. This is the sidecar the app downloads next to a routing graph so offline
+turn-by-turn can SAY/SHOW the romanized street name instead of a rule-based skeleton
+(issue #184), the same data the online tiles carry as name:latin.
+
+We keep only rows where the Latin name is a genuinely Latin-script string that differs
+from the local name, so a road already in Latin (a US street) contributes nothing and a
+non-Latin alias is never stored as if it were romanized. name:en wins over name:latin
+(a real English name beats a transliteration).
+
+Usage:  osmium export ... -f geojsonseq | roadnames_build.py <out.tsv.gz>
+"""
+import gzip
+import json
+import sys
+import unicodedata
+
+
+def is_latin(s: str) -> bool:
+    """True if s has at least one Latin letter and no letter in another script."""
+    saw_latin = False
+    for ch in s:
+        if not ch.isalpha():
+            continue
+        try:
+            name = unicodedata.name(ch)
+        except ValueError:
+            return False  # unnamed letter, treat as foreign
+        if name.startswith("LATIN"):
+            saw_latin = True
+        else:
+            return False  # a non-Latin letter (Hebrew, Cyrillic, Han, ...)
+    return saw_latin
+
+
+def main() -> int:
+    out_path = sys.argv[1]
+    seen: dict[str, str] = {}
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            props = json.loads(line).get("properties") or {}
+        except (ValueError, AttributeError):
+            continue
+        name = (props.get("name") or "").strip()
+        if not name or name in seen:
+            continue
+        eng = (props.get("name:en") or props.get("name:latin") or "").strip()
+        if not eng or eng == name or not is_latin(eng):
+            continue
+        # tabs/newlines would corrupt the TSV; roads never legitimately contain them.
+        seen[name] = eng.replace("\t", " ").replace("\n", " ")
+
+    with gzip.open(out_path, "wt", encoding="utf-8") as f:
+        for local, eng in seen.items():
+            f.write(f"{local}\t{eng}\n")
+    print(f"road-names: {len(seen)} local->latin pairs -> {out_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/roadnames_build.py
+++ b/scripts/roadnames_build.py
@@ -61,7 +61,9 @@ def main() -> int:
         for local, eng in seen.items():
             f.write(f"{local}\t{eng}\n")
     print(f"road-names: {len(seen)} local->latin pairs -> {out_path}", file=sys.stderr)
-    return 0
+    # exit 1 on an empty map so the caller skips uploading a useless sidecar (a region with no
+    # name:en/name:latin roads, e.g. an all-Latin area) instead of publishing an empty file.
+    return 0 if seen else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Builds on the online romanization (nav-translit, #186 — this branch contains those commits) and adds the offline half.

Online, the real romanized street name comes off the map tiles. Offline there are no tiles, so a downloaded graph would fall back to the raw local-script name (or an unpronounceable ICU skeleton). This adds a small per-region `names.tsv.gz` sidecar (`<local name>\t<English name>`, built in CI from OSM `name:en`/`name:latin`) that downloads alongside the graph, so offline turn-by-turn speaks and shows the real romanized name.

- CI builds + publishes the sidecar per region (all 135 regions baked)
- App downloads it with the graph, merges all installed sidecars into `offlineRoadNames`
- Voice + banner + map labels use it when offline

Additive: old installs ignore the extra manifest fields; a region without a sidecar just isn't romanized (no crash). Device-verified fully offline on the P4a — banner showed the real romanized name with radios off.

Note: supersedes #186 (contains its commits).