### PR TITLE
New logo and README hero

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1354,12 +1354,12 @@ Defaults that make the safe path the easy one:
 
 ## Brand assets (2026-07-23)
 
-One mark everywhere: the two-tone SAILBOAT (white jib + `#39e0c8` main with a
-mast gap between them, white hull) on the `#0d3d43` to `#149387` gradient.
-No star, and deliberately NOT a pin (the mast gap is what stops the sail
-reading as a warped nav arrow; a pin was considered and rejected as the
-generic-maps-fork look, and a sail inside a pin turns to mush at launcher
-size). Canonical file is `docs/logo.svg` (512, rounded square). Derived copies that must stay in sync
+One mark everywhere: the two-tone NAV CHEVRON (notched arrowhead, white left
+half + `#39e0c8` right half) on the `#0d3d43` to `#149387` gradient. The
+user's explicit pick (2026-07-23) after three rounds: sailboat variants, a
+pin, a route-V, a constellation and a puck-in-circle were all considered and
+rejected; they wanted the nav-arrow paradigm, two-toned, with NO circle, NO
+star, NO pin. Canonical file is `docs/logo.svg` (512, rounded square). Derived copies that must stay in sync
 when the mark changes: the launcher adaptive icon
 (`drawable/ic_launcher_foreground.xml` + `ic_launcher_background.xml` gradient +
 `ic_launcher_monochrome.xml` for themed icons; the old

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1352,6 +1352,21 @@ Defaults that make the safe path the easy one:
   docs/voice-demo.mp4 (`ffmpeg -vn -c:a copy`) - regenerate it whenever the voice demo is
   re-rendered. No Android Auto on the site yet (user 2026-07-16, not confident it works).
 
+## Brand assets (2026-07-23)
+
+One mark everywhere: the two-tone sail (white jib + `#39e0c8` main) with the
+4-point star, on the `#0d3d43` to `#149387` gradient. Canonical file is
+`docs/logo.svg` (512, rounded square). Derived copies that must stay in sync
+when the mark changes: the launcher adaptive icon
+(`drawable/ic_launcher_foreground.xml` + `ic_launcher_background.xml` gradient +
+`ic_launcher_monochrome.xml` for themed icons; the old
+`@color/ic_launcher_background` is gone), the site navbar mark + favicon data
+URI (`site/index.html`), and the README hero. The README hero also carries the
+shields badge row + quick-nav links + website button (bambuddy-style); badge
+URLs are shields.io (README only - the SITE stays zero-external-requests).
+The GitHub social-preview image is uploaded manually in repo Settings and does
+NOT live in the repo - re-upload it if the mark changes.
+
 ## README layout rule (2026-07-11)
 
 The README stays SHORT: pitch, screenshots, install, what-you-get, the **privacy comparison

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1354,9 +1354,12 @@ Defaults that make the safe path the easy one:
 
 ## Brand assets (2026-07-23)
 
-One mark everywhere: the two-tone sail (white jib + `#39e0c8` main) with the
-4-point star, on the `#0d3d43` to `#149387` gradient. Canonical file is
-`docs/logo.svg` (512, rounded square). Derived copies that must stay in sync
+One mark everywhere: the two-tone SAILBOAT (white jib + `#39e0c8` main with a
+mast gap between them, white hull) on the `#0d3d43` to `#149387` gradient.
+No star, and deliberately NOT a pin (the mast gap is what stops the sail
+reading as a warped nav arrow; a pin was considered and rejected as the
+generic-maps-fork look, and a sail inside a pin turns to mush at launcher
+size). Canonical file is `docs/logo.svg` (512, rounded square). Derived copies that must stay in sync
 when the mark changes: the launcher adaptive icon
 (`drawable/ic_launcher_foreground.xml` + `ic_launcher_background.xml` gradient +
 `ic_launcher_monochrome.xml` for themed icons; the old

--- a/README.md
+++ b/README.md
@@ -1,4 +1,25 @@
+<div align="center">
+
+<img src="docs/logo.svg" width="120" alt="Vela Maps logo">
+
 # Vela Maps
+
+**Google Maps, degoogled.**
+
+Live traffic, real place data and turn-by-turn navigation, with zero Google on your phone.
+
+[![Stable release](https://img.shields.io/github/v/release/PimpinPumpkin/Vela?label=stable&color=149387)](https://github.com/PimpinPumpkin/Vela/releases/latest)
+[![Build](https://img.shields.io/github/actions/workflow/status/PimpinPumpkin/Vela/ci.yml?branch=main&label=build)](https://github.com/PimpinPumpkin/Vela/actions/workflows/ci.yml)
+[![License: GPL v3](https://img.shields.io/github/license/PimpinPumpkin/Vela?color=blue)](LICENSE)
+[![Downloads](https://img.shields.io/github/downloads/PimpinPumpkin/Vela/total?color=149387)](https://github.com/PimpinPumpkin/Vela/releases)
+[![Translated on Weblate](https://img.shields.io/badge/translations-Weblate-2ecccf)](https://hosted.weblate.org/projects/vela-maps/)
+[![Stars](https://img.shields.io/github/stars/PimpinPumpkin/Vela?style=flat&color=ffd43b)](https://github.com/PimpinPumpkin/Vela/stargazers)
+
+[Install](#install) · [What you get](#what-you-get) · [Privacy](#privacy) · [How it works](docs/HOW-IT-WORKS.md) · [Build](#build) · [Discussions](https://github.com/PimpinPumpkin/Vela/discussions) · [Translate](docs/TRANSLATING.md)
+
+[<img src="https://img.shields.io/badge/VISIT%20THE%20WEBSITE-149387?style=for-the-badge" alt="Visit the website">](https://pimpinpumpkin.github.io/Vela/)
+
+</div>
 
 A degoogled maps & navigation client for Android - *what NewPipe is to YouTube,
 for Google Maps.* Open vector tiles for the basemap, the device itself scraping

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Brand gradient behind the launcher sail, matching docs/logo.svg. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="315"
+        android:startColor="#0D3D43"
+        android:endColor="#149387"
+        android:type="linear" />
+</shape>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -3,21 +3,18 @@
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
-    <!-- Vela sailboat mark: white jib, teal main, white hull. Drawn in the
+    <!-- Vela mark: two-tone nav chevron (white left, teal right). Drawn in the
          512-space of docs/logo.svg, scaled into the adaptive-icon safe zone. -->
     <group
-        android:scaleX="0.15"
-        android:scaleY="0.15"
-        android:translateX="14.4"
-        android:translateY="15.0">
+        android:scaleX="0.18"
+        android:scaleY="0.18"
+        android:translateX="7.92"
+        android:translateY="11.16">
         <path
             android:fillColor="#FFFFFF"
-            android:pathData="M240,128 C204,208 170,282 140,352 L240,352 Z" />
+            android:pathData="M256,100 L146,376 L256,318 Z" />
         <path
             android:fillColor="#39E0C8"
-            android:pathData="M268,88 C314,172 358,258 398,352 L268,352 Z" />
-        <path
-            android:fillColor="#FFFFFF"
-            android:pathData="M130,388 L398,388 C390,420 356,432 310,432 L218,432 C172,432 138,420 130,388 Z" />
+            android:pathData="M256,100 L366,376 L256,318 Z" />
     </group>
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -3,21 +3,21 @@
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
-    <!-- Vela sail mark: white jib + teal main, star upper right. Drawn in the
+    <!-- Vela sailboat mark: white jib, teal main, white hull. Drawn in the
          512-space of docs/logo.svg, scaled into the adaptive-icon safe zone. -->
     <group
-        android:scaleX="0.16"
-        android:scaleY="0.16"
-        android:translateX="11.76"
-        android:translateY="14.8">
+        android:scaleX="0.15"
+        android:scaleY="0.15"
+        android:translateX="14.4"
+        android:translateY="15.0">
         <path
             android:fillColor="#FFFFFF"
-            android:pathData="M242,88 C194,186 164,292 146,402 L242,354 Z" />
+            android:pathData="M240,128 C204,208 170,282 140,352 L240,352 Z" />
         <path
             android:fillColor="#39E0C8"
-            android:pathData="M242,88 C260,200 292,306 338,402 L242,354 Z" />
+            android:pathData="M268,88 C314,172 358,258 398,352 L268,352 Z" />
         <path
             android:fillColor="#FFFFFF"
-            android:pathData="M352,122 l8,22 22,8 -22,8 -8,22 -8,-22 -22,-8 22,-8 Z" />
+            android:pathData="M130,388 L398,388 C390,420 356,432 310,432 L218,432 C172,432 138,420 130,388 Z" />
     </group>
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -3,14 +3,14 @@
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
-    <!-- Single-ink sailboat for Android 13+ themed icons (system supplies the tint). -->
+    <!-- Single-ink chevron for Android 13+ themed icons (system supplies the tint). -->
     <group
-        android:scaleX="0.15"
-        android:scaleY="0.15"
-        android:translateX="14.4"
-        android:translateY="15.0">
+        android:scaleX="0.18"
+        android:scaleY="0.18"
+        android:translateX="7.92"
+        android:translateY="11.16">
         <path
             android:fillColor="#FFFFFF"
-            android:pathData="M240,128 C204,208 170,282 140,352 L240,352 Z M268,88 C314,172 358,258 398,352 L268,352 Z M130,388 L398,388 C390,420 356,432 310,432 L218,432 C172,432 138,420 130,388 Z" />
+            android:pathData="M256,100 L146,376 L256,318 Z M256,100 L366,376 L256,318 Z" />
     </group>
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -3,8 +3,7 @@
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
-    <!-- Vela sail mark: white jib + teal main, star upper right. Drawn in the
-         512-space of docs/logo.svg, scaled into the adaptive-icon safe zone. -->
+    <!-- Single-ink sail for Android 13+ themed icons (system supplies the tint). -->
     <group
         android:scaleX="0.16"
         android:scaleY="0.16"
@@ -12,10 +11,7 @@
         android:translateY="14.8">
         <path
             android:fillColor="#FFFFFF"
-            android:pathData="M242,88 C194,186 164,292 146,402 L242,354 Z" />
-        <path
-            android:fillColor="#39E0C8"
-            android:pathData="M242,88 C260,200 292,306 338,402 L242,354 Z" />
+            android:pathData="M242,88 C194,186 164,292 146,402 L242,354 Z M242,88 C260,200 292,306 338,402 L242,354 Z" />
         <path
             android:fillColor="#FFFFFF"
             android:pathData="M352,122 l8,22 22,8 -22,8 -8,22 -8,-22 -22,-8 22,-8 Z" />

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -3,17 +3,14 @@
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
-    <!-- Single-ink sail for Android 13+ themed icons (system supplies the tint). -->
+    <!-- Single-ink sailboat for Android 13+ themed icons (system supplies the tint). -->
     <group
-        android:scaleX="0.16"
-        android:scaleY="0.16"
-        android:translateX="11.76"
-        android:translateY="14.8">
+        android:scaleX="0.15"
+        android:scaleY="0.15"
+        android:translateX="14.4"
+        android:translateY="15.0">
         <path
             android:fillColor="#FFFFFF"
-            android:pathData="M242,88 C194,186 164,292 146,402 L242,354 Z M242,88 C260,200 292,306 338,402 L242,354 Z" />
-        <path
-            android:fillColor="#FFFFFF"
-            android:pathData="M352,122 l8,22 22,8 -22,8 -8,22 -8,-22 -22,-8 22,-8 Z" />
+            android:pathData="M240,128 C204,208 170,282 140,352 L240,352 Z M268,88 C314,172 358,258 398,352 L268,352 Z M130,388 L398,388 C390,420 356,432 310,432 L218,432 C172,432 138,420 130,388 Z" />
     </group>
 </vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@color/ic_launcher_background" />
+    <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#14857A</color>
+    <!-- Launcher background is @drawable/ic_launcher_background (brand gradient) now. -->
 </resources>

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d3d43"/>
+      <stop offset="1" stop-color="#149387"/>
+    </linearGradient>
+  </defs>
+  <rect x="16" y="16" width="480" height="480" rx="128" fill="url(#bg)"/>
+  <g transform="translate(-14 0)">
+    <path d="M256 88 C 208 186 178 292 160 402 L 256 354 Z" fill="#ffffff"/>
+    <path d="M256 88 C 274 200 306 306 352 402 L 256 354 Z" fill="#39e0c8"/>
+  </g>
+  <path d="M366 122 l8 22 22 8 -22 8 -8 22 -8 -22 -22 -8 22 -8 Z" fill="#ffffff"/>
+</svg>

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,12 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#0d3d43"/>
-      <stop offset="1" stop-color="#149387"/>
-    </linearGradient>
-  </defs>
-  <rect x="16" y="16" width="480" height="480" rx="128" fill="url(#bg)"/>
-  <path d="M240 128 C 204 208 170 282 140 352 L 240 352 Z" fill="#ffffff"/>
-  <path d="M268 88 C 314 172 358 258 398 352 L 268 352 Z" fill="#39e0c8"/>
-  <path d="M130 388 L 398 388 C 390 420 356 432 310 432 L 218 432 C 172 432 138 420 130 388 Z" fill="#ffffff"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512"><defs><linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0d3d43"/><stop offset="1" stop-color="#149387"/></linearGradient></defs><rect x="16" y="16" width="480" height="480" rx="128" fill="url(#bg)"/><path d="M256 100 L 146 376 L 256 318 Z" fill="#ffffff"/><path d="M256 100 L 366 376 L 256 318 Z" fill="#39e0c8"/></svg>

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -6,9 +6,7 @@
     </linearGradient>
   </defs>
   <rect x="16" y="16" width="480" height="480" rx="128" fill="url(#bg)"/>
-  <g transform="translate(-14 0)">
-    <path d="M256 88 C 208 186 178 292 160 402 L 256 354 Z" fill="#ffffff"/>
-    <path d="M256 88 C 274 200 306 306 352 402 L 256 354 Z" fill="#39e0c8"/>
-  </g>
-  <path d="M366 122 l8 22 22 8 -22 8 -8 22 -8 -22 -22 -8 22 -8 Z" fill="#ffffff"/>
+  <path d="M240 128 C 204 208 170 282 140 352 L 240 352 Z" fill="#ffffff"/>
+  <path d="M268 88 C 314 172 358 258 398 352 L 268 352 Z" fill="#39e0c8"/>
+  <path d="M130 388 L 398 388 C 390 420 356 432 310 432 L 218 432 C 172 432 138 420 130 388 Z" fill="#ffffff"/>
 </svg>

--- a/site/index.html
+++ b/site/index.html
@@ -9,7 +9,7 @@
 <meta property="og:description" content="Google Maps, degoogled. Free and open source, no account, no tracking.">
 <meta property="og:image" content="assets/05-navigation.webp">
 <meta property="og:type" content="website">
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Crect x='16' y='16' width='480' height='480' rx='128' fill='%230d3d43'/%3E%3Cg transform='translate(-14 0)'%3E%3Cpath d='M256 88 C 208 186 178 292 160 402 L 256 354 Z' fill='%23ffffff'/%3E%3Cpath d='M256 88 C 274 200 306 306 352 402 L 256 354 Z' fill='%2339e0c8'/%3E%3C/g%3E%3Cpath d='M366 122 l8 22 22 8 -22 8 -8 22 -8 -22 -22 -8 22 -8 Z' fill='%23ffffff'/%3E%3C/svg%3E">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Crect x='16' y='16' width='480' height='480' rx='128' fill='%230d3d43'/%3E%3Cpath d='M240 128 C 204 208 170 282 140 352 L 240 352 Z' fill='%23ffffff'/%3E%3Cpath d='M268 88 C 314 172 358 258 398 352 L 268 352 Z' fill='%2339e0c8'/%3E%3Cpath d='M130 388 L 398 388 C 390 420 356 432 310 432 L 218 432 C 172 432 138 420 130 388 Z' fill='%23ffffff'/%3E%3C/svg%3E">
 <style>
   :root {
     --bg: #06080d;
@@ -374,7 +374,7 @@
 <div class="navbar">
   <div class="bar">
     <a class="brand" href="#top">
-      <svg viewBox="0 0 512 512" aria-hidden="true"><g transform="translate(-14 0)"><path d="M256 88 C 208 186 178 292 160 402 L 256 354 Z" fill="#eafffb"/><path d="M256 88 C 274 200 306 306 352 402 L 256 354 Z" fill="#2fd8c1"/></g><path d="M366 122 l8 22 22 8 -22 8 -8 22 -8 -22 -22 -8 22 -8 Z" fill="#eafffb"/></svg>
+      <svg viewBox="0 0 512 512" aria-hidden="true"><path d="M240 128 C 204 208 170 282 140 352 L 240 352 Z" fill="#eafffb"/><path d="M268 88 C 314 172 358 258 398 352 L 268 352 Z" fill="#2fd8c1"/><path d="M130 388 L 398 388 C 390 420 356 432 310 432 L 218 432 C 172 432 138 420 130 388 Z" fill="#eafffb"/></svg>
       Vela Maps
     </a>
     <div class="nav-links">

--- a/site/index.html
+++ b/site/index.html
@@ -9,7 +9,7 @@
 <meta property="og:description" content="Google Maps, degoogled. Free and open source, no account, no tracking.">
 <meta property="og:image" content="assets/05-navigation.webp">
 <meta property="og:type" content="website">
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Crect x='16' y='16' width='480' height='480' rx='128' fill='%230d3d43'/%3E%3Cpath d='M240 128 C 204 208 170 282 140 352 L 240 352 Z' fill='%23ffffff'/%3E%3Cpath d='M268 88 C 314 172 358 258 398 352 L 268 352 Z' fill='%2339e0c8'/%3E%3Cpath d='M130 388 L 398 388 C 390 420 356 432 310 432 L 218 432 C 172 432 138 420 130 388 Z' fill='%23ffffff'/%3E%3C/svg%3E">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Crect x='16' y='16' width='480' height='480' rx='128' fill='%230d3d43'/%3E%3Cpath d='M256 100 L 146 376 L 256 318 Z' fill='%23ffffff'/%3E%3Cpath d='M256 100 L 366 376 L 256 318 Z' fill='%2339e0c8'/%3E%3C/svg%3E">
 <style>
   :root {
     --bg: #06080d;
@@ -374,7 +374,7 @@
 <div class="navbar">
   <div class="bar">
     <a class="brand" href="#top">
-      <svg viewBox="0 0 512 512" aria-hidden="true"><path d="M240 128 C 204 208 170 282 140 352 L 240 352 Z" fill="#eafffb"/><path d="M268 88 C 314 172 358 258 398 352 L 268 352 Z" fill="#2fd8c1"/><path d="M130 388 L 398 388 C 390 420 356 432 310 432 L 218 432 C 172 432 138 420 130 388 Z" fill="#eafffb"/></svg>
+      <svg viewBox="0 0 512 512" aria-hidden="true"><path d="M256 100 L 146 376 L 256 318 Z" fill="#eafffb"/><path d="M256 100 L 366 376 L 256 318 Z" fill="#2fd8c1"/></svg>
       Vela Maps
     </a>
     <div class="nav-links">

--- a/site/index.html
+++ b/site/index.html
@@ -9,7 +9,7 @@
 <meta property="og:description" content="Google Maps, degoogled. Free and open source, no account, no tracking.">
 <meta property="og:image" content="assets/05-navigation.webp">
 <meta property="og:type" content="website">
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%230b1220'/%3E%3Cpath d='M32 12 L40 40 L32 34 L24 40 Z' fill='%232dd4bf'/%3E%3C/svg%3E">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Crect x='16' y='16' width='480' height='480' rx='128' fill='%230d3d43'/%3E%3Cg transform='translate(-14 0)'%3E%3Cpath d='M256 88 C 208 186 178 292 160 402 L 256 354 Z' fill='%23ffffff'/%3E%3Cpath d='M256 88 C 274 200 306 306 352 402 L 256 354 Z' fill='%2339e0c8'/%3E%3C/g%3E%3Cpath d='M366 122 l8 22 22 8 -22 8 -8 22 -8 -22 -22 -8 22 -8 Z' fill='%23ffffff'/%3E%3C/svg%3E">
 <style>
   :root {
     --bg: #06080d;
@@ -374,7 +374,7 @@
 <div class="navbar">
   <div class="bar">
     <a class="brand" href="#top">
-      <svg viewBox="0 0 64 64" aria-hidden="true"><circle cx="32" cy="32" r="30" fill="none" stroke="#2fd8c1" stroke-width="4"/><path d="M32 14 L41 44 L32 37.5 L23 44 Z" fill="#2fd8c1"/></svg>
+      <svg viewBox="0 0 512 512" aria-hidden="true"><g transform="translate(-14 0)"><path d="M256 88 C 208 186 178 292 160 402 L 256 354 Z" fill="#eafffb"/><path d="M256 88 C 274 200 306 306 352 402 L 256 354 Z" fill="#2fd8c1"/></g><path d="M366 122 l8 22 22 8 -22 8 -8 22 -8 -22 -22 -8 22 -8 Z" fill="#eafffb"/></svg>
       Vela Maps
     </a>
     <div class="nav-links">


### PR DESCRIPTION
One brand mark everywhere, and a README front door that matches the repos people compare us to.

## The mark

A billowed white jib + teal mainsail (Vela is the Sails constellation) with a small star, on a dark-to-teal gradient. Canonical file: docs/logo.svg.

| Where | What changed |
|---|---|
| Launcher | Adaptive icon redrawn from the mark: sail foreground, gradient background drawable, plus a monochrome layer for Android 13 themed icons. The stock white Material pin is gone. |
| Site | Navbar mark + favicon swapped to the sail. |
| README | Centered logo hero, tagline, shields badge row (stable, build, license, downloads, Weblate, stars), quick-nav links, website button. |

## Notes

- The badge row is shields.io in the README only; the site stays zero-external-requests.
- Debug build compiles clean; the launcher icon is vector-only (minSdk 26, so every device takes the adaptive path).
- The GitHub social preview image is a repo Settings upload and is not in this diff.

Preview the hero render on this branch's README before merging.