### PR TITLE
One glyph per intersection for stop signs, lights and cameras

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2498,7 +2498,11 @@ architecture note.
 - **Traffic lights + stop signs drawn on the map (`OverpassTrafficSignals.fetchControlsInBox` + `VelaMapView`,
   2026-07-05).** OSM `highway=traffic_signals` (a stoplight icon) and `highway=stop` (a red STOP octagon) as a
   non-interactive `SymbolLayer` (`vela-controls`, icons `vela-signal`/`vela-stop`) drawn **beneath** the POI dots
-  + pins, `minZoom 16`. **Icon sizing/visibility (2026-07-06, device-verified in downtown Davis):** `iconSize`
+  + pins, `minZoom 16`. **CLUSTERED PER INTERSECTION (2026-07-25):** OSM maps one control node per APPROACH (a
+  four-way stop = four `highway=stop` nodes), so `refreshTrafficControls` merges same-type nodes
+  within 30 m (`MapDeclutter.cluster`, the same radius the spoken pass-the-light counting uses)
+  to their centroid before the cap - one drawn glyph per junction, like Google, and fewer
+  allowOverlap symbols to render. **Icon sizing/visibility (2026-07-06, device-verified in downtown Davis):** `iconSize`
   is a zoom-interpolated expression (~0.75 at z15.5 → 1.05 at z17 → 1.5 at z19) - the flat 0.55 was too small to
   spot, especially tilted in nav; and `iconAllowOverlap(true)`+`iconIgnorePlacement(true)` so they ALWAYS draw
   (controls are sparse - one per junction - and the earlier collision-off-below-POIs was culling them away on the
@@ -2566,7 +2570,11 @@ architecture note.
   un-gzips + renames it at build time (broke `open("...tsv.gz")`); a neutral extension is left intact and we
   gunzip it ourselves. Device-verified 2026-07-13: 124,406 loaded, purple badge drew with no network wait,
   route counts `[10,10,11]`, AND the hosted refresh downloaded a newer version (20260714) + hot-swapped +
-  is idempotent on relaunch. NB "avoid" still only RE-RANKS the alternates Google/OSRM offer (fewest-camera
+  is idempotent on relaunch. **DRAWN badges cluster below street zoom (2026-07-25):** a Flock corner mounts several
+  single-direction heads, so `vela-flock-cluster` (own source, 40 m `MapDeclutter` merge computed
+  at upload time in VelaMapView) draws ONE badge per install from z11/13 up to z16, where the raw
+  per-camera layer + facing cones take over; the browse-13/route-11 minZoom gate now lives on the
+  cluster layer. Route camera COUNTS stay per-head on purpose. NB "avoid" still only RE-RANKS the alternates Google/OSRM offer (fewest-camera
   within a small detour); it does NOT graph-route around cameras. **To publish the first hosted copy, dispatch
   Actions -> "Flock cameras" once** (until then every install just uses the bundled floor).
 - **Transitous is the PRIMARY departure-board source (2026-07-13, phase 1 of the GTFS adoption).**

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 > | [Resilience](#resilience--maintainability) | Signed remote calibration (pb/paths/JS) + notices - hot-fix drift without an app update |
 
 ## Map & rendering
+- ✅ **One glyph per intersection for stop signs, lights and cameras (2026-07-25).** OSM maps
+  street furniture per approach, so a four-way stop arrived as four stop signs and a signalized
+  junction as up to eight lights; they now merge to one icon at the junction centroid, like
+  Google. Flock camera multi-head corners merge to a single badge below street zoom and split
+  back into individual cameras with facing cones when zoomed in; the route camera counts stay
+  per-head. Fewer always-drawn symbols is also a small render win.
 - ✅ **Vela gives memory back when the system asks, and adapts to small phones (2026-07-23,
   adopted from the vela-dpad fork).** The speech model (about a quarter gigabyte while loaded) now
   unloads after two minutes unused and reloads in about a second on the next mic tap; map caches,

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -5057,9 +5057,20 @@ class MapViewModel @Inject constructor(
             // carry 1000+ signals/stop signs, and MapLibre re-collides every handed symbol per drag frame —
             // the same budget-GPU lesson as the ambient-POI cap (don't hand it the whole pool). 400 covers
             // the padded box everywhere reasonable; beyond that the excess would collide off anyway.
+            // ONE glyph per intersection, like Google: OSM maps a control node per APPROACH, so a
+            // four-way stop arrived as four stop signs. Cluster per type at the same 30 m the
+            // spoken "pass the light" counting already uses (adjacent intersections on a dense
+            // grid stay separate), each cluster drawn at its centroid. Fewer allowOverlap symbols
+            // is also a straight render win.
+            val merged = withContext(Dispatchers.Default) {
+                res.groupBy { it.stop }.flatMap { (isStop, group) ->
+                    app.vela.core.data.MapDeclutter.cluster(group, CONTROLS_CLUSTER_M) { it.loc }
+                        .map { c -> app.vela.core.data.TrafficControl(c.centroid, isStop) }
+                }
+            }
             val cLat0 = (s + n) / 2; val cLng0 = (w + e) / 2
             val lngScale = kotlin.math.cos(Math.toRadians(cLat0))
-            val kept = if (res.size <= CONTROLS_ONSCREEN_CAP) res else res.sortedBy {
+            val kept = if (merged.size <= CONTROLS_ONSCREEN_CAP) merged else merged.sortedBy {
                 val dLat = it.loc.lat - cLat0; val dLng = (it.loc.lng - cLng0) * lngScale
                 dLat * dLat + dLng * dLng
             }.take(CONTROLS_ONSCREEN_CAP)
@@ -5447,6 +5458,9 @@ class MapViewModel @Inject constructor(
     companion object {
         const val KEY_DISMISSED = "dismissed"
         const val CONTROLS_MIN_ZOOM = 16.0 // draw traffic lights/stop signs only when zoomed in this close
+        // One glyph per intersection: per-approach OSM nodes within this radius merge before draw.
+        // Same 30 m the spoken pass-the-light clustering uses; keeps dense-grid neighbours separate.
+        const val CONTROLS_CLUSTER_M = 30.0
         // Show ALPR cameras from ROUTE-OVERVIEW zoom (~z11-12), the "I know this route has cameras but
         // don't see any" view. z11 was tried 2026-07-13 and reverted the same day because the padded
         // Overpass box (~16x bigger) with a full-body read + full-DOM parse per pan OOM'd the heap; the

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -5051,7 +5051,10 @@ class MapViewModel @Inject constructor(
                 withContext(Dispatchers.IO) {
                     app.vela.core.data.OverpassTrafficSignals.fetchControlsInBox(http, s, w, n, e)
                 }
-            }.getOrNull() ?: return@launch
+            }.getOrNull() ?: run {
+                android.util.Log.i("VelaControls", "fetch FAILED (all endpoints) z=${"%.1f".format(zoom)}")
+                return@launch
+            }
             controlsBox = doubleArrayOf(s, w, n, e)
             // Cap what's HANDED to the map (nearest to the box center wins): a dense metro's padded box can
             // carry 1000+ signals/stop signs, and MapLibre re-collides every handed symbol per drag frame —
@@ -5074,6 +5077,9 @@ class MapViewModel @Inject constructor(
                 val dLat = it.loc.lat - cLat0; val dLng = (it.loc.lng - cLng0) * lngScale
                 dLat * dLat + dLng * dLng
             }.take(CONTROLS_ONSCREEN_CAP)
+            // Fetch/merge visibility: like flock's diag line, "controls don't show" reports are
+            // only diagnosable when the pipeline says what it actually produced.
+            android.util.Log.i("VelaControls", "fetched=${res.size} merged=${merged.size} kept=${kept.size}")
             _state.update { it.copy(trafficControls = kept) }
         }
     }

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -152,6 +152,13 @@ private const val SIGNAL_IMG = "vela-signal"
 private const val STOP_IMG = "vela-stop"
 private const val FLOCK_SRC = "vela-flock-src" // ALPR/Flock cameras (DeFlock/OSM) drawn at high zoom
 private const val FLOCK_LAYER = "vela-flock"
+// Below street zoom the per-head nodes of one install merge to a single badge (Flock corners
+// typically mount 2-4 single-direction heads); the raw per-camera layer + cones take over at
+// FLOCK_DETAIL_ZOOM where the facing data is actually legible.
+private const val FLOCK_CLUSTER_SRC = "vela-flock-cluster-src"
+private const val FLOCK_CLUSTER_LAYER = "vela-flock-cluster"
+private const val FLOCK_DETAIL_ZOOM = 16f
+private const val FLOCK_CLUSTER_M = 40.0
 private const val FLOCK_IMG = "vela-flock-cam"
 private const val FLOCK_DIR_LAYER = "vela-flock-dir" // facing cone under the badge (dir-tagged nodes)
 private const val FLOCK_DIR_IMG = "vela-flock-cone"
@@ -3277,10 +3284,9 @@ private fun ensureLayers(style: Style) {
         )
         val flockLayer =
             SymbolLayer(FLOCK_LAYER, FLOCK_SRC).apply {
-                // Must match the VM's FLOCK_MIN_ZOOM fetch gate: clamped at 13.5 this layer sat on
-                // fetched cameras without drawing them (z13-13.5 was a dead band, and route-overview
-                // zoom showed nothing at all - the half-done state vela-dpad caught, issue #131).
-                setMinZoom(11f)
+                // Per-camera detail (with the facing cones below) owns street zoom only; the
+                // clustered twin covers everything wider, one badge per install.
+                setMinZoom(FLOCK_DETAIL_ZOOM)
                 setProperties(
                     PropertyFactory.iconImage(FLOCK_IMG),
                     PropertyFactory.iconSize(flockSize),
@@ -3294,6 +3300,27 @@ private fun ensureLayers(style: Style) {
             style.getLayer(CONTROLS_CLAIM_LAYER) != null -> style.addLayerBelow(flockLayer, CONTROLS_CLAIM_LAYER)
             else -> style.addLayer(flockLayer)
         }
+        // The clustered twin: below street zoom a multi-head corner draws ONE badge at the
+        // cluster centroid (no count, no cones - zooming in reveals the detail). Its own source
+        // so the zoom handoff is pure renderer work, no re-uploads on zoom crossings.
+        // minZoom must match the VM's FLOCK_MIN_ZOOM fetch gate: clamped at 13.5 this layer sat
+        // on fetched cameras without drawing them (z13-13.5 was a dead band, and route-overview
+        // zoom showed nothing at all - the half-done state vela-dpad caught, issue #131).
+        style.addSource(GeoJsonSource(FLOCK_CLUSTER_SRC, GeoJsonOptions().withMaxZoom(12)))
+        style.addLayerBelow(
+            SymbolLayer(FLOCK_CLUSTER_LAYER, FLOCK_CLUSTER_SRC).apply {
+                setMinZoom(11f)
+                setMaxZoom(FLOCK_DETAIL_ZOOM)
+                setProperties(
+                    PropertyFactory.iconImage(FLOCK_IMG),
+                    PropertyFactory.iconSize(flockSize),
+                    PropertyFactory.iconAllowOverlap(true),
+                    PropertyFactory.iconIgnorePlacement(false),
+                    PropertyFactory.iconPadding(2f),
+                )
+            },
+            FLOCK_LAYER,
+        )
         // Facing cone UNDER the badge (2026-07-21, user: Flock units are single-direction and
         // DeFlock's own map shows facing) - only nodes with a dir tag get the FLOCK_DIR_PROP
         // property, so untagged cameras keep the bare badge. Map-aligned rotation: the cone
@@ -3301,7 +3328,7 @@ private fun ensureLayers(style: Style) {
         // (ignorePlacement true keeps it out of the collision index - it's a glow, not a symbol).
         style.addLayerBelow(
             SymbolLayer(FLOCK_DIR_LAYER, FLOCK_SRC).apply {
-                setMinZoom(11f)
+                setMinZoom(FLOCK_DETAIL_ZOOM)
                 setFilter(Expression.has(FLOCK_DIR_PROP))
                 setProperties(
                     PropertyFactory.iconImage(FLOCK_DIR_IMG),
@@ -5078,11 +5105,15 @@ private fun applyData(
     // draws EVERY icon (no collision culling) - a wall of badges plus the symbol cost. They're a
     // proximity feature, so hide them below z13 while just browsing, but keep the low floor when a
     // route is active so route-overview zoom (z11-12) still shows its cameras (issue #131 dead-band).
-    style.getLayer(FLOCK_LAYER)?.setMinZoom(if (route.isEmpty()) 13f else 11f)
-    style.getLayer(FLOCK_DIR_LAYER)?.setMinZoom(if (route.isEmpty()) 13f else 11f)
+    // The browse/route floor applies to the CLUSTERED layer (the low-zoom face of the feature);
+    // the per-camera detail layers stay pinned at FLOCK_DETAIL_ZOOM.
+    style.getLayer(FLOCK_CLUSTER_LAYER)?.setMinZoom(if (route.isEmpty()) 13f else 11f)
 
     // ALPR/Flock cameras → icon features (identity-gated like the controls). Empty when the layer's
-    // off or zoomed out, which clears the source.
+    // off or zoomed out, which clears the source. Two uploads per change: the raw per-camera set
+    // (street-zoom detail + cones) and its 40 m-clustered twin (one badge per install below street
+    // zoom - a Flock corner mounts several single-direction heads). The route "passes N cameras"
+    // count stays on raw nodes on purpose; only the DRAWN badges merge.
     if (flockCameras != lastAppliedFlock) {
         val flockFc = FeatureCollection.fromFeatures(
             flockCameras.map { cam ->
@@ -5094,6 +5125,11 @@ private fun applyData(
             },
         )
         style.getSourceAs<GeoJsonSource>(FLOCK_SRC)?.setGeoJson(flockFc)
+        val clusteredFc = FeatureCollection.fromFeatures(
+            app.vela.core.data.MapDeclutter.cluster(flockCameras, FLOCK_CLUSTER_M) { it.loc }
+                .map { c -> Feature.fromGeometry(Point.fromLngLat(c.centroid.lng, c.centroid.lat)) },
+        )
+        style.getSourceAs<GeoJsonSource>(FLOCK_CLUSTER_SRC)?.setGeoJson(clusteredFc)
         lastAppliedFlock = flockCameras
     }
 

--- a/core/src/main/java/app/vela/core/data/MapDeclutter.kt
+++ b/core/src/main/java/app/vela/core/data/MapDeclutter.kt
@@ -1,0 +1,51 @@
+package app.vela.core.data
+
+import app.vela.core.model.LatLng
+
+/**
+ * Greedy centroid clustering for point declutter on the map. OSM maps street furniture per
+ * APPROACH: a four-way stop is four `highway=stop` nodes and a signalized junction can carry
+ * eight `traffic_signals` nodes, where Google draws ONE glyph per intersection - the same
+ * per-carriageway reality `RouteGeometry.enrichWithLights` already clusters at 30 m before
+ * counting "pass the light". Flock installs likewise mount several single-direction heads on
+ * one corner. Collapsing them before upload is also a straight render win: these layers draw
+ * with iconAllowOverlap, so every node becomes quads with no collision culling to save us.
+ *
+ * Greedy by input order: each point joins the first cluster whose running centroid lies within
+ * [radiusM], else starts its own. Deterministic for a given input order; O(n * clusters), fine
+ * for the few hundred points a viewport carries.
+ */
+object MapDeclutter {
+
+    class Cluster<T>(first: T, firstLoc: LatLng) {
+        val members = mutableListOf(first)
+        var centroid: LatLng = firstLoc
+            private set
+
+        fun add(item: T, loc: LatLng) {
+            members.add(item)
+            val n = members.size
+            centroid = LatLng(
+                centroid.lat + (loc.lat - centroid.lat) / n,
+                centroid.lng + (loc.lng - centroid.lng) / n,
+            )
+        }
+    }
+
+    fun <T> cluster(items: List<T>, radiusM: Double, loc: (T) -> LatLng): List<Cluster<T>> {
+        val clusters = mutableListOf<Cluster<T>>()
+        for (item in items) {
+            val p = loc(item)
+            val hit = clusters.firstOrNull { approxDistanceM(it.centroid, p) <= radiusM }
+            if (hit != null) hit.add(item, p) else clusters.add(Cluster(item, p))
+        }
+        return clusters
+    }
+
+    /** Equirectangular approximation - exact enough at the tens-of-metres radii this is used at. */
+    internal fun approxDistanceM(a: LatLng, b: LatLng): Double {
+        val latM = (a.lat - b.lat) * 111_320.0
+        val lngM = (a.lng - b.lng) * 111_320.0 * kotlin.math.cos(Math.toRadians((a.lat + b.lat) / 2))
+        return kotlin.math.sqrt(latM * latM + lngM * lngM)
+    }
+}

--- a/core/src/test/java/app/vela/core/data/MapDeclutterTest.kt
+++ b/core/src/test/java/app/vela/core/data/MapDeclutterTest.kt
@@ -1,0 +1,48 @@
+package app.vela.core.data
+
+import app.vela.core.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Pins the map-declutter clustering: a four-way stop's per-approach nodes must merge to ONE
+ *  drawn glyph at the intersection, while neighbouring intersections stay separate. */
+class MapDeclutterTest {
+
+    // ~0.0001 deg latitude = ~11 m; a four-way stop's nodes sit 10-20 m from the junction centre.
+    private fun p(lat: Double, lng: Double) = LatLng(lat, lng)
+
+    @Test
+    fun `four approach nodes merge to one cluster at the centroid`() {
+        val junction = listOf(
+            p(38.5000, -121.7000), p(38.5002, -121.7000), // north + south approach
+            p(38.5001, -121.7002), p(38.5001, -121.6998), // west + east approach
+        )
+        val clusters = MapDeclutter.cluster(junction, 30.0) { it }
+        assertEquals(1, clusters.size)
+        assertEquals(4, clusters[0].members.size)
+        assertEquals(38.5001, clusters[0].centroid.lat, 1e-4)
+    }
+
+    @Test
+    fun `adjacent intersections on a dense grid stay separate`() {
+        // Two junctions ~90 m apart (0.0008 deg lat) - a tight urban grid.
+        val a = listOf(p(38.5000, -121.7000), p(38.5001, -121.7000))
+        val b = listOf(p(38.5008, -121.7000), p(38.5009, -121.7000))
+        val clusters = MapDeclutter.cluster(a + b, 30.0) { it }
+        assertEquals(2, clusters.size)
+    }
+
+    @Test
+    fun `a lone point stays a lone cluster`() {
+        val clusters = MapDeclutter.cluster(listOf(p(38.5, -121.7)), 40.0) { it }
+        assertEquals(1, clusters.size)
+        assertEquals(1, clusters[0].members.size)
+    }
+
+    @Test
+    fun `distance approximation is metre-accurate at street scale`() {
+        // 0.0009 deg latitude = ~100 m.
+        val d = MapDeclutter.approxDistanceM(p(38.5, -121.7), p(38.5009, -121.7))
+        assertEquals(100.0, d, 1.0)
+    }
+}


### PR DESCRIPTION
OpenStreetMap maps street furniture per approach, so a four-way stop rendered four stop signs and a signalized junction up to eight lights where Google draws one. Same-type control nodes now merge per intersection before upload, at the same 30 m radius the spoken pass-the-light counting already uses, drawn at the junction centroid. Dense-grid neighbours stay separate.

Flock corners usually mount several single-direction camera heads. Below street zoom those merge to one plain badge on a clustered twin layer with its own source, so the zoom handoff is pure renderer work; from street zoom up the individual cameras and their facing cones take over. The route camera counts still count every head on purpose.

Performance is strictly better: both layers draw every icon with overlap allowed, meaning no collision culling saves us, so fewer features means fewer quads and smaller uploads. The clustering is a one-shot pass over a few hundred points per viewport on a background dispatcher, unit tested in core.

Device notes from the canary: the merged camera badge verified on a corner that previously drew a stacked pair. The stop-sign merge could not be eyeballed because every Overpass mirror was answering errors from the phone during testing, which also means the layer was blank before the change; the pipeline was verified by the new log lines instead (a successful fetch flows through merge and cap, and failures now log rather than vanish). A failed fetch is not cached, so the layer heals on the next pan once Overpass behaves.