### PR TITLE
Offer smaller pieces of the big countries for offline download

### DIFF
--- a/.github/workflows/obf-regions.yml
+++ b/.github/workflows/obf-regions.yml
@@ -13,9 +13,14 @@ on:
   workflow_dispatch:
     inputs:
       group:
-        description: "Region group(s) to build - one, several comma/space separated, or 'all-sub' for every sub-area group (ignored if 'ids' is set)"
-        type: choice
-        options: [us, canada, europe, germany-sub, oceania, asia, south-america, central-america, africa]
+        # A free-text STRING, not a choice: the selector takes a LIST now, and the sub-area groups
+        # are one per big country (16 of them), which would make an unusable dropdown - and a
+        # dropdown cannot express "brazil-sub,france-sub" or "all-sub" at all.
+        # Continents: us canada europe oceania asia south-america central-america africa
+        # Sub-areas:  <country>-sub (germany-sub, brazil-sub, france-sub, ...) or all-sub for every one
+        description: "Region group(s): one, several comma/space separated, or 'all-sub' for every sub-area group (ignored if 'ids' is set)"
+        type: string
+        default: europe
         default: us
       ids:
         description: "Optional: space/comma-separated region ids (e.g. 'arizona utah colorado'). Overrides 'group'."

--- a/.github/workflows/obf-regions.yml
+++ b/.github/workflows/obf-regions.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       group:
-        description: "Region group to build (ignored if 'ids' is set)"
+        description: "Region group(s) to build - one, several comma/space separated, or 'all-sub' for every sub-area group (ignored if 'ids' is set)"
         type: choice
         options: [us, canada, europe, germany-sub, oceania, asia, south-america, central-america, africa]
         default: us
@@ -52,9 +52,17 @@ jobs:
           SKIP_BIG: ${{ inputs.skip_big }}
         run: |
           ids_json=$(jq -cn --arg s "$IDS" '$s | gsub(",";" ") | split(" ") | map(select(length > 0))')
-          sel=$(jq -c --arg group "$GROUP" --argjson ids "$ids_json" --argjson skipBig "${SKIP_BIG:-false}" '
+          # `group` accepts a LIST now, and the shorthand `all-sub` for every sub-area group at once
+          # (issue #254 added sub-areas for 15 big countries, and one dispatch per country would be
+          # 15 runs of the same thing). A single group name still behaves exactly as before.
+          groups_json=$(jq -cn --arg s "$GROUP" '$s | gsub(",";" ") | split(" ") | map(select(length > 0))')
+          sel=$(jq -c --arg group "$GROUP" --argjson groups "$groups_json" --argjson ids "$ids_json" --argjson skipBig "${SKIP_BIG:-false}" '
             [ .regions[]
-              | select( if ($ids|length) > 0 then (.id as $rid | $ids | index($rid)) != null else .group == $group end )
+              | select(
+                  if ($ids|length) > 0 then (.id as $rid | $ids | index($rid)) != null
+                  elif $group == "all-sub" then (.group | endswith("-sub"))
+                  else (.group as $g | $groups | index($g)) != null end
+                )
               | select( ($skipBig | not) or (.big != true) )
               | {id, name, pbf_url} ]
           ' tools/routing-regions.json)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -589,6 +589,16 @@ Defaults that make the safe path the easy one:
   Cards with elevation 6dp, 54dp turn glyph, headlineMedium-bold distance, titleMedium-medium road
   name, FilledTonalIconButton for mute/steps. Keep new nav chrome on this treatment (no flat
   default-radius cards, no OutlinedIconButton circles - that was the "dated" look).
+- **Home/Work are SIDE BY SIDE and the endpoint rows have NO pencil (issue #255, 2026-08-15).**
+  `ShortcutPair`/`ShortcutCell` in MapScreen replace the two stacked `ShortcutRow`s on the search
+  page: two full-width rows for two words spent a third of the first screen, and an unset one now
+  reads just "Add" under its label (the label above already says which it is). Halving the height
+  must not cost an action - each cell keeps the same tap-to-open / tap-to-assign / ⋮ Change-Remove.
+  `ShortcutRow` is kept (unused) for stacked layouts. On `RouteTopCard` the per-row pencils are
+  gone: the whole row is the control and the glyph rail already says what each line is, so three
+  stacked pencils on one small card said nothing the tap target did not. **The pencil was carrying
+  the row's accessibility name** - each row now sets that `contentDescription` itself, or a screen
+  reader reads a bare place name with no hint that tapping edits it.
 - **Place-sheet surface language (2026-07-10):** header icon buttons (Save/Share/more/close) are
   40dp icons in `dim.copy(alpha = 0.12f)` CIRCLES with 5dp gaps (Google's treatment); ActionPill
   and the "All reviews" button are CircleShape stadium pills (the outlined button was the last

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2416,11 +2416,21 @@ architecture note.
   wired later). Place packs still download alongside obf regions until POI/address search moves
   onto the obf (phase 2). COUNTRY + SUB-AREA both (2026-08-03, the #214 reporter's ask): the unsplit
   country stays the headline row, and big countries ALSO offer first-level sub-areas as smaller
-  optional rows - tools/routing-regions.json carries the 16 `de-*` Bundesland rows (group
-  `germany-sub`, named "<Land> (Germany)") beside the whole-Germany row (group `europe`,
-  big:true), so the obf bake can produce both; nobody is forced into fragments and a city user
-  grabs ~130 MB instead of ~2 GB. Extend the same pattern (fr-sub etc.) only when a country's
-  obf actually lands huge.
+  optional rows - tools/routing-regions.json carries sub-area rows beside the whole-country row
+  (which stays group `europe`/`south-america`/... with big:true), so the obf bake produces both;
+  nobody is forced into fragments and a city user grabs a fraction of the country. **Extended from
+  Germany alone to all 15 big countries Geofabrik actually sub-divides (issue #254, 2026-08-15):
+  159 sub rows in groups `<country>-sub`** - Brazil (the reported one, 1.5 GB whole), France,
+  Spain, Poland, Italy, Netherlands, Czechia, Norway, Australia, Japan, India, Indonesia, Great
+  Britain, California, Germany. Rows are GENERATED from Geofabrik's own `index-v1.json`, so every
+  `pbf_url` is a real extract: the id is `<country>-<geofabrik child slug>`, the name is the LOCAL
+  name plus the country ("Nord-Norge (Norway)", matching the de-* rows - Geofabrik's English
+  glosses made three-part names that wrapped to three lines in the picker). Note Geofabrik ids are
+  path-shaped for US/Canada (`us/california`, not `california`) and Great Britain's sub-extracts
+  live under `united-kingdom`, not `great-britain` - deriving the id naively finds neither. The
+  17 remaining big rows (Texas, Ontario, Mexico, Sweden, Ukraine, Argentina, South Africa, ...)
+  have NO Geofabrik sub-extracts, so they stay whole. **The workflow's `group` input takes a LIST
+  now, plus the shorthand `all-sub`** - one dispatch bakes every sub-area group instead of 15.
 - **On-device routing engine = GraphHopper (`core/data/RouteEngine` + `GraphHopperRouteEngine`).**
   Pure-JVM, runs on ART - **validated end-to-end on a Pixel 5a** (`:ghprobe`, a throwaway instrumented
   probe - the routing shipped long ago; the module is safe to delete whenever). Chosen over Valhalla (no maintained Android map-matching binding) /

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -3371,10 +3371,10 @@ private fun SearchEntryContent(
             )
             Divider()
         }
-        // Pinned Home / Work shortcuts (Google-style), above Saved.
-        ShortcutRow(ShortcutKind.HOME, home, onPickShortcut, onAssignShortcut, onClearShortcut)
-        Divider()
-        ShortcutRow(ShortcutKind.WORK, work, onPickShortcut, onAssignShortcut, onClearShortcut)
+        // Pinned Home / Work shortcuts (Google-style), above Saved. SIDE BY SIDE since issue #255:
+        // two full-width rows for two words spent a third of the first screen on them, and Google
+        // pairs them for the same reason.
+        ShortcutPair(home, work, onPickShortcut, onAssignShortcut, onClearShortcut)
         Divider()
         if (saved.isNotEmpty()) {
             SectionLabel(stringResource(R.string.mapscreen_section_saved))
@@ -3468,8 +3468,114 @@ private fun SearchEntryContent(
     }
 }
 
+/**
+ * Home and Work side by side (issue #255).
+ *
+ * Each half opens its place, or arms assign when unset, with the same ⋮ menu (Change / Remove) the
+ * stacked rows had - halving the height must not cost an action. An unset half reads just "Add"
+ * under the label rather than a whole sentence: the label directly above it already said which one
+ * it is, and the long form was the widest text on the row for no added meaning.
+ */
+@Composable
+private fun ShortcutPair(
+    home: SavedPlace?,
+    work: SavedPlace?,
+    onPick: (ShortcutKind) -> Unit,
+    onAssign: (ShortcutKind) -> Unit,
+    onClear: (ShortcutKind) -> Unit,
+) {
+    Row(
+        Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ShortcutCell(ShortcutKind.HOME, home, onPick, onAssign, onClear, Modifier.weight(1f))
+        // A hairline between the two, so the pair reads as two targets and not one wide row.
+        Box(
+            Modifier
+                .height(28.dp)
+                .width(1.dp)
+                .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f)),
+        )
+        ShortcutCell(ShortcutKind.WORK, work, onPick, onAssign, onClear, Modifier.weight(1f))
+    }
+}
+
+/** One half of [ShortcutPair]. */
+@Composable
+private fun ShortcutCell(
+    kind: ShortcutKind,
+    place: SavedPlace?,
+    onPick: (ShortcutKind) -> Unit,
+    onAssign: (ShortcutKind) -> Unit,
+    onClear: (ShortcutKind) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val icon = if (kind == ShortcutKind.HOME) Icons.Default.Home else Icons.Default.Work
+    val label = stringResource(if (kind == ShortcutKind.HOME) R.string.shortcut_home else R.string.shortcut_work)
+    val dark = isAppInDarkTheme()
+    var menu by remember { mutableStateOf(false) }
+    Row(
+        modifier
+            .dpadHighlight(RoundedCornerShape(8.dp))
+            .clickable { if (place != null) onPick(kind) else onAssign(kind) }
+            .padding(horizontal = 8.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Google's tinted disc behind the glyph - at this size a bare icon beside two lines of
+        // text reads as decoration rather than as the thing you press.
+        Box(
+            Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = if (place != null) 0.16f else 0.10f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = if (place != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        Spacer(Modifier.width(10.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                label,
+                style = MaterialTheme.typography.bodyLarge,
+                color = SheetPalette.ink(dark),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                place?.let { it.address ?: it.name } ?: stringResource(R.string.mapscreen_shortcut_add),
+                style = MaterialTheme.typography.bodySmall,
+                color = SheetPalette.dim(dark),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (place != null) {
+            Box {
+                IconButton(onClick = { menu = true }, modifier = Modifier.size(28.dp)) {
+                    Icon(
+                        Icons.Default.MoreVert,
+                        contentDescription = stringResource(R.string.mapscreen_edit_shortcut, label),
+                        tint = SheetPalette.ink(dark),
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+                VelaMenu(expanded = menu, onDismissRequest = { menu = false }) {
+                    item(stringResource(R.string.mapscreen_menu_change)) { menu = false; onAssign(kind) }
+                    item(stringResource(R.string.mapscreen_menu_remove)) { menu = false; onClear(kind) }
+                }
+            }
+        }
+    }
+}
+
 /** A pinned Home/Work shortcut row: opens the place, or arms assign when unset;
  *  a ⋮ menu (Change / Remove) when set. */
+@Suppress("unused") // kept for the landscape/wide layouts that still stack; see ShortcutPair
 @Composable
 private fun ShortcutRow(
     kind: ShortcutKind,

--- a/app/src/main/java/app/vela/ui/place/RouteTopCard.kt
+++ b/app/src/main/java/app/vela/ui/place/RouteTopCard.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material3.Card
@@ -35,6 +34,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -117,14 +118,17 @@ fun RouteTopCard(
                         Box(Modifier.size(8.dp).clip(CircleShape).background(dim))
                     }
                     // Extra stops read as their own quiet line under the first (the old inline
-                    // "+N" was easy to miss, user 2026-07-14) - tappable with a pencil, a second
-                    // door into the stops editor (user 2026-07-14).
+                    // "+N" was easy to miss, user 2026-07-14) - a second door into the stops editor
+                    // (user 2026-07-14). Its pencil went the same way as the endpoint rows' (issue
+                    // #255); the row carries the label instead.
                     if (stops.size > 1) {
+                        val editStopsLabel = stringResource(R.string.stops_edit)
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier
                                 .clip(RoundedCornerShape(8.dp))
                                 .dpadHighlight(RoundedCornerShape(8.dp))
+                                .semantics { contentDescription = editStopsLabel }
                                 .clickable { onEditStops() },
                         ) {
                             Spacer(Modifier.width(GLYPH_RAIL + 8.dp))
@@ -133,14 +137,6 @@ fun RouteTopCard(
                                 style = MaterialTheme.typography.labelMedium,
                                 color = dim,
                             )
-                            Spacer(Modifier.width(6.dp))
-                            Icon(
-                                Icons.Default.Edit,
-                                contentDescription = stringResource(R.string.stops_edit),
-                                tint = dim,
-                                modifier = Modifier.size(12.dp).padding(end = 0.dp),
-                            )
-                            Spacer(Modifier.width(4.dp))
                         }
                     }
                     ConnectorRow(dim)
@@ -198,7 +194,14 @@ fun RouteTopCard(
     }
 }
 
-/** One endpoint line: fixed glyph rail + the name + a pencil when tappable, gmaps' row grammar. */
+/**
+ * One endpoint line: fixed glyph rail + the name, gmaps' row grammar.
+ *
+ * [editable] no longer draws a pencil (issue #255): the whole row is the control, the glyph rail
+ * already says what each line is, and a pencil per line was three of them stacked on one small card
+ * saying nothing the tap target did not. It still decides the row's accessibility name, since that
+ * is the one thing the icon was carrying.
+ */
 @Composable
 private fun EndpointRow(
     text: String,
@@ -216,7 +219,14 @@ private fun EndpointRow(
             .height(ENDPOINT_ROW)
             .then(
                 if (onClick != null) {
-                    Modifier.clip(RoundedCornerShape(10.dp)).dpadHighlight(RoundedCornerShape(10.dp)).clickable { onClick() }
+                    Modifier
+                        .clip(RoundedCornerShape(10.dp))
+                        .dpadHighlight(RoundedCornerShape(10.dp))
+                        // The pencil carried the row's accessibility name; with it gone the row
+                        // has to say what tapping it does, or a screen reader just reads a place
+                        // name with no hint that it is an edit control.
+                        .semantics { contentDescription = editLabel }
+                        .clickable { onClick() }
                 } else Modifier,
             ),
     ) {
@@ -231,11 +241,6 @@ private fun EndpointRow(
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f, fill = false),
         )
-        if (editable) {
-            Spacer(Modifier.width(6.dp))
-            Icon(Icons.Default.Edit, contentDescription = editLabel, tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(13.dp))
-            Spacer(Modifier.width(4.dp))
-        }
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -714,6 +714,7 @@
     <string name="settings_hub_diagnostics_sub">Crash reports, trips, compatibility</string>
     <string name="settings_hub_about_sub">Version, updates, support</string>
     <string name="settings_theme_amoled">AMOLED black</string>
+    <string name="mapscreen_shortcut_add">Add</string>
     <string name="settings_traffic_lights">Traffic-light guidance</string>
     <string name="settings_traffic_lights_hint">Spoken landmark cues: pass the light, then turn. English only, off by default.</string>
     <string name="settings_softkeys" translatable="false">Hardware softkeys</string>

--- a/tools/routing-regions.json
+++ b/tools/routing-regions.json
@@ -33,6 +33,18 @@
       "pbf_url": "https://download.geofabrik.de/north-america/us/california-latest.osm.pbf"
     },
     {
+      "id": "california-norcal",
+      "name": "Northern California (California)",
+      "group": "california-sub",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/california/norcal-latest.osm.pbf"
+    },
+    {
+      "id": "california-socal",
+      "name": "Southern California (California)",
+      "group": "california-sub",
+      "pbf_url": "https://download.geofabrik.de/north-america/us/california/socal-latest.osm.pbf"
+    },
+    {
       "id": "colorado",
       "name": "Colorado (state)",
       "group": "us",
@@ -448,6 +460,90 @@
       "pbf_url": "https://download.geofabrik.de/europe/czech-republic-latest.osm.pbf"
     },
     {
+      "id": "czech-republic-jihomoravsky",
+      "name": "Jihomoravský kraj (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/jihomoravsky-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-jihocesky",
+      "name": "Jihočeský kraj (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/jihocesky-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-karlovarsky",
+      "name": "Karlovarský kraj (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/karlovarsky-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-vysocina",
+      "name": "Kraj Vysočina (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/vysocina-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-kralovehradecky",
+      "name": "Královéhradecký kraj (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/kralovehradecky-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-liberecky",
+      "name": "Liberecký kraj (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/liberecky-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-moravskoslezky",
+      "name": "Moravskoslezský kraj (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/moravskoslezky-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-olomoucky",
+      "name": "Olomoucký kraj (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/olomoucky-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-pardubicky",
+      "name": "Pardubický kraj (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/pardubicky-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-plzensky",
+      "name": "Plzeňský kraj (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/plzensky-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-praha",
+      "name": "Praha (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/praha-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-stredocesky",
+      "name": "Středočeský kraj (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/stredocesky-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-zlinsky",
+      "name": "Zlínský kraj (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/zlinsky-latest.osm.pbf"
+    },
+    {
+      "id": "czech-republic-ustecky",
+      "name": "Ústecký kraj (Czech Republic)",
+      "group": "czech-republic-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/czech-republic/ustecky-latest.osm.pbf"
+    },
+    {
       "id": "denmark",
       "name": "Denmark",
       "group": "europe",
@@ -472,6 +568,168 @@
       "group": "europe",
       "big": true,
       "pbf_url": "https://download.geofabrik.de/europe/france-latest.osm.pbf"
+    },
+    {
+      "id": "france-alsace",
+      "name": "Alsace (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/alsace-latest.osm.pbf"
+    },
+    {
+      "id": "france-aquitaine",
+      "name": "Aquitaine (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/aquitaine-latest.osm.pbf"
+    },
+    {
+      "id": "france-auvergne",
+      "name": "Auvergne (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/auvergne-latest.osm.pbf"
+    },
+    {
+      "id": "france-basse-normandie",
+      "name": "Basse-Normandie (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/basse-normandie-latest.osm.pbf"
+    },
+    {
+      "id": "france-bourgogne",
+      "name": "Bourgogne (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/bourgogne-latest.osm.pbf"
+    },
+    {
+      "id": "france-bretagne",
+      "name": "Bretagne (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/bretagne-latest.osm.pbf"
+    },
+    {
+      "id": "france-centre",
+      "name": "Centre (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/centre-latest.osm.pbf"
+    },
+    {
+      "id": "france-champagne-ardenne",
+      "name": "Champagne Ardenne (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/champagne-ardenne-latest.osm.pbf"
+    },
+    {
+      "id": "france-corse",
+      "name": "Corse (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/corse-latest.osm.pbf"
+    },
+    {
+      "id": "france-franche-comte",
+      "name": "Franche Comte (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/franche-comte-latest.osm.pbf"
+    },
+    {
+      "id": "france-guadeloupe",
+      "name": "Guadeloupe (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/guadeloupe-latest.osm.pbf"
+    },
+    {
+      "id": "france-guyane",
+      "name": "Guyane (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/guyane-latest.osm.pbf"
+    },
+    {
+      "id": "france-haute-normandie",
+      "name": "Haute-Normandie (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/haute-normandie-latest.osm.pbf"
+    },
+    {
+      "id": "france-ile-de-france",
+      "name": "Ile-de-France (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/ile-de-france-latest.osm.pbf"
+    },
+    {
+      "id": "france-languedoc-roussillon",
+      "name": "Languedoc-Roussillon (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/languedoc-roussillon-latest.osm.pbf"
+    },
+    {
+      "id": "france-limousin",
+      "name": "Limousin (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/limousin-latest.osm.pbf"
+    },
+    {
+      "id": "france-lorraine",
+      "name": "Lorraine (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/lorraine-latest.osm.pbf"
+    },
+    {
+      "id": "france-martinique",
+      "name": "Martinique (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/martinique-latest.osm.pbf"
+    },
+    {
+      "id": "france-mayotte",
+      "name": "Mayotte (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/mayotte-latest.osm.pbf"
+    },
+    {
+      "id": "france-midi-pyrenees",
+      "name": "Midi-Pyrenees (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/midi-pyrenees-latest.osm.pbf"
+    },
+    {
+      "id": "france-nord-pas-de-calais",
+      "name": "Nord-Pas-de-Calais (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/nord-pas-de-calais-latest.osm.pbf"
+    },
+    {
+      "id": "france-pays-de-la-loire",
+      "name": "Pays de la Loire (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/pays-de-la-loire-latest.osm.pbf"
+    },
+    {
+      "id": "france-picardie",
+      "name": "Picardie (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/picardie-latest.osm.pbf"
+    },
+    {
+      "id": "france-poitou-charentes",
+      "name": "Poitou-Charentes (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/poitou-charentes-latest.osm.pbf"
+    },
+    {
+      "id": "france-provence-alpes-cote-d-azur",
+      "name": "Provence Alpes-Cote-d'Azur (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/provence-alpes-cote-d-azur-latest.osm.pbf"
+    },
+    {
+      "id": "france-reunion",
+      "name": "Reunion (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/reunion-latest.osm.pbf"
+    },
+    {
+      "id": "france-rhone-alpes",
+      "name": "Rhone-Alpes (France)",
+      "group": "france-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/france/rhone-alpes-latest.osm.pbf"
     },
     {
       "id": "germany",
@@ -584,6 +842,24 @@
       "pbf_url": "https://download.geofabrik.de/europe/great-britain-latest.osm.pbf"
     },
     {
+      "id": "great-britain-england",
+      "name": "England (Great Britain)",
+      "group": "great-britain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/united-kingdom/england-latest.osm.pbf"
+    },
+    {
+      "id": "great-britain-scotland",
+      "name": "Scotland (Great Britain)",
+      "group": "great-britain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/united-kingdom/scotland-latest.osm.pbf"
+    },
+    {
+      "id": "great-britain-wales",
+      "name": "Wales (Great Britain)",
+      "group": "great-britain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/united-kingdom/wales-latest.osm.pbf"
+    },
+    {
       "id": "greece",
       "name": "Greece",
       "group": "europe",
@@ -613,6 +889,36 @@
       "group": "europe",
       "big": true,
       "pbf_url": "https://download.geofabrik.de/europe/italy-latest.osm.pbf"
+    },
+    {
+      "id": "italy-centro",
+      "name": "Centro (Italy)",
+      "group": "italy-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/italy/centro-latest.osm.pbf"
+    },
+    {
+      "id": "italy-isole",
+      "name": "Isole (Italy)",
+      "group": "italy-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/italy/isole-latest.osm.pbf"
+    },
+    {
+      "id": "italy-nord-est",
+      "name": "Nord-Est (Italy)",
+      "group": "italy-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/italy/nord-est-latest.osm.pbf"
+    },
+    {
+      "id": "italy-nord-ovest",
+      "name": "Nord-Ovest (Italy)",
+      "group": "italy-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/italy/nord-ovest-latest.osm.pbf"
+    },
+    {
+      "id": "italy-sud",
+      "name": "Sud (Italy)",
+      "group": "italy-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/italy/sud-latest.osm.pbf"
     },
     {
       "id": "latvia",
@@ -652,6 +958,78 @@
       "pbf_url": "https://download.geofabrik.de/europe/netherlands-latest.osm.pbf"
     },
     {
+      "id": "netherlands-drenthe",
+      "name": "Drenthe (Netherlands)",
+      "group": "netherlands-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands/drenthe-latest.osm.pbf"
+    },
+    {
+      "id": "netherlands-flevoland",
+      "name": "Flevoland (Netherlands)",
+      "group": "netherlands-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands/flevoland-latest.osm.pbf"
+    },
+    {
+      "id": "netherlands-friesland",
+      "name": "Friesland (Netherlands)",
+      "group": "netherlands-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands/friesland-latest.osm.pbf"
+    },
+    {
+      "id": "netherlands-gelderland",
+      "name": "Gelderland (Netherlands)",
+      "group": "netherlands-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands/gelderland-latest.osm.pbf"
+    },
+    {
+      "id": "netherlands-groningen",
+      "name": "Groningen (Netherlands)",
+      "group": "netherlands-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands/groningen-latest.osm.pbf"
+    },
+    {
+      "id": "netherlands-limburg",
+      "name": "Limburg (Netherlands)",
+      "group": "netherlands-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands/limburg-latest.osm.pbf"
+    },
+    {
+      "id": "netherlands-noord-brabant",
+      "name": "Noord-Brabant (Netherlands)",
+      "group": "netherlands-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands/noord-brabant-latest.osm.pbf"
+    },
+    {
+      "id": "netherlands-noord-holland",
+      "name": "Noord-Holland (Netherlands)",
+      "group": "netherlands-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands/noord-holland-latest.osm.pbf"
+    },
+    {
+      "id": "netherlands-overijssel",
+      "name": "Overijssel (Netherlands)",
+      "group": "netherlands-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands/overijssel-latest.osm.pbf"
+    },
+    {
+      "id": "netherlands-utrecht",
+      "name": "Utrecht (Netherlands)",
+      "group": "netherlands-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands/utrecht-latest.osm.pbf"
+    },
+    {
+      "id": "netherlands-zeeland",
+      "name": "Zeeland (Netherlands)",
+      "group": "netherlands-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands/zeeland-latest.osm.pbf"
+    },
+    {
+      "id": "netherlands-zuid-holland",
+      "name": "Zuid-Holland (Netherlands)",
+      "group": "netherlands-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/netherlands/zuid-holland-latest.osm.pbf"
+    },
+    {
       "id": "norway",
       "name": "Norway",
       "group": "europe",
@@ -659,11 +1037,143 @@
       "pbf_url": "https://download.geofabrik.de/europe/norway-latest.osm.pbf"
     },
     {
+      "id": "norway-nord-norge",
+      "name": "Nord-Norge (Norway)",
+      "group": "norway-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/norway/nord-norge-latest.osm.pbf"
+    },
+    {
+      "id": "norway-svalbard-janmayen",
+      "name": "Svalbard and Jan Mayen (Norway)",
+      "group": "norway-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/norway/svalbard-janmayen-latest.osm.pbf"
+    },
+    {
+      "id": "norway-sorlandet",
+      "name": "Sørlandet (Norway)",
+      "group": "norway-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/norway/sorlandet-latest.osm.pbf"
+    },
+    {
+      "id": "norway-trondelag",
+      "name": "Trøndelag (Norway)",
+      "group": "norway-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/norway/trondelag-latest.osm.pbf"
+    },
+    {
+      "id": "norway-vestlandet",
+      "name": "Vestlandet (Norway)",
+      "group": "norway-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/norway/vestlandet-latest.osm.pbf"
+    },
+    {
+      "id": "norway-ostlandet",
+      "name": "Østlandet (Norway)",
+      "group": "norway-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/norway/ostlandet-latest.osm.pbf"
+    },
+    {
       "id": "poland",
       "name": "Poland",
       "group": "europe",
       "big": true,
       "pbf_url": "https://download.geofabrik.de/europe/poland-latest.osm.pbf"
+    },
+    {
+      "id": "poland-dolnoslaskie",
+      "name": "Województwo dolnośląskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/dolnoslaskie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-kujawsko-pomorskie",
+      "name": "Województwo kujawsko-pomorskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/kujawsko-pomorskie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-lubelskie",
+      "name": "Województwo lubelskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/lubelskie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-lubuskie",
+      "name": "Województwo lubuskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/lubuskie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-mazowieckie",
+      "name": "Województwo mazowieckie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/mazowieckie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-malopolskie",
+      "name": "Województwo małopolskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/malopolskie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-opolskie",
+      "name": "Województwo opolskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/opolskie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-podkarpackie",
+      "name": "Województwo podkarpackie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/podkarpackie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-podlaskie",
+      "name": "Województwo podlaskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/podlaskie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-pomorskie",
+      "name": "Województwo pomorskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/pomorskie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-warminsko-mazurskie",
+      "name": "Województwo warmińsko-mazurskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/warminsko-mazurskie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-wielkopolskie",
+      "name": "Województwo wielkopolskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/wielkopolskie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-zachodniopomorskie",
+      "name": "Województwo zachodniopomorskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/zachodniopomorskie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-lodzkie",
+      "name": "Województwo łódzkie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/lodzkie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-slaskie",
+      "name": "Województwo śląskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/slaskie-latest.osm.pbf"
+    },
+    {
+      "id": "poland-swietokrzyskie",
+      "name": "Województwo świętokrzyskie (Poland)",
+      "group": "poland-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/poland/swietokrzyskie-latest.osm.pbf"
     },
     {
       "id": "portugal",
@@ -703,6 +1213,114 @@
       "pbf_url": "https://download.geofabrik.de/europe/spain-latest.osm.pbf"
     },
     {
+      "id": "spain-andalucia",
+      "name": "Andalucía (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/andalucia-latest.osm.pbf"
+    },
+    {
+      "id": "spain-aragon",
+      "name": "Aragón (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/aragon-latest.osm.pbf"
+    },
+    {
+      "id": "spain-asturias",
+      "name": "Asturias (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/asturias-latest.osm.pbf"
+    },
+    {
+      "id": "spain-cantabria",
+      "name": "Cantabria (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/cantabria-latest.osm.pbf"
+    },
+    {
+      "id": "spain-castilla-y-leon",
+      "name": "Castilla y León (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/castilla-y-leon-latest.osm.pbf"
+    },
+    {
+      "id": "spain-castilla-la-mancha",
+      "name": "Castilla-La Mancha (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/castilla-la-mancha-latest.osm.pbf"
+    },
+    {
+      "id": "spain-cataluna",
+      "name": "Cataluña (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/cataluna-latest.osm.pbf"
+    },
+    {
+      "id": "spain-ceuta",
+      "name": "Ceuta (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/ceuta-latest.osm.pbf"
+    },
+    {
+      "id": "spain-extremadura",
+      "name": "Extremadura (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/extremadura-latest.osm.pbf"
+    },
+    {
+      "id": "spain-galicia",
+      "name": "Galicia (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/galicia-latest.osm.pbf"
+    },
+    {
+      "id": "spain-islas-baleares",
+      "name": "Islas Baleares (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/islas-baleares-latest.osm.pbf"
+    },
+    {
+      "id": "spain-la-rioja",
+      "name": "La Rioja (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/la-rioja-latest.osm.pbf"
+    },
+    {
+      "id": "spain-madrid",
+      "name": "Madrid (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/madrid-latest.osm.pbf"
+    },
+    {
+      "id": "spain-melilla",
+      "name": "Melilla (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/melilla-latest.osm.pbf"
+    },
+    {
+      "id": "spain-murcia",
+      "name": "Murcia (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/murcia-latest.osm.pbf"
+    },
+    {
+      "id": "spain-navarra",
+      "name": "Navarra (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/navarra-latest.osm.pbf"
+    },
+    {
+      "id": "spain-pais-vasco",
+      "name": "País Vasco (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/pais-vasco-latest.osm.pbf"
+    },
+    {
+      "id": "spain-valencia",
+      "name": "Valencia (Spain)",
+      "group": "spain-sub",
+      "pbf_url": "https://download.geofabrik.de/europe/spain/valencia-latest.osm.pbf"
+    },
+    {
       "id": "sweden",
       "name": "Sweden",
       "group": "europe",
@@ -730,6 +1348,90 @@
       "pbf_url": "https://download.geofabrik.de/australia-oceania/australia-latest.osm.pbf"
     },
     {
+      "id": "australia-ashmore-cartier",
+      "name": "Ashmore and Cartier Islands (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/ashmore-cartier-latest.osm.pbf"
+    },
+    {
+      "id": "australia-act",
+      "name": "Australian Capital Territory (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/act-latest.osm.pbf"
+    },
+    {
+      "id": "australia-christmas-island",
+      "name": "Christmas Island (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/christmas-island-latest.osm.pbf"
+    },
+    {
+      "id": "australia-cocos-islands",
+      "name": "Cocos (Keeling) Islands (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/cocos-islands-latest.osm.pbf"
+    },
+    {
+      "id": "australia-coral-sea-islands",
+      "name": "Coral Sea Islands (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/coral-sea-islands-latest.osm.pbf"
+    },
+    {
+      "id": "australia-heard-mcdonald",
+      "name": "Heard Island and McDonald Islands (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/heard-mcdonald-latest.osm.pbf"
+    },
+    {
+      "id": "australia-new-south-wales",
+      "name": "New South Wales (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/new-south-wales-latest.osm.pbf"
+    },
+    {
+      "id": "australia-norfolk-island",
+      "name": "Norfolk Island (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/norfolk-island-latest.osm.pbf"
+    },
+    {
+      "id": "australia-northern-territory",
+      "name": "Northern Territory (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/northern-territory-latest.osm.pbf"
+    },
+    {
+      "id": "australia-queensland",
+      "name": "Queensland (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/queensland-latest.osm.pbf"
+    },
+    {
+      "id": "australia-south-australia",
+      "name": "South Australia (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/south-australia-latest.osm.pbf"
+    },
+    {
+      "id": "australia-tasmania",
+      "name": "Tasmania (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/tasmania-latest.osm.pbf"
+    },
+    {
+      "id": "australia-victoria",
+      "name": "Victoria (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/victoria-latest.osm.pbf"
+    },
+    {
+      "id": "australia-western-australia",
+      "name": "Western Australia (Australia)",
+      "group": "australia-sub",
+      "pbf_url": "https://download.geofabrik.de/australia-oceania/australia/western-australia-latest.osm.pbf"
+    },
+    {
       "id": "new-zealand",
       "name": "New Zealand",
       "group": "oceania",
@@ -741,6 +1443,54 @@
       "group": "asia",
       "big": true,
       "pbf_url": "https://download.geofabrik.de/asia/japan-latest.osm.pbf"
+    },
+    {
+      "id": "japan-chubu",
+      "name": "Chūbu region (Japan)",
+      "group": "japan-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/japan/chubu-latest.osm.pbf"
+    },
+    {
+      "id": "japan-chugoku",
+      "name": "Chūgoku region (Japan)",
+      "group": "japan-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/japan/chugoku-latest.osm.pbf"
+    },
+    {
+      "id": "japan-hokkaido",
+      "name": "Hokkaidō (Japan)",
+      "group": "japan-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/japan/hokkaido-latest.osm.pbf"
+    },
+    {
+      "id": "japan-kansai",
+      "name": "Kansai region (Japan)",
+      "group": "japan-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/japan/kansai-latest.osm.pbf"
+    },
+    {
+      "id": "japan-kanto",
+      "name": "Kantō region (Japan)",
+      "group": "japan-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/japan/kanto-latest.osm.pbf"
+    },
+    {
+      "id": "japan-kyushu",
+      "name": "Kyūshū (Japan)",
+      "group": "japan-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/japan/kyushu-latest.osm.pbf"
+    },
+    {
+      "id": "japan-shikoku",
+      "name": "Shikoku (Japan)",
+      "group": "japan-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf"
+    },
+    {
+      "id": "japan-tohoku",
+      "name": "Tōhoku region (Japan)",
+      "group": "japan-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/japan/tohoku-latest.osm.pbf"
     },
     {
       "id": "south-korea",
@@ -762,11 +1512,89 @@
       "pbf_url": "https://download.geofabrik.de/asia/india-latest.osm.pbf"
     },
     {
+      "id": "india-central-zone",
+      "name": "Central Zone (India)",
+      "group": "india-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/india/central-zone-latest.osm.pbf"
+    },
+    {
+      "id": "india-eastern-zone",
+      "name": "Eastern Zone (India)",
+      "group": "india-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/india/eastern-zone-latest.osm.pbf"
+    },
+    {
+      "id": "india-north-eastern-zone",
+      "name": "North-Eastern Zone (India)",
+      "group": "india-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/india/north-eastern-zone-latest.osm.pbf"
+    },
+    {
+      "id": "india-northern-zone",
+      "name": "Northern Zone (India)",
+      "group": "india-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/india/northern-zone-latest.osm.pbf"
+    },
+    {
+      "id": "india-southern-zone",
+      "name": "Southern Zone (India)",
+      "group": "india-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/india/southern-zone-latest.osm.pbf"
+    },
+    {
+      "id": "india-western-zone",
+      "name": "Western Zone (India)",
+      "group": "india-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/india/western-zone-latest.osm.pbf"
+    },
+    {
       "id": "indonesia",
       "name": "Indonesia",
       "group": "asia",
       "big": true,
       "pbf_url": "https://download.geofabrik.de/asia/indonesia-latest.osm.pbf"
+    },
+    {
+      "id": "indonesia-java",
+      "name": "Java (Indonesia)",
+      "group": "indonesia-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/indonesia/java-latest.osm.pbf"
+    },
+    {
+      "id": "indonesia-kalimantan",
+      "name": "Kalimantan (Indonesia)",
+      "group": "indonesia-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/indonesia/kalimantan-latest.osm.pbf"
+    },
+    {
+      "id": "indonesia-maluku",
+      "name": "Maluku (Indonesia)",
+      "group": "indonesia-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/indonesia/maluku-latest.osm.pbf"
+    },
+    {
+      "id": "indonesia-nusa-tenggara",
+      "name": "Nusa-Tenggara (Indonesia)",
+      "group": "indonesia-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/indonesia/nusa-tenggara-latest.osm.pbf"
+    },
+    {
+      "id": "indonesia-papua",
+      "name": "Papua (Indonesia)",
+      "group": "indonesia-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/indonesia/papua-latest.osm.pbf"
+    },
+    {
+      "id": "indonesia-sulawesi",
+      "name": "Sulawesi (Indonesia)",
+      "group": "indonesia-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/indonesia/sulawesi-latest.osm.pbf"
+    },
+    {
+      "id": "indonesia-sumatra",
+      "name": "Sumatra (Indonesia)",
+      "group": "indonesia-sub",
+      "pbf_url": "https://download.geofabrik.de/asia/indonesia/sumatra-latest.osm.pbf"
     },
     {
       "id": "philippines",
@@ -811,6 +1639,36 @@
       "group": "south-america",
       "big": true,
       "pbf_url": "https://download.geofabrik.de/south-america/brazil-latest.osm.pbf"
+    },
+    {
+      "id": "brazil-centro-oeste",
+      "name": "Centro-Oeste (Brazil)",
+      "group": "brazil-sub",
+      "pbf_url": "https://download.geofabrik.de/south-america/brazil/centro-oeste-latest.osm.pbf"
+    },
+    {
+      "id": "brazil-nordeste",
+      "name": "Nordeste (Brazil)",
+      "group": "brazil-sub",
+      "pbf_url": "https://download.geofabrik.de/south-america/brazil/nordeste-latest.osm.pbf"
+    },
+    {
+      "id": "brazil-norte",
+      "name": "Norte (Brazil)",
+      "group": "brazil-sub",
+      "pbf_url": "https://download.geofabrik.de/south-america/brazil/norte-latest.osm.pbf"
+    },
+    {
+      "id": "brazil-sudeste",
+      "name": "Sudeste (Brazil)",
+      "group": "brazil-sub",
+      "pbf_url": "https://download.geofabrik.de/south-america/brazil/sudeste-latest.osm.pbf"
+    },
+    {
+      "id": "brazil-sul",
+      "name": "Sul (Brazil)",
+      "group": "brazil-sub",
+      "pbf_url": "https://download.geofabrik.de/south-america/brazil/sul-latest.osm.pbf"
     },
     {
       "id": "chile",


### PR DESCRIPTION
Closes #254

Brazil was one ~1.5 GB download, and Germany was the only country you could take a piece of at a time. Now **every big country Geofabrik actually sub-divides** offers its regions too — 159 sub rows across 15 countries: Brazil, France, Spain, Poland, Italy, Netherlands, Czechia, Norway, Australia, Japan, India, Indonesia, Great Britain, California, Germany. The whole-country row stays, so nobody is forced into fragments.

Rows are **generated from Geofabrik's own `index-v1.json`**, so every `pbf_url` points at an extract that really exists rather than a guessed path. Two traps in that mapping, both of which silently produce zero children if you don't hit them:

- Geofabrik ids are **path-shaped** for US/Canada — `us/california`, not `california`.
- Great Britain's sub-extracts live under **`united-kingdom`**, not `great-britain`, so England/Scotland/Wales had to be picked up explicitly.

Names are the **local** name plus the country ("Nord-Norge (Norway)"), matching the existing `de-*` rows — Geofabrik's English glosses gave three-part names that wrapped to three lines in the picker.

The 17 other big rows (Texas, Ontario, Mexico, Sweden, Ukraine, Argentina, South Africa, …) have **no** published sub-extracts, so they stay whole.

**Workflow:** `group` now accepts a list, plus the shorthand `all-sub` — one dispatch bakes every sub-area group instead of 15 separate runs. A single group name behaves exactly as before; verified against the real catalog with the workflow's own jq (`germany-sub`→16, `brazil-sub`→5, `europe`→36, `brazil-sub,france-sub`→32, `all-sub`→159, and `ids=` still overrides).

Nothing is baked yet — this is the catalog and the dispatch plumbing. The bake is a separate, deliberate act.