### PR TITLE
Draw the roundabout icon from the real turn instead of one fixed picture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -585,6 +585,23 @@ Defaults that make the safe path the easy one:
   maneuvers[liveStep-1].ref; the exit fold adopts the folded branch's road/ref so it survives
   on-ramps). Rerouting plays a two-note earcon (VoiceGuide.reroutingChime, in-process synth,
   muted-gated) before the throttled spoken word.
+  **The ROUNDABOUT glyph is DRAWN, not picked (issue #259, 2026-08-15).** It used to be Material's
+  `RoundaboutLeft` for every roundabout on earth: a counter-clockwise circulation exiting at 270
+  degrees, so it was wrong about the exit for nearly every roundabout and wrong about the direction
+  of travel for every left-hand-traffic driver - and the glyph is what you take in at a glance while
+  the text is what you read only if you have time. `ui/nav/RoundaboutGlyph.kt` builds an ImageVector
+  per maneuver from `Maneuver.roundabout` (`RoundaboutGeometry`): the arc you TRAVEL is drawn heavier
+  than the arc you do not, going round the correct way, and the exit stub leaves at the measured
+  angle. **Both facts are derived from OSRM, never assumed:** OSRM splits a roundabout into an enter
+  and an exit step, so `RouteGeometry.roundaboutGeoms` pairs them - the exit angle is the exit road's
+  bearing relative to the road you approached on, and the DRIVING SIDE is the sign of the entry
+  turn, because you always veer toward the circulating lane (live-captured: Paris entries turn +84,
+  Milton Keynes entries turn -24 to -52; pinned in `RoundaboutGeometryTest` with those real numbers).
+  With no geometry (Google fallback, offline GraphHopper/obf, or an entry too straight for its sign
+  to mean anything) it draws its NEUTRAL form - ring plus entry stub, NO exit arrow - because an
+  arrow pointing somewhere we did not measure is the whole bug. `maneuverIcon(type)` can only produce
+  the neutral form; call `maneuverIconFor(maneuver)` wherever the Maneuver is in hand. NB the
+  notification glyph (`service/NavGlyphs`) still draws its own fixed straight-out roundabout.
   **Nav UI style (2026-07-08):** ManeuverBanner + NavControls are RoundedCornerShape(24/28dp)
   Cards with elevation 6dp, 54dp turn glyph, headlineMedium-bold distance, titleMedium-medium road
   name, FilledTonalIconButton for mute/steps. Keep new nav chrome on this treatment (no flat

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1278,11 +1278,13 @@ fun MapScreen(
                     state.nav.distanceToNextManeuver
                 },
                 type = shown?.type ?: ManeuverType.STRAIGHT,
+                roundabout = shown?.roundabout,
                 ref = shown?.ref,
                 laneHint = shown?.laneHint,
                 lanes = shown?.lanes.orEmpty(),
                 nextText = next?.instruction?.let { navRomanize(it) },
                 nextType = next?.type,
+                nextRoundabout = next?.roundabout,
                 nextRef = next?.ref,
                 // The road being driven = the one entered by the LIVE maneuver last passed
                 // (never the previewed one - previewing shouldn't change where you "are").

--- a/app/src/main/java/app/vela/ui/nav/NavOverlays.kt
+++ b/app/src/main/java/app/vela/ui/nav/NavOverlays.kt
@@ -97,11 +97,15 @@ fun ManeuverBanner(
     text: String,
     distanceMeters: Double,
     type: ManeuverType = ManeuverType.STRAIGHT,
+    // Roundabout shape for [type], when the router measured one - lets the glyph be drawn at the
+    // real exit angle and circulation instead of a fixed picture (issue #259). Null draws neutral.
+    roundabout: app.vela.core.model.RoundaboutGeometry? = null,
     ref: String? = null,
     laneHint: String? = null,
     lanes: List<Lane> = emptyList(),
     nextText: String? = null,
     nextType: ManeuverType? = null,
+    nextRoundabout: app.vela.core.model.RoundaboutGeometry? = null,
     nextRef: String? = null,
     currentRef: String? = null, // highway ref of the road being driven -> persistent shield chip
     nextDistanceMeters: Double? = null,
@@ -218,7 +222,7 @@ fun ManeuverBanner(
                             .graphicsLayer { rotationZ = angle },
                     )
                 } else Icon(
-                    maneuverIcon(type),
+                    if (isRoundabout(type)) rememberRoundaboutGlyph(roundabout) else maneuverIcon(type),
                     contentDescription = null,
                     modifier = Modifier.size(if (compact) 36.dp else 54.dp),
                 )
@@ -327,7 +331,11 @@ fun ManeuverBanner(
                         color = content.copy(alpha = 0.7f),
                     )
                     Spacer(Modifier.width(8.dp))
-                    Icon(maneuverIcon(nextType), contentDescription = null, modifier = Modifier.size(20.dp))
+                    Icon(
+                        if (isRoundabout(nextType)) rememberRoundaboutGlyph(nextRoundabout) else maneuverIcon(nextType),
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                    )
                     Spacer(Modifier.width(6.dp))
                     nextSigns.firstOrNull()?.let { SignChip(it); Spacer(Modifier.width(6.dp)) }
                     // Short form: the chip beside it names the route, and the full sign used to

--- a/app/src/main/java/app/vela/ui/nav/RoundaboutGlyph.kt
+++ b/app/src/main/java/app/vela/ui/nav/RoundaboutGlyph.kt
@@ -93,6 +93,19 @@ internal fun roundaboutGlyph(geom: RoundaboutGeometry?): ImageVector {
     val sweep = if (geom.clockwise) mod360(exitDeg - 180.0) else mod360(180.0 - exitDeg)
     val (exitX, exitY) = ring(exitDeg)
 
+    // A ±180 exit - going round and back the way you came - makes one arc the WHOLE ring and the
+    // other nothing, and an arcTo whose start and end coincide is dropped entirely by the path
+    // spec: the ring vanished and the glyph was an entry stub with an arrow floating off it. Draw
+    // the closed ring instead. (Genuinely rare, genuinely reachable: a roundabout U-turn.)
+    if (sweep <= 1.0 || 360.0 - sweep <= 1.0) {
+        b.path(
+            stroke = ink, strokeLineWidth = TRAVELLED_W,
+            strokeLineCap = StrokeCap.Round, strokeLineJoin = StrokeJoin.Round,
+        ) { circleAt(R) }
+        exitStub(b, ink, exitDeg)
+        return b.build()
+    }
+
     // The travelled arc. isPositiveArc is the SVG sweep flag: true draws clockwise on screen, which
     // is left-hand-traffic circulation.
     if (sweep > 1.0) {
@@ -113,9 +126,15 @@ internal fun roundaboutGlyph(geom: RoundaboutGeometry?): ImageVector {
         }
     }
 
-    // The exit road, leaving radially at the measured angle, with a solid head so the direction out
-    // is unmistakable. Drawn as a triangle rather than two strokes: a stroked chevron at this size
-    // renders as a smudge on a low-density screen.
+    exitStub(b, ink, exitDeg)
+    return b.build()
+}
+
+/** The exit road leaving radially at [exitDeg], with a solid head so the direction out is
+ *  unmistakable. A triangle rather than two strokes: a stroked chevron at this size renders as a
+ *  smudge on a low-density screen. */
+private fun exitStub(b: ImageVector.Builder, ink: SolidColor, exitDeg: Double) {
+    val (exitX, exitY) = ring(exitDeg)
     val (outX, outY) = ring(exitDeg, R + STUB * 0.55f)
     b.path(
         stroke = ink, strokeLineWidth = TRAVELLED_W,
@@ -125,18 +144,16 @@ internal fun roundaboutGlyph(geom: RoundaboutGeometry?): ImageVector {
         lineTo(outX, outY)
     }
     val tip = ring(exitDeg, R + STUB + 1.4f)
-    val baseR = R + STUB * 0.55f
+    val base = ring(exitDeg, R + STUB * 0.55f)
     val perp = Math.toRadians(exitDeg + 90.0)
     val hx = (2.0 * sin(perp)).toFloat()
     val hy = (-2.0 * cos(perp)).toFloat()
-    val base = ring(exitDeg, baseR)
     b.path(fill = ink) {
         moveTo(tip.first, tip.second)
         lineTo(base.first + hx, base.second + hy)
         lineTo(base.first - hx, base.second - hy)
         close()
     }
-    return b.build()
 }
 
 /** A full circle of [radius] about the glyph centre, as four arc quadrants (a path has no circle

--- a/app/src/main/java/app/vela/ui/nav/RoundaboutGlyph.kt
+++ b/app/src/main/java/app/vela/ui/nav/RoundaboutGlyph.kt
@@ -1,0 +1,161 @@
+package app.vela.ui.nav
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.vela.core.model.RoundaboutGeometry
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * A roundabout turn glyph DRAWN from the maneuver's own geometry (issue #259).
+ *
+ * The old glyph was Material's `RoundaboutLeft`, one fixed picture used for every roundabout: a
+ * counter-clockwise circulation exiting at 270 degrees. That is wrong about the direction of travel
+ * for every left-hand-traffic driver, and wrong about the exit for nearly every roundabout anywhere
+ * - which matters because the glyph is what you take in at a glance while the text is what you read
+ * only if you have time. The reporter's read was that a wrong icon is worse than none.
+ *
+ * So it is built per maneuver instead:
+ *  - the ring is drawn as the arc you actually TRAVEL (heavier) plus the part you do not (lighter),
+ *    going round the correct way, so circulation direction is visible rather than implied;
+ *  - the exit stub leaves at the real angle, measured off the road you approached on;
+ *  - with no geometry (a fallback router that gives no bearings) it draws its NEUTRAL form - ring
+ *    plus entry stub, no exit arrow - because an arrow pointing somewhere we did not measure is
+ *    exactly the thing being fixed here.
+ *
+ * Angles are compass-style on the glyph: 0 is straight up (the way you entered), positive turns
+ * clockwise on screen, matching [RoundaboutGeometry.exitAngleDeg].
+ */
+
+private const val VP = 24f // viewport, matching the Material icon set so it drops into the same slots
+private const val CX = 12f
+private const val CY = 12f
+private const val R = 6.0f // ring radius
+private const val STUB = 4.2f // how far the entry/exit roads stick out past the ring
+private const val TRAVELLED_W = 2.1f
+private const val UNTRAVELLED_W = 1.1f
+
+/** Ring point at compass angle [deg] (0 = up, positive clockwise on screen). */
+private fun ring(deg: Double, radius: Float = R): Pair<Float, Float> {
+    val r = Math.toRadians(deg)
+    return (CX + radius * sin(r)).toFloat() to (CY - radius * cos(r)).toFloat()
+}
+
+/**
+ * The roundabout glyph for [geom], or the neutral ring when it is null.
+ *
+ * Cached per distinct geometry: the banner recomposes on every frame of the distance countdown and
+ * building an ImageVector allocates a whole node tree, so an uncached build would run 60x a second
+ * for the entire approach to the roundabout.
+ */
+@Composable
+fun rememberRoundaboutGlyph(geom: RoundaboutGeometry?): ImageVector =
+    remember(geom?.exitAngleDeg, geom?.clockwise) { roundaboutGlyph(geom) }
+
+internal fun roundaboutGlyph(geom: RoundaboutGeometry?): ImageVector {
+    val b = ImageVector.Builder(
+        name = "vela_roundabout",
+        defaultWidth = 24.dp, defaultHeight = 24.dp,
+        viewportWidth = VP, viewportHeight = VP,
+    )
+    val ink = SolidColor(Color.Black) // Icon()'s tint colours the whole vector; this is just a placeholder
+
+    // You always enter from the bottom of the glyph heading up, whatever the real compass heading -
+    // the whole picture is drawn relative to your approach, which is how a driver reads it.
+    val (entryX, entryY) = ring(180.0)
+    b.path(
+        stroke = ink, strokeLineWidth = TRAVELLED_W,
+        strokeLineCap = StrokeCap.Round, strokeLineJoin = StrokeJoin.Round,
+    ) {
+        moveTo(CX, CY + R + STUB)
+        lineTo(entryX, entryY)
+    }
+
+    if (geom == null) {
+        // Neutral: a plain ring. It says "roundabout" without claiming an exit we never measured.
+        b.path(stroke = ink, strokeLineWidth = UNTRAVELLED_W) { circleAt(R) }
+        return b.build()
+    }
+
+    // Sweep from the entry point round to where the exit road meets the ring. Right-hand traffic
+    // circulates counter-clockwise on screen, so the ring angle DECREASES from 180 toward the exit;
+    // left-hand traffic increases it. (Sanity check, right-hand: exit angle +90 - a first exit,
+    // a right turn out - gives a quarter of the ring. Exit angle -90 - a third exit - gives three
+    // quarters, the long way round, which is exactly what you drive.)
+    val exitDeg = geom.exitAngleDeg
+    val sweep = if (geom.clockwise) mod360(exitDeg - 180.0) else mod360(180.0 - exitDeg)
+    val (exitX, exitY) = ring(exitDeg)
+
+    // The travelled arc. isPositiveArc is the SVG sweep flag: true draws clockwise on screen, which
+    // is left-hand-traffic circulation.
+    if (sweep > 1.0) {
+        b.path(
+            stroke = ink, strokeLineWidth = TRAVELLED_W,
+            strokeLineCap = StrokeCap.Round, strokeLineJoin = StrokeJoin.Round,
+        ) {
+            moveTo(entryX, entryY)
+            arcTo(R, R, 0f, sweep > 180.0, geom.clockwise, exitX, exitY)
+        }
+    }
+    // ...and the rest of the ring, thinner, so the roundabout still reads as a full circle.
+    val rest = 360.0 - sweep
+    if (rest > 1.0) {
+        b.path(stroke = ink, strokeLineWidth = UNTRAVELLED_W) {
+            moveTo(exitX, exitY)
+            arcTo(R, R, 0f, rest > 180.0, geom.clockwise, entryX, entryY)
+        }
+    }
+
+    // The exit road, leaving radially at the measured angle, with a solid head so the direction out
+    // is unmistakable. Drawn as a triangle rather than two strokes: a stroked chevron at this size
+    // renders as a smudge on a low-density screen.
+    val (outX, outY) = ring(exitDeg, R + STUB * 0.55f)
+    b.path(
+        stroke = ink, strokeLineWidth = TRAVELLED_W,
+        strokeLineCap = StrokeCap.Round, strokeLineJoin = StrokeJoin.Round,
+    ) {
+        moveTo(exitX, exitY)
+        lineTo(outX, outY)
+    }
+    val tip = ring(exitDeg, R + STUB + 1.4f)
+    val baseR = R + STUB * 0.55f
+    val perp = Math.toRadians(exitDeg + 90.0)
+    val hx = (2.0 * sin(perp)).toFloat()
+    val hy = (-2.0 * cos(perp)).toFloat()
+    val base = ring(exitDeg, baseR)
+    b.path(fill = ink) {
+        moveTo(tip.first, tip.second)
+        lineTo(base.first + hx, base.second + hy)
+        lineTo(base.first - hx, base.second - hy)
+        close()
+    }
+    return b.build()
+}
+
+/** A full circle of [radius] about the glyph centre, as four arc quadrants (a path has no circle
+ *  primitive, and one 360-degree arcTo is degenerate - start and end coincide). */
+private fun androidx.compose.ui.graphics.vector.PathBuilder.circleAt(radius: Float) {
+    moveTo(CX, CY - radius)
+    arcTo(radius, radius, 0f, false, true, CX + radius, CY)
+    arcTo(radius, radius, 0f, false, true, CX, CY + radius)
+    arcTo(radius, radius, 0f, false, true, CX - radius, CY)
+    arcTo(radius, radius, 0f, false, true, CX, CY - radius)
+}
+
+/** [deg] wrapped into [0, 360). */
+private fun mod360(deg: Double): Double {
+    val d = deg % 360.0
+    return if (d < 0) d + 360.0 else d
+}
+
+/** True when [type] should render the drawn roundabout glyph rather than a Material icon. */
+internal fun isRoundabout(type: app.vela.core.model.ManeuverType): Boolean =
+    type == app.vela.core.model.ManeuverType.ROUNDABOUT ||
+        type == app.vela.core.model.ManeuverType.EXIT_ROUNDABOUT

--- a/app/src/main/java/app/vela/ui/nav/StepsSheet.kt
+++ b/app/src/main/java/app/vela/ui/nav/StepsSheet.kt
@@ -31,7 +31,6 @@ import androidx.compose.material.icons.filled.ForkRight
 import androidx.compose.material.icons.filled.Merge
 import androidx.compose.material.icons.filled.RampLeft
 import androidx.compose.material.icons.filled.RampRight
-import androidx.compose.material.icons.filled.RoundaboutLeft
 import androidx.compose.material.icons.filled.Straight
 import androidx.compose.material.icons.filled.TripOrigin
 import androidx.compose.material.icons.filled.TurnLeft
@@ -231,7 +230,7 @@ fun StepsSheet(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Icon(
-                            maneuverIcon(m.type),
+                            maneuverIconFor(m),
                             contentDescription = null,
                             tint = if (active) MaterialTheme.colorScheme.primary else ink,
                             // size + gap must be SEPARATE modifiers: `.size(24).padding(end=16)`
@@ -303,7 +302,14 @@ fun StepsSheet(
     }
 }
 
-/** A turn-arrow glyph for each maneuver type (Material "turn_*" symbols). */
+/**
+ * A turn-arrow glyph for each maneuver type (Material "turn_*" symbols).
+ *
+ * Roundabouts are the exception: they are DRAWN from the maneuver's own geometry, because no fixed
+ * picture can be right about both the exit and the direction of travel (issue #259). This
+ * type-only entry point can only produce the neutral form - callers holding the whole [Maneuver]
+ * should use [maneuverIconFor] so the real exit angle is shown.
+ */
 fun maneuverIcon(type: ManeuverType): ImageVector = when (type) {
     ManeuverType.DEPART -> Icons.Filled.TripOrigin
     ManeuverType.ARRIVE -> Icons.Filled.Flag
@@ -319,7 +325,17 @@ fun maneuverIcon(type: ManeuverType): ImageVector = when (type) {
     ManeuverType.FORK_RIGHT -> Icons.Filled.ForkRight
     ManeuverType.RAMP_LEFT -> Icons.Filled.RampLeft
     ManeuverType.RAMP_RIGHT -> Icons.Filled.RampRight
-    ManeuverType.ROUNDABOUT, ManeuverType.EXIT_ROUNDABOUT -> Icons.Filled.RoundaboutLeft
+    ManeuverType.ROUNDABOUT, ManeuverType.EXIT_ROUNDABOUT -> NEUTRAL_ROUNDABOUT
     ManeuverType.CONTINUE, ManeuverType.STRAIGHT -> Icons.Filled.Straight
     ManeuverType.UNKNOWN -> Icons.AutoMirrored.Filled.ArrowForward
 }
+
+/** The neutral roundabout glyph (ring + entry, no exit claimed), built once - it is the fallback
+ *  for every call site that has only a [ManeuverType] and no measured geometry. */
+private val NEUTRAL_ROUNDABOUT: ImageVector by lazy { roundaboutGlyph(null) }
+
+/** The glyph for [m], drawing a roundabout at its real exit angle and circulation where the router
+ *  gave us the bearings to derive them (issue #259). Prefer this wherever the Maneuver is in hand. */
+@androidx.compose.runtime.Composable
+fun maneuverIconFor(m: app.vela.core.model.Maneuver): ImageVector =
+    if (isRoundabout(m.type)) rememberRoundaboutGlyph(m.roundabout) else maneuverIcon(m.type)

--- a/core/src/main/java/app/vela/core/data/RouteGeometry.kt
+++ b/core/src/main/java/app/vela/core/data/RouteGeometry.kt
@@ -7,6 +7,7 @@ import app.vela.core.model.LatLng
 import app.vela.core.model.Maneuver
 import app.vela.core.model.ManeuverType
 import app.vela.core.model.Route
+import app.vela.core.model.RoundaboutGeometry
 import app.vela.core.model.RouteLeg
 import app.vela.core.model.TravelMode
 import app.vela.core.model.distanceTo
@@ -237,7 +238,13 @@ object RouteGeometry {
         val dist = r["distance"]?.jsonPrimitive?.doubleOrNull ?: return null
         val dur = r["duration"]?.jsonPrimitive?.doubleOrNull ?: 0.0
         val raw = (r["legs"]?.jsonArray ?: return null).flatMap { leg ->
-            leg.jsonObject["steps"]?.jsonArray?.mapNotNull { osrmStep(it.jsonObject) } ?: emptyList()
+            val steps: List<JsonObject> =
+                leg.jsonObject["steps"]?.jsonArray?.map { it.jsonObject } ?: emptyList()
+            // Roundabout geometry needs BOTH steps of the pair (OSRM splits a roundabout into an
+            // enter step and an exit step), so it is filled in a pass over the raw step objects
+            // rather than inside osrmStep, which only ever sees one.
+            val geoms = roundaboutGeometries(steps)
+            steps.mapIndexedNotNull { i, s -> osrmStep(s)?.let { m -> geoms[i]?.let { m.copy(roundabout = it) } ?: m } }
         }
         // A multi-waypoint (via) route splits into legs, inserting a spurious "arrive"+"depart" at
         // each via. Drop those so it reads as one continuous trip — keep only the first DEPART and
@@ -425,6 +432,72 @@ object RouteGeometry {
         }
         return route.copy(legs = legs)
     }
+
+    /** The bearings a roundabout pass needs off one OSRM step. Kept separate from the JSON so the
+     *  pairing logic below is a pure function the unit tests can drive with real captured numbers. */
+    internal data class RbStep(val type: String, val bearingBefore: Double?, val bearingAfter: Double?)
+
+    private val RB_ENTER = setOf("roundabout", "rotary")
+    private val RB_EXIT = setOf("exit roundabout", "exit rotary")
+
+    /** Below this the entry turn is too small for its SIGN to mean anything (a roundabout you enter
+     *  dead straight), so the driving side is genuinely unknown and we say so rather than guess -
+     *  the glyph then draws its neutral form instead of claiming a direction of travel. */
+    private const val RB_ENTRY_TURN_MIN_DEG = 5.0
+
+    /** Signed angle in (-180, 180]: how far you turn going from bearing [from] to bearing [to],
+     *  positive to the right. */
+    internal fun bearingDelta(from: Double, to: Double): Double {
+        var d = (to - from) % 360.0
+        if (d > 180.0) d -= 360.0
+        if (d <= -180.0) d += 360.0
+        return d
+    }
+
+    /**
+     * Fill in [RoundaboutGeometry] for the roundabout steps of one leg, indexed alongside [steps].
+     *
+     * OSRM splits a roundabout into an ENTER step and an EXIT step, and neither one alone describes
+     * the maneuver: the enter step knows the road you came in on, the exit step knows the road you
+     * leave on. Pair them and both facts fall out - the exit's direction relative to your approach,
+     * and (from the sign of the entry turn, which always points into the circulating lane) which way
+     * traffic goes round. BOTH steps get the same geometry, since both can be shown as a card.
+     */
+    internal fun roundaboutGeoms(steps: List<RbStep>): List<RoundaboutGeometry?> {
+        val out = arrayOfNulls<RoundaboutGeometry>(steps.size)
+        for (i in steps.indices) {
+            if (steps[i].type !in RB_ENTER) continue
+            val entryBefore = steps[i].bearingBefore ?: continue
+            val entryAfter = steps[i].bearingAfter ?: continue
+            // The matching exit step: the next one, but stop at another enter - two roundabouts in a
+            // row (common on a distributor road) must not borrow each other's exit.
+            var j = i + 1
+            while (j < steps.size && steps[j].type !in RB_EXIT && steps[j].type !in RB_ENTER) j++
+            if (j >= steps.size || steps[j].type !in RB_EXIT) continue
+            val exitAfter = steps[j].bearingAfter ?: continue
+            val entryTurn = bearingDelta(entryBefore, entryAfter)
+            if (kotlin.math.abs(entryTurn) < RB_ENTRY_TURN_MIN_DEG) continue
+            val g = RoundaboutGeometry(
+                exitAngleDeg = bearingDelta(entryBefore, exitAfter),
+                clockwise = entryTurn < 0,
+            )
+            out[i] = g
+            out[j] = g
+        }
+        return out.toList()
+    }
+
+    private fun roundaboutGeometries(steps: List<JsonObject>): List<RoundaboutGeometry?> =
+        roundaboutGeoms(
+            steps.map { s ->
+                val m = s["maneuver"]?.jsonObject
+                RbStep(
+                    type = m?.get("type")?.jsonPrimitive?.contentOrNull.orEmpty(),
+                    bearingBefore = m?.get("bearing_before")?.jsonPrimitive?.doubleOrNull,
+                    bearingAfter = m?.get("bearing_after")?.jsonPrimitive?.doubleOrNull,
+                )
+            },
+        )
 
     private fun osrmStep(s: JsonObject): Maneuver? {
         val man = s["maneuver"]?.jsonObject ?: return null

--- a/core/src/main/java/app/vela/core/model/Route.kt
+++ b/core/src/main/java/app/vela/core/model/Route.kt
@@ -24,7 +24,26 @@ data class Maneuver(
     val side: String? = null,     // ARRIVE only: "left"/"right" — which side the destination is on
                                   // (OSRM's arrive modifier); null = unknown/straight ahead
     val lanes: List<Lane> = emptyList(), // per-lane turn guidance (from OSRM) for the Google-style diagram
+    val roundabout: RoundaboutGeometry? = null, // ROUNDABOUT/EXIT_ROUNDABOUT only: how to draw the glyph
 )
+
+/**
+ * The shape of a roundabout maneuver, so its glyph can be DRAWN rather than picked from a fixed
+ * pair of icons (issue #259: the old glyph was Material's `RoundaboutLeft` for every roundabout on
+ * earth - permanently a 270-degree counter-clockwise exit, so it was wrong about the exit for
+ * nearly every roundabout and wrong about the direction of travel for every left-hand-traffic
+ * driver; a glance at it actively misinformed).
+ *
+ * [exitAngleDeg] is where the exit road leaves RELATIVE to the road you approached on: 0 = straight
+ * on through, +90 = a right turn out, -90 = a left turn out, +/-180 = back the way you came.
+ * Normalized to (-180, 180].
+ *
+ * [clockwise] is which way traffic circulates - true in left-hand-traffic countries, false in
+ * right-hand ones. It is DERIVED, never assumed: joining a roundabout you always veer toward the
+ * circulating lane, so the sign of the entry step's own turn is the driving side (verified against
+ * live OSRM: an entry in Paris turns +84 degrees, entries in Milton Keynes turn -24 to -52).
+ */
+data class RoundaboutGeometry(val exitAngleDeg: Double, val clockwise: Boolean)
 
 /** One approach lane's turn guidance: the arrow directions it permits ([indications], OSRM's set —
  *  "straight", "left", "slight right", "sharp left", "uturn", "none", …) and whether it's a valid lane

--- a/core/src/test/java/app/vela/core/data/RoundaboutGeometryTest.kt
+++ b/core/src/test/java/app/vela/core/data/RoundaboutGeometryTest.kt
@@ -1,0 +1,88 @@
+package app.vela.core.data
+
+import app.vela.core.data.RouteGeometry.RbStep
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Roundabout glyph geometry (issue #259). The bearings below are REAL, captured from the FOSSGIS
+ * OSRM server for public landmarks in each traffic convention, so this pins the derivation against
+ * data rather than against my reading of the docs.
+ */
+class RoundaboutGeometryTest {
+
+    private fun enter(before: Double, after: Double) = RbStep("rotary", before, after)
+    private fun exit(before: Double, after: Double) = RbStep("exit rotary", before, after)
+
+    // Place Charles de Gaulle, Paris - right-hand traffic. Captured: enter 56 -> 140,
+    // exit ... -> 115.
+    @Test fun `right-hand traffic reads as counter-clockwise`() {
+        val g = RouteGeometry.roundaboutGeoms(listOf(enter(56.0, 140.0), exit(29.0, 115.0)))
+        assertFalse("entry veers right, so traffic circulates counter-clockwise", g[0]!!.clockwise)
+        assertEquals(59.0, g[0]!!.exitAngleDeg, 0.001) // exit road bears 59 deg right of the approach
+    }
+
+    // Milton Keynes, UK - left-hand traffic. Captured entries: 123 -> 99, 43 -> 351, 53 -> 22.
+    @Test fun `left-hand traffic reads as clockwise`() {
+        assertTrue(RouteGeometry.roundaboutGeoms(listOf(enter(123.0, 99.0), exit(99.0, 73.0)))[0]!!.clockwise)
+        assertTrue(RouteGeometry.roundaboutGeoms(listOf(enter(43.0, 351.0), exit(109.0, 68.0)))[0]!!.clockwise)
+        assertTrue(RouteGeometry.roundaboutGeoms(listOf(enter(53.0, 22.0), exit(22.0, 340.0)))[0]!!.clockwise)
+    }
+
+    @Test fun `exit angle is measured off the approach road and wraps correctly`() {
+        // 43 -> exit road 68: a 25 deg bear right, even though you went round clockwise to get there.
+        assertEquals(25.0, RouteGeometry.roundaboutGeoms(listOf(enter(43.0, 351.0), exit(109.0, 68.0)))[0]!!.exitAngleDeg, 0.001)
+        // 53 -> 340: crosses north, so it must come out as -73, not +287.
+        assertEquals(-73.0, RouteGeometry.roundaboutGeoms(listOf(enter(53.0, 22.0), exit(22.0, 340.0)))[0]!!.exitAngleDeg, 0.001)
+    }
+
+    @Test fun `both steps of the pair carry the same geometry`() {
+        val g = RouteGeometry.roundaboutGeoms(listOf(enter(56.0, 140.0), exit(29.0, 115.0)))
+        assertEquals(g[0], g[1])
+    }
+
+    @Test fun `steps around the roundabout are untouched`() {
+        val g = RouteGeometry.roundaboutGeoms(
+            listOf(RbStep("depart", 0.0, 90.0), enter(56.0, 140.0), exit(29.0, 115.0), RbStep("arrive", 115.0, null)),
+        )
+        assertNull(g[0])
+        assertNull(g[3])
+        assertEquals(false, g[1]!!.clockwise)
+    }
+
+    // Two roundabouts in a row on a distributor road: the first must NOT borrow the second's exit
+    // step, or its glyph draws an exit belonging to a different junction.
+    @Test fun `back to back roundabouts do not borrow each others exit`() {
+        val g = RouteGeometry.roundaboutGeoms(
+            listOf(enter(123.0, 99.0), exit(99.0, 73.0), enter(37.0, 8.0), exit(102.0, 73.0)),
+        )
+        assertEquals(-50.0, g[0]!!.exitAngleDeg, 0.001) // 123 -> 73
+        assertEquals(36.0, g[2]!!.exitAngleDeg, 0.001) // 37 -> 73
+    }
+
+    @Test fun `an enter step with no exit step yields nothing`() {
+        assertNull(RouteGeometry.roundaboutGeoms(listOf(enter(56.0, 140.0)))[0])
+        assertNull(RouteGeometry.roundaboutGeoms(listOf(enter(56.0, 140.0), enter(20.0, 40.0)))[0])
+    }
+
+    // A roundabout entered dead straight gives an entry turn whose SIGN is noise, so the driving
+    // side is genuinely unknown - the glyph must fall back to its neutral form rather than guess.
+    @Test fun `a dead straight entry does not guess a driving side`() {
+        assertNull(RouteGeometry.roundaboutGeoms(listOf(enter(90.0, 92.0), exit(92.0, 120.0)))[0])
+    }
+
+    @Test fun `missing bearings yield nothing`() {
+        assertNull(RouteGeometry.roundaboutGeoms(listOf(RbStep("rotary", null, 140.0), exit(29.0, 115.0)))[0])
+        assertNull(RouteGeometry.roundaboutGeoms(listOf(enter(56.0, 140.0), RbStep("exit rotary", 29.0, null)))[0])
+    }
+
+    @Test fun `bearing delta is signed and wraps`() {
+        assertEquals(10.0, RouteGeometry.bearingDelta(355.0, 5.0), 0.001)
+        assertEquals(-10.0, RouteGeometry.bearingDelta(5.0, 355.0), 0.001)
+        assertEquals(180.0, RouteGeometry.bearingDelta(0.0, 180.0), 0.001)
+        assertEquals(0.0, RouteGeometry.bearingDelta(90.0, 90.0), 0.001)
+    }
+}


### PR DESCRIPTION
Fixes #259

The reporter is right on both counts, and right that a misleading glyph is worse than none: it was Material's `RoundaboutLeft` for every roundabout on earth — permanently anti-clockwise, permanently a 270° exit.

Rather than drop it, it's now **drawn per maneuver**, with both facts derived rather than assumed:

- **Exit angle** = the exit road's bearing measured against the road you approached on. OSRM splits a roundabout into an enter step and an exit step, so neither alone describes the turn; `RouteGeometry.roundaboutGeoms` pairs them.
- **Direction of travel** = the sign of the entry turn, because you always veer *toward* the circulating lane. Verified against live FOSSGIS OSRM: Paris entries turn **+84°**, Milton Keynes entries turn **−24° to −52°**. Those exact numbers are the test fixtures.

The arc you actually drive is drawn heavier than the arc you don't, so circulation is visible rather than implied. Rendered check of the path math:

| right-hand, exit 1 | right-hand, exit 3 | left-hand, exit 2 |
|---|---|---|
| short arc round the **right** | long way round, exit pointing left | travels up the **left** side |

**When we can't measure it, it says so:** a route from the Google fallback or the offline engine (no bearings), or an entry too straight for its sign to mean anything, draws the neutral form — ring plus entry stub, no exit arrow. An arrow pointing at a guess is the bug.

`maneuverIcon(type)` can now only produce the neutral form; `maneuverIconFor(maneuver)` is the one to call where the maneuver is in hand (banner, "then" row, step list all wired).

13 unit tests, including back-to-back roundabouts not borrowing each other's exit step. Still worth a look on a real drive — the geometry is verified, the on-device look isn't.

Known remaining site: the notification glyph (`service/NavGlyphs`) still draws its own fixed straight-out roundabout.