### PR TITLE
Tidy the directions card and put Home and Work side by side

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -589,6 +589,16 @@ Defaults that make the safe path the easy one:
   Cards with elevation 6dp, 54dp turn glyph, headlineMedium-bold distance, titleMedium-medium road
   name, FilledTonalIconButton for mute/steps. Keep new nav chrome on this treatment (no flat
   default-radius cards, no OutlinedIconButton circles - that was the "dated" look).
+- **Home/Work are SIDE BY SIDE and the endpoint rows have NO pencil (issue #255, 2026-08-15).**
+  `ShortcutPair`/`ShortcutCell` in MapScreen replace the two stacked `ShortcutRow`s on the search
+  page: two full-width rows for two words spent a third of the first screen, and an unset one now
+  reads just "Add" under its label (the label above already says which it is). Halving the height
+  must not cost an action - each cell keeps the same tap-to-open / tap-to-assign / ⋮ Change-Remove.
+  `ShortcutRow` is kept (unused) for stacked layouts. On `RouteTopCard` the per-row pencils are
+  gone: the whole row is the control and the glyph rail already says what each line is, so three
+  stacked pencils on one small card said nothing the tap target did not. **The pencil was carrying
+  the row's accessibility name** - each row now sets that `contentDescription` itself, or a screen
+  reader reads a bare place name with no hint that tapping edits it.
 - **Place-sheet surface language (2026-07-10):** header icon buttons (Save/Share/more/close) are
   40dp icons in `dim.copy(alpha = 0.12f)` CIRCLES with 5dp gaps (Google's treatment); ActionPill
   and the "All reviews" button are CircleShape stadium pills (the outlined button was the last

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -3371,10 +3371,10 @@ private fun SearchEntryContent(
             )
             Divider()
         }
-        // Pinned Home / Work shortcuts (Google-style), above Saved.
-        ShortcutRow(ShortcutKind.HOME, home, onPickShortcut, onAssignShortcut, onClearShortcut)
-        Divider()
-        ShortcutRow(ShortcutKind.WORK, work, onPickShortcut, onAssignShortcut, onClearShortcut)
+        // Pinned Home / Work shortcuts (Google-style), above Saved. SIDE BY SIDE since issue #255:
+        // two full-width rows for two words spent a third of the first screen on them, and Google
+        // pairs them for the same reason.
+        ShortcutPair(home, work, onPickShortcut, onAssignShortcut, onClearShortcut)
         Divider()
         if (saved.isNotEmpty()) {
             SectionLabel(stringResource(R.string.mapscreen_section_saved))
@@ -3468,8 +3468,114 @@ private fun SearchEntryContent(
     }
 }
 
+/**
+ * Home and Work side by side (issue #255).
+ *
+ * Each half opens its place, or arms assign when unset, with the same ⋮ menu (Change / Remove) the
+ * stacked rows had - halving the height must not cost an action. An unset half reads just "Add"
+ * under the label rather than a whole sentence: the label directly above it already said which one
+ * it is, and the long form was the widest text on the row for no added meaning.
+ */
+@Composable
+private fun ShortcutPair(
+    home: SavedPlace?,
+    work: SavedPlace?,
+    onPick: (ShortcutKind) -> Unit,
+    onAssign: (ShortcutKind) -> Unit,
+    onClear: (ShortcutKind) -> Unit,
+) {
+    Row(
+        Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ShortcutCell(ShortcutKind.HOME, home, onPick, onAssign, onClear, Modifier.weight(1f))
+        // A hairline between the two, so the pair reads as two targets and not one wide row.
+        Box(
+            Modifier
+                .height(28.dp)
+                .width(1.dp)
+                .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f)),
+        )
+        ShortcutCell(ShortcutKind.WORK, work, onPick, onAssign, onClear, Modifier.weight(1f))
+    }
+}
+
+/** One half of [ShortcutPair]. */
+@Composable
+private fun ShortcutCell(
+    kind: ShortcutKind,
+    place: SavedPlace?,
+    onPick: (ShortcutKind) -> Unit,
+    onAssign: (ShortcutKind) -> Unit,
+    onClear: (ShortcutKind) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val icon = if (kind == ShortcutKind.HOME) Icons.Default.Home else Icons.Default.Work
+    val label = stringResource(if (kind == ShortcutKind.HOME) R.string.shortcut_home else R.string.shortcut_work)
+    val dark = isAppInDarkTheme()
+    var menu by remember { mutableStateOf(false) }
+    Row(
+        modifier
+            .dpadHighlight(RoundedCornerShape(8.dp))
+            .clickable { if (place != null) onPick(kind) else onAssign(kind) }
+            .padding(horizontal = 8.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Google's tinted disc behind the glyph - at this size a bare icon beside two lines of
+        // text reads as decoration rather than as the thing you press.
+        Box(
+            Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = if (place != null) 0.16f else 0.10f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = if (place != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        Spacer(Modifier.width(10.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                label,
+                style = MaterialTheme.typography.bodyLarge,
+                color = SheetPalette.ink(dark),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                place?.let { it.address ?: it.name } ?: stringResource(R.string.mapscreen_shortcut_add),
+                style = MaterialTheme.typography.bodySmall,
+                color = SheetPalette.dim(dark),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (place != null) {
+            Box {
+                IconButton(onClick = { menu = true }, modifier = Modifier.size(28.dp)) {
+                    Icon(
+                        Icons.Default.MoreVert,
+                        contentDescription = stringResource(R.string.mapscreen_edit_shortcut, label),
+                        tint = SheetPalette.ink(dark),
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+                VelaMenu(expanded = menu, onDismissRequest = { menu = false }) {
+                    item(stringResource(R.string.mapscreen_menu_change)) { menu = false; onAssign(kind) }
+                    item(stringResource(R.string.mapscreen_menu_remove)) { menu = false; onClear(kind) }
+                }
+            }
+        }
+    }
+}
+
 /** A pinned Home/Work shortcut row: opens the place, or arms assign when unset;
  *  a ⋮ menu (Change / Remove) when set. */
+@Suppress("unused") // kept for the landscape/wide layouts that still stack; see ShortcutPair
 @Composable
 private fun ShortcutRow(
     kind: ShortcutKind,

--- a/app/src/main/java/app/vela/ui/place/RouteTopCard.kt
+++ b/app/src/main/java/app/vela/ui/place/RouteTopCard.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material3.Card
@@ -35,6 +34,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -117,14 +118,17 @@ fun RouteTopCard(
                         Box(Modifier.size(8.dp).clip(CircleShape).background(dim))
                     }
                     // Extra stops read as their own quiet line under the first (the old inline
-                    // "+N" was easy to miss, user 2026-07-14) - tappable with a pencil, a second
-                    // door into the stops editor (user 2026-07-14).
+                    // "+N" was easy to miss, user 2026-07-14) - a second door into the stops editor
+                    // (user 2026-07-14). Its pencil went the same way as the endpoint rows' (issue
+                    // #255); the row carries the label instead.
                     if (stops.size > 1) {
+                        val editStopsLabel = stringResource(R.string.stops_edit)
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier
                                 .clip(RoundedCornerShape(8.dp))
                                 .dpadHighlight(RoundedCornerShape(8.dp))
+                                .semantics { contentDescription = editStopsLabel }
                                 .clickable { onEditStops() },
                         ) {
                             Spacer(Modifier.width(GLYPH_RAIL + 8.dp))
@@ -133,14 +137,6 @@ fun RouteTopCard(
                                 style = MaterialTheme.typography.labelMedium,
                                 color = dim,
                             )
-                            Spacer(Modifier.width(6.dp))
-                            Icon(
-                                Icons.Default.Edit,
-                                contentDescription = stringResource(R.string.stops_edit),
-                                tint = dim,
-                                modifier = Modifier.size(12.dp).padding(end = 0.dp),
-                            )
-                            Spacer(Modifier.width(4.dp))
                         }
                     }
                     ConnectorRow(dim)
@@ -198,7 +194,14 @@ fun RouteTopCard(
     }
 }
 
-/** One endpoint line: fixed glyph rail + the name + a pencil when tappable, gmaps' row grammar. */
+/**
+ * One endpoint line: fixed glyph rail + the name, gmaps' row grammar.
+ *
+ * [editable] no longer draws a pencil (issue #255): the whole row is the control, the glyph rail
+ * already says what each line is, and a pencil per line was three of them stacked on one small card
+ * saying nothing the tap target did not. It still decides the row's accessibility name, since that
+ * is the one thing the icon was carrying.
+ */
 @Composable
 private fun EndpointRow(
     text: String,
@@ -216,7 +219,14 @@ private fun EndpointRow(
             .height(ENDPOINT_ROW)
             .then(
                 if (onClick != null) {
-                    Modifier.clip(RoundedCornerShape(10.dp)).dpadHighlight(RoundedCornerShape(10.dp)).clickable { onClick() }
+                    Modifier
+                        .clip(RoundedCornerShape(10.dp))
+                        .dpadHighlight(RoundedCornerShape(10.dp))
+                        // The pencil carried the row's accessibility name; with it gone the row
+                        // has to say what tapping it does, or a screen reader just reads a place
+                        // name with no hint that it is an edit control.
+                        .semantics { contentDescription = editLabel }
+                        .clickable { onClick() }
                 } else Modifier,
             ),
     ) {
@@ -231,11 +241,6 @@ private fun EndpointRow(
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f, fill = false),
         )
-        if (editable) {
-            Spacer(Modifier.width(6.dp))
-            Icon(Icons.Default.Edit, contentDescription = editLabel, tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(13.dp))
-            Spacer(Modifier.width(4.dp))
-        }
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -714,6 +714,7 @@
     <string name="settings_hub_diagnostics_sub">Crash reports, trips, compatibility</string>
     <string name="settings_hub_about_sub">Version, updates, support</string>
     <string name="settings_theme_amoled">AMOLED black</string>
+    <string name="mapscreen_shortcut_add">Add</string>
     <string name="settings_traffic_lights">Traffic-light guidance</string>
     <string name="settings_traffic_lights_hint">Spoken landmark cues: pass the light, then turn. English only, off by default.</string>
     <string name="settings_softkeys" translatable="false">Hardware softkeys</string>


### PR DESCRIPTION
Closes #255

Both of the reporter's asks.

**Pencils off the endpoint rows.** The whole row is already the control and the glyph rail already says what each line is, so three stacked pencils on one small card added nothing the tap target didn't. Removed from the "+N more stops" line too, for consistency on the same card.

One thing that would have been a silent regression: **the pencil was carrying each row's accessibility name.** Deleting the icon would have left a screen reader announcing a bare place name with no hint that tapping it edits the endpoint. Each row now sets that `contentDescription` itself.

**Home and Work side by side** (`ShortcutPair`/`ShortcutCell`). Two full-width rows for two words spent about a third of the first screen of search on them. An unset half now reads just "Add" under the label, as suggested — the label directly above already says which one it is. Halving the height doesn't cost an action: each cell keeps tap-to-open, tap-to-assign when unset, and the ⋮ Change/Remove menu.

Not done from the issue: the contact photo idea. That's a different feature (contacts are already opt-in for search suggestions), worth its own issue if wanted.

D-pad audit clean. Wants a look on a device — it's a layout change, and the two cells get tighter on a narrow screen.