### PR TITLE
No more phantom ramps on divided-road renames

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1797,7 +1797,11 @@ architecture note.
   all road+bridge geometry, still below text. (2) **Exit consolidation** - OSRM splits one exit into ramp +
   fork/merge steps, each spoken separately ("Take exit 15"…"Keep right"…"Merge"). `RouteGeometry.consolidateExits`
   folds a ramp's immediately-following, <500 m-gapped FORK/MERGE run into the ramp maneuver (sums distances so
-  they still tile the polyline; stops at any real turn / far gap) → one prompt. Unit-tested. **Sibling
+  they still tile the polyline; stops at any real turn / far gap) → one prompt. Unit-tested. **Cousin `rampReclass` (2026-07-21):** a SIGNLESS
+  dead-straight "on ramp" (dual-carriageway rename transitions get tagged *_link in OSM, so OSRM
+  calls them ramps) reclassifies to "new name" before typing/phrasing - silent CONTINUE, never
+  "Take the ramp" on a road that just renames; narrow on purpose (straight/null modifier only,
+  destinations present always keeps the ramp). **Sibling
   `RouteGeometry.foldRenames` (2026-07-06)** folds a pure-rename CONTINUE (OSRM `continue`/`new name` going
   straight, no genuine fork - "Olive Dr becomes Richards Blvd") into the PRECEDING maneuver so it's not its own
   banner card / step at all - NavEngine already SILENCED its voice, but it still showed a silly "Continue onto X"

--- a/core/src/main/java/app/vela/core/data/RouteGeometry.kt
+++ b/core/src/main/java/app/vela/core/data/RouteGeometry.kt
@@ -450,9 +450,10 @@ object RouteGeometry {
                     ?: return@mapNotNull null
                 Lane(inds, o["valid"]?.jsonPrimitive?.booleanOrNull ?: false)
             }.orEmpty()
+        val effType = rampReclass(type, mod, dest)
         return Maneuver(
-            type = osrmType(type, mod),
-            instruction = osrmPhrase(type, mod, road, dest, exits, man["exit"]?.jsonPrimitive?.intOrNull),
+            type = osrmType(effType, mod),
+            instruction = osrmPhrase(effType, mod, road, dest, exits, man["exit"]?.jsonPrimitive?.intOrNull),
             side = if (type == "arrive" && mod != null) {
                 when {
                     mod.contains("left") -> "left"
@@ -468,6 +469,21 @@ object RouteGeometry {
             lanes = lanes,
         )
     }
+
+    /** A SIGNLESS, DEAD-STRAIGHT "on ramp" is a divided-road transition, not a ramp (real-drive
+     *  report 2026-07-21: "take the ramp" spoken while going straight on the same physical road
+     *  through a rename, median and all). Where a dual carriageway continues straight and only
+     *  changes name, the transition way is often tagged *_link in OSM and OSRM dutifully emits
+     *  "on ramp" - but with NO destinations (there is no sign) and a straight modifier. A real
+     *  freeway entrance virtually always carries sign destinations, and one you must steer onto
+     *  carries a left/right/slight modifier. Reclassify the signless straight case as "new name"
+     *  so it rides the rename path: CONTINUE on the banner, silent by voice, foldable by
+     *  foldRenames - what Google does there. Deliberately NARROW (straight/null only): a signless
+     *  SLIGHT ramp could still be a real unsigned entrance, and a wrongly silenced real ramp is
+     *  worse than a wrongly spoken phantom one. */
+    internal fun rampReclass(type: String, mod: String?, dest: String?): String =
+        if ((type == "on ramp" || type == "ramp") && dest == null && (mod == null || mod == "straight")) "new name"
+        else type
 
     /** OSRM `maneuver.type` + `modifier` → Vela [ManeuverType] (for the arrow + haptic). */
     internal fun osrmType(type: String, mod: String?): ManeuverType {

--- a/core/src/test/java/app/vela/core/OsrmRouterTest.kt
+++ b/core/src/test/java/app/vela/core/OsrmRouterTest.kt
@@ -44,6 +44,20 @@ class OsrmRouterTest {
         assertEquals(ManeuverType.UTURN, RouteGeometry.osrmType("turn", "uturn"))
     }
 
+    @Test fun signlessStraightRampIsARename() {
+        // A dual carriageway continuing straight through a name change is often tagged *_link in
+        // OSM, so OSRM calls it "on ramp" - with no sign destinations and a straight modifier.
+        // That reclassifies to the rename path (silent CONTINUE), never "Take the ramp".
+        assertEquals("new name", RouteGeometry.rampReclass("on ramp", "straight", null))
+        assertEquals("new name", RouteGeometry.rampReclass("on ramp", null, null))
+        assertEquals("new name", RouteGeometry.rampReclass("ramp", "straight", null))
+        // A REAL entrance keeps the ramp: it has a sign, or you must steer onto it.
+        assertEquals("on ramp", RouteGeometry.rampReclass("on ramp", "straight", "I 80 East: Sacramento"))
+        assertEquals("on ramp", RouteGeometry.rampReclass("on ramp", "slight right", null))
+        assertEquals("on ramp", RouteGeometry.rampReclass("on ramp", "right", null))
+        assertEquals("off ramp", RouteGeometry.rampReclass("off ramp", "straight", null)) // exits untouched
+    }
+
     @Test fun phrasesReadNaturally() {
         assertEquals("Turn right onto the local street", RouteGeometry.osrmPhrase("turn", "right", "the local street", null, null, null))
         assertEquals("Continue onto Olive Dr", RouteGeometry.osrmPhrase("new name", "straight", "Olive Dr", null, null, null))


### PR DESCRIPTION
Real-drive report: nav spoke "take the ramp" on a dead-straight continuation of the same physical road, which merely changes name across a median-divided junction. OSM often tags that transition way `*_link`, so OSRM classifies it "on ramp".

The discriminator: a genuine freeway entrance virtually always carries sign `destinations`, and one you must steer onto carries a left/right/slight modifier. A SIGNLESS on-ramp with a straight (or absent) modifier now reclassifies to "new name" before typing/phrasing, riding the existing rename path: CONTINUE on the banner, silent by voice, foldable by `foldRenames` - what Google does there. Deliberately narrow: destinations or a steering modifier always keeps the ramp phrase, since a wrongly silenced real ramp is worse than a wrongly spoken phantom.

Unit-tested both directions; core tests pass.