### PR TITLE
Fix rerouting that could get stuck on "Re-routing" for the rest of a drive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1978,7 +1978,19 @@ architecture note.
   can ABANDON (the orphan finishes into the void - same trap and same shape as
   `AVOID_ONDEVICE_TIMEOUT_MS`), and `NavSession.rerouteGate` (pure, unit-tested in
   `RerouteGateTest`) declares a job dead past deadline + `REROUTE_STUCK_GRACE_MS` so single-flight
-  can never be permanent. **Never gate rerouting on job liveness alone.**
+  can never be permanent. **Never gate rerouting on job liveness alone.** **SECOND cause, same
+  symptom (2026-08-16):** a mid-drive reroute is `urgent`, i.e. a SINGLE-SHOT fetch with no retry
+  ladder - correct, because the full ladder outlived the deadline on a weak link (#185/#236) - but
+  a single shot on a genuinely flaky link fails over and over and NOTHING escalated, so the driver
+  sat on "Re-routing" through attempt after attempt while ending nav and starting again worked
+  first time (a fresh plan is not urgent and gets the 3-try ladder). That workaround was the clue.
+  Attempts now start lean and ESCALATE: `NavSession.rerouteAttempt(failStreak)` (pure, tested)
+  keeps the first `REROUTE_ESCALATE_AFTER` attempts urgent, then switches to the full ladder with
+  the longer `REROUTE_LADDER_TIMEOUT_MS`; the streak resets on any adopted route and on session
+  start/stop, so one drive's bad coverage does not send the next drive's first reroute down the
+  slow path. `rerouteGate` therefore takes the attempt's OWN deadline - judging an escalated
+  attempt by the lean one would declare a healthy fetch wedged and kill it just before it
+  succeeded, the original bug wearing a new hat.
   since 2026-08-04 the reroute fetch is URGENT (`directions(urgent = true)`, issues #185/#236):
   single-shot OSRM + Google (no 3x ladders), no divergence snap - the full planning ladder
   regularly outlived the deadline on a weak link, so the timeout cancelled fetches that were

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1968,6 +1968,17 @@ architecture note.
   ladders inside directions() could hold the single-flight latch for a minute on a flaky cell
   link, silently dropping every new RerouteNeeded (a real-drive hang); past the deadline it
   fails into the same retry-while-deviated path so the next fix fires a fresh request. And
+  **The reroute fetch is UNSTRUCTURED and the single-flight guard is TIME-BOUNDED (issue #258,
+  2026-08-15).** `withTimeoutOrNull` only interrupts at suspension points, so a fetch wedged in
+  non-cancellable work (a socket read that never returns, the offline engine's native compute)
+  outlived its own deadline and kept `rerouteJob` active - and the guard then rejected EVERY later
+  reroute for the rest of the drive: "Re-routing" on screen forever, cleared only by ending and
+  restarting nav (real-drive report, dangerous precisely because the workaround needs the phone in
+  your hand). Two fixes, both required: the fetch runs as a `CoroutineScope(IO).async` the deadline
+  can ABANDON (the orphan finishes into the void - same trap and same shape as
+  `AVOID_ONDEVICE_TIMEOUT_MS`), and `NavSession.rerouteGate` (pure, unit-tested in
+  `RerouteGateTest`) declares a job dead past deadline + `REROUTE_STUCK_GRACE_MS` so single-flight
+  can never be permanent. **Never gate rerouting on job liveness alone.**
   since 2026-08-04 the reroute fetch is URGENT (`directions(urgent = true)`, issues #185/#236):
   single-shot OSRM + Google (no 3x ladders), no divergence snap - the full planning ladder
   regularly outlived the deadline on a weak link, so the timeout cancelled fetches that were

--- a/core/src/main/java/app/vela/core/nav/NavSession.kt
+++ b/core/src/main/java/app/vela/core/nav/NavSession.kt
@@ -81,6 +81,10 @@ class NavSession @Inject constructor(
     // start() can't resurrect the previous destination's route into the fresh session.
     private var rerouteJob: Job? = null
     private var rerouteStartedMs = 0L
+    /** Deadline the in-flight reroute is running under (see [rerouteAttempt]). */
+    private var rerouteDeadlineMs = REROUTE_FETCH_TIMEOUT_MS
+    /** Consecutive reroute attempts that came back with nothing; reset on any adopted route. */
+    private var rerouteFailStreak = 0
     // @Volatile: written on the Default dispatcher (reroute coroutine) / caller thread and read
     // on the location thread — a stale read would defeat the cooldown or the generation guard.
     @Volatile private var lastRerouteAdoptMs = 0L
@@ -171,6 +175,10 @@ class NavSession @Inject constructor(
         sessionGen += 1               // orphan any in-flight reroute/recheck from a previous session
         rerouteJob?.cancel()
         pendingLatchClear.set(false)  // a stale clear from the previous session must not leak in
+        // A new drive starts lean: the previous drive's bad patch of coverage says nothing about
+        // this one, and inheriting its streak would send the first reroute straight to the ladder.
+        rerouteFailStreak = 0
+        rerouteDeadlineMs = REROUTE_FETCH_TIMEOUT_MS
         dismissedFasterKey = 0L
         dismissedFasterSaving = 0.0
         etaScale = 1.0
@@ -224,6 +232,8 @@ class NavSession @Inject constructor(
         recheckJob?.cancel()
         rerouteJob?.cancel()
         pendingLatchClear.set(false)
+        rerouteFailStreak = 0
+        rerouteDeadlineMs = REROUTE_FETCH_TIMEOUT_MS
         voice.stop()
         destination = null
         synchronized(stopLock) { stops = emptyList(); stopMarks = emptyList(); passedStops = 0; planRoute = null }
@@ -611,7 +621,7 @@ class NavSession @Inject constructor(
         // too, 4 s later another "Rerouting…" — forever). The engine keeps emitting RerouteNeeded
         // while deviated (the latch clears on failure below), so a skipped request here is simply
         // retried by the next qualifying fix after the cooldown.
-        when (rerouteGate(rerouteJob?.isActive == true, rerouteStartedMs, lastRerouteAdoptMs, now)) {
+        when (rerouteGate(rerouteJob?.isActive == true, rerouteStartedMs, lastRerouteAdoptMs, now, rerouteDeadlineMs)) {
             RerouteGate.SKIP_IN_FLIGHT, RerouteGate.SKIP_COOLDOWN -> return
             RerouteGate.ABANDON_STUCK_AND_START -> {
                 diag.record("nav", "previous reroute wedged past its deadline - abandoning it and retrying")
@@ -638,6 +648,11 @@ class NavSession @Inject constructor(
         // we're fetching (see the back-on-course check below), we abandon the reroute rather than swap.
         val fromRoute = _state.value.route
         rerouteStartedMs = now
+        val attempt = rerouteAttempt(rerouteFailStreak)
+        rerouteDeadlineMs = attempt.timeoutMs
+        if (!attempt.urgent) {
+            diag.record("nav", "reroute escalating to the full ladder after $rerouteFailStreak failed attempts")
+        }
         rerouteJob = scope.launch {
             // A reroute that doesn't actually reach the destination is a bad result — keep guiding on the
             // current route rather than swapping to a truncated/wrong one. (Guard unchanged: the route still
@@ -662,10 +677,10 @@ class NavSession @Inject constructor(
             // (reported on a real drive; the same trap the avoid path hit, see
             // AVOID_ONDEVICE_TIMEOUT_MS). The orphan finishes into the void and is discarded.
             val fetch = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).async {
-                runCatching { dataSource.directions(loc, dest, mode, remainingStops.map { it.location }, urgent = true) }
+                runCatching { dataSource.directions(loc, dest, mode, remainingStops.map { it.location }, urgent = attempt.urgent) }
                     .getOrNull()?.firstOrNull()?.takeIf { it.reaches(dest) }
             }
-            val r = kotlinx.coroutines.withTimeoutOrNull(REROUTE_FETCH_TIMEOUT_MS) { fetch.await() }
+            val r = kotlinx.coroutines.withTimeoutOrNull(attempt.timeoutMs) { fetch.await() }
             if (r == null) fetch.cancel() // best effort; a wedged blocking read ignores this and is orphaned
             if (gen != sessionGen) return@launch // session ended / restarted while fetching — drop it
             // BACK ON COURSE: while we were fetching (~1-3 s), did the driver return to the ORIGINAL route?
@@ -690,7 +705,8 @@ class NavSession @Inject constructor(
                 // old route. Flag the latch clear for the LOCATION THREAD to consume (writing nav
                 // state from here raced the in-flight onLocation frame) — 4 more deviated fixes
                 // then request again (~4 s natural backoff, OsmAnd-style retry-while-deviated).
-                diag.record("nav", "reroute FAILED — will retry while off-route")
+                rerouteFailStreak++
+                diag.record("nav", "reroute FAILED (streak $rerouteFailStreak) — will retry while off-route")
                 pendingLatchClear.set(true)
                 return@launch
             }
@@ -709,6 +725,7 @@ class NavSession @Inject constructor(
                 voice.speak(app.vela.core.i18n.NavStringsRegistry.current().stopsNotIncluded())
                 diag.record("nav", "reroute missing ${marks.count { it == null }}/${remainingStops.size} stops")
             }
+            rerouteFailStreak = 0 // a route landed: back to lean, fast attempts
             lastSwapReason = "reroute"
             lastRecheckMs = SystemClock.elapsedRealtime()
             lastRerouteAdoptMs = SystemClock.elapsedRealtime()
@@ -754,6 +771,12 @@ class NavSession @Inject constructor(
         const val REROUTE_FETCH_TIMEOUT_MS = 20_000L
         // Slack past the deadline before a still-running reroute job is declared wedged.
         const val REROUTE_STUCK_GRACE_MS = 5_000L
+        // After this many reroute attempts in a row have come back with nothing, stop being lean
+        // and use the FULL planning ladder - see [rerouteAttempt].
+        const val REROUTE_ESCALATE_AFTER = 2
+        // Deadline for an escalated attempt: the ladder makes several tries, so the lean deadline
+        // would cut it off mid-way and we would never see the retry pay off.
+        const val REROUTE_LADDER_TIMEOUT_MS = 40_000L
 
         /**
          * May a reroute start right now? Pure so the rule that broke in issue #258 is pinned by a
@@ -764,13 +787,43 @@ class NavSession @Inject constructor(
          * forever rejected every later reroute for the rest of the drive - the spinner that only
          * a nav restart cleared. Past the deadline plus a grace window the job is declared dead.
          */
-        fun rerouteGate(jobActive: Boolean, jobStartedMs: Long, lastAdoptMs: Long, now: Long): RerouteGate = when {
-            jobActive && now - jobStartedMs >= REROUTE_FETCH_TIMEOUT_MS + REROUTE_STUCK_GRACE_MS ->
+        fun rerouteGate(
+            jobActive: Boolean,
+            jobStartedMs: Long,
+            lastAdoptMs: Long,
+            now: Long,
+            // The deadline THIS attempt is running under - an escalated attempt is allowed longer,
+            // and judging it by the lean deadline would declare a healthy fetch wedged and kill it.
+            deadlineMs: Long = REROUTE_FETCH_TIMEOUT_MS,
+        ): RerouteGate = when {
+            jobActive && now - jobStartedMs >= deadlineMs + REROUTE_STUCK_GRACE_MS ->
                 RerouteGate.ABANDON_STUCK_AND_START
             jobActive -> RerouteGate.SKIP_IN_FLIGHT
             now - lastAdoptMs < REROUTE_COOLDOWN_MS -> RerouteGate.SKIP_COOLDOWN
             else -> RerouteGate.START
         }
+        /** How the next reroute attempt should be made, given how many have just failed. */
+        data class RerouteAttempt(val urgent: Boolean, val timeoutMs: Long)
+
+        /**
+         * Reroute attempts start LEAN and ESCALATE (issue #258, second cause).
+         *
+         * A mid-drive reroute is `urgent`, which means a SINGLE-SHOT fetch with no retry ladder -
+         * deliberately, because the full ladder used to outlive the deadline on a weak link and got
+         * cancelled just as it was about to succeed (issues #185/#236). But a single shot on a
+         * genuinely flaky link can fail over and over, and nothing ever escalated: the driver sat
+         * on "Re-routing" through attempt after attempt, while ENDING NAV AND STARTING AGAIN worked
+         * first time - because a fresh plan is not urgent and gets the 3-try ladder. That is
+         * exactly the reported workaround, and it is a different fault from the wedged job the
+         * gate above handles.
+         *
+         * So: the first couple of attempts stay lean and fast, and after that we spend the time and
+         * use the full ladder. Fast when the network is merely blipping, thorough when it is bad.
+         */
+        fun rerouteAttempt(failStreak: Int): RerouteAttempt =
+            if (failStreak >= REROUTE_ESCALATE_AFTER) RerouteAttempt(urgent = false, timeoutMs = REROUTE_LADDER_TIMEOUT_MS)
+            else RerouteAttempt(urgent = true, timeoutMs = REROUTE_FETCH_TIMEOUT_MS)
+
         const val REROUTE_SPEAK_MIN_MS = 30_000L   // "Rerouting" spoken at most this often (retries are silent)
         const val BACK_ON_COURSE_HITS = 2          // consecutive on-corridor fixes before an in-flight reroute
                                                    // is abandoned as "back on course" — >1 so a single grazing

--- a/core/src/main/java/app/vela/core/nav/NavSession.kt
+++ b/core/src/main/java/app/vela/core/nav/NavSession.kt
@@ -9,6 +9,7 @@ import app.vela.core.model.TravelMode
 import app.vela.core.model.distanceTo
 import app.vela.core.voice.VoiceGuide
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -33,6 +34,9 @@ import javax.inject.Singleton
  * behaviour traffic apps live on.
  */
 @Singleton
+/** Outcome of [NavSession.rerouteGate] - whether a reroute request may proceed. */
+enum class RerouteGate { START, SKIP_IN_FLIGHT, SKIP_COOLDOWN, ABANDON_STUCK_AND_START }
+
 class NavSession @Inject constructor(
     private val dataSource: MapDataSource,
     private val voice: VoiceGuide,
@@ -76,6 +80,7 @@ class NavSession @Inject constructor(
     // shouldn't re-announce), and a GENERATION stamp so a fetch that completes after stop()/a new
     // start() can't resurrect the previous destination's route into the fresh session.
     private var rerouteJob: Job? = null
+    private var rerouteStartedMs = 0L
     // @Volatile: written on the Default dispatcher (reroute coroutine) / caller thread and read
     // on the location thread — a stale read would defeat the cooldown or the generation guard.
     @Volatile private var lastRerouteAdoptMs = 0L
@@ -606,7 +611,14 @@ class NavSession @Inject constructor(
         // too, 4 s later another "Rerouting…" — forever). The engine keeps emitting RerouteNeeded
         // while deviated (the latch clears on failure below), so a skipped request here is simply
         // retried by the next qualifying fix after the cooldown.
-        if (rerouteJob?.isActive == true || now - lastRerouteAdoptMs < REROUTE_COOLDOWN_MS) return
+        when (rerouteGate(rerouteJob?.isActive == true, rerouteStartedMs, lastRerouteAdoptMs, now)) {
+            RerouteGate.SKIP_IN_FLIGHT, RerouteGate.SKIP_COOLDOWN -> return
+            RerouteGate.ABANDON_STUCK_AND_START -> {
+                diag.record("nav", "previous reroute wedged past its deadline - abandoning it and retrying")
+                rerouteJob?.cancel()
+            }
+            RerouteGate.START -> Unit
+        }
         // Announce sparsely: the first attempt of a burst speaks, silent retries don't re-announce.
         if (now - lastRerouteSpokeMs > REROUTE_SPEAK_MIN_MS) {
             lastRerouteSpokeMs = now
@@ -625,6 +637,7 @@ class NavSession @Inject constructor(
         // The route we were following when we went off-route. If the driver returns to THIS line while
         // we're fetching (see the back-on-course check below), we abandon the reroute rather than swap.
         val fromRoute = _state.value.route
+        rerouteStartedMs = now
         rerouteJob = scope.launch {
             // A reroute that doesn't actually reach the destination is a bad result — keep guiding on the
             // current route rather than swapping to a truncated/wrong one. (Guard unchanged: the route still
@@ -640,10 +653,20 @@ class NavSession @Inject constructor(
             // cancelled work that was about to succeed and the driver sat unrerouted through
             // repeated attempts. A lean route lands in seconds; the recheck loop restores
             // traffic/steps quality afterwards.
-            val r = kotlinx.coroutines.withTimeoutOrNull(REROUTE_FETCH_TIMEOUT_MS) {
+            // The fetch runs as an UNSTRUCTURED async so the deadline can actually ABANDON it
+            // (issue #258). withTimeoutOrNull only interrupts at suspension points: a structured
+            // child that blocks in non-cancellable work - a socket read that never returns, or the
+            // offline engine's native compute - keeps this coroutine alive long past the deadline,
+            // and `rerouteJob?.isActive` above then rejects EVERY later reroute for the rest of the
+            // drive. That is the "Re-routing" spinner that never exits and only a restart clears
+            // (reported on a real drive; the same trap the avoid path hit, see
+            // AVOID_ONDEVICE_TIMEOUT_MS). The orphan finishes into the void and is discarded.
+            val fetch = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).async {
                 runCatching { dataSource.directions(loc, dest, mode, remainingStops.map { it.location }, urgent = true) }
                     .getOrNull()?.firstOrNull()?.takeIf { it.reaches(dest) }
             }
+            val r = kotlinx.coroutines.withTimeoutOrNull(REROUTE_FETCH_TIMEOUT_MS) { fetch.await() }
+            if (r == null) fetch.cancel() // best effort; a wedged blocking read ignores this and is orphaned
             if (gen != sessionGen) return@launch // session ended / restarted while fetching — drop it
             // BACK ON COURSE: while we were fetching (~1-3 s), did the driver return to the ORIGINAL route?
             // A U-turn (or any wobble) fires RerouteNeeded, but by the time the fetch lands the driver has
@@ -729,6 +752,25 @@ class NavSession @Inject constructor(
         // Deadline on one reroute FETCH: generous next to Google's 1-3 s but far under the retry
         // ladders' worst case; past it the position the request was computed from is stale anyway.
         const val REROUTE_FETCH_TIMEOUT_MS = 20_000L
+        // Slack past the deadline before a still-running reroute job is declared wedged.
+        const val REROUTE_STUCK_GRACE_MS = 5_000L
+
+        /**
+         * May a reroute start right now? Pure so the rule that broke in issue #258 is pinned by a
+         * test instead of living inside a coroutine that needs a device to exercise.
+         *
+         * Single-flight is right, but it must never be PERMANENT: a fetch wedged in
+         * non-cancellable I/O outlives its own deadline, and treating that job as "in flight"
+         * forever rejected every later reroute for the rest of the drive - the spinner that only
+         * a nav restart cleared. Past the deadline plus a grace window the job is declared dead.
+         */
+        fun rerouteGate(jobActive: Boolean, jobStartedMs: Long, lastAdoptMs: Long, now: Long): RerouteGate = when {
+            jobActive && now - jobStartedMs >= REROUTE_FETCH_TIMEOUT_MS + REROUTE_STUCK_GRACE_MS ->
+                RerouteGate.ABANDON_STUCK_AND_START
+            jobActive -> RerouteGate.SKIP_IN_FLIGHT
+            now - lastAdoptMs < REROUTE_COOLDOWN_MS -> RerouteGate.SKIP_COOLDOWN
+            else -> RerouteGate.START
+        }
         const val REROUTE_SPEAK_MIN_MS = 30_000L   // "Rerouting" spoken at most this often (retries are silent)
         const val BACK_ON_COURSE_HITS = 2          // consecutive on-corridor fixes before an in-flight reroute
                                                    // is abandoned as "back on course" — >1 so a single grazing

--- a/core/src/test/java/app/vela/core/nav/RerouteGateTest.kt
+++ b/core/src/test/java/app/vela/core/nav/RerouteGateTest.kt
@@ -1,0 +1,73 @@
+package app.vela.core.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Rerouting must be single-flight but never permanently blocked (issue #258: "Re-routing" shown
+ * forever, only a nav restart cleared it, reported on a real drive where touching the phone is
+ * itself the hazard).
+ *
+ * The failing shape: a fetch wedged in non-cancellable I/O outlives its own deadline, so the job
+ * stays active; the old guard read that as "a reroute is in flight" and rejected every later
+ * request for the rest of the drive. The deadline on the fetch cannot be the only protection,
+ * because the thing being bounded is exactly what ignores cancellation.
+ */
+class RerouteGateTest {
+    private val deadline = NavSession.REROUTE_FETCH_TIMEOUT_MS
+    private val grace = NavSession.REROUTE_STUCK_GRACE_MS
+    private val cooldown = NavSession.REROUTE_COOLDOWN_MS
+
+    @Test fun `idle session starts a reroute`() {
+        assertEquals(RerouteGate.START, NavSession.rerouteGate(false, 0L, 0L, 1_000_000L))
+    }
+
+    @Test fun `a genuinely in-flight fetch is not duplicated`() {
+        val now = 1_000_000L
+        assertEquals(
+            RerouteGate.SKIP_IN_FLIGHT,
+            NavSession.rerouteGate(true, now - deadline / 2, 0L, now),
+        )
+    }
+
+    @Test fun `a job wedged past the deadline is abandoned, not obeyed forever`() {
+        // THE REGRESSION: before the fix this returned "in flight" for the rest of the drive.
+        val now = 1_000_000L
+        assertEquals(
+            RerouteGate.ABANDON_STUCK_AND_START,
+            NavSession.rerouteGate(true, now - (deadline + grace), 0L, now),
+        )
+    }
+
+    @Test fun `a wedged job stays abandonable however long it hangs`() {
+        val now = 9_000_000L
+        assertEquals(
+            RerouteGate.ABANDON_STUCK_AND_START,
+            NavSession.rerouteGate(true, now - 60 * 60_000L, 0L, now),
+        )
+    }
+
+    @Test fun `a just-adopted reroute is not immediately re-run`() {
+        val now = 1_000_000L
+        assertEquals(
+            RerouteGate.SKIP_COOLDOWN,
+            NavSession.rerouteGate(false, 0L, now - cooldown / 2, now),
+        )
+    }
+
+    @Test fun `the cooldown expires`() {
+        val now = 1_000_000L
+        assertEquals(
+            RerouteGate.START,
+            NavSession.rerouteGate(false, 0L, now - cooldown - 1, now),
+        )
+    }
+
+    @Test fun `a wedged job outranks the cooldown so a stuck drive always recovers`() {
+        val now = 1_000_000L
+        assertEquals(
+            RerouteGate.ABANDON_STUCK_AND_START,
+            NavSession.rerouteGate(true, now - (deadline + grace), now - 1, now),
+        )
+    }
+}

--- a/core/src/test/java/app/vela/core/nav/RerouteGateTest.kt
+++ b/core/src/test/java/app/vela/core/nav/RerouteGateTest.kt
@@ -1,6 +1,8 @@
 package app.vela.core.nav
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -68,6 +70,43 @@ class RerouteGateTest {
         assertEquals(
             RerouteGate.ABANDON_STUCK_AND_START,
             NavSession.rerouteGate(true, now - (deadline + grace), now - 1, now),
+        )
+    }
+
+    // --- Attempts start lean and ESCALATE (issue #258, second cause) -------------------------
+    // A mid-drive reroute is single-shot on purpose. On a genuinely flaky link that can fail over
+    // and over while ending nav and starting again works first time - because a fresh plan is not
+    // urgent and gets the full retry ladder. That was the reported workaround, so the retry ladder
+    // has to become reachable without restarting.
+
+    @Test fun `the first attempts are lean and fast`() {
+        val a = NavSession.rerouteAttempt(0)
+        assertTrue(a.urgent)
+        assertEquals(NavSession.REROUTE_FETCH_TIMEOUT_MS, a.timeoutMs)
+        assertTrue(NavSession.rerouteAttempt(1).urgent)
+    }
+
+    @Test fun `after repeated failures it uses the full ladder and allows it longer`() {
+        val a = NavSession.rerouteAttempt(NavSession.REROUTE_ESCALATE_AFTER)
+        assertFalse("the ladder is the whole point of escalating", a.urgent)
+        assertTrue("the ladder needs longer than a single shot", a.timeoutMs > NavSession.REROUTE_FETCH_TIMEOUT_MS)
+        assertFalse(NavSession.rerouteAttempt(9).urgent)
+    }
+
+    // The stuck-job rule must judge an attempt by ITS OWN deadline: an escalated attempt is allowed
+    // longer, and measuring it against the lean deadline would declare a healthy fetch wedged and
+    // kill it right before it succeeded - reintroducing the bug in a new form.
+    @Test fun `an escalated attempt is not declared wedged at the lean deadline`() {
+        val started = 1_000L
+        val justPastLean = started + NavSession.REROUTE_FETCH_TIMEOUT_MS + NavSession.REROUTE_STUCK_GRACE_MS + 1
+        assertEquals(
+            RerouteGate.SKIP_IN_FLIGHT,
+            NavSession.rerouteGate(true, started, 0L, justPastLean, NavSession.REROUTE_LADDER_TIMEOUT_MS),
+        )
+        val pastLadder = started + NavSession.REROUTE_LADDER_TIMEOUT_MS + NavSession.REROUTE_STUCK_GRACE_MS + 1
+        assertEquals(
+            RerouteGate.ABANDON_STUCK_AND_START,
+            NavSession.rerouteGate(true, started, 0L, pastLadder, NavSession.REROUTE_LADDER_TIMEOUT_MS),
         )
     }
 }


### PR DESCRIPTION
Fixes #258

A reroute fetch that wedges in work the timeout cannot interrupt (a socket read that never returns, or the offline engine's native compute) outlived its own deadline, leaving the job marked as still running. The single-flight guard then rejected every later reroute attempt for the rest of the trip, so the banner sat on "Re-routing" until the driver ended navigation and started it again — a bad thing to ask of someone mid-drive, which is the reporter's point.

Two changes, both needed:

- The fetch runs unstructured so the deadline can actually abandon it. `withTimeoutOrNull` only interrupts at suspension points, so bounding a blocking call from the outside never worked. Same trap and same shape as the avoid-routing timeout.
- Single-flight is now time-bounded: a job still alive past its deadline plus a grace window is declared dead and replaced, so the guard can never block rerouting permanently.

The rule that failed is extracted into `NavSession.rerouteGate`, a pure function, and covered by `RerouteGateTest` including the stuck case — the surrounding coroutine needs a device to exercise, which is why the original bug went unnoticed.

Not reproducible on the bench (it needs a wedged network read mid-drive); the logic is pinned by tests instead.