### PR TITLE
Germany as 16 sub-regions (issue #214 follow-up)

### DIFF
--- a/.github/workflows/poi-packs.yml
+++ b/.github/workflows/poi-packs.yml
@@ -19,7 +19,7 @@ on:
       group:
         description: "Region group to build (ignored if 'ids' is set)"
         type: choice
-        options: [us, canada, europe, oceania, asia, south-america, central-america, africa]
+        options: [us, canada, europe, germany-sub, oceania, asia, south-america, central-america, africa]
         default: us
       ids:
         description: "Optional: space/comma-separated region ids (e.g. 'washington oregon'). Overrides 'group'."

--- a/.github/workflows/routing-graphs.yml
+++ b/.github/workflows/routing-graphs.yml
@@ -19,7 +19,7 @@ on:
       group:
         description: "Region group to build (ignored if 'ids' is set)"
         type: choice
-        options: [us, canada, europe, oceania, asia, south-america, central-america, africa]
+        options: [us, canada, europe, germany-sub, oceania, asia, south-america, central-america, africa]
         default: us
       ids:
         description: "Optional: space/comma-separated region ids (e.g. 'arizona utah colorado'). Overrides 'group'."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2307,6 +2307,13 @@ architecture note.
   offline map *tiles* for an area ALSO pulls that area's routing region (`MapViewModel.downloadRoutingForArea`).
   `directions()` uses the engine when OSRM is empty. A trip must fit ONE region's monolithic graph (cross-region
   → online).
+  **Sub-country regions (2026-07-23, issue #214):** big countries split into Geofabrik
+  first-level extracts in the catalog - Germany is 16 `de-*` Bundesland rows (group
+  `germany-sub` in both workflow dispatch choices) beside the kept whole-country row, so the
+  smallest-covering-box rule serves a Berlin user the Berlin graph+pack instead of ~8 GB of
+  Germany. No app change needed (the picker + Local-area auto-pull already prefer the smallest
+  covering region). Remaining big countries are a ROADMAP item; the pattern is copy the rows,
+  add the group to the two workflows, dispatch. \
   **Hosting + world catalog (DONE 2026-06-30):** graphs + `routing-manifest.json` are assets on the
   **`routing-graphs` GitHub release** (fixed-tag prerelease, never the "Latest" the APK tracks). The catalog is
   **`tools/routing-regions.json`** (135 regions, grouped by continent; `big:true` = country-sized). CI

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -228,6 +228,12 @@ worth an offline drive past a signed exit to hear it).
   Settings, subdued (below POIs, 0.6 opacity). Not dropped entirely (still useful for
   scanning a wider area), not rebuilt (no keyless vector congestion source).
 
+
+- Split the remaining big countries into first-level sub-regions the way Germany now is
+  (France, Italy, Great Britain, Poland, then the rest of the 18 chunked countries), so a
+  city user never has to take a whole-country graph. The catalog pattern is in place; each
+  country is a batch of rows plus a workflow dispatch.
+
 ## Big bets
 
 ### Buildings  *(done - keyless, no key, no infra)*

--- a/tools/routing-regions.json
+++ b/tools/routing-regions.json
@@ -1,147 +1,943 @@
 {
   "_comment": "World catalog of offline-routing regions. CI (.github/workflows/routing-graphs.yml) builds these into GraphHopper CH graphs and publishes them to the `routing-graphs` release; the app lists whatever ends up in routing-manifest.json. Dispatch ONE `group` per run (a matrix of <=256 jobs). `big:true` regions have large PBFs (a country-sized graph) and can run long / need RAM — build them in small batches. To add a region: append {id,name,group,pbf_url} with a Geofabrik .osm.pbf URL; ids must be unique (re-running an id updates it in place).",
   "regions": [
-    {"id":"alabama","name":"Alabama (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/alabama-latest.osm.pbf"},
-    {"id":"alaska","name":"Alaska (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/alaska-latest.osm.pbf"},
-    {"id":"arizona","name":"Arizona (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/arizona-latest.osm.pbf"},
-    {"id":"arkansas","name":"Arkansas (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/arkansas-latest.osm.pbf"},
-    {"id":"california","name":"California (state)","group":"us","big":true,"pbf_url":"https://download.geofabrik.de/north-america/us/california-latest.osm.pbf"},
-    {"id":"colorado","name":"Colorado (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/colorado-latest.osm.pbf"},
-    {"id":"connecticut","name":"Connecticut (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/connecticut-latest.osm.pbf"},
-    {"id":"delaware","name":"Delaware (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/delaware-latest.osm.pbf"},
-    {"id":"florida","name":"Florida (state)","group":"us","big":true,"pbf_url":"https://download.geofabrik.de/north-america/us/florida-latest.osm.pbf"},
-    {"id":"georgia","name":"Georgia (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/georgia-latest.osm.pbf"},
-    {"id":"hawaii","name":"Hawaii (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/hawaii-latest.osm.pbf"},
-    {"id":"idaho","name":"Idaho (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/idaho-latest.osm.pbf"},
-    {"id":"illinois","name":"Illinois (state)","group":"us","big":true,"pbf_url":"https://download.geofabrik.de/north-america/us/illinois-latest.osm.pbf"},
-    {"id":"indiana","name":"Indiana (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/indiana-latest.osm.pbf"},
-    {"id":"iowa","name":"Iowa (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/iowa-latest.osm.pbf"},
-    {"id":"kansas","name":"Kansas (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/kansas-latest.osm.pbf"},
-    {"id":"kentucky","name":"Kentucky (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/kentucky-latest.osm.pbf"},
-    {"id":"louisiana","name":"Louisiana (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/louisiana-latest.osm.pbf"},
-    {"id":"maine","name":"Maine (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/maine-latest.osm.pbf"},
-    {"id":"maryland","name":"Maryland (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/maryland-latest.osm.pbf"},
-    {"id":"massachusetts","name":"Massachusetts (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/massachusetts-latest.osm.pbf"},
-    {"id":"michigan","name":"Michigan (state)","group":"us","big":true,"pbf_url":"https://download.geofabrik.de/north-america/us/michigan-latest.osm.pbf"},
-    {"id":"minnesota","name":"Minnesota (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/minnesota-latest.osm.pbf"},
-    {"id":"mississippi","name":"Mississippi (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/mississippi-latest.osm.pbf"},
-    {"id":"missouri","name":"Missouri (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/missouri-latest.osm.pbf"},
-    {"id":"montana","name":"Montana (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/montana-latest.osm.pbf"},
-    {"id":"nebraska","name":"Nebraska (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/nebraska-latest.osm.pbf"},
-    {"id":"nevada","name":"Nevada (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/nevada-latest.osm.pbf"},
-    {"id":"new-hampshire","name":"New Hampshire (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/new-hampshire-latest.osm.pbf"},
-    {"id":"new-jersey","name":"New Jersey (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/new-jersey-latest.osm.pbf"},
-    {"id":"new-mexico","name":"New Mexico (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/new-mexico-latest.osm.pbf"},
-    {"id":"new-york","name":"New York (state)","group":"us","big":true,"pbf_url":"https://download.geofabrik.de/north-america/us/new-york-latest.osm.pbf"},
-    {"id":"north-carolina","name":"North Carolina (state)","group":"us","big":true,"pbf_url":"https://download.geofabrik.de/north-america/us/north-carolina-latest.osm.pbf"},
-    {"id":"north-dakota","name":"North Dakota (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/north-dakota-latest.osm.pbf"},
-    {"id":"ohio","name":"Ohio (state)","group":"us","big":true,"pbf_url":"https://download.geofabrik.de/north-america/us/ohio-latest.osm.pbf"},
-    {"id":"oklahoma","name":"Oklahoma (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/oklahoma-latest.osm.pbf"},
-    {"id":"oregon","name":"Oregon (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/oregon-latest.osm.pbf"},
-    {"id":"pennsylvania","name":"Pennsylvania (state)","group":"us","big":true,"pbf_url":"https://download.geofabrik.de/north-america/us/pennsylvania-latest.osm.pbf"},
-    {"id":"rhode-island","name":"Rhode Island (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/rhode-island-latest.osm.pbf"},
-    {"id":"south-carolina","name":"South Carolina (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/south-carolina-latest.osm.pbf"},
-    {"id":"south-dakota","name":"South Dakota (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/south-dakota-latest.osm.pbf"},
-    {"id":"tennessee","name":"Tennessee (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/tennessee-latest.osm.pbf"},
-    {"id":"texas","name":"Texas (state)","group":"us","big":true,"pbf_url":"https://download.geofabrik.de/north-america/us/texas-latest.osm.pbf"},
-    {"id":"utah","name":"Utah (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/utah-latest.osm.pbf"},
-    {"id":"vermont","name":"Vermont (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/vermont-latest.osm.pbf"},
-    {"id":"virginia","name":"Virginia (state)","group":"us","big":true,"pbf_url":"https://download.geofabrik.de/north-america/us/virginia-latest.osm.pbf"},
-    {"id":"washington","name":"Washington (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/washington-latest.osm.pbf"},
-    {"id":"west-virginia","name":"West Virginia (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/west-virginia-latest.osm.pbf"},
-    {"id":"wisconsin","name":"Wisconsin (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/wisconsin-latest.osm.pbf"},
-    {"id":"wyoming","name":"Wyoming (state)","group":"us","pbf_url":"https://download.geofabrik.de/north-america/us/wyoming-latest.osm.pbf"},
-
-    {"id":"alberta","name":"Alberta (Canada)","group":"canada","pbf_url":"https://download.geofabrik.de/north-america/canada/alberta-latest.osm.pbf"},
-    {"id":"british-columbia","name":"British Columbia (Canada)","group":"canada","pbf_url":"https://download.geofabrik.de/north-america/canada/british-columbia-latest.osm.pbf"},
-    {"id":"manitoba","name":"Manitoba (Canada)","group":"canada","pbf_url":"https://download.geofabrik.de/north-america/canada/manitoba-latest.osm.pbf"},
-    {"id":"new-brunswick","name":"New Brunswick (Canada)","group":"canada","pbf_url":"https://download.geofabrik.de/north-america/canada/new-brunswick-latest.osm.pbf"},
-    {"id":"newfoundland-and-labrador","name":"Newfoundland & Labrador (Canada)","group":"canada","pbf_url":"https://download.geofabrik.de/north-america/canada/newfoundland-and-labrador-latest.osm.pbf"},
-    {"id":"northwest-territories","name":"Northwest Territories (Canada)","group":"canada","pbf_url":"https://download.geofabrik.de/north-america/canada/northwest-territories-latest.osm.pbf"},
-    {"id":"nova-scotia","name":"Nova Scotia (Canada)","group":"canada","pbf_url":"https://download.geofabrik.de/north-america/canada/nova-scotia-latest.osm.pbf"},
-    {"id":"nunavut","name":"Nunavut (Canada)","group":"canada","pbf_url":"https://download.geofabrik.de/north-america/canada/nunavut-latest.osm.pbf"},
-    {"id":"ontario","name":"Ontario (Canada)","group":"canada","big":true,"pbf_url":"https://download.geofabrik.de/north-america/canada/ontario-latest.osm.pbf"},
-    {"id":"prince-edward-island","name":"Prince Edward Island (Canada)","group":"canada","pbf_url":"https://download.geofabrik.de/north-america/canada/prince-edward-island-latest.osm.pbf"},
-    {"id":"quebec","name":"Quebec (Canada)","group":"canada","big":true,"pbf_url":"https://download.geofabrik.de/north-america/canada/quebec-latest.osm.pbf"},
-    {"id":"saskatchewan","name":"Saskatchewan (Canada)","group":"canada","pbf_url":"https://download.geofabrik.de/north-america/canada/saskatchewan-latest.osm.pbf"},
-    {"id":"yukon","name":"Yukon (Canada)","group":"canada","pbf_url":"https://download.geofabrik.de/north-america/canada/yukon-latest.osm.pbf"},
-    {"id":"mexico","name":"Mexico","group":"canada","big":true,"pbf_url":"https://download.geofabrik.de/north-america/mexico-latest.osm.pbf"},
-
-    {"id":"albania","name":"Albania","group":"europe","pbf_url":"https://download.geofabrik.de/europe/albania-latest.osm.pbf"},
-    {"id":"austria","name":"Austria","group":"europe","pbf_url":"https://download.geofabrik.de/europe/austria-latest.osm.pbf"},
-    {"id":"belarus","name":"Belarus","group":"europe","pbf_url":"https://download.geofabrik.de/europe/belarus-latest.osm.pbf"},
-    {"id":"belgium","name":"Belgium","group":"europe","pbf_url":"https://download.geofabrik.de/europe/belgium-latest.osm.pbf"},
-    {"id":"bosnia-herzegovina","name":"Bosnia & Herzegovina","group":"europe","pbf_url":"https://download.geofabrik.de/europe/bosnia-herzegovina-latest.osm.pbf"},
-    {"id":"bulgaria","name":"Bulgaria","group":"europe","pbf_url":"https://download.geofabrik.de/europe/bulgaria-latest.osm.pbf"},
-    {"id":"croatia","name":"Croatia","group":"europe","pbf_url":"https://download.geofabrik.de/europe/croatia-latest.osm.pbf"},
-    {"id":"czech-republic","name":"Czech Republic","group":"europe","big":true,"pbf_url":"https://download.geofabrik.de/europe/czech-republic-latest.osm.pbf"},
-    {"id":"denmark","name":"Denmark","group":"europe","pbf_url":"https://download.geofabrik.de/europe/denmark-latest.osm.pbf"},
-    {"id":"estonia","name":"Estonia","group":"europe","pbf_url":"https://download.geofabrik.de/europe/estonia-latest.osm.pbf"},
-    {"id":"finland","name":"Finland","group":"europe","big":true,"pbf_url":"https://download.geofabrik.de/europe/finland-latest.osm.pbf"},
-    {"id":"france","name":"France","group":"europe","big":true,"pbf_url":"https://download.geofabrik.de/europe/france-latest.osm.pbf"},
-    {"id":"germany","name":"Germany","group":"europe","big":true,"pbf_url":"https://download.geofabrik.de/europe/germany-latest.osm.pbf"},
-    {"id":"great-britain","name":"Great Britain","group":"europe","big":true,"pbf_url":"https://download.geofabrik.de/europe/great-britain-latest.osm.pbf"},
-    {"id":"greece","name":"Greece","group":"europe","pbf_url":"https://download.geofabrik.de/europe/greece-latest.osm.pbf"},
-    {"id":"hungary","name":"Hungary","group":"europe","pbf_url":"https://download.geofabrik.de/europe/hungary-latest.osm.pbf"},
-    {"id":"iceland","name":"Iceland","group":"europe","pbf_url":"https://download.geofabrik.de/europe/iceland-latest.osm.pbf"},
-    {"id":"ireland-and-northern-ireland","name":"Ireland","group":"europe","pbf_url":"https://download.geofabrik.de/europe/ireland-and-northern-ireland-latest.osm.pbf"},
-    {"id":"italy","name":"Italy","group":"europe","big":true,"pbf_url":"https://download.geofabrik.de/europe/italy-latest.osm.pbf"},
-    {"id":"latvia","name":"Latvia","group":"europe","pbf_url":"https://download.geofabrik.de/europe/latvia-latest.osm.pbf"},
-    {"id":"lithuania","name":"Lithuania","group":"europe","pbf_url":"https://download.geofabrik.de/europe/lithuania-latest.osm.pbf"},
-    {"id":"luxembourg","name":"Luxembourg","group":"europe","pbf_url":"https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf"},
-    {"id":"moldova","name":"Moldova","group":"europe","pbf_url":"https://download.geofabrik.de/europe/moldova-latest.osm.pbf"},
-    {"id":"montenegro","name":"Montenegro","group":"europe","pbf_url":"https://download.geofabrik.de/europe/montenegro-latest.osm.pbf"},
-    {"id":"netherlands","name":"Netherlands","group":"europe","big":true,"pbf_url":"https://download.geofabrik.de/europe/netherlands-latest.osm.pbf"},
-    {"id":"norway","name":"Norway","group":"europe","big":true,"pbf_url":"https://download.geofabrik.de/europe/norway-latest.osm.pbf"},
-    {"id":"poland","name":"Poland","group":"europe","big":true,"pbf_url":"https://download.geofabrik.de/europe/poland-latest.osm.pbf"},
-    {"id":"portugal","name":"Portugal","group":"europe","pbf_url":"https://download.geofabrik.de/europe/portugal-latest.osm.pbf"},
-    {"id":"romania","name":"Romania","group":"europe","pbf_url":"https://download.geofabrik.de/europe/romania-latest.osm.pbf"},
-    {"id":"serbia","name":"Serbia","group":"europe","pbf_url":"https://download.geofabrik.de/europe/serbia-latest.osm.pbf"},
-    {"id":"slovakia","name":"Slovakia","group":"europe","pbf_url":"https://download.geofabrik.de/europe/slovakia-latest.osm.pbf"},
-    {"id":"slovenia","name":"Slovenia","group":"europe","pbf_url":"https://download.geofabrik.de/europe/slovenia-latest.osm.pbf"},
-    {"id":"spain","name":"Spain","group":"europe","big":true,"pbf_url":"https://download.geofabrik.de/europe/spain-latest.osm.pbf"},
-    {"id":"sweden","name":"Sweden","group":"europe","big":true,"pbf_url":"https://download.geofabrik.de/europe/sweden-latest.osm.pbf"},
-    {"id":"switzerland","name":"Switzerland","group":"europe","pbf_url":"https://download.geofabrik.de/europe/switzerland-latest.osm.pbf"},
-    {"id":"ukraine","name":"Ukraine","group":"europe","big":true,"pbf_url":"https://download.geofabrik.de/europe/ukraine-latest.osm.pbf"},
-
-    {"id":"australia","name":"Australia","group":"oceania","big":true,"pbf_url":"https://download.geofabrik.de/australia-oceania/australia-latest.osm.pbf"},
-    {"id":"new-zealand","name":"New Zealand","group":"oceania","pbf_url":"https://download.geofabrik.de/australia-oceania/new-zealand-latest.osm.pbf"},
-
-    {"id":"japan","name":"Japan","group":"asia","big":true,"pbf_url":"https://download.geofabrik.de/asia/japan-latest.osm.pbf"},
-    {"id":"south-korea","name":"South Korea","group":"asia","pbf_url":"https://download.geofabrik.de/asia/south-korea-latest.osm.pbf"},
-    {"id":"taiwan","name":"Taiwan","group":"asia","pbf_url":"https://download.geofabrik.de/asia/taiwan-latest.osm.pbf"},
-    {"id":"india","name":"India","group":"asia","big":true,"pbf_url":"https://download.geofabrik.de/asia/india-latest.osm.pbf"},
-    {"id":"indonesia","name":"Indonesia","group":"asia","big":true,"pbf_url":"https://download.geofabrik.de/asia/indonesia-latest.osm.pbf"},
-    {"id":"philippines","name":"Philippines","group":"asia","pbf_url":"https://download.geofabrik.de/asia/philippines-latest.osm.pbf"},
-    {"id":"thailand","name":"Thailand","group":"asia","pbf_url":"https://download.geofabrik.de/asia/thailand-latest.osm.pbf"},
-    {"id":"vietnam","name":"Vietnam","group":"asia","pbf_url":"https://download.geofabrik.de/asia/vietnam-latest.osm.pbf"},
-    {"id":"malaysia-singapore-brunei","name":"Malaysia, Singapore & Brunei","group":"asia","pbf_url":"https://download.geofabrik.de/asia/malaysia-singapore-brunei-latest.osm.pbf"},
-    {"id":"israel-and-palestine","name":"Israel & Palestine","group":"asia","pbf_url":"https://download.geofabrik.de/asia/israel-and-palestine-latest.osm.pbf"},
-
-    {"id":"argentina","name":"Argentina","group":"south-america","big":true,"pbf_url":"https://download.geofabrik.de/south-america/argentina-latest.osm.pbf"},
-    {"id":"brazil","name":"Brazil","group":"south-america","big":true,"pbf_url":"https://download.geofabrik.de/south-america/brazil-latest.osm.pbf"},
-    {"id":"chile","name":"Chile","group":"south-america","pbf_url":"https://download.geofabrik.de/south-america/chile-latest.osm.pbf"},
-    {"id":"colombia","name":"Colombia","group":"south-america","pbf_url":"https://download.geofabrik.de/south-america/colombia-latest.osm.pbf"},
-    {"id":"peru","name":"Peru","group":"south-america","pbf_url":"https://download.geofabrik.de/south-america/peru-latest.osm.pbf"},
-    {"id":"ecuador","name":"Ecuador","group":"south-america","pbf_url":"https://download.geofabrik.de/south-america/ecuador-latest.osm.pbf"},
-    {"id":"bolivia","name":"Bolivia","group":"south-america","pbf_url":"https://download.geofabrik.de/south-america/bolivia-latest.osm.pbf"},
-    {"id":"paraguay","name":"Paraguay","group":"south-america","pbf_url":"https://download.geofabrik.de/south-america/paraguay-latest.osm.pbf"},
-    {"id":"uruguay","name":"Uruguay","group":"south-america","pbf_url":"https://download.geofabrik.de/south-america/uruguay-latest.osm.pbf"},
-
-    {"id":"guatemala","name":"Guatemala","group":"central-america","pbf_url":"https://download.geofabrik.de/central-america/guatemala-latest.osm.pbf"},
-    {"id":"belize","name":"Belize","group":"central-america","pbf_url":"https://download.geofabrik.de/central-america/belize-latest.osm.pbf"},
-    {"id":"honduras","name":"Honduras","group":"central-america","pbf_url":"https://download.geofabrik.de/central-america/honduras-latest.osm.pbf"},
-    {"id":"el-salvador","name":"El Salvador","group":"central-america","pbf_url":"https://download.geofabrik.de/central-america/el-salvador-latest.osm.pbf"},
-    {"id":"nicaragua","name":"Nicaragua","group":"central-america","pbf_url":"https://download.geofabrik.de/central-america/nicaragua-latest.osm.pbf"},
-    {"id":"costa-rica","name":"Costa Rica","group":"central-america","pbf_url":"https://download.geofabrik.de/central-america/costa-rica-latest.osm.pbf"},
-    {"id":"panama","name":"Panama","group":"central-america","pbf_url":"https://download.geofabrik.de/central-america/panama-latest.osm.pbf"},
-
-    {"id":"south-africa","name":"South Africa","group":"africa","big":true,"pbf_url":"https://download.geofabrik.de/africa/south-africa-latest.osm.pbf"},
-    {"id":"morocco","name":"Morocco","group":"africa","pbf_url":"https://download.geofabrik.de/africa/morocco-latest.osm.pbf"},
-    {"id":"egypt","name":"Egypt","group":"africa","pbf_url":"https://download.geofabrik.de/africa/egypt-latest.osm.pbf"},
-    {"id":"kenya","name":"Kenya","group":"africa","pbf_url":"https://download.geofabrik.de/africa/kenya-latest.osm.pbf"},
-    {"id":"nigeria","name":"Nigeria","group":"africa","pbf_url":"https://download.geofabrik.de/africa/nigeria-latest.osm.pbf"},
-    {"id":"tanzania","name":"Tanzania","group":"africa","pbf_url":"https://download.geofabrik.de/africa/tanzania-latest.osm.pbf"},
-    {"id":"ghana","name":"Ghana","group":"africa","pbf_url":"https://download.geofabrik.de/africa/ghana-latest.osm.pbf"}
+    {
+      "id": "alabama",
+      "name": "Alabama (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/alabama-latest.osm.pbf"
+    },
+    {
+      "id": "alaska",
+      "name": "Alaska (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/alaska-latest.osm.pbf"
+    },
+    {
+      "id": "arizona",
+      "name": "Arizona (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/arizona-latest.osm.pbf"
+    },
+    {
+      "id": "arkansas",
+      "name": "Arkansas (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/arkansas-latest.osm.pbf"
+    },
+    {
+      "id": "california",
+      "name": "California (state)",
+      "group": "us",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/us/california-latest.osm.pbf"
+    },
+    {
+      "id": "colorado",
+      "name": "Colorado (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/colorado-latest.osm.pbf"
+    },
+    {
+      "id": "connecticut",
+      "name": "Connecticut (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/connecticut-latest.osm.pbf"
+    },
+    {
+      "id": "delaware",
+      "name": "Delaware (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/delaware-latest.osm.pbf"
+    },
+    {
+      "id": "florida",
+      "name": "Florida (state)",
+      "group": "us",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/us/florida-latest.osm.pbf"
+    },
+    {
+      "id": "georgia",
+      "name": "Georgia (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/georgia-latest.osm.pbf"
+    },
+    {
+      "id": "hawaii",
+      "name": "Hawaii (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/hawaii-latest.osm.pbf"
+    },
+    {
+      "id": "idaho",
+      "name": "Idaho (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/idaho-latest.osm.pbf"
+    },
+    {
+      "id": "illinois",
+      "name": "Illinois (state)",
+      "group": "us",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/us/illinois-latest.osm.pbf"
+    },
+    {
+      "id": "indiana",
+      "name": "Indiana (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/indiana-latest.osm.pbf"
+    },
+    {
+      "id": "iowa",
+      "name": "Iowa (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/iowa-latest.osm.pbf"
+    },
+    {
+      "id": "kansas",
+      "name": "Kansas (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/kansas-latest.osm.pbf"
+    },
+    {
+      "id": "kentucky",
+      "name": "Kentucky (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/kentucky-latest.osm.pbf"
+    },
+    {
+      "id": "louisiana",
+      "name": "Louisiana (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/louisiana-latest.osm.pbf"
+    },
+    {
+      "id": "maine",
+      "name": "Maine (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/maine-latest.osm.pbf"
+    },
+    {
+      "id": "maryland",
+      "name": "Maryland (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/maryland-latest.osm.pbf"
+    },
+    {
+      "id": "massachusetts",
+      "name": "Massachusetts (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/massachusetts-latest.osm.pbf"
+    },
+    {
+      "id": "michigan",
+      "name": "Michigan (state)",
+      "group": "us",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/us/michigan-latest.osm.pbf"
+    },
+    {
+      "id": "minnesota",
+      "name": "Minnesota (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/minnesota-latest.osm.pbf"
+    },
+    {
+      "id": "mississippi",
+      "name": "Mississippi (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/mississippi-latest.osm.pbf"
+    },
+    {
+      "id": "missouri",
+      "name": "Missouri (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/missouri-latest.osm.pbf"
+    },
+    {
+      "id": "montana",
+      "name": "Montana (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/montana-latest.osm.pbf"
+    },
+    {
+      "id": "nebraska",
+      "name": "Nebraska (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/nebraska-latest.osm.pbf"
+    },
+    {
+      "id": "nevada",
+      "name": "Nevada (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/nevada-latest.osm.pbf"
+    },
+    {
+      "id": "new-hampshire",
+      "name": "New Hampshire (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/new-hampshire-latest.osm.pbf"
+    },
+    {
+      "id": "new-jersey",
+      "name": "New Jersey (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/new-jersey-latest.osm.pbf"
+    },
+    {
+      "id": "new-mexico",
+      "name": "New Mexico (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/new-mexico-latest.osm.pbf"
+    },
+    {
+      "id": "new-york",
+      "name": "New York (state)",
+      "group": "us",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/us/new-york-latest.osm.pbf"
+    },
+    {
+      "id": "north-carolina",
+      "name": "North Carolina (state)",
+      "group": "us",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/us/north-carolina-latest.osm.pbf"
+    },
+    {
+      "id": "north-dakota",
+      "name": "North Dakota (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/north-dakota-latest.osm.pbf"
+    },
+    {
+      "id": "ohio",
+      "name": "Ohio (state)",
+      "group": "us",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/us/ohio-latest.osm.pbf"
+    },
+    {
+      "id": "oklahoma",
+      "name": "Oklahoma (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/oklahoma-latest.osm.pbf"
+    },
+    {
+      "id": "oregon",
+      "name": "Oregon (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/oregon-latest.osm.pbf"
+    },
+    {
+      "id": "pennsylvania",
+      "name": "Pennsylvania (state)",
+      "group": "us",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/us/pennsylvania-latest.osm.pbf"
+    },
+    {
+      "id": "rhode-island",
+      "name": "Rhode Island (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/rhode-island-latest.osm.pbf"
+    },
+    {
+      "id": "south-carolina",
+      "name": "South Carolina (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/south-carolina-latest.osm.pbf"
+    },
+    {
+      "id": "south-dakota",
+      "name": "South Dakota (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/south-dakota-latest.osm.pbf"
+    },
+    {
+      "id": "tennessee",
+      "name": "Tennessee (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/tennessee-latest.osm.pbf"
+    },
+    {
+      "id": "texas",
+      "name": "Texas (state)",
+      "group": "us",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/us/texas-latest.osm.pbf"
+    },
+    {
+      "id": "utah",
+      "name": "Utah (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/utah-latest.osm.pbf"
+    },
+    {
+      "id": "vermont",
+      "name": "Vermont (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/vermont-latest.osm.pbf"
+    },
+    {
+      "id": "virginia",
+      "name": "Virginia (state)",
+      "group": "us",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/us/virginia-latest.osm.pbf"
+    },
+    {
+      "id": "washington",
+      "name": "Washington (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/washington-latest.osm.pbf"
+    },
+    {
+      "id": "west-virginia",
+      "name": "West Virginia (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/west-virginia-latest.osm.pbf"
+    },
+    {
+      "id": "wisconsin",
+      "name": "Wisconsin (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/wisconsin-latest.osm.pbf"
+    },
+    {
+      "id": "wyoming",
+      "name": "Wyoming (state)",
+      "group": "us",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/wyoming-latest.osm.pbf"
+    },
+    {
+      "id": "alberta",
+      "name": "Alberta (Canada)",
+      "group": "canada",
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/alberta-latest.osm.pbf"
+    },
+    {
+      "id": "british-columbia",
+      "name": "British Columbia (Canada)",
+      "group": "canada",
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/british-columbia-latest.osm.pbf"
+    },
+    {
+      "id": "manitoba",
+      "name": "Manitoba (Canada)",
+      "group": "canada",
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/manitoba-latest.osm.pbf"
+    },
+    {
+      "id": "new-brunswick",
+      "name": "New Brunswick (Canada)",
+      "group": "canada",
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/new-brunswick-latest.osm.pbf"
+    },
+    {
+      "id": "newfoundland-and-labrador",
+      "name": "Newfoundland & Labrador (Canada)",
+      "group": "canada",
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/newfoundland-and-labrador-latest.osm.pbf"
+    },
+    {
+      "id": "northwest-territories",
+      "name": "Northwest Territories (Canada)",
+      "group": "canada",
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/northwest-territories-latest.osm.pbf"
+    },
+    {
+      "id": "nova-scotia",
+      "name": "Nova Scotia (Canada)",
+      "group": "canada",
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/nova-scotia-latest.osm.pbf"
+    },
+    {
+      "id": "nunavut",
+      "name": "Nunavut (Canada)",
+      "group": "canada",
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/nunavut-latest.osm.pbf"
+    },
+    {
+      "id": "ontario",
+      "name": "Ontario (Canada)",
+      "group": "canada",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/ontario-latest.osm.pbf"
+    },
+    {
+      "id": "prince-edward-island",
+      "name": "Prince Edward Island (Canada)",
+      "group": "canada",
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/prince-edward-island-latest.osm.pbf"
+    },
+    {
+      "id": "quebec",
+      "name": "Quebec (Canada)",
+      "group": "canada",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/quebec-latest.osm.pbf"
+    },
+    {
+      "id": "saskatchewan",
+      "name": "Saskatchewan (Canada)",
+      "group": "canada",
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/saskatchewan-latest.osm.pbf"
+    },
+    {
+      "id": "yukon",
+      "name": "Yukon (Canada)",
+      "group": "canada",
+      "pbf_url": "https://download.geofabrik.de/north-america/canada/yukon-latest.osm.pbf"
+    },
+    {
+      "id": "mexico",
+      "name": "Mexico",
+      "group": "canada",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/north-america/mexico-latest.osm.pbf"
+    },
+    {
+      "id": "albania",
+      "name": "Albania",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/albania-latest.osm.pbf"
+    },
+    {
+      "id": "austria",
+      "name": "Austria",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/austria-latest.osm.pbf"
+    },
+    {
+      "id": "belarus",
+      "name": "Belarus",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/belarus-latest.osm.pbf"
+    },
+    {
+      "id": "belgium",
+      "name": "Belgium",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/belgium-latest.osm.pbf"
+    },
+    {
+      "id": "bosnia-herzegovina",
+      "name": "Bosnia & Herzegovina",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/bosnia-herzegovina-latest.osm.pbf"
+    },
+    {
+      "id": "bulgaria",
+      "name": "Bulgaria",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/bulgaria-latest.osm.pbf"
+    },
+    {
+      "id": "croatia",
+      "name": "Croatia",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/croatia-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic",
+      "name": "Czech Republic",
+      "group": "europe",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic-latest.osm.pbf"
+    },
+    {
+      "id": "denmark",
+      "name": "Denmark",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/denmark-latest.osm.pbf"
+    },
+    {
+      "id": "estonia",
+      "name": "Estonia",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/estonia-latest.osm.pbf"
+    },
+    {
+      "id": "finland",
+      "name": "Finland",
+      "group": "europe",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/europe/finland-latest.osm.pbf"
+    },
+    {
+      "id": "france",
+      "name": "France",
+      "group": "europe",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/europe/france-latest.osm.pbf"
+    },
+    {
+      "id": "germany",
+      "name": "Germany",
+      "group": "europe",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/europe/germany-latest.osm.pbf"
+    },
+    {
+      "id": "de-baden-wuerttemberg",
+      "name": "Baden-Württemberg (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/baden-wuerttemberg-latest.osm.pbf"
+    },
+    {
+      "id": "de-bayern",
+      "name": "Bayern (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/bayern-latest.osm.pbf"
+    },
+    {
+      "id": "de-berlin",
+      "name": "Berlin (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf"
+    },
+    {
+      "id": "de-brandenburg",
+      "name": "Brandenburg (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/brandenburg-latest.osm.pbf"
+    },
+    {
+      "id": "de-bremen",
+      "name": "Bremen (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/bremen-latest.osm.pbf"
+    },
+    {
+      "id": "de-hamburg",
+      "name": "Hamburg (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/hamburg-latest.osm.pbf"
+    },
+    {
+      "id": "de-hessen",
+      "name": "Hessen (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/hessen-latest.osm.pbf"
+    },
+    {
+      "id": "de-mecklenburg-vorpommern",
+      "name": "Mecklenburg-Vorpommern (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/mecklenburg-vorpommern-latest.osm.pbf"
+    },
+    {
+      "id": "de-niedersachsen",
+      "name": "Niedersachsen (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/niedersachsen-latest.osm.pbf"
+    },
+    {
+      "id": "de-nordrhein-westfalen",
+      "name": "Nordrhein-Westfalen (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/nordrhein-westfalen-latest.osm.pbf"
+    },
+    {
+      "id": "de-rheinland-pfalz",
+      "name": "Rheinland-Pfalz (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/rheinland-pfalz-latest.osm.pbf"
+    },
+    {
+      "id": "de-saarland",
+      "name": "Saarland (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/saarland-latest.osm.pbf"
+    },
+    {
+      "id": "de-sachsen",
+      "name": "Sachsen (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/sachsen-latest.osm.pbf"
+    },
+    {
+      "id": "de-sachsen-anhalt",
+      "name": "Sachsen-Anhalt (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/sachsen-anhalt-latest.osm.pbf"
+    },
+    {
+      "id": "de-schleswig-holstein",
+      "name": "Schleswig-Holstein (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/schleswig-holstein-latest.osm.pbf"
+    },
+    {
+      "id": "de-thueringen",
+      "name": "Thüringen (Germany)",
+      "group": "germany-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/germany/thueringen-latest.osm.pbf"
+    },
+    {
+      "id": "great-britain",
+      "name": "Great Britain",
+      "group": "europe",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/europe/great-britain-latest.osm.pbf"
+    },
+    {
+      "id": "greece",
+      "name": "Greece",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/greece-latest.osm.pbf"
+    },
+    {
+      "id": "hungary",
+      "name": "Hungary",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/hungary-latest.osm.pbf"
+    },
+    {
+      "id": "iceland",
+      "name": "Iceland",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/iceland-latest.osm.pbf"
+    },
+    {
+      "id": "ireland-and-northern-ireland",
+      "name": "Ireland",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/ireland-and-northern-ireland-latest.osm.pbf"
+    },
+    {
+      "id": "italy",
+      "name": "Italy",
+      "group": "europe",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/europe/italy-latest.osm.pbf"
+    },
+    {
+      "id": "latvia",
+      "name": "Latvia",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/latvia-latest.osm.pbf"
+    },
+    {
+      "id": "lithuania",
+      "name": "Lithuania",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/lithuania-latest.osm.pbf"
+    },
+    {
+      "id": "luxembourg",
+      "name": "Luxembourg",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf"
+    },
+    {
+      "id": "moldova",
+      "name": "Moldova",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/moldova-latest.osm.pbf"
+    },
+    {
+      "id": "montenegro",
+      "name": "Montenegro",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/montenegro-latest.osm.pbf"
+    },
+    {
+      "id": "netherlands",
+      "name": "Netherlands",
+      "group": "europe",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands-latest.osm.pbf"
+    },
+    {
+      "id": "norway",
+      "name": "Norway",
+      "group": "europe",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/europe/norway-latest.osm.pbf"
+    },
+    {
+      "id": "poland",
+      "name": "Poland",
+      "group": "europe",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/europe/poland-latest.osm.pbf"
+    },
+    {
+      "id": "portugal",
+      "name": "Portugal",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/portugal-latest.osm.pbf"
+    },
+    {
+      "id": "romania",
+      "name": "Romania",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/romania-latest.osm.pbf"
+    },
+    {
+      "id": "serbia",
+      "name": "Serbia",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/serbia-latest.osm.pbf"
+    },
+    {
+      "id": "slovakia",
+      "name": "Slovakia",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/slovakia-latest.osm.pbf"
+    },
+    {
+      "id": "slovenia",
+      "name": "Slovenia",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/slovenia-latest.osm.pbf"
+    },
+    {
+      "id": "spain",
+      "name": "Spain",
+      "group": "europe",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/europe/spain-latest.osm.pbf"
+    },
+    {
+      "id": "sweden",
+      "name": "Sweden",
+      "group": "europe",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/europe/sweden-latest.osm.pbf"
+    },
+    {
+      "id": "switzerland",
+      "name": "Switzerland",
+      "group": "europe",
+      "pbf_url": "https://download.geofabrik.de/europe/switzerland-latest.osm.pbf"
+    },
+    {
+      "id": "ukraine",
+      "name": "Ukraine",
+      "group": "europe",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/europe/ukraine-latest.osm.pbf"
+    },
+    {
+      "id": "australia",
+      "name": "Australia",
+      "group": "oceania",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia-latest.osm.pbf"
+    },
+    {
+      "id": "new-zealand",
+      "name": "New Zealand",
+      "group": "oceania",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/new-zealand-latest.osm.pbf"
+    },
+    {
+      "id": "japan",
+      "name": "Japan",
+      "group": "asia",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/asia/japan-latest.osm.pbf"
+    },
+    {
+      "id": "south-korea",
+      "name": "South Korea",
+      "group": "asia",
+      "pbf_url": "https://download.geofabrik.de/asia/south-korea-latest.osm.pbf"
+    },
+    {
+      "id": "taiwan",
+      "name": "Taiwan",
+      "group": "asia",
+      "pbf_url": "https://download.geofabrik.de/asia/taiwan-latest.osm.pbf"
+    },
+    {
+      "id": "india",
+      "name": "India",
+      "group": "asia",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/asia/india-latest.osm.pbf"
+    },
+    {
+      "id": "indonesia",
+      "name": "Indonesia",
+      "group": "asia",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/asia/indonesia-latest.osm.pbf"
+    },
+    {
+      "id": "philippines",
+      "name": "Philippines",
+      "group": "asia",
+      "pbf_url": "https://download.geofabrik.de/asia/philippines-latest.osm.pbf"
+    },
+    {
+      "id": "thailand",
+      "name": "Thailand",
+      "group": "asia",
+      "pbf_url": "https://download.geofabrik.de/asia/thailand-latest.osm.pbf"
+    },
+    {
+      "id": "vietnam",
+      "name": "Vietnam",
+      "group": "asia",
+      "pbf_url": "https://download.geofabrik.de/asia/vietnam-latest.osm.pbf"
+    },
+    {
+      "id": "malaysia-singapore-brunei",
+      "name": "Malaysia, Singapore & Brunei",
+      "group": "asia",
+      "pbf_url": "https://download.geofabrik.de/asia/malaysia-singapore-brunei-latest.osm.pbf"
+    },
+    {
+      "id": "israel-and-palestine",
+      "name": "Israel & Palestine",
+      "group": "asia",
+      "pbf_url": "https://download.geofabrik.de/asia/israel-and-palestine-latest.osm.pbf"
+    },
+    {
+      "id": "argentina",
+      "name": "Argentina",
+      "group": "south-america",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/south-america/argentina-latest.osm.pbf"
+    },
+    {
+      "id": "brazil",
+      "name": "Brazil",
+      "group": "south-america",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/south-america/brazil-latest.osm.pbf"
+    },
+    {
+      "id": "chile",
+      "name": "Chile",
+      "group": "south-america",
+      "pbf_url": "https://download.geofabrik.de/south-america/chile-latest.osm.pbf"
+    },
+    {
+      "id": "colombia",
+      "name": "Colombia",
+      "group": "south-america",
+      "pbf_url": "https://download.geofabrik.de/south-america/colombia-latest.osm.pbf"
+    },
+    {
+      "id": "peru",
+      "name": "Peru",
+      "group": "south-america",
+      "pbf_url": "https://download.geofabrik.de/south-america/peru-latest.osm.pbf"
+    },
+    {
+      "id": "ecuador",
+      "name": "Ecuador",
+      "group": "south-america",
+      "pbf_url": "https://download.geofabrik.de/south-america/ecuador-latest.osm.pbf"
+    },
+    {
+      "id": "bolivia",
+      "name": "Bolivia",
+      "group": "south-america",
+      "pbf_url": "https://download.geofabrik.de/south-america/bolivia-latest.osm.pbf"
+    },
+    {
+      "id": "paraguay",
+      "name": "Paraguay",
+      "group": "south-america",
+      "pbf_url": "https://download.geofabrik.de/south-america/paraguay-latest.osm.pbf"
+    },
+    {
+      "id": "uruguay",
+      "name": "Uruguay",
+      "group": "south-america",
+      "pbf_url": "https://download.geofabrik.de/south-america/uruguay-latest.osm.pbf"
+    },
+    {
+      "id": "guatemala",
+      "name": "Guatemala",
+      "group": "central-america",
+      "pbf_url": "https://download.geofabrik.de/central-america/guatemala-latest.osm.pbf"
+    },
+    {
+      "id": "belize",
+      "name": "Belize",
+      "group": "central-america",
+      "pbf_url": "https://download.geofabrik.de/central-america/belize-latest.osm.pbf"
+    },
+    {
+      "id": "honduras",
+      "name": "Honduras",
+      "group": "central-america",
+      "pbf_url": "https://download.geofabrik.de/central-america/honduras-latest.osm.pbf"
+    },
+    {
+      "id": "el-salvador",
+      "name": "El Salvador",
+      "group": "central-america",
+      "pbf_url": "https://download.geofabrik.de/central-america/el-salvador-latest.osm.pbf"
+    },
+    {
+      "id": "nicaragua",
+      "name": "Nicaragua",
+      "group": "central-america",
+      "pbf_url": "https://download.geofabrik.de/central-america/nicaragua-latest.osm.pbf"
+    },
+    {
+      "id": "costa-rica",
+      "name": "Costa Rica",
+      "group": "central-america",
+      "pbf_url": "https://download.geofabrik.de/central-america/costa-rica-latest.osm.pbf"
+    },
+    {
+      "id": "panama",
+      "name": "Panama",
+      "group": "central-america",
+      "pbf_url": "https://download.geofabrik.de/central-america/panama-latest.osm.pbf"
+    },
+    {
+      "id": "south-africa",
+      "name": "South Africa",
+      "group": "africa",
+      "big": true,
+      "pbf_url": "https://download.geofabrik.de/africa/south-africa-latest.osm.pbf"
+    },
+    {
+      "id": "morocco",
+      "name": "Morocco",
+      "group": "africa",
+      "pbf_url": "https://download.geofabrik.de/africa/morocco-latest.osm.pbf"
+    },
+    {
+      "id": "egypt",
+      "name": "Egypt",
+      "group": "africa",
+      "pbf_url": "https://download.geofabrik.de/africa/egypt-latest.osm.pbf"
+    },
+    {
+      "id": "kenya",
+      "name": "Kenya",
+      "group": "africa",
+      "pbf_url": "https://download.geofabrik.de/africa/kenya-latest.osm.pbf"
+    },
+    {
+      "id": "nigeria",
+      "name": "Nigeria",
+      "group": "africa",
+      "pbf_url": "https://download.geofabrik.de/africa/nigeria-latest.osm.pbf"
+    },
+    {
+      "id": "tanzania",
+      "name": "Tanzania",
+      "group": "africa",
+      "pbf_url": "https://download.geofabrik.de/africa/tanzania-latest.osm.pbf"
+    },
+    {
+      "id": "ghana",
+      "name": "Ghana",
+      "group": "africa",
+      "pbf_url": "https://download.geofabrik.de/africa/ghana-latest.osm.pbf"
+    }
   ]
 }


### PR DESCRIPTION
Follow-up to #216 for the other half of #214: nobody in Berlin should need an 8 GB country download to go offline.

Adds the 16 Bundeslaender to the region catalog as their own graph and place-pack regions (all slugs verified against Geofabrik), keeping the whole-country row for people who genuinely want it. No app change: the picker and the Local area auto-pull already choose the smallest region covering you, so this alone turns "download this area" in Berlin from a ~8 GB pull into the Berlin graph and pack.

Both workflows get a germany-sub group choice. After merge, dispatch Build offline routing graphs and Build offline place packs with group=germany-sub to bake and host the 16. France, Italy, Great Britain and Poland follow the same pattern and are on the roadmap.