### PR TITLE
Stop the nav puck surging and wobbling on a real drive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1988,7 +1988,29 @@ architecture note.
   `navSession.onLocation` path - puck/banner/voice keep working, `navStarved` keeps the
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
-  Nav zoom range is 18.0→15.5 (2026-07-14, was 17.3→15.0). **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
+  Nav zoom range is 18.0→15.5 (2026-07-14, was 17.3→15.0). **PUCK JITTER: TWO COUPLINGS, BOTH FIXED 2026-08-16 (issue #251, real drives - the demo-clock
+  fix below was a DIFFERENT bug on the same symptom and did not help a real drive).**
+  (1) **Front-to-back.** The puck eased toward `targetM + reckonedM` and was then clamped
+  monotonic. Individually sensible, together a surge-and-stall at the fix cadence: every fix resets
+  targetM/reckonedM, so `predicted` JUMPS by whatever the dead reckoning over- or under-shot;
+  overshoot puts predicted BEHIND the puck, the ease pulls backward, and the monotonic clamp
+  FREEZES the puck until the reckoning catches up. With a few metres of ordinary GPS noise that is
+  a stall or a lurch every second. Corrected in the RATE domain now: the puck always advances at
+  the modelled speed and the fix error enters as a BOUNDED nudge to that rate
+  (`PUCK_CORRECT_TIME_S`, catch-up capped at 0.5x speed + 1 m/s, hold-back at 0.25x + 0.5). Cannot
+  stall, cannot lurch, still monotonic. Same synthetic fix stream through both rules: 6.8% of
+  frames stalled -> 0%, frame-to-frame speed error 36% -> 20%.
+  (2) **Side-to-side, and it was a REGRESSION from the 2026-07-24 commit that meant to fix the
+  jitter** (c00d31f1, which replaced a fixed 3-point average with a speed-scaled boxcar). The
+  window half-width was tied to the LIVE Kalman speed (`speed*0.7`, 5-14 m). On a curve the
+  averaged point sits inside the arc by ~`win^2/(6R)`, so the WIDTH IS A LATERAL POSITION: swinging
+  it 5->14 m moves the puck ~0.6 m sideways on a 50 m curve, ~1.1 m on a 25 m one - and in
+  heading-up nav the puck is the camera anchor, so it moves the WHOLE MAP. Speed noise was being
+  converted directly into sideways motion. The width now eases with a long time constant
+  (`PUCK_WIN_TAU_S` 2.5 s): it still tracks town-vs-motorway, which is all it was for, but per-fix
+  speed wobble cannot reach it. **Rule: anything that sets the puck's smoothing geometry must
+  change slowly - a fast-moving smoother is not a smoother.**
+  **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
   dominant cause of the "record needle" swim).** `startDemoDrive` feeds
   `locationProvider.replay(fixes, speedup = 1f)` - REAL-TIME fixes - but it also sets
   `replaying`, and MapScreen keyed `replaySpeedup` off that flag alone, so a demo drive

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1570,8 +1570,25 @@ fun VelaMapView(
                 // zoom/look-ahead don't ride a stale speed forever. A resumed fix re-measures.
                 if (sinceFix > 3.0) navPuck.kalman.decay(dtT.coerceAtMost(0.5))
                 val predicted = navPuck.targetM + navPuck.reckonedM
-                val eased = navPuck.progressM + (predicted - navPuck.progressM) * (1f - kotlin.math.exp(-dtEase / 0.25f))
-                navPuck.progressM = maxOf(navPuck.progressM, eased) // monotonic — never backward
+                // FRONT-TO-BACK SMOOTHNESS (issue #251). The puck used to ease toward `predicted`
+                // and then get clamped monotonic. Both halves are individually reasonable and
+                // together they surge and stall at exactly the fix cadence: every fix resets
+                // targetM/reckonedM, so `predicted` JUMPS by however much the dead reckoning
+                // over- or under-shot. Overshoot means predicted lands BEHIND the puck, the ease
+                // pulls backward, the monotonic clamp freezes the puck instead - and it stays
+                // frozen until the reckoning catches up. Undershoot lurches it forward. With GPS
+                // noise of a few metres, that is a stall or a lurch once a second, forever.
+                //
+                // Corrected in the RATE domain instead: the puck always advances at the modelled
+                // speed, and the fix error is fed in as a BOUNDED nudge to that speed. It cannot
+                // stall (the rate floor is 0 only when the model says stopped), it cannot lurch
+                // (the nudge is capped as a fraction of speed), and it is still monotonic. A big
+                // error closes over a couple of seconds rather than in one frame.
+                val err = predicted - navPuck.progressM
+                val maxCatchUp = navPuck.speed * 0.5 + 1.0   // m/s of extra closing speed
+                val maxHoldBack = navPuck.speed * 0.25 + 0.5 // ...and of braking, so it never reverses
+                val corr = (err / PUCK_CORRECT_TIME_S).coerceIn(-maxHoldBack, maxCatchUp)
+                navPuck.progressM += ((navPuck.speed + corr) * dtT.coerceAtMost(0.5)).coerceAtLeast(0.0)
                 val (ptC, segBrg) = pointAtMeters(routePolyline, routeCum, navPuck.progressM)
                 // Lateral de-jitter: drawn straight off the polyline, the puck traced every
                 // lane-level micro-kink of the dense OSM geometry - side-to-side wiggle "like a
@@ -1583,7 +1600,19 @@ fun VelaMapView(
                 // so wiggle shorter than the window CANCELS instead of shrinking. Pure geometry
                 // smoothing, no temporal lag; corners round by a couple of metres at speed,
                 // which is what Google's puck does too.
-                val win = (navPuck.speed * 0.7).coerceIn(5.0, 14.0)
+                // ...but the window WIDTH must not follow the live speed (issue #251, the
+                // side-to-side wobble this very smoothing was added to fix, 2026-07-24). On a
+                // curve the averaged point sits inside the arc by about win^2/(6R), so the width
+                // IS a lateral position: swinging it 5 m to 14 m with the speed estimate moves the
+                // puck ~0.6 m sideways on a 50 m curve and ~1.1 m on a 25 m one - and in
+                // heading-up nav the puck is the camera anchor, so that moves the WHOLE MAP.
+                // Speed noise became sideways motion. The width now eases with a long time
+                // constant: it still grows with speed over tens of seconds, which is all it was
+                // ever meant to do, but per-fix speed wobble cannot reach it.
+                val winTarget = (navPuck.speed * 0.7).coerceIn(5.0, 14.0)
+                navPuck.smoothWin = if (navPuck.smoothWin.isNaN()) winTarget
+                    else navPuck.smoothWin + (winTarget - navPuck.smoothWin) * (1f - kotlin.math.exp(-dtEase / PUCK_WIN_TAU_S))
+                val win = navPuck.smoothWin
                 var sLat = 0.0
                 var sLng = 0.0
                 for (k in 0 until PUCK_SMOOTH_SAMPLES) {
@@ -2434,6 +2463,7 @@ fun VelaMapView(
             var accepted = false
             if (!navPuck.engaged) {
                 navPuck.progressM = m; navPuck.targetM = m; navPuck.engaged = true
+                navPuck.smoothWin = Double.NaN // re-seed the window from the first real speed
                 navPuck.fwdRejects = 0
                 accepted = true
             } else {
@@ -4977,6 +5007,9 @@ private class NavPuck {
     var fwdRejects = 0            // consecutive over-maxStep forward steps — a persistent one is
                                   // the new reality (long fix gap at speed), accept it rather than
                                   // deadlock targetM against a stale plausibility cap
+    var smoothWin = Double.NaN    // the along-route smoothing half-window ACTUALLY in use, eased —
+                                  // see the note at its use site: tying it straight to the live
+                                  // speed made speed noise into sideways puck movement
     var speedAtAccept = 0.0       // kalman speed when the last fix was ACCEPTED — sizes the snap
                                   // look-ahead through an outage (the live model decays to ~0
                                   // exactly when the resume fix needs the window big)
@@ -5050,6 +5083,15 @@ private fun indexAtMeters(cum: DoubleArray, m: Double): Int {
 // Samples in the puck's along-route boxcar average; the half-window itself is speed-scaled at the
 // call site (5-14 m). Odd so the current position is one of the samples.
 private const val PUCK_SMOOTH_SAMPLES = 7
+
+/** Seconds the puck takes to absorb a fix-position error, spread over its own speed rather than
+ *  applied as a jump. Short enough that a real correction is not visibly late, long enough that
+ *  one noisy fix is not a lurch. */
+private const val PUCK_CORRECT_TIME_S = 0.6
+
+/** Time constant for the smoothing window's WIDTH. Deliberately long: the width is meant to track
+ *  the difference between town and motorway, not the difference between two consecutive fixes. */
+private const val PUCK_WIN_TAU_S = 2.5f
 
 private fun pointAtMeters(poly: List<LatLng>, cum: DoubleArray, meters: Double): Pair<LatLng, Float> {
     if (poly.size < 2) return (poly.firstOrNull() ?: LatLng(0.0, 0.0)) to 0f


### PR DESCRIPTION
Real-drive report on 0.4.975: puck still jitters side to side, and front to back too. The earlier demo-clock fix was a genuinely different bug wearing the same symptom, and it did nothing for a real drive. Two couplings here, one of them a regression.

### Front-to-back — surge and stall at the fix cadence

The puck eased toward `targetM + reckonedM` and was then clamped monotonic. Each half is sensible; together they fight. Every fix resets `targetM`/`reckonedM`, so `predicted` **jumps** by however much the dead reckoning over- or under-shot. Overshoot puts `predicted` *behind* the puck, the ease pulls backward, and the monotonic clamp **freezes** it until the reckoning catches up. A few metres of ordinary GPS noise does that once a second, forever.

Now corrected in the **rate domain**: the puck always advances at the modelled speed, and the fix error enters as a bounded nudge to that rate. Can't stall, can't lurch, still monotonic.

Same synthetic fix stream (15 m/s, 1 Hz fixes, ±3 m noise, 60 fps) through both rules:

| | frames stalled | frame-to-frame speed error |
|---|---|---|
| old | 6.8% | 36% |
| new | **0%** | **20%** |

### Side-to-side — a regression from the commit that meant to fix it

c00d31f1 (2026-07-24) replaced a fixed 3-point average with a speed-scaled boxcar, and tied the half-width to the **live** Kalman speed (`speed*0.7`, 5–14 m). On a curve the averaged point sits inside the arc by ~`win²/(6R)` — so **the width is a lateral position**:

| curve radius | lateral swing, win 5→14 m | at nav zoom |
|---|---|---|
| 100 m | 0.28 m | 1.2 dp |
| 50 m | 0.57 m | 2.4 dp |
| 25 m | 1.14 m | 4.9 dp |

Speed noise was being converted straight into sideways movement — and in heading-up nav the puck is the camera anchor, so it moves the **whole map**, not a dot on it. The width now eases with a 2.5 s time constant: still tracks town vs motorway, which is all it was for, but per-fix wobble can't reach it.

**Rule worth keeping: a fast-moving smoother is not a smoother.**

Needs a real drive to confirm — that's the only thing that counts here, and the nav trace (Settings → Diagnostics) will show it numerically if it's still off.