### PR TITLE
Use a lot less memory, and give it back when the system asks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,23 @@ Defaults that make the safe path the easy one:
   so faces read discrete. At ~500 ft dense-city towers used to lean over and bury the roads. The
   search/place fly-to lands at z15.5 (~1000 ft, matches the locate fly) so a city search arrives
   BELOW every building tier - roads+labels+POIs only - instead of slamming all of it at z16.5.
+- **MEMORY PRESSURE IS HANDLED NOW (2026-07-23, ported from vela-dpad, credit alltechdev):**
+  `app/ui/MemoryPressure` (holder, `init()` in VelaApp before the Coil cap reads it) fans
+  `Application.onTrimMemory` out to registered releasers - before this NOTHING implemented
+  ComponentCallbacks2 and a TRIM_MEMORY_COMPLETE freed 0 KB. Registered: the ASR model (severe
+  trims + a 120 s idle reap - the loaded model costs ~267 MB PSS and used to live for the whole
+  process; an in-flight listen blocks release via an inFlight counter, or freeing native memory
+  mid-decode is a use-after-free crash), PiperSynth (CRITICAL only - dropping the nav voice
+  mid-drive costs a missed turn), MapLibre's native caches (`mapView.onLowMemory()`, registered in
+  the map's DisposableEffect), all five hidden WebViews (severe trim = immediate reap on the main
+  thread), and Coil (severe trim clears the bitmap cache). `MemoryPressure.lowRam` (isLowRamDevice
+  OR heap class < 128 MB; debug override `adb shell setprop debug.vela.lowram true`) drives the
+  constrained-device path: 16 MB Coil cap (vs 48), no ASR warm-up at launch, no speculative
+  WebView warms per search, and - via `:core` `LowRamMode` (same seam as CategoryFilter) - an
+  8-term ambient fan-out with a !7i30 pool instead of 15 terms at !7i60 (school/park are KEPT in
+  the subset: with ambient active the OSM poi layers are hidden, so they have no second source).
+  deleteAsrEngine releases the loaded model before deleting files (Remove used to reclaim disk
+  but no memory). Any NEW large/native holding must register a releaser here.
 - **Memory: the browse map runs near the heap ceiling, so keep allocation LOW (2026-07-13).**
   Panning already churns ~180 MB/12 s at baseline (ambient POI scrape + parse per pan) - this is
   pre-existing (0.4.542 hit ~260 MB too), close enough to the default ~256 MB heap that any EXTRA

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,13 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **Vela gives memory back when the system asks, and adapts to small phones (2026-07-23,
+  adopted from the vela-dpad fork).** The speech model (about a quarter gigabyte while loaded) now
+  unloads after two minutes unused and reloads in about a second on the next mic tap; map caches,
+  the hidden web fetchers, and the image cache all release under real memory pressure instead of
+  forcing the system to kill the app. Low-memory devices additionally skip speculative warm-ups
+  and fetch a leaner map POI set, which targets exactly the out-of-memory crashes reported on
+  budget tablets.
 - ✅ **Voice search says why it failed, and a corrupt speech model can't crash-loop the app
   (2026-07-23, adopted from the vela-dpad fork).** Every voice-search failure now names its cause
   (model missing, mic permission, recorder busy, and so on) in a dialog with a retry, instead of the

--- a/app/src/main/java/app/vela/VelaApp.kt
+++ b/app/src/main/java/app/vela/VelaApp.kt
@@ -30,7 +30,7 @@ class VelaApp : Application(), coil.ImageLoaderFactory {
     override fun newImageLoader(): coil.ImageLoader = coil.ImageLoader.Builder(this)
         .memoryCache {
             coil.memory.MemoryCache.Builder(this)
-                .maxSizeBytes(48 * 1024 * 1024)
+                .maxSizeBytes(if (app.vela.ui.MemoryPressure.lowRam) 16 * 1024 * 1024 else 48 * 1024 * 1024)
                 .build()
         }
         .build()
@@ -38,12 +38,32 @@ class VelaApp : Application(), coil.ImageLoaderFactory {
     /** Apply the persisted in-app language to the Application context too (no-op when following the
      *  system), so `getString` from the ViewModel/nav-notification also localizes — resolved at launch
      *  from the saved pref (an in-session change re-reads it on next launch). */
+    /**
+     * Hand OS memory pressure to every holder that owns a large or native allocation (ported from
+     * vela-dpad, 2026-07-23). Before this existed nothing in the app implemented
+     * ComponentCallbacks2, so a TRIM_MEMORY_COMPLETE released nothing at all and the OS had no
+     * option but to kill us. Coil's own cache is trimmed here; everything else releases through
+     * [app.vela.ui.MemoryPressure].
+     */
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        app.vela.ui.MemoryPressure.dispatch(level)
+        if (app.vela.ui.MemoryPressure.isSevere(level)) {
+            runCatching { coil.Coil.imageLoader(this).memoryCache?.clear() }
+        }
+    }
+
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(AppLocale.wrap(app.vela.ui.AdaptiveDensity.wrap(base)))
     }
 
     override fun onCreate() {
         super.onCreate()
+        // Device memory class first: the Coil cap and the eager-warm decisions read it.
+        app.vela.ui.MemoryPressure.init(this)
+        // Push the device class down to :core, which cannot read an :app holder (same seam as
+        // CategoryFilter.enabled). Gates the ambient POI fan-out in GoogleMapsDataSource.
+        app.vela.core.data.LowRamMode.enabled = app.vela.ui.MemoryPressure.lowRam
         Units.init(this)
         AppTheme.init(this)
         DynamicColor.init(this)

--- a/app/src/main/java/app/vela/ui/MemoryPressure.kt
+++ b/app/src/main/java/app/vela/ui/MemoryPressure.kt
@@ -1,0 +1,106 @@
+package app.vela.ui
+
+import android.app.ActivityManager
+import android.content.ComponentCallbacks2
+import android.content.Context
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Process-wide memory-pressure fan-out, in the same shape as the other app-level holders
+ * (`TransitLayer`, `AppTheme`): `init()` from `VelaApp`, then anything holding a large or native
+ * allocation registers a release callback.
+ *
+ * Why registration and not a Hilt entry point: reaching `WhisperRecognizer`/`PiperSynth` from
+ * `onTrimMemory` through an EntryPoint would CONSTRUCT them if they had never been used, so a
+ * trim would allocate the very models it is trying to free. A holder registers only once it
+ * actually owns something worth releasing, so a trim can never create work.
+ *
+ * Measured on the M5 (2.9 GB, Android 13, standardDebug) before this existed: TRIM_MEMORY_COMPLETE
+ * released 0 KB, because nothing in the app implemented ComponentCallbacks2 at all.
+ */
+object MemoryPressure {
+
+    /** A registered releaser. [level] is a `ComponentCallbacks2.TRIM_MEMORY_*` constant. */
+    fun interface Listener {
+        fun release(level: Int)
+    }
+
+    private val listeners = CopyOnWriteArrayList<Listener>()
+
+    /**
+     * True when the OS classes this device as low-RAM (`ActivityManager.isLowRamDevice`) OR its
+     * heap class is small enough that our normal budgets do not fit. The heap-class arm matters:
+     * plenty of cheap keypad phones do NOT set the low-RAM system property yet still hand out a
+     * 96 MB heap class, and those are exactly the phones this work is for.
+     */
+    @Volatile var lowRam: Boolean = false
+        private set
+
+    /** The device's normal (non-large) heap class in MB. 0 until [init]. */
+    @Volatile var heapClassMb: Int = 0
+        private set
+
+    fun init(context: Context) {
+        val am = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        heapClassMb = am?.memoryClass ?: 0
+        val forced = forcedLowRam()
+        lowRam = forced ?: ((am?.isLowRamDevice == true) || (heapClassMb in 1..127))
+        android.util.Log.i("MemoryPressure", "init lowRam=$lowRam heapClassMb=$heapClassMb forced=${forced?.toString() ?: "no"}")
+    }
+
+    /**
+     * Debug-only override so the low-RAM path can be exercised on a normal dev phone:
+     *
+     *     adb shell setprop debug.vela.lowram true    # then relaunch the app
+     *     adb shell setprop debug.vela.lowram ""      # back to real detection
+     *
+     * Without this the low-RAM branches are dead code on every device we actually own (the M5 dev
+     * phone reports heapClassMb=256, lowRam=false), which means they would ship unverified. Returns
+     * null when unset or on a non-debug build, so release behaviour is untouched.
+     */
+    private fun forcedLowRam(): Boolean? {
+        if (!app.vela.BuildConfig.DEBUG) return null
+        val v = runCatching {
+            @Suppress("PrivateApi")
+            val sp = Class.forName("android.os.SystemProperties")
+            sp.getMethod("get", String::class.java).invoke(null, "debug.vela.lowram") as? String
+        }.getOrNull()
+        return when (v?.lowercase()) {
+            "true", "1" -> true
+            "false", "0" -> false
+            else -> null
+        }
+    }
+
+    /** Register [listener]; returns a handle whose `close()` unregisters. Safe to call any time. */
+    fun register(listener: Listener): AutoCloseable {
+        listeners.add(listener)
+        return AutoCloseable { listeners.remove(listener) }
+    }
+
+    /**
+     * Fan a trim out to every registered holder. Each listener is isolated: one throwing must not
+     * stop the rest from releasing, since under real pressure we want every byte we can get.
+     */
+    fun dispatch(level: Int) {
+        android.util.Log.i("MemoryPressure", "dispatch level=$level listeners=${listeners.size}")
+        for (l in listeners) {
+            runCatching { l.release(level) }
+                .onFailure { android.util.Log.w("MemoryPressure", "listener failed", it) }
+        }
+    }
+
+    /**
+     * The app is backgrounded or the OS is genuinely short of memory, so caches that only speed
+     * things up should go. Everything at or above this level is a "drop it" signal.
+     */
+    fun isSevere(level: Int): Boolean =
+        level >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND ||
+            level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL ||
+            level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
+
+    /** Only the harshest levels, where we drop things that cost real time to rebuild. */
+    fun isCritical(level: Int): Boolean =
+        level >= ComponentCallbacks2.TRIM_MEMORY_COMPLETE ||
+            level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL
+}

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -1475,8 +1475,14 @@ class MapViewModel @Inject constructor(
         // popular times AND the photo gallery land faster when the user taps a result
         // (both idempotent; the photo warm primes the renderer + HTTP/2 sockets + cache
         // so the first place page skips the cold start).
-        viewModelScope.launch { runCatching { webPopularTimes.prewarm() } }
-        runCatching { webPhotos.warm() }
+        // Skipped on low-RAM devices: each warm spins up a Chromium renderer SPECULATIVELY, on
+        // the guess that a search predicts a place tap. When memory is the scarce resource that
+        // trade is backwards - two renderers paid on every search whether or not a place opens
+        // (ported from vela-dpad, 2026-07-23). Those phones build the WebView on first real use.
+        if (!app.vela.ui.MemoryPressure.lowRam) {
+            viewModelScope.launch { runCatching { webPopularTimes.prewarm() } }
+            runCatching { webPhotos.warm() }
+        }
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
             // A fresh typed search leaves any along-route browse: picks open places normally again.
@@ -4292,6 +4298,10 @@ class MapViewModel @Inject constructor(
     /** Remove a downloaded engine's files. If it was active, [AsrEngine.active] falls back to another
      *  installed engine (or the default), so the mic keeps working when possible. */
     fun deleteAsrEngine(engine: app.vela.voice.AsrEngine) {
+        // Free the loaded model BEFORE removing its files. Deleting the directory alone left the
+        // native recognizer resident for the rest of the process (~267 MB measured on the fork),
+        // so Remove reclaimed disk but no memory at all (ported from vela-dpad, 2026-07-23).
+        asrRecognizer.release()
         engine.dir(appContext).deleteRecursively()
         refreshAsr()
         if (app.vela.voice.AsrEngine.anyInstalled(appContext)) asrRecognizer.warmUp()

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1683,7 +1683,17 @@ fun VelaMapView(
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
+        // MapLibre keeps its tile, glyph and sprite caches in NATIVE memory, and the only way to ask
+        // it to shrink them is onLowMemory(). Nothing called it before (ported from vela-dpad,
+        // 2026-07-23), so the map held its full cache through every trim the OS sent. Registered in
+        // the map's own DisposableEffect so the listener can never outlive the MapView it points at.
+        val trim = app.vela.ui.MemoryPressure.register { level ->
+            if (app.vela.ui.MemoryPressure.isSevere(level)) {
+                runCatching { mapView.onLowMemory() }
+            }
+        }
         onDispose {
+            trim.close()
             lifecycleOwner.lifecycle.removeObserver(observer)
             mapView.onPause()
             mapView.onStop()

--- a/app/src/main/java/app/vela/voice/AsrRecognizer.kt
+++ b/app/src/main/java/app/vela/voice/AsrRecognizer.kt
@@ -48,6 +48,65 @@ class AsrRecognizer @Inject constructor(
     @Volatile private var recognizer: OfflineRecognizer? = null
     @Volatile private var loadedKey: String? = null
 
+    /** Non-zero while a [listen] is inside the native recognizer. [release] refuses to free the
+     *  model while this is set: `OfflineRecognizer.release()` frees C++ memory that an in-flight
+     *  decode is still reading, which is a use-after-free that takes the process down rather than
+     *  throwing. A trim arriving mid-utterance simply keeps the model until the utterance ends. */
+    private val inFlight = java.util.concurrent.atomic.AtomicInteger(0)
+
+    /** Idle-reap timer, same idea as the web fetchers' REAP_IDLE_MS. One daemon thread, shared,
+     *  created lazily so a device that never loads a model never starts it. */
+    private val reaper by lazy {
+        java.util.concurrent.Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "asr-reaper").apply { isDaemon = true }
+        }
+    }
+    @Volatile private var reapTask: java.util.concurrent.ScheduledFuture<*>? = null
+
+    init {
+        // Measured on the fork's test phone: the loaded Whisper tiny int8 model costs ~267 MB PSS
+        // (~101 MB of weights plus ~146 MB of onnxruntime arena), resident for the whole process
+        // with no way to reclaim it. It is by far the largest single reclaimable allocation in the
+        // app, so it releases on any severe trim and reloads (~1 s) on the next listen (ported
+        // from vela-dpad, 2026-07-23).
+        app.vela.ui.MemoryPressure.register { level ->
+            if (app.vela.ui.MemoryPressure.isSevere(level)) release()
+        }
+    }
+
+    /**
+     * Drop the model after a quiet period, on EVERY device, not just low-RAM ones. Warming at
+     * startup buys an instant first mic tap (user ask, 2026-07-10) but the app was then holding
+     * ~267 MB for the whole session on the CHANCE of a tap many users never make. Reaping after
+     * idle keeps the instant first tap and stops the model outliving the user's interest; a later
+     * tap pays the same ~1 s load the very first one used to. Every load and every listen re-arm
+     * the timer, so an active dictation session never reaps mid-use.
+     */
+    private fun armIdleReap() {
+        reapTask?.cancel(false)
+        reapTask = runCatching {
+            reaper.schedule({ release() }, REAP_IDLE_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
+        }.getOrNull()
+    }
+
+    /**
+     * Free the native recognizer. Safe to call any time: no-op when nothing is loaded, and declines
+     * while a listen is in flight (see [inFlight]). The next [listen]/[warmUp] rebuilds it.
+     */
+    fun release() {
+        if (inFlight.get() > 0) {
+            android.util.Log.i(TAG, "release skipped, listen in flight")
+            return
+        }
+        synchronized(loadLock) {
+            val r = recognizer ?: return
+            recognizer = null
+            loadedKey = null
+            runCatching { r.release() }
+            android.util.Log.i(TAG, "recognizer released")
+        }
+    }
+
     private val audioManager by lazy { context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager }
     @Volatile private var focusRequest: AudioFocusRequest? = null
 
@@ -90,6 +149,10 @@ class AsrRecognizer @Inject constructor(
         const val SAMPLE_RATE = 16000
         const val VAD_WINDOW = 512            // Silero v4/v5 window at 16 kHz
         const val MAX_SECONDS = 15            // hard cap on one utterance
+        // Drop the loaded model after this quiet period. Matches the web fetchers' REAP_IDLE_MS:
+        // long enough that a dictation session never reaps between utterances, short enough that
+        // a session-long ~267 MB hold cannot happen.
+        const val REAP_IDLE_MS = 120_000L
     }
 
     private fun prefs() = context.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
@@ -139,6 +202,14 @@ class AsrRecognizer @Inject constructor(
      *  built recognizer for the current engine+language. */
     fun warmUp() {
         if (!AsrEngine.anyInstalled(context)) return
+        // On a low-RAM device the warm-up is a bad trade: it spends ~267 MB at EVERY launch to
+        // save ~1 s on a mic tap the user may never make (refreshAsr calls this from VM init plus
+        // two LaunchedEffects). Those phones load on first listen instead; roomier devices keep
+        // the instant-mic behaviour they have always had.
+        if (app.vela.ui.MemoryPressure.lowRam) {
+            android.util.Log.i(TAG, "skipping ASR warm-up on a low-RAM device, will load on first listen")
+            return
+        }
         Thread({ runCatching { ensureRecognizer() } }, "asr-warmup").start()
     }
 
@@ -242,6 +313,7 @@ class AsrRecognizer @Inject constructor(
             prefs.edit().putInt(strikesKey, 0).apply()
             recognizer = r
             loadedKey = key
+            if (r != null) armIdleReap() // start the quiet-period countdown from the load
             return r
         }
     }
@@ -255,6 +327,22 @@ class AsrRecognizer @Inject constructor(
     /** Listen, transcribe, and say WHY when it does not work - see [VoiceResult]. Every failure exit
      *  logs under `VELAASR` so a tester's logcat names the cause without another round-trip. */
     suspend fun listen(
+        onLevel: (Float) -> Unit,
+        onListening: () -> Unit,
+        cancelled: () -> Boolean,
+    ): VoiceResult = withContext(Dispatchers.Default) {
+        // Mark the recognizer busy so a memory trim arriving mid-utterance cannot free the native
+        // model out from under the decode (see inFlight); re-arm the idle reap on every exit.
+        inFlight.incrementAndGet()
+        try {
+            listenInner(onLevel, onListening, cancelled)
+        } finally {
+            inFlight.decrementAndGet()
+            armIdleReap()
+        }
+    }
+
+    private suspend fun listenInner(
         onLevel: (Float) -> Unit,
         onListening: () -> Unit,
         cancelled: () -> Boolean,

--- a/app/src/main/java/app/vela/voice/PiperSynth.kt
+++ b/app/src/main/java/app/vela/voice/PiperSynth.kt
@@ -38,6 +38,19 @@ class PiperSynth @Inject constructor(
     @Volatile private var loadFailed = false
     @Volatile private var generation = 0
 
+    init {
+        // The Piper VITS model is the app's second-largest native holding after the ASR model.
+        // CRITICAL only, deliberately narrower than the recognizer's severe trigger: dropping the
+        // synth costs a reload on the next prompt, and a prompt arriving late during navigation is
+        // a missed turn. TRIM_MEMORY_COMPLETE only reaches background processes, and
+        // RUNNING_CRITICAL means the device is about to start killing things regardless.
+        // release() posts to the piper-tts worker, so it is already serialized against an
+        // in-flight synthesis and cannot free the model out from under one.
+        app.vela.ui.MemoryPressure.register { level ->
+            if (app.vela.ui.MemoryPressure.isCritical(level)) release()
+        }
+    }
+
     /** Which voice id `tts` currently holds — lets [ensureLoaded] detect a voice switch and rebuild. */
     @Volatile private var loadedVoiceId: String? = null
 

--- a/app/src/main/java/app/vela/web/WebDirectionsFetcher.kt
+++ b/app/src/main/java/app/vela/web/WebDirectionsFetcher.kt
@@ -63,12 +63,24 @@ class WebDirectionsFetcher @Inject constructor(
      *  real memory. The next fetch after a reap just re-creates it. */
     private fun scheduleReap() {
         reap?.let(main::removeCallbacks)
-        val r = Runnable {
-            webView?.let { runCatching { it.loadUrl("about:blank"); it.destroy() } }
-            webView = null
-        }
+        val r = Runnable { reapNow() }
         reap = r
         main.postDelayed(r, REAP_IDLE_MS)
+    }
+
+    /** Destroy the WebView immediately. Must run on the main thread (WebView requirement). */
+    private fun reapNow() {
+        webView?.let { runCatching { it.loadUrl("about:blank"); it.destroy() } }
+        webView = null
+    }
+
+    init {
+        // Under real memory pressure the 120 s idle timer is far too slow - the OS is asking for
+        // memory NOW and a Chromium renderer is one of the largest things we hold (ported from
+        // vela-dpad, 2026-07-23). Reap on the main thread, since WebView.destroy() requires it.
+        app.vela.ui.MemoryPressure.register { level ->
+            if (app.vela.ui.MemoryPressure.isSevere(level)) main.post { cancelReap(); reapNow() }
+        }
     }
 
     private fun cancelReap() {

--- a/app/src/main/java/app/vela/web/WebPhotoFetcher.kt
+++ b/app/src/main/java/app/vela/web/WebPhotoFetcher.kt
@@ -63,6 +63,26 @@ class WebPhotoFetcher @Inject constructor(
     @Volatile private var webView: WebView? = null
     @Volatile private var warmed = false
 
+    init {
+        // Unlike the other four web fetchers this one has NO idle reaper, so a warmed gallery
+        // renderer was pinned for the whole session with only renderer-death to clear it. A
+        // Chromium renderer is one of the largest things the app holds, and this fetcher is one of
+        // the two warmed speculatively on every search, so it releases under pressure (ported from
+        // vela-dpad, 2026-07-23).
+        app.vela.ui.MemoryPressure.register { level ->
+            if (app.vela.ui.MemoryPressure.isSevere(level)) main.post { reapNow() }
+        }
+    }
+
+    /** Destroy the WebView immediately. Main thread only (WebView requirement). The next
+     *  [warm]/fetch rebuilds it via `ensureWebView`, exactly as after a renderer death. */
+    private fun reapNow() {
+        val wv = webView ?: return
+        webView = null
+        warmed = false
+        runCatching { wv.loadUrl("about:blank"); wv.destroy() }
+    }
+
     // featureId → its scraped gallery. Re-tapping a place (or bouncing back from directions) then
     // shows photos INSTANTLY instead of re-running the ~20 s scrape. Access-order LRU, small cap.
     private val cache = object : LinkedHashMap<String, List<Photo>>(16, 0.75f, true) {

--- a/app/src/main/java/app/vela/web/WebPopularTimesFetcher.kt
+++ b/app/src/main/java/app/vela/web/WebPopularTimesFetcher.kt
@@ -58,13 +58,25 @@ class WebPopularTimesFetcher @Inject constructor(
      *  reap re-warms (google.com -> maps), a one-off few-second cost after minutes idle. */
     private fun scheduleReap() {
         reap?.let(main::removeCallbacks)
-        val r = Runnable {
-            webView?.let { runCatching { it.loadUrl("about:blank"); it.destroy() } }
-            webView = null
-            warm = null // ensureWarm re-runs the warm sequence on the next fetch
-        }
+        val r = Runnable { reapNow() }
         reap = r
         main.postDelayed(r, REAP_IDLE_MS)
+    }
+
+    /** Destroy the WebView immediately. Must run on the main thread (WebView requirement). */
+    private fun reapNow() {
+        webView?.let { runCatching { it.loadUrl("about:blank"); it.destroy() } }
+        webView = null
+        warm = null // ensureWarm re-runs the warm sequence on the next fetch
+    }
+
+    init {
+        // Under real memory pressure the 120 s idle timer is far too slow - the OS is asking for
+        // memory NOW and a Chromium renderer is one of the largest things we hold (ported from
+        // vela-dpad, 2026-07-23). Reap on the main thread, since WebView.destroy() requires it.
+        app.vela.ui.MemoryPressure.register { level ->
+            if (app.vela.ui.MemoryPressure.isSevere(level)) main.post { cancelReap(); reapNow() }
+        }
     }
 
     private fun cancelReap() {

--- a/app/src/main/java/app/vela/web/WebReviewsFetcher.kt
+++ b/app/src/main/java/app/vela/web/WebReviewsFetcher.kt
@@ -58,12 +58,24 @@ class WebReviewsFetcher @Inject constructor(
      *  real memory. The next fetch after a reap just re-creates it. */
     private fun scheduleReap() {
         reap?.let(main::removeCallbacks)
-        val r = Runnable {
-            webView?.let { runCatching { it.loadUrl("about:blank"); it.destroy() } }
-            webView = null
-        }
+        val r = Runnable { reapNow() }
         reap = r
         main.postDelayed(r, REAP_IDLE_MS)
+    }
+
+    /** Destroy the WebView immediately. Must run on the main thread (WebView requirement). */
+    private fun reapNow() {
+        webView?.let { runCatching { it.loadUrl("about:blank"); it.destroy() } }
+        webView = null
+    }
+
+    init {
+        // Under real memory pressure the 120 s idle timer is far too slow - the OS is asking for
+        // memory NOW and a Chromium renderer is one of the largest things we hold (ported from
+        // vela-dpad, 2026-07-23). Reap on the main thread, since WebView.destroy() requires it.
+        app.vela.ui.MemoryPressure.register { level ->
+            if (app.vela.ui.MemoryPressure.isSevere(level)) main.post { cancelReap(); reapNow() }
+        }
     }
 
     private fun cancelReap() {

--- a/app/src/main/java/app/vela/web/WebStopDeparturesFetcher.kt
+++ b/app/src/main/java/app/vela/web/WebStopDeparturesFetcher.kt
@@ -53,12 +53,24 @@ class WebStopDeparturesFetcher @Inject constructor(
      *  just re-creates it - a one-off warm-up, only after minutes of not using the feature. */
     private fun scheduleReap() {
         reap?.let(main::removeCallbacks)
-        val r = Runnable {
-            webView?.let { runCatching { it.loadUrl("about:blank"); it.destroy() } }
-            webView = null
-        }
+        val r = Runnable { reapNow() }
         reap = r
         main.postDelayed(r, REAP_IDLE_MS)
+    }
+
+    /** Destroy the WebView immediately. Must run on the main thread (WebView requirement). */
+    private fun reapNow() {
+        webView?.let { runCatching { it.loadUrl("about:blank"); it.destroy() } }
+        webView = null
+    }
+
+    init {
+        // Under real memory pressure the 120 s idle timer is far too slow - the OS is asking for
+        // memory NOW and a Chromium renderer is one of the largest things we hold (ported from
+        // vela-dpad, 2026-07-23). Reap on the main thread, since WebView.destroy() requires it.
+        app.vela.ui.MemoryPressure.register { level ->
+            if (app.vela.ui.MemoryPressure.isSevere(level)) main.post { cancelReap(); reapNow() }
+        }
     }
 
     private fun cancelReap() {

--- a/core/src/main/java/app/vela/core/data/LowRamMode.kt
+++ b/core/src/main/java/app/vela/core/data/LowRamMode.kt
@@ -1,0 +1,17 @@
+package app.vela.core.data
+
+/**
+ * Whether this device is memory-constrained, exposed as a `:core`-visible flag.
+ *
+ * Same shape and reason as [CategoryFilter.enabled]: the detection lives in `:app`
+ * (`app.vela.ui.MemoryPressure`, which needs `ActivityManager`), but the behaviour it gates has to
+ * act down at the data-source seam. `:core` stays UI-agnostic and never reads an app holder, so the
+ * app pushes the value in at startup instead.
+ *
+ * Off by default, which keeps every roomier device byte-identical to previous behaviour.
+ */
+object LowRamMode {
+
+    /** Set once from `VelaApp.onCreate` after `MemoryPressure.init`. */
+    @Volatile var enabled: Boolean = false
+}

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -6,6 +6,7 @@ import app.vela.core.config.JsTransforms
 import app.vela.core.diag.DiagLog
 import app.vela.core.data.CalibrationNeededException
 import app.vela.core.data.CategoryFilter
+import app.vela.core.data.LowRamMode
 import app.vela.core.data.MapDataSource
 import app.vela.core.data.RouteEngine
 import app.vela.core.data.RouteGeometry
@@ -187,7 +188,7 @@ class GoogleMapsDataSource @Inject constructor(
         // FAN OUT across category terms + merge: one "places" query is biased to prominent food/
         // shops, so it misses whole tiers (a strip mall's plumber, nail salon, IT shop). A handful
         // of category queries roughly DOUBLES local coverage (live: 22→52 unique within 600 m).
-        val terms = listOf(
+        val allTerms = listOf(
             "places", "restaurants", "coffee", "stores", "shopping", "services", "beauty salon", "fast food",
             // High-traffic everyday categories the food/shop-biased set above under-returns, so the map
             // shows a Google-like MIX (a gas station, a gym, a grocer) rather than mostly restaurants.
@@ -199,12 +200,36 @@ class GoogleMapsDataSource @Inject constructor(
             // their prominence low, so they surface in quiet/residential views without crowding businesses.
             "school", "park",
         )
+        // LOW-RAM: the fan-out is the app's single largest allocation burst. Each term buffers a
+        // full response String, a stripped copy, and a JsonElement DOM (GoogleResponse.parse), and
+        // 15 of those run 4-at-a-time per pan - the documented ~180 MB/12 s churn. Constrained
+        // devices fetch an 8-term subset instead (ported from vela-dpad, 2026-07-23).
+        //
+        // The subset is NOT just the first N. "school" and "park" are retained DELIBERATELY: while
+        // the ambient layer is active at z14+ the basemap's OSM poi layers are filter-hidden, so
+        // those categories have NO second source - dropping them makes parks and schools vanish
+        // from the map entirely (the fork lost every park/school pin on a first 6-term attempt,
+        // caught by A/B screenshot). What goes instead are terms whose places still surface via
+        // "places"/"stores" or degrade gracefully: shopping, services, beauty salon, fast food,
+        // gym, bar, pharmacy. Fewer ambient POIs is a visible trade, and the right one on a phone
+        // that otherwise OOMs. Roomier devices are unaffected.
+        val terms = if (LowRamMode.enabled) {
+            listOf("places", "restaurants", "coffee", "stores", "grocery store", "gas station", "school", "park")
+        } else {
+            allTerms
+        }
         suspend fun fetchTerm(term: String): List<Place> = ambientFanout.withPermit {
             runCatching {
                 val pb = SearchPb.build(term, center, cal.searchPb)
                     .replaceFirst(Regex("!1d[0-9.]+"), "!1d${spanMeters.toInt()}")
                     .replaceFirst(Regex("!4f[0-9.]+"), "!4f${String.format(java.util.Locale.US, "%.1f", zoom)}")
-                    .replaceFirst(Regex("!7i\\d+"), "!7i60") // deep pool per term, so zooming in can go down the rank
+                    .replaceFirst(
+                        Regex("!7i\\d+"),
+                        // Deep pool per term, so zooming in can go down the rank. Halved on low-RAM:
+                        // the pool size drives the RESPONSE BODY size, and the body is what gets
+                        // buffered and DOM-parsed per term.
+                        if (LowRamMode.enabled) "!7i30" else "!7i60",
+                    )
                 val url = "${cal.searchEndpoint}&q=${term.enc()}&pb=${pb.enc()}".localized()
                 SearchParser.parse(term, GoogleResponse.parse(get(url)), center, cal.paths).places
             }.getOrDefault(emptyList())


### PR DESCRIPTION
Adopted from the vela-dpad fork (alltechdev) and adapted to our multi-engine recognizer. Stacked on the voice-robustness PR; merge that one first.

Nothing in the app implemented memory-pressure callbacks: when Android asked us to shrink, we freed nothing, and the system's only option was to kill the process. That is the failure class behind the OOM crash on the 512 MB tablet in issue #95 and our own heap-ceiling battles.

- A **MemoryPressure** holder fans every `onTrimMemory` out to registered releasers.
- The **speech model** (~267 MB PSS while loaded, previously resident for the whole process and surviving even model removal) drops after 2 minutes unused and on severe pressure, reloading in ~1 s on the next mic tap. An in-flight counter blocks release mid-decode, which would otherwise be a native use-after-free.
- The **nav voice** releases only at critical pressure, since reloading mid-drive risks a late prompt.
- **MapLibre's native caches** get `onLowMemory()` (never called before), all **five hidden WebViews** reap immediately under pressure, and **Coil's** bitmap cache clears on severe trims.
- Devices the OS classes low-RAM, or with a heap class under 128 MB, also skip the launch speech warm-up and the speculative per-search WebView warms, cap the image cache at 16 MB, and fetch an 8-term ambient fan-out with a halved pool (schools and parks kept, since ambient is their only source at browse zoom). `adb shell setprop debug.vela.lowram true` exercises the path on any phone.

Fork-measured on a 2.9 GB device: idle PSS 421 MB to 299 MB, and the model reclaim verified at the 2-minute mark. Canary built; on-device before/after PSS numbers on the 4a to follow once the phone frees up (it currently carries the vela-dpad Android Auto canary).
