### PR TITLE
Honest offline sizes, big-download confirm, storage breakdown (issue #214)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1683,6 +1683,17 @@ architecture note.
   an address). Rarely seeing it = data-dependent, not removed. "People also search for"
   (`similarPlaces`) is the different, related-places row.
 
+- **Offline sizes are INSTALLED sizes (issue #214, 2026-07-23).** Region manifests carry
+  `installedMb` (measured by the bake scripts: du of the unpacked graph dir / raw pack db);
+  the app falls back to zip x 1.8 (graphs) / x 2.35 (packs, WA measured 143->335 MB) for
+  manifests baked before the field existed. The Settings row shows graph+pack SUMMED
+  (`regionInstalledMb` in OfflineSettings), regions over 1 GB installed confirm via VelaDialog
+  before downloading, and the Storage group at the bottom of Offline maps reads
+  `MapViewModel.offlineStorageBreakdown()` (.mapbox db + overlays / graphs / poipacks /
+  piper+asr) with `clearMapCache()` = MapLibre `clearAmbientCache` (saved areas untouched).
+  Old translated locales had the zip-size strings DELETED (orphans fail lint); the new
+  installed-size keys are base-English until Weblate fills them.
+
 ## Working on the scraper
 
 - The `pb` request *grammar* (`PbBuilder`) and `PolylineCodec` are correct and

--- a/app/src/main/java/app/vela/offline/PoiPackStore.kt
+++ b/app/src/main/java/app/vela/offline/PoiPackStore.kt
@@ -62,6 +62,7 @@ class PoiPackStore @Inject constructor(
                 RoutingRegion(
                     o.getString("id"), o.getString("name"), o.getString("url"), o.optInt("sizeMb"),
                     b.getDouble(0), b.getDouble(1), b.getDouble(2), b.getDouble(3),
+                    installedMb = o.optInt("installedMb"),
                     rev = o.optInt("rev"),
                     counts = counts,
                     deltaUrl = delta?.optString("url")?.takeIf { it.isNotBlank() },

--- a/app/src/main/java/app/vela/offline/RoutingGraphStore.kt
+++ b/app/src/main/java/app/vela/offline/RoutingGraphStore.kt
@@ -25,6 +25,7 @@ data class RoutingRegion(
     val w: Double,
     val n: Double,
     val e: Double,
+    val installedMb: Int = 0,               // unpacked on-disk size; 0 in old manifests (estimate from the zip)
     val rev: Int = 0,                       // pack revision (bumped every rebuild)
     val counts: Map<String, Long> = emptyMap(), // expected per-table row counts, verifies a delta apply
     val deltaUrl: String? = null,           // row-level delta from [deltaFromRev] to [rev], if published
@@ -102,6 +103,7 @@ class RoutingGraphStore @Inject constructor(
                 RoutingRegion(
                     o.getString("id"), o.getString("name"), o.getString("url"), o.optInt("sizeMb"),
                     b.getDouble(0), b.getDouble(1), b.getDouble(2), b.getDouble(3),
+                    installedMb = o.optInt("installedMb"),
                     namesUrl = o.optString("namesUrl").ifBlank { null },
                     namesSizeKb = o.optInt("namesSizeKb"),
                 )

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -4868,6 +4868,43 @@ class MapViewModel @Inject constructor(
 
     /** Download tiles + POIs for the area the map was last showing (Google-style
      *  "download this area", but invoked from Settings → Offline maps). */
+    /** On-disk sizes for the Offline maps storage breakdown (issue #214: 8 GB arrived unannounced). */
+    data class OfflineStorage(val mapsMb: Int, val routingMb: Int, val placesMb: Int, val voicesMb: Int)
+
+    suspend fun offlineStorageBreakdown(): OfflineStorage = kotlinx.coroutines.withContext(Dispatchers.IO) {
+        fun mbOf(f: java.io.File): Int = when {
+            !f.exists() -> 0
+            f.isFile -> (f.length() / (1024 * 1024)).toInt()
+            else -> (f.walkBottomUp().filter { it.isFile }.sumOf { it.length() } / (1024 * 1024)).toInt()
+        }
+        val files = appContext.filesDir
+        OfflineStorage(
+            // MapLibre keeps saved areas AND the browsing cache in one database (.mapbox);
+            // the downloaded building/address overlays are map data too.
+            mapsMb = mbOf(java.io.File(files, ".mapbox")) + mbOf(java.io.File(files, "mbgl-offline.db")) +
+                mbOf(java.io.File(files, "overlays")),
+            routingMb = mbOf(java.io.File(files, "graphs")),
+            placesMb = mbOf(java.io.File(files, "poipacks")),
+            voicesMb = mbOf(java.io.File(files, "piper")) + mbOf(java.io.File(files, "asr")),
+        )
+    }
+
+    /** Clear MapLibre's ambient (browsing) tile cache. Saved offline areas are untouched -
+     *  clearAmbientCache only drops the cache the map filled while browsing. */
+    suspend fun clearMapCache(): Unit = kotlinx.coroutines.withContext(Dispatchers.Main) {
+        kotlinx.coroutines.suspendCancellableCoroutine { cont ->
+            runCatching {
+                org.maplibre.android.offline.OfflineManager.getInstance(appContext).clearAmbientCache(
+                    object : org.maplibre.android.offline.OfflineManager.FileSourceCallback {
+                        override fun onSuccess() { if (cont.isActive) cont.resume(Unit) { _, _, _ -> } }
+                        override fun onError(message: String) { if (cont.isActive) cont.resume(Unit) { _, _, _ -> } }
+                    },
+                )
+            }.onFailure { if (cont.isActive) cont.resume(Unit) { _, _, _ -> } }
+        }
+        flashStatus(appContext.getString(R.string.settings_map_cache_cleared))
+    }
+
     fun downloadViewport() {
         val v = viewport ?: run { showStatus(appContext.getString(R.string.mapvm_pan_to_area_first)); return }
         val (s, w, n, e, zoom) = listOf(v[0], v[1], v[2], v[3], v[4])

--- a/app/src/main/java/app/vela/ui/settings/sections/OfflineSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/OfflineSettings.kt
@@ -25,8 +25,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -61,6 +64,19 @@ import org.maplibre.android.offline.OfflineRegion
 internal fun OfflineSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onCloseSettings: () -> Unit) {
     val state by vm.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    var confirmRegion by remember { mutableStateOf<app.vela.offline.RoutingRegion?>(null) }
+    confirmRegion?.let { region ->
+        val packRegion = state.poiPackRegions.firstOrNull { it.id == region.id }
+        app.vela.ui.VelaDialog(
+            onDismissRequest = { confirmRegion = null },
+            title = stringResource(R.string.settings_region_confirm_title, region.name),
+            text = { Text(stringResource(R.string.settings_region_confirm_body, region.name, fmtMb(regionInstalledMb(region, packRegion)))) },
+            confirmText = stringResource(R.string.settings_download),
+            onConfirm = { confirmRegion = null; vm.downloadRoutingGraph(region) },
+            dismissText = stringResource(R.string.settings_cancel),
+            onDismiss = { confirmRegion = null },
+        )
+    }
     SettingsScaffold(stringResource(R.string.settings_offline), onBack) { topRow ->
         Spacer(Modifier.height(4.dp))
         PageIntro(stringResource(R.string.settings_offline_hint))
@@ -203,8 +219,8 @@ internal fun OfflineSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onClose
                                 updateAvailable -> stringResource(R.string.settings_routing_update_available)
                                 installed && packInstalled -> stringResource(R.string.settings_routing_installed_places)
                                 installed -> stringResource(R.string.settings_routing_installed)
-                                here -> stringResource(R.string.settings_routing_size_here, region.sizeMb)
-                                else -> stringResource(R.string.settings_routing_size, region.sizeMb)
+                                here -> stringResource(R.string.settings_routing_size_installed_here, fmtMb(regionInstalledMb(region, packRegion)))
+                                else -> stringResource(R.string.settings_routing_size_installed, fmtMb(regionInstalledMb(region, packRegion)))
                             },
                             style = MaterialTheme.typography.bodySmall,
                             color = if ((here && !installed && !downloading) || updateAvailable) MaterialTheme.colorScheme.primary
@@ -260,7 +276,12 @@ internal fun OfflineSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onClose
                         else -> {
                             DpadFocusHandoff(keeper)
                             FilledTonalButton(
-                                onClick = { vm.downloadRoutingGraph(region) },
+                                // Big regions confirm first with the real installed size (issue #214:
+                                // Germany reads 1.6 GB on the row but lands at ~8 GB on disk).
+                                onClick = {
+                                    if (regionInstalledMb(region, packRegion) > CONFIRM_MB) confirmRegion = region
+                                    else vm.downloadRoutingGraph(region)
+                                },
                                 enabled = state.routingDownloadingId == null,
                                 modifier = Modifier.dpadFocusKept(keeper),
                             ) { Text(stringResource(R.string.settings_download)) }
@@ -271,6 +292,58 @@ internal fun OfflineSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onClose
             }
             }
         }
+        // What offline data actually costs on this phone (issue #214: 8 GB arrived unannounced,
+        // and 533 MB of "empty" app is mostly the browsing cache with no way to clear it).
+        SubHead(stringResource(R.string.settings_storage_title))
+        var storageTick by remember { mutableStateOf(0) }
+        val storage by produceState<MapViewModel.OfflineStorage?>(null, storageTick, state.routingInstalledIds, state.poiPackInstalledIds) {
+            value = vm.offlineStorageBreakdown()
+        }
+        val storageScope = rememberCoroutineScope()
+        SettingsGroup {
+            storage?.let { st ->
+                StorageRow(stringResource(R.string.settings_storage_maps), st.mapsMb)
+                GroupDivider()
+                StorageRow(stringResource(R.string.settings_storage_routing), st.routingMb)
+                GroupDivider()
+                StorageRow(stringResource(R.string.settings_storage_places), st.placesMb)
+                GroupDivider()
+                StorageRow(stringResource(R.string.settings_storage_voices), st.voicesMb)
+            } ?: Hint(stringResource(R.string.settings_storage_measuring))
+            androidx.compose.foundation.layout.Box(Modifier.padding(horizontal = 8.dp)) {
+                androidx.compose.material3.TextButton(
+                    onClick = { storageScope.launch { vm.clearMapCache(); storageTick++ } },
+                    modifier = Modifier.dpadHighlight(androidx.compose.foundation.shape.CircleShape),
+                ) { Text(stringResource(R.string.settings_clear_map_cache)) }
+            }
+            Hint(stringResource(R.string.settings_clear_map_cache_hint))
+        }
         Spacer(Modifier.height(24.dp))
     }
 }
+
+/** One "label ..... size" line in the storage group. */
+@Composable
+private fun StorageRow(label: String, mb: Int) {
+    Row(
+        Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+        Text(fmtMb(mb), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+/** The size a region really lands at: manifest installedMb when the bake published it, else an
+ *  estimate from the zip (graphs unpack ~1.8x, packs ~2.35x - the WA pack measured 143 -> 335 MB).
+ *  The graph and its place pack install together, so the shown number is their SUM. */
+internal fun regionInstalledMb(graph: app.vela.offline.RoutingRegion, pack: app.vela.offline.RoutingRegion?): Int {
+    val g = if (graph.installedMb > 0) graph.installedMb else (graph.sizeMb * 1.8).toInt()
+    val p = pack?.let { if (it.installedMb > 0) it.installedMb else (it.sizeMb * 2.35).toInt() } ?: 0
+    return g + p
+}
+
+internal fun fmtMb(mb: Int): String =
+    if (mb >= 1024) String.format(java.util.Locale.getDefault(), "%.1f GB", mb / 1024f) else "$mb MB"
+
+private const val CONFIRM_MB = 1024

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -89,8 +89,6 @@
     <string name="settings_get_places">Orte laden</string>
     <string name="settings_update_places">Orte aktualisieren</string>
     <string name="settings_routing_update_available">Installiert · Orte-Update verfügbar</string>
-    <string name="settings_routing_size_here">%1$s MB · deckt Ihren Standort ab</string>
-    <string name="settings_routing_size">%1$s MB</string>
     <string name="settings_routing_remove">Offline-Routing entfernen</string>
     <string name="settings_download">Herunterladen</string>
     <string name="settings_saved_places">Gespeicherte Orte</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -89,8 +89,6 @@
     <string name="settings_get_places">Obtener lugares</string>
     <string name="settings_update_places">Actualizar lugares</string>
     <string name="settings_routing_update_available">Instalado · actualización de lugares disponible</string>
-    <string name="settings_routing_size_here">%1$s MB · cubre tu ubicación</string>
-    <string name="settings_routing_size">%1$s MB</string>
     <string name="settings_routing_remove">Quitar rutas sin conexión</string>
     <string name="settings_download">Descargar</string>
     <string name="settings_saved_places">Lugares guardados</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -89,8 +89,6 @@
     <string name="settings_get_places">Obtenir les lieux</string>
     <string name="settings_update_places">Mettre à jour les lieux</string>
     <string name="settings_routing_update_available">Installé · mise à jour des lieux disponible</string>
-    <string name="settings_routing_size_here">%1$s Mo · couvre votre position</string>
-    <string name="settings_routing_size">%1$s Mo</string>
     <string name="settings_routing_remove">Supprimer le routage hors ligne</string>
     <string name="settings_download">Télécharger</string>
     <string name="settings_saved_places">Lieux enregistrés</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -89,8 +89,6 @@
     <string name="settings_get_places">Scarica luoghi</string>
     <string name="settings_update_places">Aggiorna luoghi</string>
     <string name="settings_routing_update_available">Installato · aggiornamento luoghi disponibile</string>
-    <string name="settings_routing_size_here">%1$s MB · copre la tua posizione</string>
-    <string name="settings_routing_size">%1$s MB</string>
     <string name="settings_routing_remove">Rimuovi percorsi offline</string>
     <string name="settings_download">Scarica</string>
     <string name="settings_saved_places">Luoghi salvati</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -89,8 +89,6 @@
     <string name="settings_get_places">קבל מקומות</string>
     <string name="settings_update_places">עדכן מקומות</string>
     <string name="settings_routing_update_available">מותקן · עדכון מקומות זמין</string>
-    <string name="settings_routing_size_here">%1$s מ\"ב · מכסה את מיקומך</string>
-    <string name="settings_routing_size">%1$s מ\"ב</string>
     <string name="settings_routing_remove">הסר ניתוב לא מקוון</string>
     <string name="settings_download">הורד</string>
     <string name="settings_saved_places">מקומות שמורים</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -113,8 +113,6 @@
     <string name="settings_get_places">場所を取得</string>
     <string name="settings_update_places">場所を更新</string>
     <string name="settings_routing_update_available">インストール済み · 場所の更新があります</string>
-    <string name="settings_routing_size_here">%1$s MB · 現在地を含む</string> <!-- format -->
-    <string name="settings_routing_size">%1$s MB</string> <!-- format -->
     <string name="settings_routing_remove">オフライン経路データを削除</string>
     <string name="settings_download">ダウンロード</string>
     <string name="settings_saved_places">保存済みの場所</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -89,8 +89,6 @@
     <string name="settings_get_places">Plaatsen ophalen</string>
     <string name="settings_update_places">Plaatsen bijwerken</string>
     <string name="settings_routing_update_available">Geïnstalleerd · update voor plaatsen beschikbaar</string>
-    <string name="settings_routing_size_here">%1$s MB · dekt uw locatie</string>
-    <string name="settings_routing_size">%1$s MB</string>
     <string name="settings_routing_remove">Offline routering verwijderen</string>
     <string name="settings_download">Downloaden</string>
     <string name="settings_saved_places">Opgeslagen plaatsen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -89,8 +89,6 @@
     <string name="settings_get_places">Pobierz miejsca</string>
     <string name="settings_update_places">Zaktualizuj miejsca</string>
     <string name="settings_routing_update_available">Zainstalowano · dostępna aktualizacja miejsc</string>
-    <string name="settings_routing_size_here">%1$s MB · obejmuje Twoją lokalizację</string>
-    <string name="settings_routing_size">%1$s MB</string>
     <string name="settings_routing_remove">Usuń trasy offline</string>
     <string name="settings_download">Pobierz</string>
     <string name="settings_saved_places">Zapisane miejsca</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -89,8 +89,6 @@
     <string name="settings_get_places">Obter locais</string>
     <string name="settings_update_places">Atualizar locais</string>
     <string name="settings_routing_update_available">Instalado · atualização de locais disponível</string>
-    <string name="settings_routing_size_here">%1$s MB · abrange a sua localização</string>
-    <string name="settings_routing_size">%1$s MB</string>
     <string name="settings_routing_remove">Remover percursos offline</string>
     <string name="settings_download">Transferir</string>
     <string name="settings_saved_places">Locais guardados</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -89,8 +89,6 @@
     <string name="settings_get_places">Скачать места</string>
     <string name="settings_update_places">Обновить места</string>
     <string name="settings_routing_update_available">Установлено · доступно обновление мест</string>
-    <string name="settings_routing_size_here">%1$s МБ · покрывает ваше местоположение</string>
-    <string name="settings_routing_size">%1$s МБ</string>
     <string name="settings_routing_remove">Удалить офлайн-маршрутизацию</string>
     <string name="settings_download">Загрузить</string>
     <string name="settings_saved_places">Сохранённые места</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -89,8 +89,6 @@
     <string name="settings_get_places">Hämta platser</string>
     <string name="settings_update_places">Uppdatera platser</string>
     <string name="settings_routing_update_available">Installerad · platsuppdatering tillgänglig</string>
-    <string name="settings_routing_size_here">%1$s MB · täcker din plats</string>
-    <string name="settings_routing_size">%1$s MB</string>
     <string name="settings_routing_remove">Ta bort offlineruttning</string>
     <string name="settings_download">Hämta</string>
     <string name="settings_saved_places">Sparade platser</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -89,8 +89,6 @@
     <string name="settings_get_places">Завантажити місця</string>
     <string name="settings_update_places">Оновити місця</string>
     <string name="settings_routing_update_available">Встановлено · доступне оновлення місць</string>
-    <string name="settings_routing_size_here">%1$s МБ · охоплює ваше місцезнаходження</string>
-    <string name="settings_routing_size">%1$s МБ</string>
     <string name="settings_routing_remove">Видалити офлайн-маршрутизацію</string>
     <string name="settings_download">Завантажити</string>
     <string name="settings_saved_places">Збережені місця</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -113,8 +113,6 @@
     <string name="settings_get_places">取得地點</string>
     <string name="settings_update_places">更新地點</string>
     <string name="settings_routing_update_available">已安裝 · 有地點更新可用</string>
-    <string name="settings_routing_size_here">%1$s MB · 涵蓋你的位置</string> <!-- format -->
-    <string name="settings_routing_size">%1$s MB</string> <!-- format -->
     <string name="settings_routing_remove">移除離線路線規劃資料</string>
     <string name="settings_download">下載</string>
     <string name="settings_saved_places">已儲存的地點</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -113,8 +113,6 @@
     <string name="settings_get_places">获取地点</string>
     <string name="settings_update_places">更新地点</string>
     <string name="settings_routing_update_available">已安装 · 有地点数据更新</string>
-    <string name="settings_routing_size_here">%1$s MB · 覆盖您的位置</string> <!-- format -->
-    <string name="settings_routing_size">%1$s MB</string> <!-- format -->
     <string name="settings_routing_remove">移除离线路线数据</string>
     <string name="settings_download">下载</string>
     <string name="settings_saved_places">已保存的地点</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,7 +111,7 @@
     <string name="settings_hide_external_links">Hide website &amp; external links</string>
     <string name="settings_hide_external_links_hint">On = place pages don’t show the Website, Street View, or Book / Reserve / Order buttons (no launching arbitrary external sites).</string>
     <string name="settings_offline">Offline maps</string>
-    <string name="settings_offline_hint">Two ways to go offline. Save the area you\'re in for the full map here, or a whole state or country below for directions and search across all of it.</string>
+    <string name="settings_offline_hint">Saving the area around you is usually all you need: the full map, addresses and places nearby, plus routing. Whole states and countries are for long trips with no signal, and they are large.</string>
     <string name="settings_offline_map_area">This area (full map)</string>
     <string name="settings_offline_download_viewport">Download the area you\'re viewing</string>
     <string name="settings_offline_download_viewport_hint">Saves the whole map you\'re looking at, its streets, house numbers and buildings, plus turn-by-turn directions for the region around it. Everything here keeps working with no signal.</string>
@@ -119,7 +119,7 @@
     <string name="settings_offline_addresses_missing">Areas you saved before this update don\'t include address data. Update them to search and route to addresses offline.</string>
     <string name="settings_offline_addresses_update">Update saved areas</string>
     <string name="settings_offline_delete_area">Delete this offline area</string>
-    <string name="settings_routing_regions">States &amp; countries (directions only)</string>
+    <string name="settings_routing_regions">Entire states &amp; countries</string>
     <string name="settings_routing_regions_hint">Directions and place search for an entire state, province or country, so you can navigate and look things up anywhere inside it offline. This does not include the detailed map picture, which would be huge for a whole country; that comes from the areas you save above, or from being online.</string>
     <string name="settings_routing_no_regions">No regions available yet.</string>
     <string name="settings_clear_filter">Clear filter</string>
@@ -132,8 +132,19 @@
     <string name="settings_get_places">Get places</string>
     <string name="settings_update_places">Update places</string>
     <string name="settings_routing_update_available">Installed · places update available</string>
-    <string name="settings_routing_size_here">%1$s MB · covers your location</string> <!-- format -->
-    <string name="settings_routing_size">%1$s MB</string> <!-- format -->
+    <string name="settings_routing_size_installed_here">About %1$s once installed · covers your location</string> <!-- format -->
+    <string name="settings_routing_size_installed">About %1$s once installed</string> <!-- format -->
+    <string name="settings_region_confirm_title">Download %1$s?</string> <!-- format -->
+    <string name="settings_region_confirm_body">%1$s takes about %2$s of storage once installed. For day-to-day use, saving just the area around you (top of this page) is far smaller.</string> <!-- format -->
+    <string name="settings_storage_title">Storage</string>
+    <string name="settings_storage_maps">Saved areas &amp; map cache</string>
+    <string name="settings_storage_routing">Offline routing</string>
+    <string name="settings_storage_places">Offline places</string>
+    <string name="settings_storage_voices">Voices &amp; speech models</string>
+    <string name="settings_storage_measuring">Measuring…</string>
+    <string name="settings_clear_map_cache">Clear map cache</string>
+    <string name="settings_clear_map_cache_hint">Frees the tiles the map cached while browsing. Saved areas are kept.</string>
+    <string name="settings_map_cache_cleared">Map cache cleared</string>
     <string name="settings_routing_remove">Remove offline routing</string>
     <string name="settings_download">Download</string>
     <string name="settings_saved_places">Saved places</string>

--- a/scripts/build-poi-region.sh
+++ b/scripts/build-poi-region.sh
@@ -86,13 +86,15 @@ if [ "$OLD_REV" -gt 0 ] && gh release download "$TAG" --repo "$REPO" -p "$ID.zip
   fi
   rm -rf "$WORK/oldpack" "$WORK/old.zip" "$WORK/$ID.delta.db"
 fi
+INSTALLED_MB=$(du -m "$WORK/$ID.db" | cut -f1)
 rm -f "$WORK/$ID.db"
 
 gh release upload "$TAG" "$WORK/$ID.zip" --clobber --repo "$REPO"
 
 ENTRY="$(jq -nc --arg id "$ID" --arg name "$NAME" --arg url "$ASSET_URL" --argjson size "$SIZE" --argjson bbox "$BBOX" \
   --argjson rev "$REV" --arg updated "$UPDATED_AT" --argjson counts "$COUNTS" --argjson delta "$DELTA_JSON" \
-  '{id:$id,name:$name,url:$url,sizeMb:$size,bbox:$bbox,rev:$rev,updatedAt:$updated,counts:$counts}
+  --argjson installed "$INSTALLED_MB" \
+  '{id:$id,name:$name,url:$url,sizeMb:$size,installedMb:$installed,bbox:$bbox,rev:$rev,updatedAt:$updated,counts:$counts}
    + (if $delta != null then {delta:$delta} else {} end)')"
 
 # MANIFEST_MODE=emit (CI matrix): drop the entry for the central merge job (parallel builds must not

--- a/scripts/build-routing-region.sh
+++ b/scripts/build-routing-region.sh
@@ -52,7 +52,10 @@ fi
 read -r MINLON MINLAT MAXLON MAXLAT < <(osmium fileinfo -g header.boxes "$WORK/region.osm.pbf" | tr -d '()' | tr ',' ' ')
 BBOX="[$MINLAT,$MINLON,$MAXLAT,$MAXLON]"
 ASSET_URL="https://github.com/$REPO/releases/download/$TAG/$ID$SUFFIX.zip"
-echo "→ $ID: ${SIZE} MB, bbox $BBOX"
+# what the graph actually costs on the phone once unzipped (the zip number undersold Germany
+# by ~5x and users found out the hard way, issue #214)
+INSTALLED_MB=$(du -sm "$WORK/graph" | cut -f1)
+echo "→ $ID: ${SIZE} MB zip, ${INSTALLED_MB} MB installed, bbox $BBOX"
 
 # ensure the catalog release exists (prerelease so it never becomes the "Latest" the APK tracks)
 gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1 || \
@@ -66,7 +69,8 @@ gh release upload "$TAG" "$WORK/$ID$SUFFIX.zip" --clobber --repo "$REPO"
 # the extra fields, new apps download it alongside the graph)
 ENTRY="$(jq -nc --arg id "$ID" --arg name "$NAME" --arg url "$ASSET_URL" --argjson size "$SIZE" --argjson bbox "$BBOX" \
   --arg namesUrl "$NAMES_URL" --argjson namesKb "${NAMES_KB:-0}" \
-  '{id:$id,name:$name,url:$url,sizeMb:$size,bbox:$bbox}
+  --argjson installed "$INSTALLED_MB" \
+  '{id:$id,name:$name,url:$url,sizeMb:$size,installedMb:$installed,bbox:$bbox}
    + (if $namesUrl != "" then {namesUrl:$namesUrl, namesSizeKb:$namesKb} else {} end)')"
 
 # MANIFEST_MODE=emit (CI matrix): just drop the entry to $ENTRY_OUT and stop — the manifest merge is


### PR DESCRIPTION
Addresses the size half of #214.

The region list showed the zip size, but a graph unpacks to roughly 1.8x and a place pack to 2.35x, so Germany read 1.6 GB and landed at about 8 GB. Rows now show the installed size for the graph and its place pack together. The bake scripts publish a measured installedMb from now on; for manifests baked before the field, the app estimates from the zip with those factors.

Regions over 1 GB installed get a confirm dialog with the real number and a pointer to the Local area save, and the page intro now says plainly that saving your area is what most people want. The section is renamed Entire states and countries.

The bottom of Offline maps gains a Storage breakdown (saved areas and map cache, routing, places, voices) plus Clear map cache, which drops MapLibre's browsing cache without touching saved areas. That cache is most of the 533 MB the reporter sees with nothing installed, and there was no way to clear it.

The old zip-size strings were deleted from all locales (orphans fail lint); the new strings are English until Weblate catches up. City-scale downloads for big countries are the follow-up PR.