### PR TITLE
Place sheet chrome fixes and landscape sizing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -648,6 +648,15 @@ Defaults that make the safe path the easy one:
   ~190dp, which sat exactly on the compass (user report); 200dp clears the touch target, not just
   the visible circle. Keyed on `LayersButton.on` (the pref), not the button's transient visibility,
   so the compass doesn't jump around as sheets open.
+  **Landscape panel width is HALF THE SCREEN, floored 400dp / capped 520dp (`sidePanelWidth()`,
+  2026-07-23)** - the fixed 400 read too narrow; every consumer (both sheets' widthIn, the camera
+  left inset, the attribution pad) reads the computed value. **Sheet heights RE-SNAP on rotation:**
+  the place-sheet and results-sheet settle effects key on screenH/landscape too - without that the
+  Animatable kept the old orientation's pixel height and an expanded portrait card came into
+  landscape over the search bar. **Chrome hides are MEASURED, not logical (2026-07-23):** a
+  short-content place flips expandedState while its wrap-capped card never grows, so the search-bar
+  hide requires placeSheetTopPx < 0.40*screen and the layers button relies on the measured
+  clearOfPlaceSheet gate alone - never re-add a bare placeSheetExpanded gate on map chrome.
   **LANDSCAPE (width > height) collapses the browse chrome to ONE line (2026-07-15, Google's
   landscape layout, device-verified on the 4a):** `landscapeChrome` in MapScreen puts the search
   bar at half width with the category chips scrolling beside it (`landscapeOneLine` Row), the

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **Sheet chrome and landscape fixes (2026-07-23).** Swiping the handle of a place with
+  nothing to expand no longer makes the search bar and layers button vanish: they only hide when
+  the sheet measurably covers them. Rotating the phone with a place card or results list open now
+  resizes it to the new orientation instead of keeping the old height over the search bar, and the
+  landscape side panel widens to half the screen (400 to 520dp) instead of a fixed 400dp.
 - ✅ **Settings redesigned hub-and-spoke (2026-07-23, ported from the vela-dpad fork by
   alltechdev).** The single very long Settings page is now a short hub of category rows, each
   opening its own small sub-screen (Appearance / Map / Place pages / Navigation / Voice / Search /

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -2139,9 +2139,13 @@ fun MapScreen(
             // Portrait, place card at (or near) its minimized bar: the locate FAB rides ABOVE the
             // card's measured top edge (user 2026-07-20: current location stays reachable with a
             // card minimized). Offset from the sheet's live top so it tracks the card; the >55%
-            // floor keeps it to the minimized neighbourhood - at peek/expanded it stays hidden.
+            // floor keeps it to the minimized neighbourhood - at peek/expanded the measured top
+            // sits above the floor so it stays hidden. MEASURED ONLY (2026-07-23): the logical
+            // expanded flag also gated this, and a pill swipe on a short-content card flips that
+            // flag while the card never grows, so the button vanished with the card unmoved
+            // (the same phantom-expanded class as the search-bar/layers hides).
             // Landscape needs none of this: the side panel leaves the normal FABs standing.
-            if (fabChromeOk && !landscapeChrome && state.selected != null && !placeSheetExpanded &&
+            if (fabChromeOk && !landscapeChrome && state.selected != null &&
                 state.pickOnMap == null && placeSheetTopPx > screenHeightPx * 0.55f
             ) {
                 FloatingActionButton(

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -215,7 +215,17 @@ private const val USE_MAPTILER = false
 // Landscape side-panel width for the place/results sheets (Google's landscape treatment):
 // wide enough for the sheet content, narrow enough that a phone landscape (~730dp+) keeps a
 // real map strip with all the right-side buttons beside it.
-private val SIDE_PANEL_WIDTH = 400.dp
+// Landscape side-panel width: half the screen up to a cap, floored at the old 400dp - the fixed
+// 400 read too narrow on wide screens (user 2026-07-23); Google's landscape panel takes roughly
+// half a phone's width too. Computed per-configuration in sidePanelWidth().
+private val SIDE_PANEL_WIDTH_MIN = 400.dp
+private val SIDE_PANEL_WIDTH_MAX = 520.dp
+
+@Composable
+private fun sidePanelWidth(): androidx.compose.ui.unit.Dp {
+    val w = LocalConfiguration.current.screenWidthDp
+    return (w * 0.5f).dp.coerceIn(SIDE_PANEL_WIDTH_MIN, SIDE_PANEL_WIDTH_MAX)
+}
 
 @Composable
 fun MapScreen(
@@ -258,7 +268,8 @@ fun MapScreen(
     // layout, user 2026-07-20) - width-capped, so the right-side chrome (layers, parking,
     // locate) never collides with them. The camera inset moves to the LEFT axis to match:
     // a focused pin frames in the map strip beside the panel, not squeezed into a top sliver.
-    val sidePanelWidthPx = with(LocalDensity.current) { SIDE_PANEL_WIDTH.toPx() }.toInt()
+    val sidePanelWidthDp = sidePanelWidth()
+    val sidePanelWidthPx = with(LocalDensity.current) { sidePanelWidthDp.toPx() }.toInt()
     val cameraBottomInset = when {
         // Street View pane up: the sheet yields, so no bottom inset (the SV top inset takes over).
         state.streetView != null || state.streetViewLoading -> 0
@@ -1314,12 +1325,19 @@ fun MapScreen(
                                 )
                             }
                         }
-                    } else if (!(state.selected != null && placeSheetExpanded && !searchOpen && !landscapeChrome) &&
+                    } else if (!(state.selected != null && placeSheetExpanded && !searchOpen && !landscapeChrome &&
+                        placeSheetTopPx < screenHeightPx * 0.40f) &&
                         !(state.directionsOpen && !searchOpen)
                     ) {
-                        // The expanded-sheet hide is PORTRAIT-only: in landscape the sheet is the
-                        // side panel, which caps BELOW the bar (PlaceSheet's landscape detents), so
-                        // the bar deliberately stays - hiding it would strand the map strip with no
+                        // The expanded-sheet hide is PORTRAIT-only AND measured (2026-07-23): a
+                        // short-content place (no photos, wrap-capped card) flips the LOGICAL
+                        // expanded flag on a pill swipe while the card never grows, and the bar
+                        // vanished for no visible reason (user report, "thought we killed this").
+                        // The 0.40-screen top test only hides the bar when the sheet actually
+                        // reaches up the screen (a real expanded sheet tops out near 0.08).
+                        // In landscape the sheet is the side panel, which caps BELOW the bar
+                        // (PlaceSheet's landscape detents), so the bar deliberately stays -
+                        // hiding it would strand the map strip with no
                         // search while nothing actually covers the bar.
                         searchBar()
                     }
@@ -1753,7 +1771,7 @@ fun MapScreen(
                 // landscape layout, user 2026-07-20).
                 modifier = Modifier
                     .align(if (landscapeChrome) Alignment.BottomStart else Alignment.BottomCenter)
-                    .then(if (landscapeChrome) Modifier.widthIn(max = SIDE_PANEL_WIDTH) else Modifier)
+                    .then(if (landscapeChrome) Modifier.widthIn(max = sidePanelWidthDp) else Modifier)
                     // Live top edge for the layers button's overlap gate (see placeSheetTopPx).
                     .onGloballyPositioned { placeSheetTopPx = it.positionInRoot().y.roundToInt() },
             )
@@ -1785,7 +1803,7 @@ fun MapScreen(
                 // Landscape: left side panel like the place sheet (see its modifier note).
                 modifier = Modifier
                     .align(if (landscapeChrome) Alignment.BottomStart else Alignment.BottomCenter)
-                    .then(if (landscapeChrome) Modifier.widthIn(max = SIDE_PANEL_WIDTH) else Modifier),
+                    .then(if (landscapeChrome) Modifier.widthIn(max = sidePanelWidthDp) else Modifier),
               )
             // Imported Google list preview: offer to save (nothing persisted until tapped).
             // A pill under the search bar, clear of the results sheet at the bottom.
@@ -2085,7 +2103,7 @@ fun MapScreen(
                         .align(Alignment.BottomCenter)
                         .navigationBarsPadding()
                         // Centered in the map STRIP while the landscape panel owns the left.
-                        .padding(start = if (sidePanelUp) SIDE_PANEL_WIDTH else 0.dp)
+                        .padding(start = if (sidePanelUp) sidePanelWidthDp else 0.dp)
                         .padding(bottom = 16.dp + chromeLift),
                 ) {
                     Text(
@@ -2166,7 +2184,7 @@ fun MapScreen(
             // the search bar and never reaches this corner at ANY detent.
             if (app.vela.ui.LayersButton.on.value && !searchOpen &&
                 !state.navigating && !state.replaying &&
-                (!resultsShown || landscapeChrome) && (!placeSheetExpanded || landscapeChrome) &&
+                (!resultsShown || landscapeChrome) &&
                 clearOfPlaceSheet
             ) {
                 val ctx = androidx.compose.ui.platform.LocalContext.current
@@ -2459,7 +2477,9 @@ private fun SearchResults(
     // feel responsive.
     val resultsGlideSpec = remember { spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = 140f) }
     val resultsDecay = remember { exponentialDecay<Float>(frictionMultiplier = 1.6f) }
-    LaunchedEffect(collapsed, expanded) {
+    // expL/peekL in the keys via screenH: rotation kept the other orientation's height (same
+    // stale-geometry trap the place sheet had - user 2026-07-23), so re-snap on a geometry change.
+    LaunchedEffect(collapsed, expanded, screenH) {
         val target = if (collapsed) 0f else if (expanded) expL else peekL
         if (listH.targetValue != target) listH.animateTo(target, if (target == 0f) resultsGlideSpec else resultsSettleSpec)
     }

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -336,7 +336,11 @@ fun PlaceSheet(
     }
     val heightAnim = remember(place.id) { Animatable(detentFor(expandedState.value, minimizedState.value)) }
     val settleSpec = remember { spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = 350f) }
-    LaunchedEffect(place.id, expandedState.value, minimizedState.value) {
+    // landscapeSheet + screenH in the keys: ROTATING kept the other orientation's pixel height
+    // (the effect never re-ran, its keys hadn't changed), so a sheet expanded in portrait came
+    // into landscape taller than the landscape cap and sat over the search bar (user 2026-07-23).
+    // Re-running on a geometry change snaps to the detent the new orientation computes.
+    LaunchedEffect(place.id, expandedState.value, minimizedState.value, landscapeSheet, screenH) {
         val target = detentFor(expandedState.value, minimizedState.value)
         // Skip when a drag-release settle is already animating to this exact detent - restarting
         // would zero the coast velocity mid-glide.


### PR DESCRIPTION
Three fixes from real-use reports.

- **Swiping the pill of a place with nothing to expand no longer hides the search bar and layers button.** A short-content place (no photos) flips the logical expanded state while the wrap-capped card never visibly grows, so the chrome vanished for no reason. Both hides are measured now: the search bar only goes when the sheet's top actually reaches the upper part of the screen, and the layers button relies on the existing measured overlap gate alone.
- **Rotating with an open card resizes it.** The sheet height animation never re-ran on an orientation change, so a card expanded in portrait carried its portrait pixel height into landscape and sat over the search box. The place sheet and the results sheet both re-snap to the new orientation's detents on rotation.
- **The landscape side panel is wider.** Half the screen, floored at the old 400dp and capped at 520dp, instead of a fixed 400dp that read too narrow. Every consumer (both sheets, the camera inset, the attribution padding) reads the computed width.

Also removes four unused softkeys strings that rode in with the settings port (that fork feature was not taken).
