### PR TITLE
Fix terrain shading showing at startup after it was turned off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,6 +562,16 @@ Defaults that make the safe path the easy one:
   list to be open, and onPoiTap / onMapLongPress / onAddressLabelTap / onTransitStopTap
   early-return while navigating (their invisible selection popped up as a ghost sheet when
   the drive ended).
+- **The nav-declutter blanket restore must never touch a layer that has a SECOND owner (issue
+  #261, 2026-08-15).** The car-mode strip hides a list of layers during drive nav and restores
+  them all to VISIBLE otherwise - fine for layers whose only owner is that effect, WRONG for the
+  hillshade, whose visibility also belongs to the Settings > Map "Topography" toggle (the DEM
+  layer is always present; the toggle only flips visibility). The effect runs at startup with
+  navMode false, so the blanket restore turned terrain relief on for every launch regardless of
+  the pref, and flipping the toggle then hid it - which made the bug read as session-specific.
+  The hillshade is restored via `ensureTopography(style, topographyOn && !driveNav)` and the
+  effect keys on `topographyOn`. Before adding a layer to that list, check nothing else owns its
+  visibility.
 - **Nav declutter is MODE-AWARE (2026-07-16):** the aggressive strip (basemap shields, bike/trails,
   hillshade, transit lines, vela-addr numbers, gas-stations-only POIs, addr-refresh pause) keys on
   navMode && navDriveMode (DRIVE routes only) - walking/biking keeps all of it (a bike route needs

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -778,7 +778,7 @@ fun VelaMapView(
     // while navigating (keeping even the top rank still left labels flickering at the threshold)
     // for a clean nav map, and restore on exit. Keyed on styleRef so it re-applies after a style
     // (re)load (dark/light flip), which recreates the layers at default visibility.
-    LaunchedEffect(navMode, navDriveMode, styleRef) {
+    LaunchedEffect(navMode, navDriveMode, styleRef, topographyOn) {
         val style = styleRef ?: return@LaunchedEffect
         val vis = if (navMode) Property.NONE else Property.VISIBLE
         runCatching {
@@ -817,12 +817,23 @@ fun VelaMapView(
         // hard. Every one is a plain-visibility layer with no competing owner, so a blanket
         // restore on nav end is safe (ensureTransit adds/removes its layer by the toggle - a
         // missing layer just no-ops here).
+        //
+        // THE HILLSHADE IS NOT IN THAT LIST, and must not be (issue #261). It is the one layer
+        // here whose visibility has a SECOND owner - the Settings > Map "Topography" toggle,
+        // which ensureTopography applies to a layer that is always present. This effect runs at
+        // startup with navMode false, so a blanket restore turned terrain relief ON for everyone
+        // regardless of the pref; flipping the toggle then hid it "correctly" and the bug looked
+        // session-specific. Restore it to the TOGGLE instead, and key the effect on it so a flip
+        // mid-drive is not lost.
         val dvis = if (navMode && navDriveMode) Property.NONE else Property.VISIBLE
+        runCatching {
+            ensureTopography(style, topographyOn && !(navMode && navDriveMode))
+        }
         runCatching {
             (
                 listOf(
                     "highway-shield-non-us", "highway-shield-us-interstate", "road_shield_us",
-                    "vela-bikeroutes", "vela-trails", HILLSHADE_LAYER, TRANSIT_LAYER,
+                    "vela-bikeroutes", "vela-trails", TRANSIT_LAYER,
                     // Neighbourhood/hamlet titles (2026-07-16): the read-by-nobody label tier.
                     // WATER names deliberately STAY (user 2026-07-16: liked them, and rivers are
                     // real landmarks - Google keeps major water names in nav too; a viewport has


### PR DESCRIPTION
Fixes #261

The nav declutter effect hides a list of layers during drive navigation and restores them all to `VISIBLE` otherwise. The hillshade was in that list — but it is the one layer there whose visibility has a **second owner**, the Settings → Map "Topography" toggle (the DEM layer is always present; the toggle only flips visibility).

That effect runs at startup with `navMode` false, so the blanket restore turned terrain relief on for every launch regardless of the pref. Flipping the toggle afterwards called `ensureTopography` and hid it correctly, which is exactly why the reporter saw it as session-specific.

The hillshade now restores through `ensureTopography(style, topographyOn && !driveNav)`, and the effect keys on `topographyOn` so a flip mid-drive isn't lost. Drive-nav still declutters it.

Matches the reported repro: fresh launch with the toggle off now starts flat.