### PR TITLE
Floating mini map when you leave the app during navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,14 @@ Defaults that make the safe path the easy one:
   card + the cluster/HUD nav data; `ManeuverMapper` maps Vela maneuvers → car `Maneuver`/`Step`/`Trip`.
   Manifest also declares `FEATURE_CLUSTER` (instrument-cluster nav) and `CAR_INFO` (AAOS car speed).
   The PHONE also feeds NavSession when not projecting; the car and phone share the one nav loop.
+- **Picture-in-picture nav (2026-07-25):** MainActivity carries `supportsPictureInPicture` +
+  autoEnter params kept in lockstep with `vm.state.navigating` (Android 12+; pre-12 enters in
+  onUserLeaveHint). `PipMode.active` (ui/PipMode.kt) is flipped by onPictureInPictureModeChanged
+  and MapScreen wraps EVERYTHING after the VelaMapView call in one `if (!pipUi)` gate, plus a
+  tiny distance-and-turn strip for the small window - any NEW map chrome must live inside that
+  gate or it will render wall-to-wall in the mini map. The turn heads-up (NavigationService's
+  `vela_nav_turns` channel) deliberately stays quiet while PiP is up: the activity is still
+  STARTED in PiP, so AppVisibility.foreground remains true and the alert gate sees "visible".
 - **Long downloads NEVER ride viewModelScope (issue #212, 2026-07-23).** Every multi-MB download
   (voice model, ASR engine, region graph, place pack, overlay, update APK, offline place data)
   launches through `MapViewModel.downloadLaunch(label) { ... }`: the work runs on the app-lifetime

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1422,6 +1422,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 - ⬜ Self-hosted routing backend (replace the FOSSGIS community server)
 
 ## Navigation
+- ✅ **Picture-in-picture mini map while navigating (2026-07-25).** Leaving the app mid-drive
+  shrinks Vela to a floating window with the live map, route line, puck and a one-line
+  distance-plus-turn strip, Google style. Android 12+ auto-enters whenever navigation runs;
+  older versions enter on the home gesture; expanding restores the full interface. Launchers
+  that forbid picture-in-picture keep the notification-only background nav.
 - ✅ **Steps viewer: swipe down anywhere to close + no stray stops while it's up (2026-07-15,
   user).** The route step list now dismisses with a downward swipe on the BODY once the list is
   at its top (nested-scroll into the same drag the handle uses; mid-list swipes still scroll),

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -80,7 +80,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
-            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|uiMode"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden|uiMode"
+            android:supportsPictureInPicture="true"
             android:theme="@style/Theme.Vela">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/app/vela/MainActivity.kt
+++ b/app/src/main/java/app/vela/MainActivity.kt
@@ -15,6 +15,8 @@ import app.vela.ui.map.MapViewModel
 import app.vela.ui.theme.VelaTheme
 import app.vela.ui.theme.isAppInDarkTheme
 import dagger.hilt.android.AndroidEntryPoint
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -35,6 +37,23 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         // A language change re-creates this Activity so the whole UI re-reads localized resources.
         AppLocale.onLocaleChanged = { recreate() }
+        // Picture-in-picture mini map while navigating (user 2026-07-24, the Google Maps
+        // behaviour): on Android 12+ the system auto-enters PiP on Home/gesture-up whenever the
+        // params say so, so keep autoEnter in lockstep with the nav state; pre-12 the
+        // onUserLeaveHint below calls enterPictureInPictureMode by hand. Everything is
+        // best-effort (runCatching): a launcher or ROM that forbids PiP just falls back to the
+        // notification-only background nav that already works.
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+            lifecycleScope.launch {
+                var last: Boolean? = null
+                vm.state.collect { s ->
+                    if (s.navigating != last) {
+                        last = s.navigating
+                        runCatching { setPictureInPictureParams(pipParams(s.navigating)) }
+                    }
+                }
+            }
+        }
         handleIntent(intent)
         setContent {
             // Read the theme at the call site (a recomposing scope) and pass it in
@@ -54,6 +73,37 @@ class MainActivity : ComponentActivity() {
                 VelaRoot(vm = vm)
             }
         }
+    }
+
+    /** A portrait-ish mini map, Google's PiP proportions. */
+    private fun pipParams(autoEnter: Boolean): android.app.PictureInPictureParams {
+        val b = android.app.PictureInPictureParams.Builder()
+            .setAspectRatio(android.util.Rational(3, 4))
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+            b.setAutoEnterEnabled(autoEnter)
+            b.setSeamlessResizeEnabled(false) // map surfaces cross-fade better than they stretch
+        }
+        return b.build()
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onUserLeaveHint() {
+        @Suppress("DEPRECATION")
+        super.onUserLeaveHint()
+        // Pre-Android-12 manual PiP entry (12+ auto-enters via the params above).
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S &&
+            vm.state.value.navigating
+        ) {
+            runCatching { enterPictureInPictureMode(pipParams(true)) }
+        }
+    }
+
+    override fun onPictureInPictureModeChanged(
+        isInPictureInPictureMode: Boolean,
+        newConfig: android.content.res.Configuration,
+    ) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        app.vela.ui.PipMode.active.value = isInPictureInPictureMode
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/app/vela/MainActivity.kt
+++ b/app/src/main/java/app/vela/MainActivity.kt
@@ -50,6 +50,7 @@ class MainActivity : ComponentActivity() {
                     if (s.navigating != last) {
                         last = s.navigating
                         runCatching { setPictureInPictureParams(pipParams(s.navigating)) }
+                            .onFailure { android.util.Log.w("VelaPip", "setPictureInPictureParams failed", it) }
                     }
                 }
             }
@@ -95,6 +96,7 @@ class MainActivity : ComponentActivity() {
             vm.state.value.navigating
         ) {
             runCatching { enterPictureInPictureMode(pipParams(true)) }
+                .onFailure { android.util.Log.w("VelaPip", "enterPictureInPictureMode failed", it) }
         }
     }
 

--- a/app/src/main/java/app/vela/ui/PipMode.kt
+++ b/app/src/main/java/app/vela/ui/PipMode.kt
@@ -1,0 +1,13 @@
+package app.vela.ui
+
+import androidx.compose.runtime.mutableStateOf
+
+/**
+ * Is the activity currently in picture-in-picture? Set by MainActivity's
+ * onPictureInPictureModeChanged; MapScreen reads it to strip ALL chrome down to the bare map plus
+ * a one-line turn strip - the PiP window is a few hundred dp across, and full-size chrome would
+ * fill it wall to wall. Same process-wide reactive holder shape as AppTheme/Units.
+ */
+object PipMode {
+    val active = mutableStateOf(false)
+}

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1045,6 +1045,11 @@ fun MapScreen(
             dpadController = mapDpad,
             modifier = Modifier.fillMaxSize(),
         )
+        // Picture-in-picture strips the UI to the bare map + the turn strip below: the whole
+        // chrome tree composes only when the window is a real screen (MainActivity flips the
+        // holder). One gate around everything after the map keeps the diff merge-friendly.
+        val pipUi = app.vela.ui.PipMode.active.value
+        if (!pipUi) {
 
         // --- Debug badge (Settings → Developer → Building overlay debug) ---
         // Canary aid: fill-buildings auto-suppression state at a glance + a UI-thread FPS readout.
@@ -2418,6 +2423,23 @@ fun MapScreen(
                         NoticeCard(n, onDismiss = { vm.dismissNotice(n.id) })
                     }
                 }
+            }
+        }
+        }
+        if (pipUi && state.navigating && state.maneuverText.isNotEmpty()) {
+            // The one PiP overlay: distance + turn in a single dark strip, top of the window.
+            androidx.compose.material3.Surface(
+                modifier = Modifier.align(Alignment.TopCenter).padding(6.dp),
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(10.dp),
+                color = androidx.compose.ui.graphics.Color(0xCC1B1B1B),
+                contentColor = androidx.compose.ui.graphics.Color.White,
+            ) {
+                Text(
+                    text = formatDistance(state.nav.distanceToNextManeuver) + " \u00b7 " + state.maneuverText,
+                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+                    style = MaterialTheme.typography.labelLarge,
+                    maxLines = 2,
+                )
             }
         }
     }


### PR DESCRIPTION
Going home or switching apps mid-drive now shrinks Vela into a picture-in-picture window, the way Google Maps does. The live map keeps following the route with the puck and route line, topped by a one-line strip showing the distance and next turn. Android 12 and up auto-enters the window whenever navigation is running; older versions enter on the home gesture. Expanding the window brings the whole interface straight back.

In the small window every regular control hides, since nothing is usable at that size; the gate is one conditional around the chrome tree so the diff stays small. The activity got the picture-in-picture manifest attributes, and launchers or ROMs that forbid the feature just keep the existing notification-only background navigation. Verified on the 4a: home mid-drive shrank to the floating map with the turn strip, the route and puck kept moving, and expanding restored the full interface.