### PR TITLE
Fix list color label spelling + restore the en_GB voices

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -578,7 +578,7 @@
     <string name="list_name_label">List name</string>
     <string name="list_icon_label">Icon</string>
     <string name="list_emoji_label">Type any emoji</string>
-    <string name="list_color_label">Colour</string>
+    <string name="list_color_label">Color</string>
     <string name="list_delete">Delete</string>
     <string name="list_cancel">Cancel</string>
     <string name="list_save">Save</string>

--- a/core/src/main/java/app/vela/core/voice/PiperCatalog.kt
+++ b/core/src/main/java/app/vela/core/voice/PiperCatalog.kt
@@ -81,6 +81,13 @@ object PiperCatalog {
         PiperVoice("en_US-ljspeech-high", "LJSpeech (HQ)", VoiceGender.FEMALE, VoiceQuality.HIGH, 115, 1, "Polished audiobook-style US female"),
         PiperVoice("en_US-arctic-medium", "Arctic", VoiceGender.MULTI, VoiceQuality.MEDIUM, 80, 18, "18-voice US pack, variety in one download"),
         PiperVoice("en_US-glados-high", "GLaDOS", VoiceGender.NEUTRAL, VoiceQuality.HIGH, 115, 1, "Portal's GLaDOS, deadpan robotic, for fun", novelty = true),
+        // ── English (GB) ──
+        PiperVoice("en_GB-alba-medium", "Alba", VoiceGender.FEMALE, VoiceQuality.MEDIUM, 67, 1, "Scottish-tinged UK female, warm and characterful"),
+        PiperVoice("en_GB-jenny_dioco-medium", "Jenny", VoiceGender.FEMALE, VoiceQuality.MEDIUM, 67, 1, "Friendly UK female, clear, natural British read"),
+        PiperVoice("en_GB-cori-high", "Cori (HQ)", VoiceGender.FEMALE, VoiceQuality.HIGH, 115, 1, "Crisp UK female at top quality"),
+        PiperVoice("en_GB-northern_english_male-medium", "Northern Male", VoiceGender.MALE, VoiceQuality.MEDIUM, 67, 1, "Northern-English UK male, down-to-earth"),
+        PiperVoice("en_GB-alan-medium", "Alan", VoiceGender.MALE, VoiceQuality.MEDIUM, 67, 1, "Steady UK male, classic British navigation tone"),
+        PiperVoice("en_GB-vctk-medium", "VCTK", VoiceGender.MULTI, VoiceQuality.MEDIUM, 80, 109, "109-voice UK pack, a huge range of accents"),
         // ── Français ──
         PiperVoice("fr_FR-siwis-medium", "Siwis", VoiceGender.FEMALE, VoiceQuality.MEDIUM, 67, 1, "Voix française claire et standard", recommended = true),
         PiperVoice("fr_FR-tom-medium", "Tom", VoiceGender.MALE, VoiceQuality.MEDIUM, 67, 1, "Voix masculine française, naturelle"),

--- a/docs/LANGUAGES.md
+++ b/docs/LANGUAGES.md
@@ -6,7 +6,7 @@ the canonical list. Update it when a language lands or gains a layer.
 
 | Language | Code | App UI | Spoken directions | Vela voice (neural TTS) | Dictation (voice search) |
 |---|---|:-:|:-:|:-:|:-:|
-| English | `en` | ✅ | ✅ | ✅ (US voices) | ✅ |
+| English | `en` | ✅ | ✅ | ✅ (US + British voices) | ✅ |
 | French | `fr` | ✅ | ✅ | ✅ | ✅ |
 | German | `de` | ✅ | ✅ | ✅ | ✅ |
 | Spanish | `es` | ✅ | ✅ | ✅ (Spain + Mexico voices) | ✅ |


### PR DESCRIPTION
Two things:
- Change the list editor's icon-colour label from British "Colour" to American "Color".
- Revert the earlier removal of the en_GB Piper voices (that removal was a misread of the request and shouldn't have landed).