### PR TITLE
Step preview jumps instead of flying, so swiping through turns keeps up

### DIFF
--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -2446,13 +2446,23 @@ fun VelaMapView(
                 lastNavTarget = null // so nav-follow re-centres cleanly when the preview ends
                 if (previewTarget != lastPreviewTarget) {
                     lastPreviewTarget = previewTarget
-                    flightDepth[0]++
-                    map.animateCamera(
-                        CameraUpdateFactory.newLatLngZoom(
-                            MLLatLng(previewTarget.lat, previewTarget.lng), 16.5,
+                    // JUMP, don't fly (2026-07-21, real-drive "lag when swiping through turns"):
+                    // animateCamera interpolates the camera THROUGH every intermediate viewport
+                    // for the whole flight, and at nav zoom + tilt each of those frames loads and
+                    // places tiles along the way - swiping several steps queued 700 ms flights
+                    // and the map fell behind the finger on a mid-range phone. A straight
+                    // moveCamera renders exactly ONE new viewport per swipe (Google's step
+                    // preview jumps too). The tilt/bearing reset to a flat top-down preview
+                    // rides the same single move.
+                    map.moveCamera(
+                        CameraUpdateFactory.newCameraPosition(
+                            org.maplibre.android.camera.CameraPosition.Builder()
+                                .target(MLLatLng(previewTarget.lat, previewTarget.lng))
+                                .zoom(16.5)
+                                .tilt(0.0)
+                                .bearing(0.0)
+                                .build(),
                         ),
-                        700,
-                        flightCb(),
                     )
                 }
             }


### PR DESCRIPTION
Swiping through upcoming turns on the nav card lagged on a mid-range phone. The preview used a 700ms `animateCamera` flight, which renders every intermediate viewport along the way - at nav zoom + tilt that's continuous tile load/placement, and consecutive swipes queued flight after flight until the map fell behind the finger.

The preview now `moveCamera`s straight to the turn: one new viewport per swipe, which is what Google's step preview does too. It lands flat and north-up deliberately - clearer for "where is this turn", and a 55-degree camera loads a wedge of tiles to the horizon that a flat view never asks for. Ending the preview re-seeds the follow camera from the live position as before, so the ease back into the tilted chase is unchanged.

Feel-test on a real drive pending (the mechanism removes the intermediate rendering entirely).