### PR TITLE
Offline routing moves to OsmAnd obf regions

### DIFF
--- a/.github/workflows/baseline-profile.yml
+++ b/.github/workflows/baseline-profile.yml
@@ -38,6 +38,17 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
+      - name: Fetch obf routing runtime jars
+        # :core compiles against these (see ci.yml's identical step).
+        run: |
+          mkdir -p core/libs
+          for f in osmand-java.jar osmand-shared-jvm.jar gnu-trove-osmand.jar kxml2-vela.jar; do
+            curl -fSL -o "core/libs/$f" \
+              "https://github.com/${{ github.repository }}/releases/download/obf-runtime/$f" \
+            || curl -fSL -o "core/libs/$f" \
+              "https://github.com/PimpinPumpkin/Vela/releases/download/obf-runtime/$f"
+          done
+
       - name: Generate baseline profile
         run: |
           yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,23 @@ jobs:
             echo "No keystore secret — release APK will be debug-signed."
           fi
 
+      - name: Fetch obf routing runtime jars
+        # OsmAnd's Java router + obf reader (:core's offline routing engine, GPLv3 like Vela).
+        # No Maven artifacts exist, so they live on the fixed-tag `obf-runtime` release,
+        # gitignored out of the repo - same arrangement as the TTS AAR above.
+        run: |
+          mkdir -p core/libs
+          for f in osmand-java.jar osmand-shared-jvm.jar gnu-trove-osmand.jar kxml2-vela.jar; do
+            curl -fSL -o "core/libs/$f" \
+              "https://github.com/${{ github.repository }}/releases/download/obf-runtime/$f" \
+            || curl -fSL -o "core/libs/$f" \
+              "https://github.com/PimpinPumpkin/Vela/releases/download/obf-runtime/$f"
+          done
+          test "$(stat -c%s core/libs/osmand-java.jar)" -gt 10000000
+          test "$(stat -c%s core/libs/osmand-shared-jvm.jar)" -gt 1000000
+          test "$(stat -c%s core/libs/gnu-trove-osmand.jar)" -gt 100000
+          test "$(stat -c%s core/libs/kxml2-vela.jar)" -gt 10000
+
       - name: Unit tests
         run: ./gradlew :core:test --no-daemon
 

--- a/.github/workflows/obf-regions.yml
+++ b/.github/workflows/obf-regions.yml
@@ -1,0 +1,122 @@
+# Bake Vela obf regions (routing + address + POI, no rendering section) in parallel and publish
+# them to the `obf-regions` release - the successor catalog to the GraphHopper routing graphs
+# (issue #214: a country's obf is roughly a quarter of the graph+pack it replaces). The app serves
+# this catalog automatically once obf-manifest.json has entries; while it is empty the legacy
+# graph catalog keeps serving, so this workflow IS the cutover switch.
+#
+# Same race-safe matrix shape as routing-graphs.yml: each region job uploads only its own
+# <id>.obf and emits a manifest-entry artifact; one merge job folds every entry into
+# obf-manifest.json in a single upload.
+name: Build obf regions
+
+on:
+  workflow_dispatch:
+    inputs:
+      group:
+        description: "Region group to build (ignored if 'ids' is set)"
+        type: choice
+        options: [us, canada, europe, germany-sub, oceania, asia, south-america, central-america, africa]
+        default: us
+      ids:
+        description: "Optional: space/comma-separated region ids (e.g. 'arizona utah colorado'). Overrides 'group'."
+        type: string
+        default: ""
+      skip_big:
+        description: "Skip large (big:true) regions for a quick run"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: obf-regions-manifest
+  cancel-in-progress: false
+
+jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.sel.outputs.matrix }}
+      count: ${{ steps.sel.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: sel
+        env:
+          GROUP: ${{ inputs.group }}
+          IDS: ${{ inputs.ids }}
+          SKIP_BIG: ${{ inputs.skip_big }}
+        run: |
+          ids_json=$(jq -cn --arg s "$IDS" '$s | gsub(",";" ") | split(" ") | map(select(length > 0))')
+          sel=$(jq -c --arg group "$GROUP" --argjson ids "$ids_json" --argjson skipBig "${SKIP_BIG:-false}" '
+            [ .regions[]
+              | select( if ($ids|length) > 0 then (.id as $rid | $ids | index($rid)) != null else .group == $group end )
+              | select( ($skipBig | not) or (.big != true) )
+              | {id, name, pbf_url} ]
+          ' tools/routing-regions.json)
+          n=$(printf '%s' "$sel" | jq 'length')
+          echo "selected $n region(s):"; printf '%s' "$sel" | jq -r '.[].id' | paste -sd' ' -
+          if [ "$n" -eq 0 ]; then echo "::error::no regions matched group='$GROUP' ids='$IDS'"; exit 1; fi
+          if [ "$n" -gt 256 ]; then echo "::error::$n regions > 256 matrix cap"; exit 1; fi
+          echo "matrix={\"include\":$sel}" >> "$GITHUB_OUTPUT"
+          echo "count=$n" >> "$GITHUB_OUTPUT"
+      - name: Ensure the catalog release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view obf-regions --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
+            gh release create obf-regions --repo "$GITHUB_REPOSITORY" --prerelease \
+              --title "Offline obf regions" \
+              --notes "Vela-baked obf files (routing + address + POI, no rendering section) for offline routing and search. Data assets, not a code release."
+
+  build:
+    needs: prep
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 12
+      matrix: ${{ fromJSON(needs.prep.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Install tools
+        run: sudo apt-get update && sudo apt-get install -y osmium-tool jq unzip
+      - name: Bake ${{ matrix.id }} + upload obf + emit entry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VELA_REPO: ${{ github.repository }}
+          MANIFEST_MODE: emit
+          ENTRY_OUT: ${{ matrix.id }}.json
+        run: bash scripts/build-obf-region.sh "${{ matrix.id }}" "${{ matrix.name }}" "${{ matrix.pbf_url }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: entry-${{ matrix.id }}
+          path: ${{ matrix.id }}.json
+          retention-days: 1
+
+  merge:
+    needs: build
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - uses: actions/download-artifact@v4
+        with:
+          path: entries
+          pattern: entry-*
+          merge-multiple: true
+      - name: Merge entries into obf-manifest.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VELA_REPO: ${{ github.repository }}
+        run: |
+          shopt -s nullglob
+          files=(entries/*.json)
+          if [ ${#files[@]} -eq 0 ]; then echo "no region entries were built, nothing to merge"; exit 0; fi
+          echo "merging ${#files[@]} entr(y/ies)"
+          bash scripts/merge-obf-manifest.sh entries

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ ghprobe/src/androidTest/assets/seam-graph.zip
 
 # Vendored native AAR (sherpa-onnx neural TTS runtime) — large binary, fetched out-of-band
 app/libs/*.aar
+core/libs/*.jar

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2241,6 +2241,51 @@ architecture note.
   so we do **not** always-snap. Clean always-snap (and offline routing) is gated on an **on-device
   engine** - see the next bullet. Option 3 is the public-server stopgap and stays as the online/fallback
   path. **No backend needed for any of this** (the serverless constraint holds).
+- **OBF MIGRATION IN PROGRESS (2026-07-23, issue #214; user sold on the format;
+  DEVICE-VERIFIED on the 4a in airplane mode - see the canary numbers below).** Offline
+  routing's successor is OsmAnd's `.obf`: `ObfRouteEngine` (:core) routes with OsmAnd's pure-Java
+  router (GPLv3, vendored jars in `core/libs/` - gitignored, CI fetches from the `obf-runtime`
+  release like the sherpa AAR; locally copy osmand-java.jar / osmand-shared-jvm.jar /
+  gnu-trove-osmand.jar / kxml2-vela.jar from that release). MEASURED WHY: Berlin from the same PBF = GraphHopper
+  graph 105 MB vs obf routing section 26.9 MB (3.9x); a target-sections obf (routing+address+POI,
+  NO map/transport - `scripts/VelaObfShim.java` sets the IndexCreatorSettings booleans the CLI
+  lacks) makes Germany ~2 GB where graph+pack was ~8. `OfflineRouteEngine` (CoreModule) tries obf
+  then GraphHopper, so pre-cutover graphs keep working; avoids (toll/motorway) are DYNAMIC
+  routing.xml params (`avoid_toll`/`avoid_highway`) so they work offline with no baked profiles,
+  and bicycle/pedestrian profiles come free. Turn mapping pinned by ObfRouteEngineTest (CONTINUE
+  is voice-silent - a mis-mapped u-turn gets swallowed; instruction text reuses ghPhrase so all
+  languages come along). Bake: `scripts/build-obf-region.sh` + `merge-obf-manifest.sh` +
+  `.github/workflows/obf-regions.yml` (matrix clone; the MapCreator tool is pinned on the
+  `obf-tools` release); assets are RAW .obf (already deflate-compressed inside; download size ==
+  installed size). CUTOVER = the manifest: `refreshRoutingRegions` serves the obf catalog
+  (`OBF_MANIFEST_URL`, `-PobfManifestUrl=` override) whenever obf-manifest.json has entries, else
+  the legacy graph catalog - dispatching the obf-regions workflow IS the switch, no app release.
+  The trade: no precomputed shortcuts, so a cross-city route costs seconds not ~200 ms (offline is
+  the FALLBACK router, so size beats speed - user call); OsmAnd's HH precomputed mode is the
+  follow-up if long routes measure slow on-device. **4a canary numbers (2026-07-23, release build,
+  airplane mode, Berlin obf):** 1.6 km drive = 288 ms; 21 km cross-city drive = 9.1 s (252
+  segments); same trip walking = 15.9 s. Steps carry names + B-road shields + sign destinations;
+  delete via Settings removes the region and the engine drops its readers. **THREE ANDROID
+  RUNTIME TRAPS, all invisible until the engine LOGGED its failures (tag `VelaObf` - the first
+  canary swallowed them silently and read as "No drive route found"):** (1) commons-logging picks
+  LogFactoryImpl by REFLECTIVE discovery, so R8 strips it and BinaryMapIndexReader's static init
+  dies - consumer-rules keeps `org.apache.commons.logging.**`, and the discovery itself NPEs on
+  ART anyway, so ObfRouteEngine's init pins `org.apache.commons.logging.Log` ->
+  SimpleLog before any OsmAnd class loads. (2) OsmAnd instantiates `org.kxml2.io.KXmlParser`
+  directly (a desktop-classpath assumption; modern Android hides its platform copy from apps) -
+  `kxml2-vela.jar` on the obf-runtime release is upstream kxml2 2.3.0 with its bundled
+  org/xmlpull/** deleted, because the stock Maven jar duplicates the platform XmlPullParser
+  interfaces and R8 hard-fails ("Library class ... implements program class"). (3)
+  `searchRoute` UNCONDITIONALLY lazy-loads the world-regions index (its missing-maps suggestion
+  feature) from the working directory, which on Android is / and read-only -> EROFS on every
+  route; the init pre-seeds `PlatformUtil.setOsmandRegions(OsmandRegions(false))` (the no-file
+  ctor) and turns `RoutePlannerFrontEnd.CALCULATE_MISSING_MAPS` off (the flag alone does NOT
+  skip the load - the getOsmandRegions call sits before the flag check). STILL GH-ONLY: the speed-limit badge
+  (currentRoadLimit) and the romanized-names sidecar (obf carries multilingual names natively,
+  wired later). Place packs still download alongside obf regions until POI/address search moves
+  onto the obf (phase 2). NO COUNTRY SPLITS beyond the existing US states (user call - only true
+  monsters like Russia/China would ever split; obf makes unsplit Germany smaller than Organic
+  Maps' 48-piece total).
 - **On-device routing engine = GraphHopper (`core/data/RouteEngine` + `GraphHopperRouteEngine`).**
   Pure-JVM, runs on ART - **validated end-to-end on a Pixel 5a** (`:ghprobe`, a throwaway instrumented
   probe - the routing shipped long ago; the module is safe to delete whenever). Chosen over Valhalla (no maintained Android map-matching binding) /

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,14 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- 🟡 **Offline regions are moving to the obf format (issue #214, in progress).** The routing
+  engine, download store, bake pipeline and catalog cutover are built and device-verified end to
+  end (a phone in airplane mode downloaded a Berlin obf, routed a 21 km drive with named steps
+  and road shields, and deleted the region cleanly); baking the world's regions is the remaining
+  step. A region download shrinks to roughly a quarter of the GraphHopper-era size (Berlin:
+  105 MB graph to a 27 MB routing section), avoid options work offline again, and
+  walking/cycling route offline for the first time. Regions installed before the cutover keep
+  routing until re-downloaded.
 - ✅ **Vela gives memory back when the system asks, and adapts to small phones (2026-07-23,
   adopted from the vela-dpad fork).** The speech model (about a quarter gigabyte while loaded) now
   unloads after two minutes unused and reloads in about a second on the next mic tap; map caches,

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,16 @@ android {
             "\"${(project.findProperty("routingManifestUrl") as String?)
                 ?: "https://github.com/PimpinPumpkin/Vela/releases/download/routing-graphs/routing-manifest-v2.json"}\"",
         )
+        // Obf region catalog (the GraphHopper graphs' successor, issue #214). While this manifest
+        // is empty/absent the app serves the legacy routing-graph catalog; once regions are baked
+        // to the `obf-regions` release the same Settings rows download obf instead. Override for
+        // local testing with -PobfManifestUrl=http://127.0.0.1:8099/obf-manifest.json (adb reverse).
+        buildConfigField(
+            "String",
+            "OBF_MANIFEST_URL",
+            "\"${(project.findProperty("obfManifestUrl") as String?)
+                ?: "https://github.com/PimpinPumpkin/Vela/releases/download/obf-regions/obf-manifest.json"}\"",
+        )
         // Open building-footprint overlay (Microsoft, ODbL) PMTiles catalog — same override pattern
         // (-PoverlayManifestUrl=http://127.0.0.1:8099/... for local testing via `adb reverse`).
         buildConfigField(

--- a/app/src/main/java/app/vela/offline/ObfStore.kt
+++ b/app/src/main/java/app/vela/offline/ObfStore.kt
@@ -1,0 +1,108 @@
+package app.vela.offline
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Offline `.obf` region files - the successor download to [RoutingGraphStore]'s GraphHopper graphs
+ * (issue #214; see ObfRouteEngine). One raw `.obf` per region in `filesDir/obf/<id>.obf` plus the
+ * same `index.json` bbox registry the graph store keeps, which [app.vela.core.data.ObfRouteEngine]
+ * reads to pick a region per trip. No unzip: an obf's blocks are already deflate-compressed, so the
+ * asset is served raw and the download IS the install (the manifest's sizeMb and installedMb are
+ * the same number, a property the GraphHopper zips never had).
+ *
+ * The catalog manifest is the same row shape as the routing manifest, so [RoutingGraphStore.manifest]
+ * parses it - this store only owns the bytes on disk.
+ */
+@Singleton
+class ObfStore @Inject constructor(
+    @ApplicationContext private val context: Context,
+    http: OkHttpClient,
+) {
+    private val root = File(context.filesDir, "obf")
+    private val indexFile = File(root, "index.json")
+    private val indexLock = Any()
+
+    // Region files are hundreds of MB - the shared client's 12 s scrape cap would abort the body
+    // mid-read, silently (the standing large-download rule).
+    private val downloadHttp: OkHttpClient = http.newBuilder()
+        .callTimeout(0, java.util.concurrent.TimeUnit.SECONDS)
+        .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+        .build()
+
+    fun installedIds(): Set<String> =
+        readIndex().keys.filter { File(root, "$it.obf").let { f -> f.exists() && f.length() > 0 } }.toSet()
+
+    /** Download [region]'s obf to `obf/<id>.obf` and register it. 0..100 progress. */
+    suspend fun download(region: RoutingRegion, onProgress: (Int) -> Unit): Boolean = withContext(Dispatchers.IO) {
+        root.mkdirs()
+        val dest = File(root, "${region.id}.obf")
+        val tmp = File(root, "${region.id}.obf.tmp")
+        runCatching {
+            tmp.delete()
+            downloadHttp.newCall(Request.Builder().url(region.url).build()).execute().use { resp ->
+                if (!resp.isSuccessful) error("HTTP ${resp.code}")
+                val total = resp.body!!.contentLength()
+                resp.body!!.byteStream().use { input ->
+                    tmp.outputStream().use { out ->
+                        val buf = ByteArray(1 shl 16)
+                        var read = 0L
+                        var lastPct = -1
+                        while (true) {
+                            val n = input.read(buf)
+                            if (n < 0) break
+                            out.write(buf, 0, n)
+                            read += n
+                            if (total > 0) {
+                                val pct = (100 * read / total).toInt()
+                                if (pct != lastPct) { lastPct = pct; onProgress(pct) }
+                            }
+                        }
+                    }
+                }
+            }
+            // An obf leads with its version varint inside a protobuf frame; the cheap sanity check
+            // is size + the reader opening it, which the engine does lazily. Guard the obvious:
+            // a truncated/error body must not register as a region.
+            check(tmp.length() > 1024) { "downloaded obf is implausibly small" }
+            dest.delete()
+            check(tmp.renameTo(dest)) { "could not install obf (rename failed)" }
+            synchronized(indexLock) { writeIndex(readIndex() + (region.id to doubleArrayOf(region.s, region.w, region.n, region.e))) }
+            onProgress(100)
+            true
+        }.getOrElse { tmp.delete(); false }
+    }
+
+    fun delete(id: String) {
+        File(root, "$id.obf").delete()
+        synchronized(indexLock) { writeIndex(readIndex() - id) }
+    }
+
+    private fun readIndex(): Map<String, DoubleArray> = runCatching {
+        if (!indexFile.exists()) return emptyMap()
+        val arr = JSONArray(indexFile.readText())
+        (0 until arr.length()).associate { i ->
+            val o = arr.getJSONObject(i)
+            val b = o.getJSONArray("bbox")
+            o.getString("id") to doubleArrayOf(b.getDouble(0), b.getDouble(1), b.getDouble(2), b.getDouble(3))
+        }
+    }.getOrDefault(emptyMap())
+
+    private fun writeIndex(entries: Map<String, DoubleArray>) {
+        root.mkdirs()
+        val arr = JSONArray()
+        entries.forEach { (id, b) ->
+            arr.put(JSONObject().put("id", id).put("bbox", JSONArray().put(b[0]).put(b[1]).put(b[2]).put(b[3])))
+        }
+        indexFile.writeText(arr.toString())
+    }
+}

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -276,6 +276,7 @@ data class MapUiState(
     val routingInstalledIds: Set<String> = emptySet(), // region ids whose graphs are on disk
     val routingDownloadingId: String? = null,          // region id currently downloading, else null
     val routingDownloadPct: Int = 0,
+    val obfCatalog: Boolean = false,                   // region rows serve the obf catalog (successor format)
     val regionDownloadName: String? = null,            // display name for the heads-up download card
     // Offline PLACE pack (whole-region POI/address db, pulled after the region's routing graph)
     val poiPackDownloadingId: String? = null,
@@ -320,6 +321,7 @@ class MapViewModel @Inject constructor(
     private val tripStore: app.vela.replay.TripStore,
     private val routingGraphStore: app.vela.offline.RoutingGraphStore,
     private val poiPackStore: app.vela.offline.PoiPackStore,
+    private val obfStore: app.vela.offline.ObfStore,
     private val overlayStore: app.vela.offline.OverlayTileStore,
     private val maxspeedStore: app.vela.offline.MaxspeedOverlayStore,
     private val routeEngine: app.vela.core.data.RouteEngine,
@@ -5281,10 +5283,14 @@ class MapViewModel @Inject constructor(
 
     /** Reflect what's installed + fetch the manifest of downloadable region graphs. */
     fun refreshRoutingRegions() {
-        _state.update { it.copy(routingInstalledIds = routingGraphStore.installedIds()) }
+        _state.update { it.copy(routingInstalledIds = routingGraphStore.installedIds() + obfStore.installedIds()) }
         viewModelScope.launch {
-            val regions = routingGraphStore.manifest(app.vela.BuildConfig.ROUTING_MANIFEST_URL)
-            _state.update { it.copy(routingRegions = regions) }
+            // The obf catalog is the successor (issue #214, ~4x smaller regions). While its manifest
+            // is empty (not yet baked) the legacy GraphHopper catalog serves, so this switch is a
+            // release-asset upload, not an app release - the v1->v2 graph cutover precedent.
+            val obf = routingGraphStore.manifest(app.vela.BuildConfig.OBF_MANIFEST_URL)
+            val regions = obf.ifEmpty { routingGraphStore.manifest(app.vela.BuildConfig.ROUTING_MANIFEST_URL) }
+            _state.update { it.copy(routingRegions = regions, obfCatalog = obf.isNotEmpty()) }
             // The pack catalog too (revs + deltas) — Settings compares it against the installed pack
             // revisions to offer "Update places" on stale regions.
             val packs = poiPackStore.manifest(app.vela.BuildConfig.POI_PACK_MANIFEST_URL)
@@ -5303,14 +5309,20 @@ class MapViewModel @Inject constructor(
         if (_state.value.routingDownloadingId != null) return
         _state.update { it.copy(routingDownloadingId = region.id, routingDownloadPct = 0, regionDownloadName = region.name) }
         downloadLaunch(region.name) {
-            val ok = routingGraphStore.download(region) { pct ->
-                _state.update { it.copy(routingDownloadPct = pct) }
+            val obf = _state.value.obfCatalog
+            val ok = if (obf) {
+                obfStore.download(region) { pct -> _state.update { it.copy(routingDownloadPct = pct) } }
+            } else {
+                routingGraphStore.download(region) { pct -> _state.update { it.copy(routingDownloadPct = pct) } }
             }
             _state.update {
-                it.copy(routingDownloadingId = null, routingInstalledIds = routingGraphStore.installedIds())
+                it.copy(routingDownloadingId = null, routingInstalledIds = routingGraphStore.installedIds() + obfStore.installedIds())
             }
             showStatus(if (ok) appContext.getString(R.string.mapvm_offline_routing_ready, region.name) else appContext.getString(R.string.mapvm_offline_routing_failed))
-            if (ok) { refreshOfflineRoadNames(); downloadPoiPack(region) } // pick up the new region's romanized road names (issue #184)
+            // The names sidecar is a GraphHopper-era artifact - an obf carries multilingual names
+            // itself, so only the legacy path refreshes the sidecar map. The place pack still rides
+            // along in both worlds until search moves onto the obf too.
+            if (ok) { if (!obf) refreshOfflineRoadNames(); downloadPoiPack(region) }
             else _state.update { it.copy(regionDownloadName = null) }
         }
     }
@@ -5364,9 +5376,11 @@ class MapViewModel @Inject constructor(
 
     fun deleteRoutingGraph(id: String) {
         routingGraphStore.delete(id)
+        obfStore.delete(id) // whichever format this region was installed as
         poiPackStore.delete(id) // the place pack rides with the region — remove them together
+        (routeEngine as? app.vela.core.data.OfflineRouteEngine)?.shutdown() // drop cached readers for the removed region
         _state.update {
-            it.copy(routingInstalledIds = routingGraphStore.installedIds(), poiPackInstalledIds = poiPackStore.installedIds())
+            it.copy(routingInstalledIds = routingGraphStore.installedIds() + obfStore.installedIds(), poiPackInstalledIds = poiPackStore.installedIds())
         }
         viewModelScope.launch { refreshOfflineRoadNames() } // drop the removed region's road names (issue #184)
         showStatus(appContext.getString(R.string.mapvm_offline_routing_removed))

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -39,6 +39,21 @@ dependencies {
         exclude(group = "org.apache.xmlgraphics")
     }
 
+    // OsmAnd obf routing engine (ObfRouteEngine): the router + binary obf reader as plain Java
+    // jars, vendored from OsmAndMapCreator's lib (GPLv3, same license as Vela). Gitignored like
+    // the sherpa AAR - CI fetches them from the `obf-runtime` infra release; locally copy them in
+    // (see CLAUDE.md). Everything else the router needs is already on Android (org.json,
+    // kotlin-stdlib) or in this module (kotlinx-serialization). commons-logging + kxml2 are the
+    // two desktop assumptions Android does NOT satisfy: OsmAnd logs through commons-logging and
+    // instantiates org.kxml2.io.KXmlParser directly (present on a desktop classpath, not visible
+    // to apps on modern Android) - both device-caught on the release canary, 2026-07-23.
+    // kxml2-vela.jar is upstream kxml2 2.3.0 with its bundled org/xmlpull/** REMOVED - the stock
+    // Maven jar duplicates the platform's XmlPullParser interfaces and R8 hard-fails on the
+    // library/program split ("Library class android.content.res.XmlResourceParser implements
+    // program class org.xmlpull.v1.XmlPullParser").
+    implementation(files("libs/osmand-java.jar", "libs/osmand-shared-jvm.jar", "libs/gnu-trove-osmand.jar", "libs/kxml2-vela.jar"))
+    implementation("commons-logging:commons-logging:1.2")
+
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 

--- a/core/consumer-rules.pro
+++ b/core/consumer-rules.pro
@@ -49,3 +49,29 @@
 -dontwarn java.awt.**
 -dontwarn javax.xml.stream.**
 -dontwarn javax.measure.**
+
+# OsmAnd obf router (ObfRouteEngine): parses routing.xml/poi_types.xml resources by classloader and
+# wires GeneralRouter parameters reflectively enough that shrinking is not worth the risk - keep it
+# wholesale like GraphHopper. The desktop-only corners (awt image io in some utilities) never run on
+# Android; silence, don't fail.
+-keep class net.osmand.** { *; }
+-dontwarn net.osmand.**
+-keep class gnu.trove.** { *; }
+# commons-logging picks its LogFactory IMPLEMENTATION by reflective discovery, so R8 sees no
+# reference and strips LogFactoryImpl - then BinaryMapIndexReader's static init (PlatformUtil.getLog)
+# throws ClassNotFoundException and every obf open fails (release-canary find, 2026-07-23).
+-keep class org.apache.commons.logging.** { *; }
+-dontwarn org.apache.commons.logging.**
+# kxml2's parser is instantiated reflectively through the XmlPullParserFactory lookup - same
+# no-static-reference shape as LogFactoryImpl above.
+-keep class org.kxml2.** { *; }
+-dontwarn org.kxml2.**
+-dontwarn java.awt.**
+-dontwarn javax.imageio.**
+-dontwarn javax.xml.stream.**
+# Desktop-only corners of osmand-java that never run on Android (NMEA sentence parsing, the
+# wdtinc MVT reader's legacy-JTS path, kotlin-native concurrency shims) - silence, don't fail.
+-dontwarn co.touchlab.stately.**
+-dontwarn com.vividsolutions.jts.**
+-dontwarn com.wdtinc.**
+-dontwarn net.sf.marineapi.**

--- a/core/src/main/java/app/vela/core/data/ObfRouteEngine.kt
+++ b/core/src/main/java/app/vela/core/data/ObfRouteEngine.kt
@@ -1,0 +1,287 @@
+package app.vela.core.data
+
+import app.vela.core.model.LatLng
+import app.vela.core.model.Maneuver
+import app.vela.core.model.ManeuverType
+import app.vela.core.model.Route
+import app.vela.core.model.RouteLeg
+import app.vela.core.model.TravelMode
+import net.osmand.binary.BinaryMapIndexReader
+import net.osmand.data.LatLon
+import net.osmand.router.RoutePlannerFrontEnd
+import net.osmand.router.RouteSegmentResult
+import net.osmand.router.RoutingConfiguration
+import net.osmand.router.TurnType
+import net.osmand.util.MapUtils
+import org.json.JSONArray
+import java.io.File
+import java.io.RandomAccessFile
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * On-device routing from OsmAnd `.obf` region files - the successor to [GraphHopperRouteEngine]
+ * (issue #214: a whole-country GraphHopper graph + place pack landed at ~8 GB; the obf routing
+ * section for the same data measures ~4x smaller, and one obf will eventually also carry the POI +
+ * address search the place packs do today). The router is OsmAnd's own pure-Java engine (GPLv3,
+ * vendored jars in `core/libs`, fetched from the `obf-runtime` release in CI), which computes
+ * routes DYNAMICALLY from attributes in the file - so avoid-tolls / avoid-motorways work offline
+ * with no precomputed profiles, and bicycle/pedestrian come free from the same file.
+ *
+ * [obfRoot] holds `<regionId>.obf` files plus an `index.json` (`[{id, bbox:[S,W,N,E]}]`) written by
+ * the app-side store on install; per trip the engine picks the smallest region covering BOTH
+ * endpoints, same rule as GraphHopper (an obf routes only within itself; cross-region falls back
+ * online). Readers are opened once per region and cached; the actual route calc is serialized on
+ * one lock - the routing context is single-use and offline routing is one-at-a-time in practice.
+ *
+ * The trade against GraphHopper CH is calc time: no precomputed shortcuts, so a cross-city route
+ * costs seconds instead of ~200 ms. Offline is Vela's FALLBACK router (online OSRM is primary), so
+ * download size wins over calc speed here (user call, 2026-07-23). OsmAnd's HH precomputed mode is
+ * the follow-up if long routes measure too slow on-device.
+ */
+class ObfRouteEngine(private val obfRoot: File) : RouteEngine {
+
+    private data class Region(val id: String, val s: Double, val w: Double, val n: Double, val e: Double) {
+        fun covers(p: LatLng) = GraphHopperRouteEngine.inBox(s, w, n, e, p.lat, p.lng)
+    }
+
+    private val readers = ConcurrentHashMap<String, BinaryMapIndexReader>()
+    private val failed = ConcurrentHashMap.newKeySet<String>()
+    private val routeLock = Any()
+
+    init {
+        // OsmAnd logs through commons-logging, whose runtime DISCOVERY NPEs on Android (it probes
+        // system properties that are null on ART) - which broke BinaryMapIndexReader's static init
+        // and with it every obf open. Pinning the implementation skips discovery entirely.
+        if (System.getProperty(JCL_LOG_PROP) == null) {
+            System.setProperty(JCL_LOG_PROP, "org.apache.commons.logging.impl.SimpleLog")
+        }
+        // searchRoute unconditionally asks PlatformUtil for the world-regions index (its
+        // missing-maps suggestion feature, which Vela has no UI for) and the default lazy init
+        // opens regions.ocbf off the working directory - on Android that is / and read-only, so
+        // EROFS killed every route. Pre-seed the holder with the no-file constructor and keep the
+        // feature off so the empty index is never consulted.
+        RoutePlannerFrontEnd.CALCULATE_MISSING_MAPS = false
+        runCatching { net.osmand.PlatformUtil.setOsmandRegions(net.osmand.map.OsmandRegions(false)) }
+    }
+
+    override fun isReady(mode: TravelMode): Boolean =
+        profileFor(mode) != null && regions().any { it.id !in failed && hasObf(it.id) }
+
+    override fun route(origin: LatLng, destination: LatLng, mode: TravelMode, avoidTolls: Boolean, avoidHighways: Boolean): List<Route> {
+        val profile = profileFor(mode) ?: return emptyList()
+        val all = regions()
+        val candidates = all
+            .filter { it.id !in failed && it.covers(origin) && it.covers(destination) }
+            .sortedBy { (it.n - it.s) * (it.e - it.w) }
+        android.util.Log.d(TAG, "route $mode: ${all.size} installed, ${candidates.size} covering")
+        for (region in candidates) {
+            val reader = reader(region) ?: continue
+            try {
+                val startMs = System.currentTimeMillis()
+                val segments = synchronized(routeLock) {
+                    val params = buildMap {
+                        // routing.xml parameter ids - the router excludes matching roads at
+                        // calc time, no baked profiles needed (unlike the GraphHopper CH pair).
+                        if (avoidTolls) put("avoid_toll", "true")
+                        if (avoidHighways) put("avoid_highway", "true")
+                    }
+                    val config = builder().build(
+                        profile,
+                        RoutingConfiguration.RoutingMemoryLimits(MEMORY_MB, NATIVE_MEMORY_MB),
+                        params,
+                    )
+                    val fe = RoutePlannerFrontEnd()
+                    val ctx = fe.buildRoutingContext(
+                        config, null, arrayOf(reader),
+                        RoutePlannerFrontEnd.RouteCalculationMode.NORMAL,
+                    )
+                    fe.searchRoute(ctx, LatLon(origin.lat, origin.lng), LatLon(destination.lat, destination.lng), null)
+                        ?.list.orEmpty()
+                }
+                android.util.Log.d(TAG, "route ${region.id}: ${segments.size} segments in ${System.currentTimeMillis() - startMs} ms")
+                if (segments.isNotEmpty()) return listOf(toRoute(segments))
+            } catch (e: Throwable) {
+                // Log loudly, then try the next covering region; a corrupt file latches failed
+                // via reader(). Silent swallowing made a routing failure un-diagnosable on a
+                // release build (canary 2026-07-23).
+                android.util.Log.w(TAG, "route ${region.id} failed", e)
+            }
+        }
+        return emptyList()
+    }
+
+    /** Drop cached readers (after an install/delete changes the set). */
+    fun shutdown() {
+        synchronized(routeLock) {
+            readers.values.forEach { runCatching { it.close() } }
+            readers.clear()
+            failed.clear()
+        }
+    }
+
+    private fun hasObf(id: String) = File(obfRoot, "$id.obf").let { it.exists() && it.length() > 0 }
+
+    private fun regions(): List<Region> = runCatching {
+        val f = File(obfRoot, "index.json")
+        if (!f.exists()) return emptyList()
+        val arr = JSONArray(f.readText())
+        (0 until arr.length()).mapNotNull { i ->
+            val o = arr.getJSONObject(i)
+            val b = o.getJSONArray("bbox")
+            Region(o.getString("id"), b.getDouble(0), b.getDouble(1), b.getDouble(2), b.getDouble(3))
+        }
+    }.getOrDefault(emptyList())
+
+    private fun reader(region: Region): BinaryMapIndexReader? {
+        readers[region.id]?.let { return it }
+        if (region.id in failed) return null
+        synchronized(routeLock) {
+            readers[region.id]?.let { return it }
+            val f = File(obfRoot, "${region.id}.obf")
+            if (!f.exists()) return null
+            return try {
+                BinaryMapIndexReader(RandomAccessFile(f, "r"), f).also { readers[region.id] = it }
+            } catch (e: Throwable) {
+                android.util.Log.w(TAG, "open ${f.name} failed", e)
+                failed.add(region.id)
+                null
+            }
+        }
+    }
+
+    /** Segment list -> Vela [Route]: polyline from the 31-bit tile coords, one [Maneuver] per turn
+     *  (plus depart/arrive), phrased through the SAME localized token tables the OSRM and
+     *  GraphHopper paths use ([GraphHopperRouteEngine.ghPhrase]). */
+    private fun toRoute(segments: List<RouteSegmentResult>): Route {
+        val poly = ArrayList<LatLng>(segments.size * 4)
+        for (seg in segments) {
+            val obj = seg.`object`
+            val step = if (seg.startPointIndex <= seg.endPointIndex) 1 else -1
+            var i = seg.startPointIndex
+            while (true) {
+                poly.add(LatLng(MapUtils.get31LatitudeY(obj.getPoint31YTile(i)), MapUtils.get31LongitudeX(obj.getPoint31XTile(i))))
+                if (i == seg.endPointIndex) break
+                i += step
+            }
+        }
+        val totalDist = segments.sumOf { it.distance.toDouble() }
+        val totalTime = segments.sumOf { it.segmentTime.toDouble() }
+
+        val maneuvers = ArrayList<Maneuver>()
+        var pendingDist = 0.0
+        var pendingTime = 0.0
+        segments.forEachIndexed { i, seg ->
+            val turn = seg.turnType
+            val isFirst = i == 0
+            if (isFirst || turn != null) {
+                // Close out the previous maneuver's distance: each maneuver's distance is the road
+                // driven FROM it to the next one, same convention as the OSRM/GraphHopper paths.
+                if (maneuvers.isNotEmpty()) {
+                    val last = maneuvers.removeAt(maneuvers.size - 1)
+                    maneuvers.add(last.copy(distanceMeters = pendingDist, durationSeconds = pendingTime))
+                }
+                pendingDist = 0.0
+                pendingTime = 0.0
+                val obj = seg.`object`
+                val forward = seg.startPointIndex <= seg.endPointIndex
+                val name = obj.getName()?.takeIf { it.isNotBlank() }
+                val ref = runCatching { obj.getRef(null, false, forward) }.getOrNull()
+                    ?.takeIf { it.isNotBlank() }?.split(';', ',')?.first()?.trim()?.takeIf { it.isNotEmpty() }
+                val dest = runCatching { obj.getDestinationName(null, false, forward) }.getOrNull()?.takeIf { it.isNotBlank() }
+                val road = name ?: ref
+                val type = if (isFirst) ManeuverType.DEPART else obfType(turn!!)
+                val rbExit = turn?.takeIf { it.isRoundAbout }?.exitOut?.takeIf { it > 0 }
+                val at = LatLng(
+                    MapUtils.get31LatitudeY(obj.getPoint31YTile(seg.startPointIndex)),
+                    MapUtils.get31LongitudeX(obj.getPoint31XTile(seg.startPointIndex)),
+                )
+                maneuvers.add(
+                    Maneuver(
+                        type = type,
+                        instruction = GraphHopperRouteEngine.ghPhrase(type, road, rbExit, dest, null),
+                        location = at,
+                        distanceMeters = 0.0,
+                        durationSeconds = 0.0,
+                        road = road,
+                        ref = ref,
+                    ),
+                )
+            }
+            pendingDist += seg.distance
+            pendingTime += seg.segmentTime
+        }
+        if (maneuvers.isNotEmpty()) {
+            val last = maneuvers.removeAt(maneuvers.size - 1)
+            maneuvers.add(last.copy(distanceMeters = pendingDist, durationSeconds = pendingTime))
+        }
+        // OsmAnd's last segment carries no arrive turn - append one at the route end, like both
+        // other engines' outputs (NavEngine keys arrival off it).
+        poly.lastOrNull()?.let { end ->
+            maneuvers.add(
+                Maneuver(
+                    type = ManeuverType.ARRIVE,
+                    instruction = GraphHopperRouteEngine.ghPhrase(ManeuverType.ARRIVE, null),
+                    location = end,
+                    distanceMeters = 0.0,
+                    durationSeconds = 0.0,
+                    road = null,
+                    ref = null,
+                ),
+            )
+        }
+        val folded = RouteGeometry.foldRenames(maneuvers)
+        return Route(
+            polyline = poly,
+            legs = listOf(RouteLeg(totalDist, totalTime, null, folded)),
+            distanceMeters = totalDist,
+            durationSeconds = totalTime,
+            durationInTrafficSeconds = null, // offline: no live traffic
+            summary = folded.asReversed().firstNotNullOfOrNull { it.road },
+        )
+    }
+
+    internal companion object {
+        private const val TAG = "VelaObf"
+        private const val JCL_LOG_PROP = "org.apache.commons.logging.Log"
+
+        // Route-calc heap budget passed to the OsmAnd router. Modest on purpose: the browse map
+        // already runs near the ceiling (CLAUDE.md memory rules) and the router allocates within
+        // this bound, spilling to more tile loads instead of OOMing.
+        private const val MEMORY_MB = 256
+        private const val NATIVE_MEMORY_MB = 64
+
+        // routing.xml profile names.
+        private fun profileFor(mode: TravelMode): String? = when (mode) {
+            TravelMode.DRIVE -> "car"
+            TravelMode.BICYCLE -> "bicycle"
+            TravelMode.WALK -> "pedestrian"
+            else -> null
+        }
+
+        // RoutingConfiguration.getDefault() parses the bundled routing.xml - cache the parsed
+        // builder; config builds from it per call are cheap.
+        @Volatile private var cachedBuilder: RoutingConfiguration.Builder? = null
+        private fun builder(): RoutingConfiguration.Builder =
+            cachedBuilder ?: RoutingConfiguration.getDefault().also { cachedBuilder = it }
+
+        /** OsmAnd [TurnType] -> Vela [ManeuverType]. Roundabouts map by flag (value carries the
+         *  exit); KL/KR are lane keeps = our KEEP_*; TU/TRU both read as a u-turn. */
+        internal fun obfType(t: TurnType): ManeuverType = when {
+            t.isRoundAbout -> ManeuverType.ROUNDABOUT
+            else -> when (t.value) {
+                TurnType.C -> ManeuverType.CONTINUE
+                TurnType.TL -> ManeuverType.TURN_LEFT
+                TurnType.TSLL -> ManeuverType.SLIGHT_LEFT
+                TurnType.TSHL -> ManeuverType.SHARP_LEFT
+                TurnType.TR -> ManeuverType.TURN_RIGHT
+                TurnType.TSLR -> ManeuverType.SLIGHT_RIGHT
+                TurnType.TSHR -> ManeuverType.SHARP_RIGHT
+                TurnType.KL -> ManeuverType.KEEP_LEFT
+                TurnType.KR -> ManeuverType.KEEP_RIGHT
+                TurnType.TU, TurnType.TRU -> ManeuverType.UTURN
+                TurnType.OFFR -> ManeuverType.UNKNOWN // off-road start: spoken, never silenced
+                else -> ManeuverType.UNKNOWN
+            }
+        }
+    }
+}

--- a/core/src/main/java/app/vela/core/data/OfflineRouteEngine.kt
+++ b/core/src/main/java/app/vela/core/data/OfflineRouteEngine.kt
@@ -1,0 +1,37 @@
+package app.vela.core.data
+
+import app.vela.core.model.LatLng
+import app.vela.core.model.Route
+import app.vela.core.model.TravelMode
+
+/**
+ * The one offline [RouteEngine] the app talks to: obf first, GraphHopper second.
+ *
+ * Obf is the target format (issue #214 - ~4x smaller per region, dynamic avoids, three travel
+ * modes); GraphHopper stays as the fallback so every graph installed before the cutover keeps
+ * routing until its owner re-downloads the region as an obf. Once the fleet has moved, the GH
+ * engine and its loader go.
+ */
+class OfflineRouteEngine(
+    private val obf: ObfRouteEngine,
+    private val graphHopper: GraphHopperRouteEngine,
+) : RouteEngine {
+
+    override fun isReady(mode: TravelMode): Boolean =
+        obf.isReady(mode) || graphHopper.isReady(mode)
+
+    override fun route(origin: LatLng, destination: LatLng, mode: TravelMode, avoidTolls: Boolean, avoidHighways: Boolean): List<Route> =
+        obf.route(origin, destination, mode, avoidTolls, avoidHighways).ifEmpty {
+            graphHopper.route(origin, destination, mode, avoidTolls, avoidHighways)
+        }
+
+    /** Only the GraphHopper side answers the speed-limit badge for now; the obf equivalent
+     *  (nearest-road maxspeed off the routing section) is a follow-up. */
+    override fun currentRoadLimit(lat: Double, lng: Double): Double? =
+        graphHopper.currentRoadLimit(lat, lng)
+
+    fun shutdown() {
+        obf.shutdown()
+        graphHopper.shutdown()
+    }
+}

--- a/core/src/main/java/app/vela/core/di/CoreModule.kt
+++ b/core/src/main/java/app/vela/core/di/CoreModule.kt
@@ -3,6 +3,8 @@ package app.vela.core.di
 import android.content.Context
 import app.vela.core.VelaConfig
 import app.vela.core.data.GraphHopperRouteEngine
+import app.vela.core.data.ObfRouteEngine
+import app.vela.core.data.OfflineRouteEngine
 import app.vela.core.data.MapDataSource
 import app.vela.core.data.MockMapDataSource
 import app.vela.core.data.RouteEngine
@@ -66,7 +68,13 @@ object CoreModule {
     @Provides
     @Singleton
     fun routeEngine(@ApplicationContext context: Context): RouteEngine =
-        GraphHopperRouteEngine(File(context.filesDir, "graphs"))
+        OfflineRouteEngine(
+            // Obf regions first (filesDir/obf/<id>.obf, index by ObfStore) - the smaller format
+            // every new download uses; GraphHopper keeps answering for graphs installed before
+            // the cutover until their regions are re-downloaded.
+            ObfRouteEngine(File(context.filesDir, "obf")),
+            GraphHopperRouteEngine(File(context.filesDir, "graphs")),
+        )
 }
 
 /**

--- a/core/src/test/java/app/vela/core/data/ObfRouteEngineTest.kt
+++ b/core/src/test/java/app/vela/core/data/ObfRouteEngineTest.kt
@@ -1,0 +1,48 @@
+package app.vela.core.data
+
+import app.vela.core.model.ManeuverType
+import net.osmand.router.TurnType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Pins the OsmAnd TurnType -> Vela ManeuverType mapping. The router side is exercised on-device
+ *  against a real obf (JVM tests would need a fixture file); the mapping is the part that must
+ *  never drift silently - a wrong type here mis-speaks or SILENCES a turn (CONTINUE is
+ *  voice-silent in NavEngine). */
+class ObfRouteEngineTest {
+
+    private fun t(v: Int): TurnType = TurnType.valueOf(v, false)
+
+    @Test
+    fun `plain turns map to their maneuvers`() {
+        assertEquals(ManeuverType.CONTINUE, ObfRouteEngine.obfType(t(TurnType.C)))
+        assertEquals(ManeuverType.TURN_LEFT, ObfRouteEngine.obfType(t(TurnType.TL)))
+        assertEquals(ManeuverType.SLIGHT_LEFT, ObfRouteEngine.obfType(t(TurnType.TSLL)))
+        assertEquals(ManeuverType.SHARP_LEFT, ObfRouteEngine.obfType(t(TurnType.TSHL)))
+        assertEquals(ManeuverType.TURN_RIGHT, ObfRouteEngine.obfType(t(TurnType.TR)))
+        assertEquals(ManeuverType.SLIGHT_RIGHT, ObfRouteEngine.obfType(t(TurnType.TSLR)))
+        assertEquals(ManeuverType.SHARP_RIGHT, ObfRouteEngine.obfType(t(TurnType.TSHR)))
+        assertEquals(ManeuverType.KEEP_LEFT, ObfRouteEngine.obfType(t(TurnType.KL)))
+        assertEquals(ManeuverType.KEEP_RIGHT, ObfRouteEngine.obfType(t(TurnType.KR)))
+    }
+
+    @Test
+    fun `u-turns are never silenced`() {
+        // Both u-turn codes must speak: CONTINUE is voice-silent in NavEngine, and a u-turn
+        // mapped there would be swallowed whole (the GraphHopper path had this exact bug).
+        assertEquals(ManeuverType.UTURN, ObfRouteEngine.obfType(t(TurnType.TU)))
+        assertEquals(ManeuverType.UTURN, ObfRouteEngine.obfType(t(TurnType.TRU)))
+    }
+
+    @Test
+    fun `roundabouts map by flag and carry their exit`() {
+        val rb = TurnType.getExitTurn(3, 0f, false)
+        assertEquals(ManeuverType.ROUNDABOUT, ObfRouteEngine.obfType(rb))
+        assertEquals(3, rb.exitOut)
+    }
+
+    @Test
+    fun `unknown codes speak rather than silence`() {
+        assertEquals(ManeuverType.UNKNOWN, ObfRouteEngine.obfType(t(TurnType.OFFR)))
+    }
+}

--- a/scripts/VelaObfShim.java
+++ b/scripts/VelaObfShim.java
@@ -1,0 +1,29 @@
+import net.osmand.MainUtilities;
+import net.osmand.obf.preparation.IndexCreatorSettings;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Bakes a Vela obf: routing + address + POI sections only. The map-rendering and transport
+ * sections are excluded on purpose (MapLibre draws Vela's map; transit comes from GTFS), which is
+ * most of the size difference against a stock OsmAnd file. Compiled and run by
+ * scripts/build-obf-region.sh against the OsmAndMapCreator jars; kept as a shim because
+ * MainUtilities' CLI has no --no-map/--no-poi switches, only the settings object does.
+ *
+ * Usage: java VelaObfShim <region.osm.pbf>
+ * Writes <Region>.obf next to the input, exactly like `generate-obf` would.
+ */
+public class VelaObfShim {
+    public static void main(String[] args) throws Exception {
+        IndexCreatorSettings settings = new IndexCreatorSettings();
+        settings.indexMap = false;
+        settings.indexTransport = false;
+        settings.indexRouting = true;
+        settings.indexAddress = true;
+        settings.indexPOI = true;
+        List<String> a = new ArrayList<>();
+        a.add(args[0]);
+        MainUtilities.generateObf(a, settings);
+    }
+}

--- a/scripts/build-obf-region.sh
+++ b/scripts/build-obf-region.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Bake ONE region's Vela obf and publish it to the `obf-regions` release - the successor pipeline to
+# build-routing-region.sh (issue #214). The obf carries routing + address + POI sections only; the
+# map-rendering and transport sections are excluded by scripts/VelaObfShim.java (MapLibre draws the
+# map, GTFS covers transit), which is most of the size win against a stock OsmAnd file. The asset is
+# served RAW (an obf's blocks are already deflate-compressed), so download size == installed size.
+#
+#   scripts/build-obf-region.sh <id> "<display name>" <pbf-url>
+#
+# MANIFEST_MODE=emit (CI matrix) drops a single manifest-entry json to $ENTRY_OUT for the central
+# merge job; the default merges into obf-manifest.json directly (local single-region use).
+# Needs: curl, unzip, osmium, jq, a JDK, gh (auth) for upload.
+set -euo pipefail
+
+ID="${1:?region id}"
+NAME="${2:?display name}"
+PBF_URL="${3:?pbf url}"
+REPO="${VELA_REPO:-PimpinPumpkin/Vela}"
+TAG="obf-regions"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# The pinned bake tool (OsmAndMapCreator) lives on the obf-tools release - forks fall back upstream.
+curl -fSL -o "$WORK/mapcreator.zip" "https://github.com/$REPO/releases/download/obf-tools/mapcreator.zip" \
+  || curl -fSL -o "$WORK/mapcreator.zip" "https://github.com/PimpinPumpkin/Vela/releases/download/obf-tools/mapcreator.zip"
+unzip -q "$WORK/mapcreator.zip" -d "$WORK/mapcreator"
+
+curl -fSL --retry 3 -o "$WORK/region.osm.pbf" "$PBF_URL"
+
+# bbox [S,W,N,E] from the extract's declared HEADER box - same rule as every other region pipeline
+# (data.bbox is polluted by outlier nodes). osmium prints (minlon,minlat,maxlon,maxlat).
+read -r MINLON MINLAT MAXLON MAXLAT < <(osmium fileinfo -g header.boxes "$WORK/region.osm.pbf" | tr -d '()' | tr ',' ' ')
+BBOX="[$MINLAT,$MINLON,$MAXLAT,$MAXLON]"
+
+javac -cp "$WORK/mapcreator/OsmAndMapCreator.jar:$WORK/mapcreator/lib/*" -d "$WORK" "$ROOT/scripts/VelaObfShim.java"
+# Not processInRam: MapCreator's disk-backed pipeline is what lets a whole country bake inside a
+# 16 GB runner. The heap bound is for its indexes, not the region.
+( cd "$WORK" && java -Xmx12g -cp "$WORK/mapcreator/OsmAndMapCreator.jar:$WORK/mapcreator/lib/*:$WORK" VelaObfShim region.osm.pbf )
+OBF="$(ls "$WORK"/*.obf | head -1)"  # generateObf names the output from the pbf filename
+mv "$OBF" "$WORK/$ID.obf"
+
+SIZE=$(( ( $(stat -f%z "$WORK/$ID.obf" 2>/dev/null || stat -c%s "$WORK/$ID.obf") + 1048575 ) / 1048576 ))
+ASSET_URL="https://github.com/$REPO/releases/download/$TAG/$ID.obf"
+echo "→ $ID: ${SIZE} MB obf (download == installed), bbox $BBOX"
+
+gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1 || \
+  gh release create "$TAG" --repo "$REPO" --prerelease --title "Offline obf regions" \
+    --notes "Vela-baked obf files (routing + address + POI, no rendering section) for offline routing and search. Data assets, not a code release."
+
+gh release upload "$TAG" "$WORK/$ID.obf" --clobber --repo "$REPO"
+
+# Raw obf: the download size IS the installed size, so both fields carry the same number and the
+# Settings row needs no unpack estimate.
+ENTRY="$(jq -nc --arg id "$ID" --arg name "$NAME" --arg url "$ASSET_URL" --argjson size "$SIZE" --argjson bbox "$BBOX" \
+  '{id:$id,name:$name,url:$url,sizeMb:$size,installedMb:$size,bbox:$bbox}')"
+
+if [ "${MANIFEST_MODE:-merge}" = "emit" ]; then
+  printf '%s\n' "$ENTRY" > "${ENTRY_OUT:?ENTRY_OUT required in emit mode}"
+  echo "emitted manifest entry to $ENTRY_OUT"
+  exit 0
+fi
+
+ENTRY_DIR="$(mktemp -d)"; trap 'rm -rf "$WORK" "$ENTRY_DIR"' EXIT
+printf '%s\n' "$ENTRY" > "$ENTRY_DIR/$ID.json"
+bash "$ROOT/scripts/merge-obf-manifest.sh" "$ENTRY_DIR"

--- a/scripts/merge-obf-manifest.sh
+++ b/scripts/merge-obf-manifest.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Merge many obf region entries into obf-manifest.json in ONE upload - the race-safe half of the
+# obf-regions CI matrix, same shape as merge-routing-manifest.sh. Replace-by-id, so re-running a
+# region updates it; regions not in this batch are preserved.
+#
+#   scripts/merge-obf-manifest.sh <dir-of-entry-json-files>
+#
+# Each file is one {id,name,url,sizeMb,installedMb,bbox} object. Needs: gh (auth), jq.
+set -euo pipefail
+
+DIR="${1:?dir of *.json entry files}"
+REPO="${VELA_REPO:-PimpinPumpkin/Vela}"
+TAG="obf-regions"
+MANIFEST_NAME="obf-manifest.json"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+gh release download "$TAG" --repo "$REPO" -p "$MANIFEST_NAME" -O "$WORK/manifest.json" 2>/dev/null \
+  || echo '{"regions":[]}' > "$WORK/manifest.json"
+
+jq -s '.' "$DIR"/*.json > "$WORK/batch.json"
+COUNT=$(jq 'length' "$WORK/batch.json")
+echo "→ merging $COUNT obf region entr$( [ "$COUNT" = 1 ] && echo y || echo ies ) into the manifest"
+
+jq --slurpfile batch "$WORK/batch.json" '
+  ($batch[0] | map(.id)) as $ids
+  | .regions = ([.regions[] | select(.id as $i | $ids | index($i) | not)] + $batch[0])
+  | .regions |= sort_by(.name)
+' "$WORK/manifest.json" > "$WORK/$MANIFEST_NAME"
+
+jq -r '.regions[] | "   \(.name)  \(.sizeMb) MB  \(.bbox)"' "$WORK/$MANIFEST_NAME"
+gh release upload "$TAG" "$WORK/$MANIFEST_NAME" --clobber --repo "$REPO"
+echo "✓ $MANIFEST_NAME now lists $(jq '.regions | length' "$WORK/$MANIFEST_NAME") regions"


### PR DESCRIPTION
Fixes #214.

A state or country offline download becomes a single .obf file routed by OsmAnd's pure Java engine (GPLv3, same as Vela) instead of a GraphHopper graph plus place pack. Measured on Berlin from the same PBF: the routing section is 27 MB where the graph was 105 MB, which puts an unsplit Germany around 2 GB instead of 8. Avoid tolls and avoid highways work offline again as dynamic routing parameters instead of baked CH profiles, and walking and cycling route offline for the first time.

What lands here: ObfRouteEngine in :core (OsmAnd router, turn mapping pinned by unit test, instructions phrased through the same localized tables as the other engines), a composite OfflineRouteEngine that tries obf then GraphHopper so already-installed graphs keep routing, ObfStore for downloads, the bake pipeline (VelaObfShim strips the map rendering and transport sections the CLI cannot, build and merge scripts, an obf-regions workflow cloned from the routing-graphs matrix), and the catalog cutover: the app serves the obf catalog whenever the baked manifest has entries, so dispatching the workflow is the switch and no app release is needed.

Canary on a Pixel 4a release build in airplane mode: downloaded the Berlin obf over a local manifest, routed a short hop in 288 ms and a 21 km cross-city drive in 9.1 s with named steps, B-road shields and sign destinations, walked the same trip in 15.9 s, then deleted the region and the engine unloaded it. The first canary failed silently, which surfaced three Android-only runtime traps now fixed and documented: commons-logging's reflectively discovered factory gets stripped by R8 and its discovery NPEs on ART anyway (kept plus pinned to SimpleLog), OsmAnd instantiates kxml2's parser directly which Android no longer exposes to apps (a kxml2 jar with the duplicate XmlPullParser interfaces removed now rides the obf-runtime release), and the router's missing-maps lookup opens a world-regions file from the read-only working directory (pre-seeded with the no-file constructor). The engine also logs its failures now instead of swallowing them.

Still on GraphHopper for the moment: the speed limit badge and the romanized road-name sidecar. Place packs keep downloading beside obf regions until POI and address search move onto the obf. Long routes trade calc time for size since there are no precomputed shortcuts; OsmAnd's HH mode is the follow-up if that ever feels slow in practice. Baking the world's regions is the remaining step before the cutover.