### PR TITLE
Car icon-size setting reaches every marker layer, transit badges stop stomping labels

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1647,6 +1647,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   the mini-dot tier, the OSM POI icons, transit stops and traffic controls together - Small
   exists for low-density car head units (a 1024x600 screen renders the fixed-px bitmaps
   physically huge); phones default to 1.0 and are untouched. All toggles act immediately.
+  Since 2026-07-20 the scale also covers the layers the first cut missed: search-result
+  pins and rating bubbles (with their labels), the collapsed result dots, saved-place pins
+  and the surveillance-camera badges - so a gas or restaurant search on a head unit shrinks
+  with the rest of the map. Transit-stop badges also claim a collision box now, so nearby
+  labels place around them instead of printing over them.
 - ✅ **Fire stations are not bus stops anymore (2026-07-15).** The category classifier's
   transit branch matched the bare word "station" before the civic branch could claim "fire
   station", so fire houses drew with the transit icon. Civic now classifies first, and the

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -2871,7 +2871,11 @@ private fun ensureLayers(style: Style) {
         style.addLayer(
             SymbolLayer(MARKERS_LAYER, MARKERS_SRC).withProperties(
                 PropertyFactory.iconImage(Expression.get("icon")),
-                PropertyFactory.iconSize(1.15f),
+                // Result pins/bubbles scaled to ~0.8x of the old 1.15 (2026-07-20): the rating
+                // "speech bubbles" read chunky next to Google's on a phone-width screen (a pill
+                // was ~18% of a 1080px width). Uniform scale keeps the circle+glyph+text in
+                // proportion and readable; slimming just the bitmap padding would distort them.
+                PropertyFactory.iconSize(0.92f),
                 PropertyFactory.iconAnchor(Property.ICON_ANCHOR_BOTTOM),
                 PropertyFactory.iconAllowOverlap(false),
                 PropertyFactory.iconIgnorePlacement(false),

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1086,7 +1086,7 @@ fun VelaMapView(
             // shrank - on a low-density head unit exactly these (a gas search, a saved spot) were
             // the "sometimes" giants. Base values mirror layer creation; keep them in lockstep.
             st.getLayer(MARKERS_LAYER)?.setProperties(
-                PropertyFactory.iconSize(1.0f * sc),
+                PropertyFactory.iconSize(1.15f * sc),
                 PropertyFactory.textSize(13f * sc),
             )
             st.getLayer(MARKERS_DOTS_LAYER)?.setProperties(PropertyFactory.iconSize(sc))
@@ -2891,13 +2891,14 @@ private fun ensureLayers(style: Style) {
         style.addLayer(
             SymbolLayer(MARKERS_LAYER, MARKERS_SRC).withProperties(
                 PropertyFactory.iconImage(Expression.get("icon")),
-                // Result pins/bubbles at 1.0 (2026-07-20): the original 1.15 read chunky next to
-                // Google's on a phone-width screen (a rating pill was ~18% of a 1080px width), a
-                // first cut at 0.92 read a touch small on the same device - 1.0 is the calibrated
-                // middle. Uniform scale keeps the circle+glyph+text in proportion; slimming just
-                // the bitmap padding would distort them. Car screens scale this via the Settings
-                // icon-size multiplier (the poiIconScale effect re-applies it with sc baked in).
-                PropertyFactory.iconSize(1.0f),
+                // 1.15 is the calibrated size and it survived a full re-litigation (2026-07-20):
+                // a "too big" report led to 0.92 ("a little small"), then 1.0 ("kinda small"),
+                // before the real culprit surfaced - satellite mode was on, and the white pin
+                // backings over imagery read much heavier than the same bitmaps on the vector
+                // basemap. On the vector map 1.15 was right all along. Don't re-shrink this over
+                // a satellite-mode size report; car screens scale it via the Settings icon-size
+                // multiplier (the poiIconScale effect re-applies it with sc baked in).
+                PropertyFactory.iconSize(1.15f),
                 PropertyFactory.iconAnchor(Property.ICON_ANCHOR_BOTTOM),
                 PropertyFactory.iconAllowOverlap(false),
                 PropertyFactory.iconIgnorePlacement(false),

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1072,6 +1072,7 @@ fun VelaMapView(
                         Expression.stop(15f, 0.78f * sc), Expression.stop(17f, 1.1f * sc), Expression.stop(19f, 1.4f * sc),
                     ),
                 ),
+                PropertyFactory.textSize(10.5f * sc),
             )
             val controlsScaled = Expression.interpolate(
                 Expression.linear(), Expression.zoom(),
@@ -1079,6 +1080,25 @@ fun VelaMapView(
             )
             st.getLayer(CONTROLS_LAYER)?.setProperties(PropertyFactory.iconSize(controlsScaled))
             st.getLayer(CONTROLS_CLAIM_LAYER)?.setProperties(PropertyFactory.iconSize(controlsScaled))
+            // Layers the first cut MISSED (2026-07-20, car-screen report "POIs still a bit large
+            // sometimes"): search-result pins/rating bubbles, the collapsed result dots, saved-place
+            // pins and the flock badges all kept their fixed-px size while everything around them
+            // shrank - on a low-density head unit exactly these (a gas search, a saved spot) were
+            // the "sometimes" giants. Base values mirror layer creation; keep them in lockstep.
+            st.getLayer(MARKERS_LAYER)?.setProperties(
+                PropertyFactory.iconSize(1.0f * sc),
+                PropertyFactory.textSize(13f * sc),
+            )
+            st.getLayer(MARKERS_DOTS_LAYER)?.setProperties(PropertyFactory.iconSize(sc))
+            st.getLayer(SAVED_LAYER)?.setProperties(PropertyFactory.iconSize(sc))
+            st.getLayer(FLOCK_LAYER)?.setProperties(
+                PropertyFactory.iconSize(
+                    Expression.interpolate(
+                        Expression.linear(), Expression.zoom(),
+                        Expression.stop(14f, 0.7f * sc), Expression.stop(17f, 1.0f * sc), Expression.stop(19f, 1.35f * sc),
+                    ),
+                ),
+            )
         }
     }
 
@@ -2871,11 +2891,13 @@ private fun ensureLayers(style: Style) {
         style.addLayer(
             SymbolLayer(MARKERS_LAYER, MARKERS_SRC).withProperties(
                 PropertyFactory.iconImage(Expression.get("icon")),
-                // Result pins/bubbles scaled to ~0.8x of the old 1.15 (2026-07-20): the rating
-                // "speech bubbles" read chunky next to Google's on a phone-width screen (a pill
-                // was ~18% of a 1080px width). Uniform scale keeps the circle+glyph+text in
-                // proportion and readable; slimming just the bitmap padding would distort them.
-                PropertyFactory.iconSize(0.92f),
+                // Result pins/bubbles at 1.0 (2026-07-20): the original 1.15 read chunky next to
+                // Google's on a phone-width screen (a rating pill was ~18% of a 1080px width), a
+                // first cut at 0.92 read a touch small on the same device - 1.0 is the calibrated
+                // middle. Uniform scale keeps the circle+glyph+text in proportion; slimming just
+                // the bitmap padding would distort them. Car screens scale this via the Settings
+                // icon-size multiplier (the poiIconScale effect re-applies it with sc baked in).
+                PropertyFactory.iconSize(1.0f),
                 PropertyFactory.iconAnchor(Property.ICON_ANCHOR_BOTTOM),
                 PropertyFactory.iconAllowOverlap(false),
                 PropertyFactory.iconIgnorePlacement(false),
@@ -3191,8 +3213,13 @@ private fun ensureLayers(style: Style) {
                 setProperties(
                     PropertyFactory.iconImage(TRANSIT_STOP_IMG),
                     PropertyFactory.iconSize(stopSize),
+                    // The flock pattern (2026-07-20, car-screen "icons bump into the text" report):
+                    // the badge never yields itself (allowOverlap), but with ignorePlacement TRUE it
+                    // also never claimed a collision box, so later-placed labels (ambient POI names,
+                    // street names) printed straight under/over it. ignorePlacement FALSE keeps the
+                    // badge always-drawn while text finds a clear spot around it.
                     PropertyFactory.iconAllowOverlap(true),
-                    PropertyFactory.iconIgnorePlacement(true),
+                    PropertyFactory.iconIgnorePlacement(false),
                     PropertyFactory.iconPadding(2f),
                     PropertyFactory.textField(Expression.get("name")),
                     PropertyFactory.textFont(arrayOf("Noto Sans Regular")),


### PR DESCRIPTION
Started as a marker-size complaint that turned out to be satellite mode (white pin backings over imagery read much heavier than the same bitmaps on the vector basemap). Result markers stay at their long-standing 1.15, now with a comment warning future readers not to re-shrink them over a satellite-mode size report.

What actually ships:

**Car head units:** the Settings place-icon-size multiplier (Small / Default / Large) missed several layers, so with Small selected the search-result pins and rating bubbles, the collapsed result dots, saved-place pins and the surveillance-camera badges all stayed at full fixed-pixel size while everything around them shrank. The scale effect now covers all of them, labels included, with base values mirroring layer creation.

**Icons bumping into text:** transit-stop badges drew with `iconIgnorePlacement(true)`, so they never claimed a collision box and later-placed labels (POI names, street names) printed straight over them. They now follow the flock-badge pattern: always drawn, but text places around them.

Device-verified on the Pixel 4a at phone density and on a simulated 1024x600 @ 160dpi head unit (Small shrinks result bubbles and ambient icons together).

FEATURES.md updated for the wider scale coverage.