### PR TITLE
Fix F-Droid/Pages deploy on data releases + language-aware dictation fallback

### DIFF
--- a/.github/workflows/fdroid-repo.yml
+++ b/.github/workflows/fdroid-repo.yml
@@ -51,9 +51,16 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # For workflow_run triggers, only rebuild after a SUCCESSFUL main run - a red CI
-    # didn't publish anything, so there's nothing new to serve.
-    if: github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+    # Two gates:
+    #  - workflow_run: only rebuild after a SUCCESSFUL main run (a red CI published nothing).
+    #  - release: only for an APP release (tag like v0.4.854). The infra/data releases
+    #    (asr-models, routing-graphs, map-fonts, tts-models, poi-packs, flock-cameras...) fire
+    #    release events too when their assets are updated, and two of them overlapping raced the
+    #    single github-pages environment and failed the deploy (2026-07-20). App tags start "v";
+    #    data tags don't, so this skips them.
+    if: >-
+      (github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'))
+      && (github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v'))
     steps:
       - uses: actions/checkout@v4
 

--- a/app/src/main/java/app/vela/voice/AsrEngine.kt
+++ b/app/src/main/java/app/vela/voice/AsrEngine.kt
@@ -79,9 +79,20 @@ enum class AsrEngine(
         return files.all { File(d, it).length() > 0L }
     }
 
+    /** Whether this engine can actually recognize [lang] (an app language code, e.g. "en"/"he"/"ja").
+     *  Whisper covers everything; SenseVoice only en/zh/ja/ko/yue; Moonshine only English. Used to
+     *  fall back off a picked engine that can't do the current language. */
+    fun supportsLanguage(lang: String): Boolean = when (this) {
+        WHISPER_TINY -> true
+        SENSE_VOICE -> lang in SENSE_VOICE_LANGS
+        MOONSHINE -> lang == "en"
+    }
+
     companion object {
         /** Silero VAD, shipped inside every engine archive so each is self-contained. */
         const val VAD = VAD_FILE
+        /** The languages SenseVoice recognizes (its own codes). */
+        val SENSE_VOICE_LANGS = setOf("zh", "en", "ja", "ko", "yue")
         private const val PREFS = "vela_settings"
         private const val PREF_ENGINE = "asr_engine"
 
@@ -108,5 +119,17 @@ enum class AsrEngine(
         fun setActive(context: Context, engine: AsrEngine) =
             context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
                 .putString(PREF_ENGINE, engine.id).apply()
+
+        /** The engine to actually RUN for [lang]: the [active] pick if it supports the language, else
+         *  Whisper (the multilingual default) when it's installed, so dictating in a language the
+         *  picked engine can't do (e.g. SenseVoice picked, Hebrew spoken) still works instead of
+         *  returning garbage. Falls back to the pick as a last resort if Whisper isn't installed.
+         *  Note: the Settings picker's "Active" still reflects the user's raw pick ([active]); this
+         *  only changes which model the recognizer loads for the current language. */
+        fun forRecognition(context: Context, lang: String): AsrEngine {
+            val picked = active(context)
+            if (picked.supportsLanguage(lang)) return picked
+            return WHISPER_TINY.takeIf { it.isInstalled(context) } ?: picked
+        }
     }
 }

--- a/app/src/main/java/app/vela/voice/AsrRecognizer.kt
+++ b/app/src/main/java/app/vela/voice/AsrRecognizer.kt
@@ -81,9 +81,6 @@ class AsrRecognizer @Inject constructor(
         const val SAMPLE_RATE = 16000
         const val VAD_WINDOW = 512            // Silero v4/v5 window at 16 kHz
         const val MAX_SECONDS = 15            // hard cap on one utterance
-        // SenseVoice's own language codes. Vela app languages outside this set fall back to "auto"
-        // (the user picked SenseVoice knowing it's en/zh/ja/ko/yue only - the picker says so).
-        val SENSE_VOICE_LANGS = setOf("zh", "en", "ja", "ko", "yue")
     }
 
     fun isInstalled(): Boolean = AsrEngine.anyInstalled(context)
@@ -92,17 +89,25 @@ class AsrRecognizer @Inject constructor(
         ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
             PackageManager.PERMISSION_GRANTED
 
+    /** The app language, normalized. Android hands back the LEGACY code for Hebrew ("iw"), not
+     *  "he" (2026-07-12), so map it. */
+    private fun appLang(): String =
+        app.vela.ui.AppLocale.effective().language.let { if (it == "iw") "he" else it }
+
+    /** The engine the recognizer should load for the current language: the user's pick when it
+     *  supports the language, else Whisper (see [AsrEngine.forRecognition]). */
+    private fun engineForNow(): AsrEngine = AsrEngine.forRecognition(context, appLang())
+
     /** The language to pin recognition to: the app language when the engine supports it, else
      *  auto-detect (""). Pinning matters - with auto-detect, a noisy capture can be misread as a whole
      *  other language and come back in the wrong script (a garbled far-field test transcribed to
      *  Cyrillic). The app language is what the user speaks to a maps app in practice. Moonshine is
      *  English-only and takes no language, so this is unused for it. */
     private fun pinnedLang(engine: AsrEngine): String {
-        // Android hands back the LEGACY code for Hebrew ("iw"), not "he" (2026-07-12).
-        val l = app.vela.ui.AppLocale.effective().language.let { if (it == "iw") "he" else it }
+        val l = appLang()
         return when (engine) {
             AsrEngine.WHISPER_TINY -> l.takeIf { it in app.vela.ui.AppLocale.SUPPORTED } ?: ""
-            AsrEngine.SENSE_VOICE -> l.takeIf { it in SENSE_VOICE_LANGS } ?: "auto"
+            AsrEngine.SENSE_VOICE -> l.takeIf { it in AsrEngine.SENSE_VOICE_LANGS } ?: "auto"
             AsrEngine.MOONSHINE -> ""
         }
     }
@@ -120,7 +125,7 @@ class AsrRecognizer @Inject constructor(
      *  is installed or the native load fails - callers then fall back to the provider intent or hide
      *  the mic. */
     private fun ensureRecognizer(): OfflineRecognizer? {
-        val engine = AsrEngine.active(context)
+        val engine = engineForNow()
         if (!engine.isInstalled(context)) return null
         val lang = pinnedLang(engine)
         val key = "${engine.id}|$lang"
@@ -193,7 +198,7 @@ class AsrRecognizer @Inject constructor(
         val rec = ensureRecognizer() ?: return@withContext null
         if (!hasMicPermission()) return@withContext null
 
-        val vadModel = AsrEngine.active(context).let { File(it.dir(context), AsrEngine.VAD).absolutePath }
+        val vadModel = engineForNow().let { File(it.dir(context), AsrEngine.VAD).absolutePath }
         val vad = runCatching {
             Vad(
                 config = VadModelConfig(


### PR DESCRIPTION
Two fixes:

**F-Droid repo / GitHub Pages deploy (was red).** The workflow that builds the F-Droid repo and deploys the Pages site triggered on every release event, including the infra/data releases (asr-models, routing-graphs, map-fonts...). Updating the asr-models assets fired two overlapping runs that raced the single github-pages environment and failed the deploy. The release trigger is now gated to tags that start with `v` (app versions), so data-release updates no longer touch Pages.

**Language-aware dictation fallback.** If SenseVoice or Moonshine is the active engine but the current app language is outside what it covers (e.g. SenseVoice picked, Hebrew spoken), the recognizer now loads Whisper (when installed) for that language instead of feeding audio to an engine that returns garbage. `AsrEngine.forRecognition(ctx, lang)` picks the model; the Settings picker still shows the user's raw pick as Active.