### PR TITLE
Fix list editor Save button going off-screen when adding an emoji (#193)

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -3981,14 +3981,22 @@ private fun ListEditorDialog(
     var emojiOpen by remember { mutableStateOf(false) }
     var emojiText by remember { mutableStateOf("") }
     androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
+        // Cap the dialog to most of the screen: with the emoji grid + free-type field open the
+        // content grows past a short screen, which pushed the color row and Save button off the
+        // bottom with no way to reach them (issue #193). The title and the action buttons stay
+        // pinned; only the middle scrolls.
+        val maxDialogHeight = (LocalConfiguration.current.screenHeightDp * 0.9f).dp
         Surface(shape = RoundedCornerShape(20.dp), color = MaterialTheme.colorScheme.surface) {
-            Column(Modifier.padding(20.dp).widthIn(max = 420.dp)) {
+            Column(Modifier.padding(20.dp).widthIn(max = 420.dp).heightIn(max = maxDialogHeight)) {
                 Text(
                     stringResource(if (initial == null) R.string.list_new_title else R.string.list_edit_title),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                 )
                 Spacer(Modifier.height(12.dp))
+                // The form fields scroll; `fill = false` lets the column shrink to content on tall
+                // screens (no dead space) but cap + scroll on short ones so Save is always reachable.
+                Column(Modifier.weight(1f, fill = false).verticalScroll(rememberScrollState())) {
                 OutlinedTextField(
                     value = name,
                     onValueChange = { name = it },
@@ -4073,6 +4081,7 @@ private fun ListEditorDialog(
                         )
                     }
                 }
+                } // end scrolling form column
                 Spacer(Modifier.height(20.dp))
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     if (onDelete != null) {


### PR DESCRIPTION
Closes #193.

Opening the custom-emoji picker in the list editor adds the emoji grid plus a free-type field, and on a short screen that pushed the colour row and the Save button off the bottom with no way to scroll to them (reported by @KeronCyst).

The dialog content had no height cap and no scroll, so it just grew past the screen edge. Fix: cap the dialog to 90% of the screen height, put the form fields (name, icons, emoji picker, colours) in a scrolling column, and keep the title and the Cancel/Save row pinned outside the scroll so Save is always reachable.

Device-verified on a Pixel 4a at a shortened window: with the emoji grid open, the middle scrolls between the fixed header and the pinned button row, and Save stays put and tappable.