### PR TITLE
Landscape side panel for results and places, plus button visibility done right

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -146,7 +146,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   (0.26 of a ~390dp landscape height only fit the name row). The layers button's overlap gate
   short-circuits in landscape (the panel never reaches its corner); in portrait the locate
   button now rides above a minimized place card's measured top edge instead of hiding.
-  Scale bar yields to the panel; the satellite attribution centers in the map strip.
+  Scale bar yields to the panel; the satellite attribution centers in the map strip. The
+  panel's EXPANDED detent caps below the search bar (landscape is a two-stop ladder,
+  minimized <-> tall): the bar deliberately stays in landscape, so the portrait
+  hide-the-bar-when-expanded rule is portrait-only and the panel stops under it instead
+  of sliding beneath a bar that keeps taking taps.
 - ✅ **Chinese, Chinese (Taiwan) and Japanese (2026-07-11, issue #55).** Vela speaks 14
   languages now. All three layers: UI chrome (values-zh Simplified, values-zh-rTW Traditional
   with Taiwan wording, values-ja), generated turn-by-turn text (three new NavStrings tables;

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -136,6 +136,17 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   height. Focusing the bar grows it to full width in place (the field must not remount or focus
   bounces) and the search page renders full-width below as usual. Portrait is unchanged, and the
   tiny keypad phones the D-pad work targets are portrait devices, so they never see this layout.
+- ✅ **Landscape side panel for results and places (2026-07-20, user).** In landscape the search
+  results list and the place sheet render as a width-capped LEFT panel (Google's landscape
+  treatment) instead of a full-width bottom sheet, so the map keeps a real strip beside them and
+  every right-side button (layers, parking, my location) simply stays visible, no situational
+  hiding rules. The camera inset moves to the left axis to match: a focused pin or result
+  cluster frames in the strip beside the panel. The minimized place card keeps its name, rating
+  and action pills (Directions/Call) in landscape too, via a dp floor on the minimized detent
+  (0.26 of a ~390dp landscape height only fit the name row). The layers button's overlap gate
+  short-circuits in landscape (the panel never reaches its corner); in portrait the locate
+  button now rides above a minimized place card's measured top edge instead of hiding.
+  Scale bar yields to the panel; the satellite attribution centers in the map strip.
 - ✅ **Chinese, Chinese (Taiwan) and Japanese (2026-07-11, issue #55).** Vela speaks 14
   languages now. All three layers: UI chrome (values-zh Simplified, values-zh-rTW Traditional
   with Taiwan wording, values-ja), generated turn-by-turn text (three new NavStrings tables;

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -212,6 +212,11 @@ import app.vela.ui.item
 // for MapTiler Streets (needs the MAPTILER_KEY secret). Both paths stay wired.
 private const val USE_MAPTILER = false
 
+// Landscape side-panel width for the place/results sheets (Google's landscape treatment):
+// wide enough for the sheet content, narrow enough that a phone landscape (~730dp+) keeps a
+// real map strip with all the right-side buttons beside it.
+private val SIDE_PANEL_WIDTH = 400.dp
+
 @Composable
 fun MapScreen(
     vm: MapViewModel,
@@ -249,16 +254,28 @@ fun MapScreen(
     // minimized (stray building taps while the full picker covered the map added stops).
     LaunchedEffect(dirMinimized) { vm.onDirectionsCollapsed(dirMinimized) }
     LaunchedEffect(state.directionsOpen) { if (!state.directionsOpen) dirMinimized = false }
+    // Landscape: the place/results sheets render as a LEFT SIDE PANEL (Google's landscape
+    // layout, user 2026-07-20) - width-capped, so the right-side chrome (layers, parking,
+    // locate) never collides with them. The camera inset moves to the LEFT axis to match:
+    // a focused pin frames in the map strip beside the panel, not squeezed into a top sliver.
+    val sidePanelWidthPx = with(LocalDensity.current) { SIDE_PANEL_WIDTH.toPx() }.toInt()
     val cameraBottomInset = when {
         // Street View pane up: the sheet yields, so no bottom inset (the SV top inset takes over).
         state.streetView != null || state.streetViewLoading -> 0
-        placeSheetUp -> (screenHeightPx * 0.56f).toInt()
+        placeSheetUp -> if (landscapeChrome) 0 else (screenHeightPx * 0.56f).toInt()
         state.directionsOpen && !state.navigating ->
             (screenHeightPx * (if (dirMinimized) 0.14f else 0.58f)).toInt()
         // Results bottom sheet at peek covers ~the bottom half: frame the result pins
         // in the visible top half, not behind the sheet.
         state.results.isNotEmpty() && state.selected == null && !state.resultsCollapsed &&
-            !state.navigating -> (screenHeightPx * 0.50f).toInt()
+            !state.navigating -> if (landscapeChrome) 0 else (screenHeightPx * 0.50f).toInt()
+        else -> 0
+    }
+    val cameraLeftInset = if (!landscapeChrome) 0 else when {
+        state.streetView != null || state.streetViewLoading -> 0
+        placeSheetUp -> sidePanelWidthPx
+        state.results.isNotEmpty() && state.selected == null && !state.resultsCollapsed &&
+            !state.navigating -> sidePanelWidthPx
         else -> 0
     }
     // MapTiler (when a key is built in) gives the Google-like look + its own
@@ -852,6 +869,7 @@ fun MapScreen(
             cameraTargetZoom = state.centerZoom,
             recenterTick = state.recenterTick,
             cameraBottomInsetPx = cameraBottomInset,
+            cameraLeftInsetPx = cameraLeftInset,
             routePolyline = state.activeRoute?.polyline ?: emptyList(),
             routeColor = routeTrafficColor(state.activeRoute),
             routeDashed = state.travelMode == app.vela.core.model.TravelMode.WALK ||
@@ -1726,8 +1744,12 @@ fun MapScreen(
                 // No navigationBarsPadding here: the sheet's background should reach
                 // the screen bottom (no map peeking through under the nav bar); the
                 // sheet pads its own content for the nav bar instead.
+                // Landscape: a LEFT side panel (width-capped) instead of a full-width sheet,
+                // so the map and its right-side buttons stay usable beside it (Google's
+                // landscape layout, user 2026-07-20).
                 modifier = Modifier
-                    .align(Alignment.BottomCenter)
+                    .align(if (landscapeChrome) Alignment.BottomStart else Alignment.BottomCenter)
+                    .then(if (landscapeChrome) Modifier.widthIn(max = SIDE_PANEL_WIDTH) else Modifier)
                     // Live top edge for the layers button's overlap gate (see placeSheetTopPx).
                     .onGloballyPositioned { placeSheetTopPx = it.positionInRoot().y.roundToInt() },
             )
@@ -1756,7 +1778,10 @@ fun MapScreen(
                 listName = state.openListId?.let { id -> state.lists.firstOrNull { it.id == id }?.name },
                 query = state.query,
                 minimizeTick = resultsPanTick,
-                modifier = Modifier.align(Alignment.BottomCenter),
+                // Landscape: left side panel like the place sheet (see its modifier note).
+                modifier = Modifier
+                    .align(if (landscapeChrome) Alignment.BottomStart else Alignment.BottomCenter)
+                    .then(if (landscapeChrome) Modifier.widthIn(max = SIDE_PANEL_WIDTH) else Modifier),
               )
             // Imported Google list preview: offer to save (nothing persisted until tapped).
             // A pill under the search bar, clear of the results sheet at the bottom.
@@ -1910,12 +1935,20 @@ fun MapScreen(
             }
         }
 
-        // The locate + parking buttons yield to EVERY bottom surface, the route chooser and the
-        // step list included - a search from an open chooser could null the selection while
-        // directionsOpen stayed true, and both buttons drew on top of the panel.
-        if (!state.navigating && state.selected == null && !searchOpen && state.resumeNavLabel == null &&
-            !resultsShown && !state.directionsOpen && !state.showSteps
-        ) {
+        // The locate + parking buttons yield to the bottom surfaces that actually REACH them:
+        // the route chooser and step list always (full width), and in PORTRAIT the place/results
+        // sheets too. In LANDSCAPE those two render as the width-capped left panel, so the
+        // bottom-right corner is free and both buttons stay up beside an open list or place
+        // (user 2026-07-20: stop hiding buttons that nothing is covering). Street View keeps
+        // them hidden - its bottom half is the pose mini-map.
+        val fabChromeOk = !state.navigating && !searchOpen && state.resumeNavLabel == null &&
+            !state.directionsOpen && !state.showSteps &&
+            state.streetView == null && !state.streetViewLoading
+        // True while the landscape left panel (place sheet or results, any detent) is on screen -
+        // bottom-LEFT chrome (scale bar) yields to it and the attribution centers in the strip.
+        val sidePanelUp = landscapeChrome &&
+            (placeSheetUp || (state.results.isNotEmpty() && state.selected == null && !searchOpen))
+        if (fabChromeOk && (landscapeChrome || (state.selected == null && !resultsShown))) {
             // Stock M3 FAB, deliberately: a Google-style flat circle was tried (2026-07-08)
             // and reverted — every surface tone melted into the dark tiles.
             FloatingActionButton(
@@ -2047,6 +2080,8 @@ fun MapScreen(
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .navigationBarsPadding()
+                        // Centered in the map STRIP while the landscape panel owns the left.
+                        .padding(start = if (sidePanelUp) SIDE_PANEL_WIDTH else 0.dp)
                         .padding(bottom = 16.dp + chromeLift),
                 ) {
                     Text(
@@ -2066,7 +2101,8 @@ fun MapScreen(
             // Also step aside while the free-drive speed box occupies the low corner (it moved
             // down level with the locate FAB, user 2026-07-14) - the follow gate alone missed a
             // moving-but-panned map, where both used to want the same spot.
-            if (!(driveFollowing && speedOverlayArmed) && !movingFree) {
+            // The landscape panel owns the bottom-left corner - the bar would draw on top of it.
+            if (!(driveFollowing && speedOverlayArmed) && !movingFree && !sidePanelUp) {
                 ScaleBar(
                     metersPerPixel = metersPerPixel,
                     dark = darkTheme,
@@ -2077,6 +2113,30 @@ fun MapScreen(
                 )
             }
         }
+
+            // Portrait, place card at (or near) its minimized bar: the locate FAB rides ABOVE the
+            // card's measured top edge (user 2026-07-20: current location stays reachable with a
+            // card minimized). Offset from the sheet's live top so it tracks the card; the >55%
+            // floor keeps it to the minimized neighbourhood - at peek/expanded it stays hidden.
+            // Landscape needs none of this: the side panel leaves the normal FABs standing.
+            if (fabChromeOk && !landscapeChrome && state.selected != null && !placeSheetExpanded &&
+                state.pickOnMap == null && placeSheetTopPx > screenHeightPx * 0.55f
+            ) {
+                FloatingActionButton(
+                    onClick = onRecenter,
+                    modifier = Modifier
+                        .dpadHighlight(RoundedCornerShape(16.dp))
+                        .align(Alignment.TopEnd)
+                        .offset {
+                            androidx.compose.ui.unit.IntOffset(
+                                -16.dp.roundToPx(),
+                                placeSheetTopPx - 72.dp.roundToPx(),
+                            )
+                        },
+                ) {
+                    Icon(Icons.Default.MyLocation, contentDescription = stringResource(R.string.mapscreen_center_on_my_location))
+                }
+            }
 
             // Layers/satellite toggle, top-right under the search bar + chips. Shown on the browse
             // map AND while a place sheet is open, WHENEVER the button's corner actually clears the
@@ -2091,10 +2151,12 @@ fun MapScreen(
             val layersDensity = LocalDensity.current
             val layersButtonBottomPx = WindowInsets.statusBars.getTop(layersDensity) +
                 with(layersDensity) { ((if (landscapeChrome) 74.dp else 128.dp) + 42.dp + 8.dp).toPx() }
+            // Landscape short-circuits the vertical test: the sheet is the width-capped LEFT
+            // panel there, which never reaches the top-right corner whatever its detent.
             val clearOfPlaceSheet = state.selected == null ||
                 (
                     state.streetView == null && !state.streetViewLoading && state.pickOnMap == null &&
-                        placeSheetTopPx > layersButtonBottomPx
+                        (landscapeChrome || placeSheetTopPx > layersButtonBottomPx)
                     )
             if (app.vela.ui.LayersButton.on.value && !searchOpen &&
                 !state.navigating && !state.replaying && !resultsShown && !placeSheetExpanded &&

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1314,9 +1314,13 @@ fun MapScreen(
                                 )
                             }
                         }
-                    } else if (!(state.selected != null && placeSheetExpanded && !searchOpen) &&
+                    } else if (!(state.selected != null && placeSheetExpanded && !searchOpen && !landscapeChrome) &&
                         !(state.directionsOpen && !searchOpen)
                     ) {
+                        // The expanded-sheet hide is PORTRAIT-only: in landscape the sheet is the
+                        // side panel, which caps BELOW the bar (PlaceSheet's landscape detents), so
+                        // the bar deliberately stays - hiding it would strand the map strip with no
+                        // search while nothing actually covers the bar.
                         searchBar()
                     }
                     when {
@@ -2158,8 +2162,11 @@ fun MapScreen(
                     state.streetView == null && !state.streetViewLoading && state.pickOnMap == null &&
                         (landscapeChrome || placeSheetTopPx > layersButtonBottomPx)
                     )
+            // The expanded/results hides are portrait-only too: the landscape panel caps below
+            // the search bar and never reaches this corner at ANY detent.
             if (app.vela.ui.LayersButton.on.value && !searchOpen &&
-                !state.navigating && !state.replaying && !resultsShown && !placeSheetExpanded &&
+                !state.navigating && !state.replaying &&
+                (!resultsShown || landscapeChrome) && (!placeSheetExpanded || landscapeChrome) &&
                 clearOfPlaceSheet
             ) {
                 val ctx = androidx.compose.ui.platform.LocalContext.current
@@ -2441,7 +2448,10 @@ private fun SearchResults(
     // bar, peek, expanded), and the detent just stops the coast. Minimizing animates the list to
     // ZERO first and only then flips the collapsed state, so the bar swap happens invisibly.
     val peekL = screenH * 0.42f
-    val expL = screenH * 0.82f
+    // Landscape (side-panel layout): expanded caps below the search bar - the full-width bar
+    // deliberately stays in landscape, so the panel must stop under it, not slide beneath it.
+    val resultsLandscape = LocalConfiguration.current.screenWidthDp > screenH
+    val expL = if (resultsLandscape) minOf(screenH * 0.82f, maxOf(screenH - 104f, screenH * 0.55f)) else screenH * 0.82f
     val listH = remember { Animatable(if (collapsed) 0f else if (expanded) expL else peekL) }
     val resultsSettleSpec = remember { spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = 350f) }
     // Dropping to the bar GLIDES on a soft spring — at the settle stiffness the pan-triggered

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -149,6 +149,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.vela.BuildConfig
@@ -352,7 +354,15 @@ fun MapScreen(
     var filteredResultIds by remember { mutableStateOf<Set<String>?>(null) }
     // True while the place sheet sits at its EXPANDED detent (covers the search bar).
     var placeSheetExpanded by remember { mutableStateOf(false) }
-    LaunchedEffect(state.selected?.id) { if (state.selected == null) placeSheetExpanded = false }
+    // The sheet's live TOP edge in root px (0 = not measured). The layers button keys its
+    // visibility off this: shown while a POI is minimized whenever the button's own corner
+    // actually clears the sheet - a measured overlap test, not an orientation/height guess,
+    // so a tablet or portrait car screen keeps the button and a phone-landscape peek (where
+    // the sheet reaches the corner) drops it, continuously as the sheet is dragged.
+    var placeSheetTopPx by remember { mutableStateOf(0) }
+    LaunchedEffect(state.selected?.id) {
+        if (state.selected == null) { placeSheetExpanded = false; placeSheetTopPx = 0 }
+    }
     LaunchedEffect(state.results) { filteredResultIds = null }
     // Street View gates the panel too: opening the viewer clears `selected`, which used to flip
     // this back ON and draw the results list over the bottom-half mini map (user 2026-07-18).
@@ -1716,7 +1726,10 @@ fun MapScreen(
                 // No navigationBarsPadding here: the sheet's background should reach
                 // the screen bottom (no map peeking through under the nav bar); the
                 // sheet pads its own content for the nav bar instead.
-                modifier = Modifier.align(Alignment.BottomCenter),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    // Live top edge for the layers button's overlap gate (see placeSheetTopPx).
+                    .onGloballyPositioned { placeSheetTopPx = it.positionInRoot().y.roundToInt() },
             )
 
             // Search results as a BOTTOM sheet, Google-style — same detent family as the place
@@ -2026,10 +2039,66 @@ fun MapScreen(
             // Scale bar, bottom-left just past the attribution ⓘ. Hidden only while ACTUALLY
             // free-driving (moving, speed box on screen) - `!driveFollowing` alone hid it on the
             // whole browse map, since follow is armed by default (regression, 0.4.542..wave).
-            // Satellite toggle, top-right under the search bar + chips (browse map only): flips
-            // the Esri World Imagery raster under the symbol stack. Filled tint = on.
-            if (app.vela.ui.LayersButton.on.value && state.selected == null && !searchOpen &&
-                !state.navigating && !state.replaying && state.results.isEmpty()
+            // Required Esri attribution while the imagery is on - bottom center, clear of the
+            // scale bar and FABs, the year centered on its own line under the credit.
+            if (app.vela.ui.SatelliteLayer.on.value) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .navigationBarsPadding()
+                        .padding(bottom = 16.dp + chromeLift),
+                ) {
+                    Text(
+                        stringResource(R.string.map_satellite_attribution),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (darkTheme) Color(0xFFB8C2CC) else Color(0xFF4A4A4A),
+                    )
+                    state.imageryYear?.let {
+                        Text(
+                            it,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (darkTheme) Color(0xFFB8C2CC) else Color(0xFF4A4A4A),
+                        )
+                    }
+                }
+            }
+            // Also step aside while the free-drive speed box occupies the low corner (it moved
+            // down level with the locate FAB, user 2026-07-14) - the follow gate alone missed a
+            // moving-but-panned map, where both used to want the same spot.
+            if (!(driveFollowing && speedOverlayArmed) && !movingFree) {
+                ScaleBar(
+                    metersPerPixel = metersPerPixel,
+                    dark = darkTheme,
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .navigationBarsPadding()
+                        .padding(start = 46.dp, bottom = 16.dp + chromeLift),
+                )
+            }
+        }
+
+            // Layers/satellite toggle, top-right under the search bar + chips. Shown on the browse
+            // map AND while a place sheet is open, WHENEVER the button's corner actually clears the
+            // sheet (user 2026-07-20: never hide it just for orientation, only for overlap - the
+            // compass coexists the same way). The gate compares the sheet's MEASURED top edge
+            // against the button's bottom edge, so it's continuously right on any screen: phone
+            // portrait and tablets keep the button beside a minimized sheet, a phone-landscape PEEK
+            // (sheet reaches the corner) drops it, and the slim minimized bar brings it back.
+            // sheetTopPx == 0 = unmeasured (first frame) - treated as covered, no flash.
+            // Street View / pick-on-map keep a selected place with NO sheet composed, so the stale
+            // measurement must not show the button over the pano/picker - both are excluded.
+            val layersDensity = LocalDensity.current
+            val layersButtonBottomPx = WindowInsets.statusBars.getTop(layersDensity) +
+                with(layersDensity) { ((if (landscapeChrome) 74.dp else 128.dp) + 42.dp + 8.dp).toPx() }
+            val clearOfPlaceSheet = state.selected == null ||
+                (
+                    state.streetView == null && !state.streetViewLoading && state.pickOnMap == null &&
+                        placeSheetTopPx > layersButtonBottomPx
+                    )
+            if (app.vela.ui.LayersButton.on.value && !searchOpen &&
+                !state.navigating && !state.replaying && !resultsShown && !placeSheetExpanded &&
+                clearOfPlaceSheet
             ) {
                 val ctx = androidx.compose.ui.platform.LocalContext.current
                 val anyLayerOn = app.vela.ui.SatelliteLayer.on.value || Traffic.on.value ||
@@ -2082,44 +2151,6 @@ fun MapScreen(
                     }
                 }
             }
-            // Required Esri attribution while the imagery is on - bottom center, clear of the
-            // scale bar and FABs, the year centered on its own line under the credit.
-            if (app.vela.ui.SatelliteLayer.on.value) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .navigationBarsPadding()
-                        .padding(bottom = 16.dp + chromeLift),
-                ) {
-                    Text(
-                        stringResource(R.string.map_satellite_attribution),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = if (darkTheme) Color(0xFFB8C2CC) else Color(0xFF4A4A4A),
-                    )
-                    state.imageryYear?.let {
-                        Text(
-                            it,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = if (darkTheme) Color(0xFFB8C2CC) else Color(0xFF4A4A4A),
-                        )
-                    }
-                }
-            }
-            // Also step aside while the free-drive speed box occupies the low corner (it moved
-            // down level with the locate FAB, user 2026-07-14) - the follow gate alone missed a
-            // moving-but-panned map, where both used to want the same spot.
-            if (!(driveFollowing && speedOverlayArmed) && !movingFree) {
-                ScaleBar(
-                    metersPerPixel = metersPerPixel,
-                    dark = darkTheme,
-                    modifier = Modifier
-                        .align(Alignment.BottomStart)
-                        .navigationBarsPadding()
-                        .padding(start = 46.dp, bottom = 16.dp + chromeLift),
-                )
-            }
-        }
 
         // --- transient surfaces --------------------------------------------
         if (state.showPsdsTip && state.selected == null && !searchOpen && !state.navigating &&

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -282,6 +282,9 @@ fun VelaMapView(
     cameraTargetZoom: Double? = null, // deep-link z= override for the target fly (null = default framing)
     recenterTick: Int = 0, // bumped on each recenter tap → force a move even if already "centered"
     cameraBottomInsetPx: Int = 0,
+    // Landscape side-panel width (the place/results sheets as a left column): the optical centre
+    // shifts RIGHT instead of up, so a focused pin lands in the map strip beside the panel.
+    cameraLeftInsetPx: Int = 0,
     cameraTopInsetPx: Int = 0, // measured top chrome (the endpoints card) - the route fit clears it
     routePolyline: List<LatLng>,
     routeColor: String,
@@ -2371,22 +2374,25 @@ fun VelaMapView(
             }
         } else if (lastSvPos != null) {
             lastSvPos = null
-            map.setPadding(0, 0, 0, cameraBottomInsetPx) // hand padding back to the sheet logic
+            map.setPadding(cameraLeftInsetPx, 0, 0, cameraBottomInsetPx) // hand padding back to the sheet logic
         }
         // Shift the map's optical centre up by the bottom-sheet height so the
         // focused pin sits in the *visible* strip above the place sheet instead of
         // being hidden behind it. Padding is the map's single source of truth, so
         // every camera move below respects it. Reset to 0 when no sheet is up.
-        if (cameraBottomInsetPx != lastInsetPx) {
+        // Bottom (portrait sheet) and left (landscape side panel) fold into ONE key so a change
+        // on either axis re-applies padding; appearance on either axis re-frames.
+        val insetKey = cameraBottomInsetPx * 31 + cameraLeftInsetPx
+        if (insetKey != lastInsetPx) {
             // Only re-frame when the sheet APPEARS or grows (lift the pin above it). When it
             // shrinks to 0 (sheet closed) we must NOT null lastCameraTarget — doing so let the
             // else-branch below re-center on the now-stale cameraTarget at a zoomed-out level,
             // yanking the map back to the tapped place and zooming out after you'd panned away.
-            val grew = cameraBottomInsetPx > lastInsetPx
-            lastInsetPx = cameraBottomInsetPx
+            val grew = insetKey > lastInsetPx
+            lastInsetPx = insetKey
             // While Street View owns the camera padding (top inset), don't clobber it here -
             // the SV close path restores the sheet padding itself.
-            if (svPose == null) map.setPadding(0, 0, 0, cameraBottomInsetPx)
+            if (svPose == null) map.setPadding(cameraLeftInsetPx, 0, 0, cameraBottomInsetPx)
             if (grew) lastCameraTarget = null // re-frame the current target against the new inset
         }
         // While the results sheet is closed forget the last marker fit, so pulling the list back
@@ -2419,7 +2425,7 @@ fun VelaMapView(
                             val mpd = (acc.toDouble() * 2 / 0.7) / screenDp
                             (Math.log((78271.517 * Math.cos(Math.toRadians(t.lat))) / mpd) / Math.log(2.0)).coerceIn(3.0, 15.0)
                         }
-                        cameraBottomInsetPx > 0 -> app.vela.core.config.CalibrationStore.latest.tune("browseZoomFocus", 16.5)
+                        cameraBottomInsetPx > 0 || cameraLeftInsetPx > 0 -> app.vela.core.config.CalibrationStore.latest.tune("browseZoomFocus", 16.5)
                         // 15.5 (~1000ft), matching the launch-centre and search flies - the tap
                         // used to land at 15.0 while every other path used 15.5, so a follow-up
                         // camera move visibly changed zoom (part of the locate rubber-band).
@@ -2508,9 +2514,9 @@ fun VelaMapView(
             // condition) so the branches BELOW stay unreachable during nav, same pattern as the
             // nav follow branch's own pre-engage swallow.
             routePolyline.size >= 2 &&
-                (navMode || (routePolyline.hashCode() * 31 + cameraBottomInsetPx * 7 + cameraTopInsetPx) != lastFittedRouteKey) -> {
+                (navMode || (routePolyline.hashCode() * 31 + cameraBottomInsetPx * 7 + cameraLeftInsetPx * 13 + cameraTopInsetPx) != lastFittedRouteKey) -> {
                 if (!navMode) { // in-nav framing is owned by the follow ticker + navOverviewTick
-                    lastFittedRouteKey = routePolyline.hashCode() * 31 + cameraBottomInsetPx * 7 + cameraTopInsetPx
+                    lastFittedRouteKey = routePolyline.hashCode() * 31 + cameraBottomInsetPx * 7 + cameraLeftInsetPx * 13 + cameraTopInsetPx
                     val builder = MLLatLngBounds.Builder()
                     routePolyline.forEach { builder.include(MLLatLng(it.lat, it.lng)) }
                     // Reserve room at the bottom for the directions panel AND at the top for the

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -309,8 +309,18 @@ fun PlaceSheet(
     // Transit stops expand FULL-SCREEN like any other place (the short-lived peek cap from earlier
     // today blocked maximizing a stop entirely - reported independently by the user and issue #71's
     // reporter within hours; with real multi-route boards the full detent has plenty to show).
-    val minH = if (singleDetent) screenH * 0.30f else screenH * 0.26f
-    val peekH = if (singleDetent) screenH * 0.30f else screenH * 0.56f
+    // Landscape floors (2026-07-20, the side-panel layout): 0.26 of a ~390dp landscape screen is
+    // ~101dp - only the name row fits and the action pills (Directions/Call) fold out of the
+    // minimized card. The dp floor keeps the skeleton (name + rating + pills) visible minimized,
+    // and peek keeps a real gap above it so the detents stay distinguishable to drag between.
+    // Portrait numbers are untouched (0.26 of a phone portrait is already past the floor).
+    val landscapeSheet = LocalConfiguration.current.screenWidthDp > screenH
+    val minH = if (singleDetent) screenH * 0.30f
+    else if (landscapeSheet) maxOf(screenH * 0.26f, 200f).coerceAtMost(screenH * 0.6f)
+    else screenH * 0.26f
+    val peekH = if (singleDetent) screenH * 0.30f
+    else if (landscapeSheet) maxOf(screenH * 0.56f, minH + 70f)
+    else screenH * 0.56f
     val expH = if (singleDetent) screenH * 0.30f else screenH * 0.92f
     fun detentFor(expanded: Boolean, minimized: Boolean) = when {
         expanded -> expH

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -309,19 +309,26 @@ fun PlaceSheet(
     // Transit stops expand FULL-SCREEN like any other place (the short-lived peek cap from earlier
     // today blocked maximizing a stop entirely - reported independently by the user and issue #71's
     // reporter within hours; with real multi-route boards the full detent has plenty to show).
-    // Landscape floors (2026-07-20, the side-panel layout): 0.26 of a ~390dp landscape screen is
-    // ~101dp - only the name row fits and the action pills (Directions/Call) fold out of the
-    // minimized card. The dp floor keeps the skeleton (name + rating + pills) visible minimized,
-    // and peek keeps a real gap above it so the detents stay distinguishable to drag between.
-    // Portrait numbers are untouched (0.26 of a phone portrait is already past the floor).
+    // Landscape (2026-07-20, the side-panel layout) is a TWO-detent ladder: 0.26 of a ~390dp
+    // landscape screen is ~101dp - only the name row fits and the action pills (Directions/Call)
+    // fold out of the minimized card - so minimized gets a dp floor that keeps the skeleton
+    // visible. Expanded CAPS BELOW THE SEARCH BAR (screenH - 104dp): the full-height 0.92 slid the
+    // panel's top strip under the full-width bar, which kept taking taps over it (user 2026-07-20,
+    // "maximized does not hide the search bar" - in the panel layout the bar deliberately STAYS,
+    // so the panel must stop under it instead). Between a 200dp floor and a ~286dp cap there is
+    // no room for a distinct middle stop, so peek = expanded and the panel steps minimized <->
+    // tall, Google's landscape feel. Portrait numbers are untouched.
     val landscapeSheet = LocalConfiguration.current.screenWidthDp > screenH
+    val landscapeExpH = maxOf(screenH - 104f, screenH * 0.55f)
     val minH = if (singleDetent) screenH * 0.30f
-    else if (landscapeSheet) maxOf(screenH * 0.26f, 200f).coerceAtMost(screenH * 0.6f)
+    else if (landscapeSheet) maxOf(screenH * 0.26f, 200f).coerceAtMost(screenH * 0.55f)
     else screenH * 0.26f
     val peekH = if (singleDetent) screenH * 0.30f
-    else if (landscapeSheet) maxOf(screenH * 0.56f, minH + 70f)
+    else if (landscapeSheet) landscapeExpH
     else screenH * 0.56f
-    val expH = if (singleDetent) screenH * 0.30f else screenH * 0.92f
+    val expH = if (singleDetent) screenH * 0.30f
+    else if (landscapeSheet) landscapeExpH
+    else screenH * 0.92f
     fun detentFor(expanded: Boolean, minimized: Boolean) = when {
         expanded -> expH
         minimized -> minH


### PR DESCRIPTION
Three pieces, all one design: stop hiding map buttons situationally by making the landscape layout Google's.

**Landscape side panel.** In landscape the search-results list and the place sheet render as a width-capped (400dp) LEFT panel instead of a full-width bottom sheet. The map keeps a real strip beside them, so the layers, parking and my-location buttons simply stay visible whenever the map does - no overlap rules needed. The camera inset moves to the left axis to match (new `cameraLeftInsetPx` through VelaMapView), so a focused pin or the result cluster frames in the visible strip. The minimized place card keeps its name, rating and Directions/Call pills in landscape (a dp floor on the minimized detent; 0.26 of a ~390dp landscape height only fit the name row). Scale bar yields to the panel; the satellite attribution centers in the map strip.

**Layers button while a POI is open.** The button used to vanish the moment any place was selected. Portrait: it shows whenever its corner measurably clears the sheet (the sheet reports its live top edge; the gate compares it against the button's bottom, continuously as the sheet is dragged). Landscape: always clear by construction (the panel never reaches that corner). Street View / pick-on-map keep a selected place with no sheet composed and are excluded from the show side.

**Locate button with a minimized card (portrait).** The my-location FAB rides above a minimized place card's measured top edge instead of hiding, tracking the card as it moves.

Device-verified on the Pixel 4a: landscape results panel + place panel with every button standing and the cluster framed in the strip, landscape minimized card with action pills, satellite toggle with a POI open, portrait lifted locate, portrait sheets byte-identical to before. Also checked on a simulated 2560x1600 tablet.