### PR TITLE
Voice search explains its failures, and a corrupt speech model can't crash-loop the app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -980,6 +980,20 @@ Defaults that make the safe path the easy one:
   instant the utterance ends. Only the in-process path needs it; tier-2 (SYSTEM) hands off to an
   external recognizer that manages its own focus. Recording itself (an input `AudioRecord`) is
   unaffected by the output-focus request.
+- **ASR is CRASH-SENTINELED and voice failures EXPLAIN THEMSELVES (2026-07-23, ported from
+  vela-dpad, credit ars18/alltechdev):** a truncated/corrupt engine archive makes sherpa-onnx ABORT
+  natively (uncatchable - the process dies), and warmUp() runs at startup, so a bad model was an
+  unrecoverable crash loop. `AsrRecognizer` bumps `asr_load_strikes_<id>` before every native load
+  and zeroes it after; TWO stranded loads in a row latch `asr_model_bad_<id>`, delete THAT engine's
+  dir only, and report not-installed (one stranded load is forgiven - a mid-load process kill
+  strands the counter exactly like a crash, and must not delete a healthy 154 MB download). A fresh
+  download clears its own quarantine (`clearQuarantine(engine)` in downloadAsrEngine). And
+  `listen()` returns a `VoiceResult` (Text/NoSpeech/Failed(reason)) instead of String? - the seven
+  failure exits used to collapse into one silent null; MapScreen now explains MODEL / PERMISSION /
+  VAD / AUDIO_INIT / RECORDING in a VelaDialog with retry, and a DENIED mic prompt surfaces too.
+  Transcript cleanup moved to `SpeechText.cleanSearchTranscript` (:core, unit-tested): strips
+  Whisper's bracket tags ("[music]", incl. a truncated trailing "[musi") so junk collapses to
+  no-speech instead of searching for the literal tag. Logcat tag `VELAASR` names every failure.
 - **Tier-1 ASR is now a PICKABLE ENGINE, not Whisper-only (2026-07-20, device-verified on the P4a).**
   `WhisperRecognizer`→**`AsrRecognizer`** and `AsrModel`→**`AsrEngine`** (an enum catalog): three
   on-device engines share the sherpa-onnx runtime - **Whisper tiny** (`whisper`, multilingual default,

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **Voice search says why it failed, and a corrupt speech model can't crash-loop the app
+  (2026-07-23, adopted from the vela-dpad fork).** Every voice-search failure now names its cause
+  (model missing, mic permission, recorder busy, and so on) in a dialog with a retry, instead of the
+  listening sheet silently closing. A corrupt or truncated engine download is quarantined after two
+  failed loads and only that engine's files are removed; re-downloading clears the quarantine. Voice
+  providers with no label now show their app name in the picker instead of a blank row.
 - ✅ **Sheet chrome and landscape fixes (2026-07-23).** Swiping the handle of a place with
   nothing to expand no longer makes the search bar and layers button vanish: they only hide when
   the sheet measurably covers them. Rotating the phone with a place card or results list open now

--- a/app/src/main/java/app/vela/ui/VoiceSearch.kt
+++ b/app/src/main/java/app/vela/ui/VoiceSearch.kt
@@ -66,8 +66,15 @@ object VoiceSearch {
     fun providers(context: Context): List<Provider> = runCatching {
         val pm = context.packageManager
         pm.queryIntentActivities(Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH), 0).map {
+            // A provider whose activity declares NO label rendered a BLANK radio row in the
+            // Settings picker (user screenshot, 2026-07-23) - the row worked but named nothing.
+            // Fall back activity label -> application label -> package name, so every row names
+            // itself no matter how the provider is declared.
+            val label = it.loadLabel(pm).toString().ifBlank {
+                runCatching { it.activityInfo.applicationInfo.loadLabel(pm).toString() }.getOrDefault("")
+            }.ifBlank { it.activityInfo.packageName }
             Provider(
-                it.loadLabel(pm).toString(),
+                label,
                 android.content.ComponentName(it.activityInfo.packageName, it.activityInfo.name),
             )
         }

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -633,24 +633,71 @@ fun MapScreen(
     var voiceLevel by remember { mutableStateOf(0f) }
     var voiceStop by remember { mutableStateOf(false) }
     var voiceAbort by remember { mutableStateOf(false) }
+    // Non-null while a voice failure is being explained. Before this existed every failure closed
+    // the listening sheet and said nothing (the fork's issue #81; ported 2026-07-23).
+    var voiceError by remember { mutableStateOf<app.vela.voice.VoiceResult.Reason?>(null) }
     fun startLocalVoice() {
         voiceStop = false; voiceAbort = false; voiceStarted = false; voiceLevel = 0f; voiceListening = true
         voiceScope.launch {
-            val text = vm.voiceListen(
+            val result = vm.voiceListen(
                 onLevel = { voiceLevel = it },
                 onListening = { voiceStarted = true },
                 cancelled = { voiceStop },
             )
             voiceListening = false
-            if (!voiceAbort && !text.isNullOrBlank()) {
-                focusManager.clearFocus()
-                vm.applyVoiceQuery(text)
+            if (voiceAbort) return@launch // the user backed out; never talk back at them
+            when (result) {
+                is app.vela.voice.VoiceResult.Text -> {
+                    focusManager.clearFocus()
+                    vm.applyVoiceQuery(result.query)
+                }
+                // Heard nothing: the sheet closing IS the feedback. An error here would scold
+                // someone who simply changed their mind.
+                app.vela.voice.VoiceResult.NoSpeech -> Unit
+                // Anything else used to close the sheet silently and identically - the user could
+                // not tell a missing model from a mic this phone would not open, and neither could we.
+                is app.vela.voice.VoiceResult.Failed -> voiceError = result.reason
             }
         }
     }
     val recordAudioLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
-    ) { granted -> if (granted) startLocalVoice() }
+    ) { granted ->
+        // A DENIED prompt used to do nothing whatsoever - the same dead silence, and the likeliest
+        // shape of it on a locked-down ROM that answers the prompt on the user's behalf.
+        if (granted) startLocalVoice() else voiceError = app.vela.voice.VoiceResult.Reason.PERMISSION
+    }
+    voiceError?.let { reason ->
+        // One dialog, the real reason, and a route to the fix. VelaDialog is already D-pad-correct.
+        app.vela.ui.VelaDialog(
+            onDismissRequest = { voiceError = null },
+            title = stringResource(R.string.voice_error_title),
+            // "Try again" is the confirm because most of these are transient (a mic another app was
+            // holding, a recording that dropped); the message names the Settings route for the two
+            // that are not. Dismiss auto-focuses, so one OK just closes.
+            confirmText = stringResource(R.string.voice_error_retry),
+            onConfirm = {
+                voiceError = null
+                if (vm.voiceMicGranted()) startLocalVoice()
+                else recordAudioLauncher.launch(android.Manifest.permission.RECORD_AUDIO)
+            },
+            dismissText = stringResource(R.string.mapscreen_got_it),
+            onDismiss = { voiceError = null },
+            text = {
+                Text(
+                    stringResource(
+                        when (reason) {
+                            app.vela.voice.VoiceResult.Reason.MODEL -> R.string.voice_error_model
+                            app.vela.voice.VoiceResult.Reason.PERMISSION -> R.string.voice_error_permission
+                            app.vela.voice.VoiceResult.Reason.VAD -> R.string.voice_error_vad
+                            app.vela.voice.VoiceResult.Reason.AUDIO_INIT -> R.string.voice_error_audio
+                            app.vela.voice.VoiceResult.Reason.RECORDING -> R.string.voice_error_recording
+                        },
+                    ),
+                )
+            },
+        )
+    }
 
     val voiceProviderAvailable = remember { app.vela.ui.VoiceSearch.hasProvider(context) }
     val voicePrompt = stringResource(R.string.search_voice_prompt)

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -4258,6 +4258,7 @@ class MapViewModel @Inject constructor(
             return
         }
         val hadNone = app.vela.voice.AsrEngine.installed(appContext).isEmpty()
+        asrRecognizer.clearQuarantine(engine) // a fresh download replaces whatever was quarantined
         _state.update { it.copy(asrDownloadPct = 0f, asrInstalling = false, asrDownloadingId = engine.id) }
         viewModelScope.launch {
             val ok = kokoroInstaller.download(
@@ -4300,7 +4301,11 @@ class MapViewModel @Inject constructor(
 
     /** Record + transcribe on-device (tier-1); returns the heard text or null. Driven by the capture
      *  dialog, which supplies the loudness sink, a start callback and an early-stop check. */
-    suspend fun voiceListen(onLevel: (Float) -> Unit, onListening: () -> Unit, cancelled: () -> Boolean): String? =
+    suspend fun voiceListen(
+        onLevel: (Float) -> Unit,
+        onListening: () -> Unit,
+        cancelled: () -> Boolean,
+    ): app.vela.voice.VoiceResult =
         asrRecognizer.listen(onLevel, onListening, cancelled)
 
     /** Apply a transcript from either voice tier as the query and run the search. */

--- a/app/src/main/java/app/vela/voice/AsrRecognizer.kt
+++ b/app/src/main/java/app/vela/voice/AsrRecognizer.kt
@@ -31,14 +31,16 @@ import kotlin.math.min
 import kotlin.math.sqrt
 
 /**
- * On-device speech-to-text for voice search (tier-1). Loads **Whisper tiny (int8, multilingual)** +
- * **Silero VAD** through the bundled sherpa-onnx runtime, records from the mic, uses the VAD to spot
- * the end of speech, and returns the transcript. Nothing leaves the phone and no third-party voice
- * app is needed (that's tier-2 - the RECOGNIZE_SPEECH intent handoff in MapScreen).
+ * On-device speech-to-text for voice search (tier-1). Loads whichever [AsrEngine] the user has
+ * active - **Whisper tiny** (multilingual default), **SenseVoice** (en/zh/ja/ko/yue), or **Moonshine**
+ * (English) - through the bundled sherpa-onnx runtime, records from the mic, uses Silero VAD to spot
+ * the end of speech, and returns the transcript. Nothing leaves the phone and no third-party voice app
+ * is needed (that's tier-2 - the RECOGNIZE_SPEECH intent handoff in MapScreen).
  *
- * The Whisper recognizer loads lazily and is kept for the process lifetime (~1 s to load); the VAD is
- * created per listen (it's tiny and holds streaming state). R8 must keep `com.k2fsa.sherpa.onnx.**`
- * (JNI resolves classes by name) - already in `consumer-rules`/`proguard` for Piper.
+ * The recognizer loads lazily and is rebuilt when the active engine OR the app language changes (both
+ * fold into [loadedKey]); the VAD is created per listen (tiny, holds streaming state). R8 must keep
+ * `com.k2fsa.sherpa.onnx.**` (JNI resolves classes by name) - already in `consumer-rules`/`proguard`
+ * for Piper.
  */
 @Singleton
 class AsrRecognizer @Inject constructor(
@@ -111,12 +113,12 @@ class AsrRecognizer @Inject constructor(
             PackageManager.PERMISSION_GRANTED
 
     /** The app language, normalized: Android hands back the LEGACY code for Hebrew ("iw"), not "he"
-     *  (upstream PR #87), so map it. */
+     *  (2026-07-12), so map it. */
     private fun appLang(): String =
         app.vela.ui.AppLocale.effective().language.let { if (it == "iw") "he" else it }
 
     /** The engine the recognizer should LOAD for the current language: the user's pick when it can do
-     *  the language, else Whisper (upstream 137beea9). */
+     *  the language, else Whisper (see [AsrEngine.forRecognition]). */
     private fun engineForNow(): AsrEngine = AsrEngine.forRecognition(context, appLang())
 
     /** The language to pin recognition to: the app language when the engine supports it, else

--- a/app/src/main/java/app/vela/voice/AsrRecognizer.kt
+++ b/app/src/main/java/app/vela/voice/AsrRecognizer.kt
@@ -10,12 +10,13 @@ import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.MediaRecorder
 import androidx.core.content.ContextCompat
+
 import com.k2fsa.sherpa.onnx.FeatureConfig
 import com.k2fsa.sherpa.onnx.OfflineModelConfig
 import com.k2fsa.sherpa.onnx.OfflineMoonshineModelConfig
+import com.k2fsa.sherpa.onnx.OfflineSenseVoiceModelConfig
 import com.k2fsa.sherpa.onnx.OfflineRecognizer
 import com.k2fsa.sherpa.onnx.OfflineRecognizerConfig
-import com.k2fsa.sherpa.onnx.OfflineSenseVoiceModelConfig
 import com.k2fsa.sherpa.onnx.OfflineWhisperModelConfig
 import com.k2fsa.sherpa.onnx.SileroVadModelConfig
 import com.k2fsa.sherpa.onnx.Vad
@@ -30,16 +31,14 @@ import kotlin.math.min
 import kotlin.math.sqrt
 
 /**
- * On-device speech-to-text for voice search (tier-1). Loads whichever [AsrEngine] the user has
- * active - **Whisper tiny** (multilingual default), **SenseVoice** (en/zh/ja/ko/yue), or **Moonshine**
- * (English) - through the bundled sherpa-onnx runtime, records from the mic, uses Silero VAD to spot
- * the end of speech, and returns the transcript. Nothing leaves the phone and no third-party voice app
- * is needed (that's tier-2 - the RECOGNIZE_SPEECH intent handoff in MapScreen).
+ * On-device speech-to-text for voice search (tier-1). Loads **Whisper tiny (int8, multilingual)** +
+ * **Silero VAD** through the bundled sherpa-onnx runtime, records from the mic, uses the VAD to spot
+ * the end of speech, and returns the transcript. Nothing leaves the phone and no third-party voice
+ * app is needed (that's tier-2 - the RECOGNIZE_SPEECH intent handoff in MapScreen).
  *
- * The recognizer loads lazily and is kept for the process lifetime (~1–2 s to load); it's rebuilt when
- * the active engine OR the app language changes (both fold into [loadedKey]). The VAD is created per
- * listen (tiny, holds streaming state). R8 must keep `com.k2fsa.sherpa.onnx.**` (JNI resolves classes
- * by name) - already in `consumer-rules`/`proguard` for Piper.
+ * The Whisper recognizer loads lazily and is kept for the process lifetime (~1 s to load); the VAD is
+ * created per listen (it's tiny and holds streaming state). R8 must keep `com.k2fsa.sherpa.onnx.**`
+ * (JNI resolves classes by name) - already in `consumer-rules`/`proguard` for Piper.
  */
 @Singleton
 class AsrRecognizer @Inject constructor(
@@ -47,7 +46,6 @@ class AsrRecognizer @Inject constructor(
 ) {
     private val loadLock = Any()
     @Volatile private var recognizer: OfflineRecognizer? = null
-    /** "<engineId>|<lang>" - the recognizer is rebuilt whenever either changes. */
     @Volatile private var loadedKey: String? = null
 
     private val audioManager by lazy { context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager }
@@ -78,31 +76,53 @@ class AsrRecognizer @Inject constructor(
     }
 
     private companion object {
+        // Grep target for a tester's logcat: every listen() failure logs under this tag with its
+        // VoiceResult.Reason, so "it doesn't work" arrives already diagnosed (issue #81).
+        const val TAG = "VELAASR"
+        // Crash-sentinel keys are PER-ENGINE (suffixed with the engine id): a truncated SenseVoice
+        // must never quarantine or delete Whisper. KEY_LOAD_STRIKES counts loads the process died
+        // inside (bumped before the native load, zeroed once it returns); TWO in a row quarantine -
+        // one stranded load is as likely a mid-load kill (user swipe-away, memory reclaim) as a
+        // crash, and must not delete a healthy download. KEY_MODEL_BAD_ latches the quarantine so a
+        // bad model is not retried every launch; a fresh download clears it.
+        const val KEY_LOAD_STRIKES = "asr_load_strikes_"
+        const val KEY_MODEL_BAD = "asr_model_bad_"
         const val SAMPLE_RATE = 16000
         const val VAD_WINDOW = 512            // Silero v4/v5 window at 16 kHz
         const val MAX_SECONDS = 15            // hard cap on one utterance
     }
 
-    fun isInstalled(): Boolean = AsrEngine.anyInstalled(context)
+    private fun prefs() = context.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
+    private fun isQuarantined(engine: AsrEngine) = prefs().getBoolean(KEY_MODEL_BAD + engine.id, false)
+
+    /** Voice search is available when at least one engine is installed AND not quarantined. */
+    fun isInstalled(): Boolean = AsrEngine.installed(context).any { !isQuarantined(it) }
+
+    /** Lift the quarantine for [engine] after a fresh download - the bad files are gone, so the next
+     *  load may try again. Called by the installer path, never automatically. */
+    fun clearQuarantine(engine: AsrEngine = AsrEngine.DEFAULT) {
+        prefs().edit()
+            .putBoolean(KEY_MODEL_BAD + engine.id, false)
+            .putInt(KEY_LOAD_STRIKES + engine.id, 0).apply()
+    }
 
     fun hasMicPermission(): Boolean =
         ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
             PackageManager.PERMISSION_GRANTED
 
-    /** The app language, normalized. Android hands back the LEGACY code for Hebrew ("iw"), not
-     *  "he" (2026-07-12), so map it. */
+    /** The app language, normalized: Android hands back the LEGACY code for Hebrew ("iw"), not "he"
+     *  (upstream PR #87), so map it. */
     private fun appLang(): String =
         app.vela.ui.AppLocale.effective().language.let { if (it == "iw") "he" else it }
 
-    /** The engine the recognizer should load for the current language: the user's pick when it
-     *  supports the language, else Whisper (see [AsrEngine.forRecognition]). */
+    /** The engine the recognizer should LOAD for the current language: the user's pick when it can do
+     *  the language, else Whisper (upstream 137beea9). */
     private fun engineForNow(): AsrEngine = AsrEngine.forRecognition(context, appLang())
 
     /** The language to pin recognition to: the app language when the engine supports it, else
-     *  auto-detect (""). Pinning matters - with auto-detect, a noisy capture can be misread as a whole
+     *  auto-detect. Pinning matters - with auto-detect, a noisy capture can be misread as a whole
      *  other language and come back in the wrong script (a garbled far-field test transcribed to
-     *  Cyrillic). The app language is what the user speaks to a maps app in practice. Moonshine is
-     *  English-only and takes no language, so this is unused for it. */
+     *  Cyrillic). Moonshine is English-only and takes no language, so this is unused for it. */
     private fun pinnedLang(engine: AsrEngine): String {
         val l = appLang()
         return when (engine) {
@@ -115,24 +135,55 @@ class AsrRecognizer @Inject constructor(
     /** Build the recognizer ahead of the first mic tap, off the main thread. The ONNX load takes a
      *  second or two on a phone, which used to show as a "Getting ready" beat on the FIRST dictation
      *  of a session (user 2026-07-10); warmed, the mic listens immediately. Cheap to call when no
-     *  engine is installed (no-op), and safe to call repeatedly. */
+     *  engine is installed (no-op), and safe to call repeatedly - the synchronized loader keeps a
+     *  built recognizer for the current engine+language. */
     fun warmUp() {
         if (!AsrEngine.anyInstalled(context)) return
         Thread({ runCatching { ensureRecognizer() } }, "asr-warmup").start()
     }
 
-    /** Load the active engine's recognizer once per (engine, language) key. Returns null if no engine
-     *  is installed or the native load fails - callers then fall back to the provider intent or hide
+    /** Load the recognizer for the engine we'd run NOW (the pick, or Whisper for a language the pick
+     *  can't do), rebuilt when the engine or app language changes. Returns null if no engine is
+     *  installed/usable or the native load fails - callers fall back to the provider intent or hide
      *  the mic. */
     private fun ensureRecognizer(): OfflineRecognizer? {
         val engine = engineForNow()
-        if (!engine.isInstalled(context)) return null
         val lang = pinnedLang(engine)
         val key = "${engine.id}|$lang"
         recognizer?.let { if (loadedKey == key) return it }
         synchronized(loadLock) {
             recognizer?.let { if (loadedKey == key) return it else runCatching { it.release() } }
             recognizer = null
+            if (!engine.isInstalled(context)) return null
+
+            // CRASH SENTINEL around the native load, PER ENGINE. sherpa-onnx parses the .onnx files in
+            // C++, and a TRUNCATED-but-non-empty model segfaults inside libsherpa-onnx-jni rather than
+            // throwing - `runCatching` cannot catch a native abort, it takes the whole process down.
+            // Reachable in the real world: a copy that stops partway (storage full, process killed)
+            // leaves a short file that isInstalled()'s present-and-non-empty test happily accepts, and
+            // warmUp() runs at STARTUP, so the result was an unrecoverable crash loop. So: bump a
+            // strike counter before the load, zero it after; a counter that reaches TWO stranded
+            // loads means the process died inside the load twice in a row - quarantine THAT engine
+            // only and delete THAT engine's dir (a bad SenseVoice must never take out Whisper),
+            // report not-installed, let the app start. A fresh download clears the quarantine.
+            // TWO strikes, not one (the map sentinel's idiom, and device-measured necessity): the
+            // load takes seconds, and a process killed DURING it - the user swiping the app away, the
+            // system reclaiming memory, a test harness force-stop - strands the counter exactly like
+            // a native crash. One stranded load used to delete a healthy 154 MB download; a genuinely
+            // bad model crashes EVERY load, so it still self-heals one launch later.
+            val prefs = prefs()
+            val strikesKey = KEY_LOAD_STRIKES + engine.id
+            val badKey = KEY_MODEL_BAD + engine.id
+            val strikes = prefs.getInt(strikesKey, 0)
+            if (strikes >= 2) {
+                android.util.Log.e(TAG, "two ASR loads never returned (native crash) - quarantining ${engine.id}")
+                prefs.edit().putInt(strikesKey, 0).putBoolean(badKey, true).apply()
+                runCatching { engine.dir(context).deleteRecursively() }
+                return null
+            }
+            if (prefs.getBoolean(badKey, false)) return null
+            prefs.edit().putInt(strikesKey, strikes + 1).apply()
+
             val dir = engine.dir(context)
             fun p(name: String) = File(dir, name).absolutePath
             val modelConfig = when (engine) {
@@ -177,7 +228,18 @@ class AsrRecognizer @Inject constructor(
                         modelConfig = modelConfig,
                     ),
                 )
+            }.onFailure {
+                // NAME the throwable. #84 fixed "the reason was discarded at the point of failure"
+                // for listen(), but left it here: getOrNull() ate the one fact that separates a
+                // missing .so (UnsatisfiedLinkError - the v7a strip, see app/build.gradle.kts) from
+                // an OOM on a small phone, and both surfaced as "re-download the model". A tester
+                // re-downloaded 47 MB twice on that advice. The class name alone decides it.
+                android.util.Log.e(TAG, "native ASR load failed (${engine.id}): ${it::class.java.simpleName}")
             }.getOrNull()
+            // The load RETURNED (success or a catchable failure), so the process survived it: zero
+            // the strikes. Only a native abort (or a mid-load kill) leaves a strike standing, and
+            // only two in a row quarantine.
+            prefs.edit().putInt(strikesKey, 0).apply()
             recognizer = r
             loadedKey = key
             return r
@@ -185,25 +247,31 @@ class AsrRecognizer @Inject constructor(
     }
 
     /**
-     * Record from the mic and return what was said, or null if nothing usable was heard (or no
-     * engine/permission is present). [onLevel] gets a 0..1 loudness for the listening animation,
+     * Record from the mic and return what was said, or null if nothing usable was heard (or the
+     * model/permission isn't there). [onLevel] gets a 0..1 loudness for the listening animation,
      * [onListening] fires once recording actually starts, and [cancelled] lets the UI stop early
      * (the user tapped done/close). Runs off the main thread; safe to cancel via coroutine too.
      */
+    /** Listen, transcribe, and say WHY when it does not work - see [VoiceResult]. Every failure exit
+     *  logs under `VELAASR` so a tester's logcat names the cause without another round-trip. */
     suspend fun listen(
         onLevel: (Float) -> Unit,
         onListening: () -> Unit,
         cancelled: () -> Boolean,
-    ): String? = withContext(Dispatchers.Default) {
-        val rec = ensureRecognizer() ?: return@withContext null
-        if (!hasMicPermission()) return@withContext null
+    ): VoiceResult = withContext(Dispatchers.Default) {
+        fun fail(reason: VoiceResult.Reason, detail: String? = null): VoiceResult.Failed {
+            android.util.Log.e(TAG, "listen failed: $reason${detail?.let { " ($it)" } ?: ""}")
+            return VoiceResult.Failed(reason, detail)
+        }
+        val rec = ensureRecognizer()
+            ?: return@withContext fail(VoiceResult.Reason.MODEL, "model absent or native load failed")
+        if (!hasMicPermission()) return@withContext fail(VoiceResult.Reason.PERMISSION)
 
-        val vadModel = engineForNow().let { File(it.dir(context), AsrEngine.VAD).absolutePath }
         val vad = runCatching {
             Vad(
                 config = VadModelConfig(
                     sileroVadModelConfig = SileroVadModelConfig(
-                        model = vadModel,
+                        model = File(engineForNow().dir(context), AsrEngine.VAD).absolutePath,
                         threshold = 0.5f,
                         minSilenceDuration = 0.6f,   // ~0.6 s of quiet ends the utterance
                         minSpeechDuration = 0.25f,
@@ -214,7 +282,7 @@ class AsrRecognizer @Inject constructor(
                     numThreads = 1,
                 ),
             )
-        }.getOrNull() ?: return@withContext null
+        }.getOrNull() ?: return@withContext fail(VoiceResult.Reason.VAD, "silero VAD would not construct")
 
         val minBuf = AudioRecord.getMinBufferSize(
             SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT,
@@ -229,7 +297,9 @@ class AsrRecognizer @Inject constructor(
             )
         }.getOrNull()
         if (audio == null || audio.state != AudioRecord.STATE_INITIALIZED) {
-            audio?.release(); vad.release(); return@withContext null
+            val detail = if (audio == null) "constructor threw" else "state=${audio.state} minBuf=$minBuf"
+            audio?.release(); vad.release()
+            return@withContext fail(VoiceResult.Reason.AUDIO_INIT, detail)
         }
 
         val buf = ShortArray(VAD_WINDOW)
@@ -257,7 +327,8 @@ class AsrRecognizer @Inject constructor(
                 }
             }
         } catch (t: Throwable) {
-            return@withContext null
+            runCatching { vad.release() }
+            return@withContext fail(VoiceResult.Reason.RECORDING, t.message ?: t::class.java.simpleName)
         } finally {
             // Abandon focus FIRST so the music resumes even if a later call throws; every step is
             // guarded so one failure can't skip the rest and leave playback paused forever.
@@ -266,10 +337,10 @@ class AsrRecognizer @Inject constructor(
             runCatching { audio.release() }
         }
 
-        // Prefer the VAD-trimmed segment (leading/trailing silence stripped → cleaner transcript);
+        // Prefer the VAD-trimmed segment (leading/trailing silence stripped -> cleaner transcript);
         // fall back to everything captured if the user stopped before a segment closed.
         val samples = segment ?: run {
-            if (!sawSpeech && total < SAMPLE_RATE / 2) { vad.release(); return@withContext null }
+            if (!sawSpeech && total < SAMPLE_RATE / 2) { vad.release(); return@withContext VoiceResult.NoSpeech }
             val out = FloatArray(total)
             var off = 0
             for (c in chunks) { c.copyInto(out, off, 0, min(c.size, out.size - off)); off += c.size }
@@ -286,15 +357,12 @@ class AsrRecognizer @Inject constructor(
             t
         }.getOrNull().orEmpty()
 
-        cleanTranscript(text).ifBlank { null }
+        // Whisper writes prose ("Coffee shops near me.") and, on non-speech audio, bracketed sound
+        // tags ("[music]", "[thud]"). :core's SpeechText.cleanSearchTranscript strips those into a
+        // clean query (or "" -> null below = heard nothing, no search). Unit-tested there.
+        val query = app.vela.core.voice.SpeechText.cleanSearchTranscript(text).ifBlank { null }
+        if (query == null) VoiceResult.NoSpeech else VoiceResult.Text(query)
     }
-
-    /** The recognizers write prose: capitalized, ending with a period ("Coffee shops near me.").
-     *  A search query wants neither the trailing sentence punctuation nor stray wrapping, so strip
-     *  terminal . ! ? , ; : and quotes from the ends. Periods INSIDE the text are left alone -
-     *  they can be real ("St. Paul"). */
-    private fun cleanTranscript(raw: String): String =
-        raw.trim().trim('"', '“', '”').trimEnd('.', '!', '?', ',', ';', ':', '…').trim()
 
     private fun rms(f: FloatArray): Float {
         if (f.isEmpty()) return 0f

--- a/app/src/main/java/app/vela/voice/VoiceResult.kt
+++ b/app/src/main/java/app/vela/voice/VoiceResult.kt
@@ -1,0 +1,43 @@
+package app.vela.voice
+
+/**
+ * What an on-device voice-search attempt actually did.
+ *
+ * [WhisperRecognizer.listen] used to return `String?`, so its SEVEN different exits all collapsed into
+ * one indistinguishable `null` and the listening sheet just closed again. A TCL Flip 2 tester
+ * reported exactly that and nothing more - "a box pops up for a second then closes" (issue #81) - and
+ * neither they nor we could say which of a missing model, a denied mic, a failed `AudioRecord` init
+ * or an OOM it was, because the reason was discarded at the point of failure. The question "what does
+ * not working mean" was unanswerable by construction.
+ *
+ * So the reason travels back to the UI. [NoSpeech] is the benign one (tapped the mic, said nothing);
+ * every [Failed] carries a [Reason] the user is told about and logcat records under `VELAASR`.
+ */
+sealed interface VoiceResult {
+
+    /** A usable transcript, already cleaned of Whisper's prose and sound tags. */
+    data class Text(val query: String) : VoiceResult
+
+    /** Heard nothing worth searching. Not an error - no scary message, just close. */
+    data object NoSpeech : VoiceResult
+
+    /** The attempt could not run. [detail] is for the log, never for the user. */
+    data class Failed(val reason: Reason, val detail: String? = null) : VoiceResult
+
+    enum class Reason {
+        /** The Whisper model is missing, corrupt, or the native load failed (OOM on a small phone). */
+        MODEL,
+
+        /** RECORD_AUDIO is not granted - possible on a locked-down ROM that answers the prompt for you. */
+        PERMISSION,
+
+        /** The Silero VAD model could not be constructed (asset missing or corrupt). */
+        VAD,
+
+        /** `AudioRecord` refused to initialise - the prime suspect on unusual mic configurations. */
+        AUDIO_INIT,
+
+        /** Recording or decoding threw partway through. */
+        RECORDING,
+    }
+}

--- a/app/src/main/java/app/vela/voice/VoiceResult.kt
+++ b/app/src/main/java/app/vela/voice/VoiceResult.kt
@@ -3,7 +3,7 @@ package app.vela.voice
 /**
  * What an on-device voice-search attempt actually did.
  *
- * [WhisperRecognizer.listen] used to return `String?`, so its SEVEN different exits all collapsed into
+ * [AsrRecognizer.listen] used to return `String?`, so its SEVEN different exits all collapsed into
  * one indistinguishable `null` and the listening sheet just closed again. A TCL Flip 2 tester
  * reported exactly that and nothing more - "a box pops up for a second then closes" (issue #81) - and
  * neither they nor we could say which of a missing model, a denied mic, a failed `AudioRecord` init

--- a/core/src/main/java/app/vela/core/voice/SpeechText.kt
+++ b/core/src/main/java/app/vela/core/voice/SpeechText.kt
@@ -101,6 +101,34 @@ object SpeechText {
             }
         }
 
+    /**
+     * Clean a raw speech-to-text transcript into a search QUERY. Whisper (the on-device voice-search
+     * ASR) is a general audio model: on non-speech audio (silence, a tap, background music) it emits
+     * bracketed sound tags - "[music]", "[thud]", "[BLANK_AUDIO]" - instead of words. Those are never a
+     * real search, so strip every "[...]" group, then drop the trailing sentence punctuation/quotes that
+     * prose adds ("Coffee near me.") and collapse whitespace. A transcript that was ONLY sound tags
+     * collapses to "", so the caller's `.ifBlank { null }` reads it as "heard nothing" (no search runs)
+     * rather than searching for the literal "[music]". A real query with a stray tag ("coffee [noise]
+     * shop") keeps just the words. Brackets never appear in a real place search, so this is safe; an
+     * INNER period ("St. Paul") is preserved - only a trailing one is trimmed.
+     *
+     * A long non-speech run gets TRUNCATED at the utterance/15 s boundary, so the LAST tag can arrive
+     * unterminated ("[music] [music] [musi") - device-seen. We strip both complete "[...]" groups AND a
+     * dangling "[..." at the end, so that whole junk collapses to "" too (not the fragment "[musi").
+     */
+    fun cleanSearchTranscript(raw: String): String =
+        raw.replace(BRACKET_TAG, " ")
+            .replace(BRACKET_TAIL, " ")   // an unterminated trailing tag from a truncated capture
+            .replace(WHITESPACE, " ")
+            .trim()
+            .trim('"', '“', '”')
+            .trimEnd('.', '!', '?', ',', ';', ':', '…')
+            .trim()
+
+    private val BRACKET_TAG = Regex("\\[[^\\]]*]")
+    private val BRACKET_TAIL = Regex("\\[[^\\]]*$")
+    private val WHITESPACE = Regex("\\s+")
+
     private fun twoDigitOrdinal(r: Int): String = when {
         r in 10..19 -> TEEN_ORD[r - 10]
         r % 10 == 0 -> TENS_ORD[r / 10]

--- a/core/src/test/java/app/vela/core/voice/SpeechTextTest.kt
+++ b/core/src/test/java/app/vela/core/voice/SpeechTextTest.kt
@@ -166,4 +166,42 @@ class SpeechTextTest {
     @Test fun `speechFragments leaves a single clause whole with no gap`() {
         assertEquals(listOf("Turn right onto Main Street" to 0f), SpeechText.speechFragments("Turn right onto Main Street", 0.32f, 0.16f))
     }
+
+    // --- cleanSearchTranscript: turn a raw Whisper transcript into a search query ---
+
+    private fun clean(t: String) = SpeechText.cleanSearchTranscript(t)
+
+    @Test fun `whisper non-speech tags collapse to blank`() {
+        // No real speech (silence / a tap / room noise) -> Whisper emits only bracketed sound tags.
+        // These must collapse to "" so the caller's ifBlank{null} runs NO search.
+        assertEquals("", clean("[music] [music] [music]"))
+        assertEquals("", clean("[thud] [thud] [thud] [thud]"))
+        assertEquals("", clean("[BLANK_AUDIO]"))
+        assertEquals("", clean("  [ Music ]  "))
+    }
+
+    @Test fun `a truncated trailing tag from a capped capture also collapses`() {
+        // Device-seen: a long non-speech run truncated at the 15 s cap ends with an UNCLOSED tag.
+        // Both the complete groups and the dangling "[musi" must go, not leave the fragment behind.
+        assertEquals("", clean("[music] [music] [musi"))
+        assertEquals("", clean("[thud] [thud] [thud] [th"))
+        // ...but a real word before a dangling tag survives.
+        assertEquals("coffee", clean("coffee [noi"))
+    }
+
+    @Test fun `real query keeps its words and drops a stray tag`() {
+        assertEquals("coffee shop", clean("coffee [noise] shop"))
+        assertEquals("gas stations near me", clean("gas stations near me"))
+    }
+
+    @Test fun `trailing sentence punctuation and quotes are trimmed`() {
+        assertEquals("Coffee near me", clean("Coffee near me."))
+        assertEquals("pharmacy", clean("“pharmacy”"))
+        assertEquals("hardware store", clean("hardware store!"))
+    }
+
+    @Test fun `an inner period is preserved`() {
+        assertEquals("St. Paul", clean("St. Paul"))
+        assertEquals("J.C. Penney", clean("J.C. Penney."))
+    }
 }


### PR DESCRIPTION
Adopted from the vela-dpad fork; the port commit keeps ars18's authorship (the feature work there was ars18's and alltechdev's).

- **Voice failures say why.** Listening returns a typed result instead of a nullable string, so the seven different failure exits stop collapsing into one silent sheet-close. Hearing nothing still just closes the sheet, but a real failure (missing model, denied mic, recorder held by another app, audio init, dropped recording) explains itself in a dialog with a retry. A denied permission prompt surfaces too instead of doing nothing.
- **Corrupt models quarantine instead of crash-looping.** A truncated engine archive makes the native load abort uncatchably, and warm-up runs at startup, so a bad download was an unrecoverable crash loop. The load now carries the same two-strike sentinel the map renderer has, per engine: two stranded loads in a row quarantine that engine alone and delete its files; one is forgiven since a mid-load process kill strands the marker exactly like a crash. A fresh download clears its own quarantine.
- **Transcript cleanup moves to core** as cleanSearchTranscript with the fork's unit tests: Whisper's bracket noise tags ("[music]", including a truncated trailing tag) collapse to no-speech instead of being searched literally.
- Voice providers with a blank activity label are named by app label or package in the Settings picker instead of rendering an empty row.

The seven error strings arrived already translated in all 14 locales via the settings-port string union. :core tests pass, including the new transcript cases.
