### PR TITLE
Buildings preload for the area you're viewing while the map idles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,14 @@ Defaults that make the safe path the easy one:
   closed is written back (`markClosedInAmbient`: flag flipped in every cached copy + pruned from
   the painted set + persisted) so the dead dot stays gone across restarts - and the
   recently-viewed pin deliberately skips closed places (it bypasses the closed filter).
+- **Idle building warm-up (2026-07-23, `VelaMapView` camera-idle listener):** after 2.5 s of
+  stillness on the browse map at z13.5-15.9, an off-screen `MapSnapshotter` renders ONLY the active
+  building-overlay pmtiles sources at z16.2 over the camera target, which pulls the z15/16 footprint
+  tiles through MapLibre's shared ambient cache so the later zoom-in paints from cache (the "houses
+  take a sec at 200 ft" report; the snapshotter and the map share one cache database - the Android
+  Auto renderer already relies on that). One warm per ~2 km bucket per session, canceled by any
+  camera move, skipped during nav; logcat tag `VelaWarm`. It renders no basemap (those tiles cap at
+  z14 and are already resident) - the overlay range-fetches were the whole delay.
 - **The MS building-overlay gate is BOUNDED render-probing; keep its three rules (2026-07-17,
   `VelaMapView` `runOvlGate`).** The overlay (`vela-ovl-*`) is drawn beneath OSM `building` to fill
   OSM's gaps, so where OSM is dense it is pure occluded overdraw; a gate probes rendered OSM

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **Street-level buildings preload while you idle (2026-07-23).** Zooming down to the ~200 ft
+  view used to wait a beat while the building footprints streamed in. When the map sits still for a
+  moment at a mid zoom, Vela now quietly fetches the buildings for the area you're looking at in the
+  background (disk cache, no extra memory), so the zoom-in paints instantly. Canceled the moment you
+  move the map; never runs during navigation.
 - ✅ **Settings redesigned hub-and-spoke (2026-07-23, ported from the vela-dpad fork by
   alltechdev).** The single very long Settings page is now a short hub of category rows, each
   opening its own small sub-screen (Appearance / Map / Place pages / Navigation / Voice / Search /

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -781,6 +781,28 @@ fun VelaMapView(
     // streams that one via PMTiles HTTP range requests, fetching only the visible tiles, so footprints appear
     // with no download. Keyed on styleRef (re-add after a style reload) + darkTheme (fill matches the themed OSM
     // building colour, indistinguishable from a real OSM footprint).
+    // ---- Idle building warm-up (2026-07-23) ----------------------------------------------------
+    // Zooming to street level waited a beat for the building-overlay PMTiles range-fetches (the
+    // z15/16 footprint tiles only start downloading once the camera is already there). When the
+    // browse map has been SITTING STILL a moment at a mid zoom, warm the landing area ahead of
+    // time: an off-screen MapSnapshotter render of ONLY the overlay sources at z16 pulls exactly
+    // those tiles through MapLibre's shared ambient cache (the same file source the live map
+    // reads - the Android Auto renderer already relies on that sharing), so the later zoom paints
+    // from cache. Disk cache, not RAM; one warm per area bucket; canceled the moment the camera
+    // moves; browse-map only. The 2.5 s idle delay keeps it far behind the POI fetch and the
+    // overlay gate probes, so it never competes with visible work.
+    val warmHandler = remember { android.os.Handler(android.os.Looper.getMainLooper()) }
+    val warmPending = remember { arrayOf<Runnable?>(null) }
+    val warmSnapshotter = remember { arrayOf<org.maplibre.android.snapshotter.MapSnapshotter?>(null) }
+    val warmDoneBuckets = remember { HashSet<Long>() }
+    val warmCtx = rememberUpdatedState(Pair(buildingOverlays, navMode))
+    DisposableEffect(Unit) {
+        onDispose {
+            warmPending[0]?.let { warmHandler.removeCallbacks(it) }
+            warmSnapshotter[0]?.cancel(); warmSnapshotter[0] = null
+        }
+    }
+
     LaunchedEffect(buildingOverlays, styleRef, darkTheme) {
         val style = styleRef ?: return@LaunchedEffect
         // runCatching the enumerations too: the style can die between the null-check and this walk
@@ -2027,6 +2049,47 @@ fun VelaMapView(
                         map.cameraPosition.zoom,
                     )
                     runOvlGate()
+                    // Idle building warm-up: schedule after a beat of stillness; any camera move
+                    // cancels it (the move-started listener below).
+                    warmPending[0]?.let { warmHandler.removeCallbacks(it) }
+                    val warmRun = Runnable {
+                        val (overlays, naving) = warmCtx.value
+                        val z = map.cameraPosition.zoom
+                        val t = map.cameraPosition.target
+                        if (naving || overlays.isEmpty() || t == null || z < 13.5 || z >= 15.9) return@Runnable
+                        // One warm per ~2 km bucket so sitting still doesn't re-render, and a
+                        // revisit later in the session is already cached anyway.
+                        val bucket = (Math.round(t.latitude / 0.02) shl 20) xor Math.round(t.longitude / 0.02)
+                        if (!warmDoneBuckets.add(bucket)) return@Runnable
+                        val sources = StringBuilder()
+                        val layers = StringBuilder()
+                        overlays.forEachIndexed { i, uri ->
+                            if (i > 0) { sources.append(','); layers.append(',') }
+                            sources.append("\"warm$i\":{\"type\":\"vector\",\"url\":\"").append(uri).append("\"}")
+                            layers.append("{\"id\":\"warm$i\",\"type\":\"fill\",\"source\":\"warm$i\",\"source-layer\":\"building\",\"paint\":{\"fill-color\":\"#000000\"}}")
+                        }
+                        val styleJson = "{\"version\":8,\"sources\":{$sources},\"layers\":[$layers]}"
+                        runCatching {
+                            warmSnapshotter[0]?.cancel()
+                            val snap = org.maplibre.android.snapshotter.MapSnapshotter(
+                                context,
+                                org.maplibre.android.snapshotter.MapSnapshotter.Options(768, 768)
+                                    .withStyleJson(styleJson)
+                                    .withCameraPosition(
+                                        org.maplibre.android.camera.CameraPosition.Builder()
+                                            .target(t).zoom(16.2).build(),
+                                    ),
+                            )
+                            warmSnapshotter[0] = snap
+                            android.util.Log.d("VelaWarm", "warming buildings z16 at bucket=$bucket overlays=${overlays.size}")
+                            snap.start(
+                                { warmSnapshotter[0] = null; android.util.Log.d("VelaWarm", "warm done") },
+                                { warmSnapshotter[0] = null; android.util.Log.d("VelaWarm", "warm failed: $it") },
+                            )
+                        }
+                    }
+                    warmPending[0] = warmRun
+                    warmHandler.postDelayed(warmRun, 2500)
                 }
                 // A finished render means tiles may have arrived after the camera stopped - the
                 // verdict could be stale. ONLY mark dirty here (never probe): this event can fire
@@ -2046,7 +2109,11 @@ fun VelaMapView(
                     ovlDirty[0] = true
                     runOvlGate()
                 }
-                map.addOnCameraMoveListener { ovlRenderSettled[0] = false }
+                map.addOnCameraMoveListener {
+                    ovlRenderSettled[0] = false
+                    warmPending[0]?.let { warmHandler.removeCallbacks(it); warmPending[0] = null }
+                    warmSnapshotter[0]?.cancel(); warmSnapshotter[0] = null
+                }
                 // Feed the on-screen scale bar: metres-per-pixel at the centre
                 // latitude (varies with zoom AND latitude on a Mercator map).
                 val reportScale = {


### PR DESCRIPTION
Zooming down to the ~200 ft view waited a beat while the building footprints streamed in: the overlay's tiles only start downloading once the camera is already at street level. That laziness stays (nothing loads during panning or navigation), but when the browse map has been sitting still for a couple seconds at a mid zoom, an off-screen snapshot render of just the overlay sources pulls the z16 tiles for the area you're looking at through the map's shared cache. The later zoom-in then paints the houses immediately.

- Costs disk cache only, no extra memory held.
- One warm per area per sitting; any camera move cancels it; never runs during nav.
- Runs 2.5 seconds after the camera settles, so it stays behind the POI fetch and the overlay gate probes.
- Device-verified on the 4a: the warm fires at idle and completes in about a second (logcat tag VelaWarm), so the fetch happens before the zoom instead of during it.
