### PR TITLE
Let people use their own font file for the app text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1531,6 +1531,23 @@ architecture note.
   recents list keeps its own X. Menu open-state is `remember(suggestion)`-keyed so a keystroke
   that rebuilds the list closes a stranded menu.
 
+- **UI FONT: user-supplied only, and UI TEXT ONLY (issue #252, 2026-08-16).** `ui/AppFont` +
+  Settings > Appearance > Font: System font, or a font file the user picks from their own storage
+  (SAF, copied to `filesDir/fonts/ui.ttf`, applied via `velaTypography(family)` in VelaTheme).
+  **Vela ships no branded face and cannot** - the one people ask for is Google Sans, which is
+  proprietary, absent from Google Fonts, and not redistributable in a GPLv3 app; Android has no API
+  to enumerate a user's installed fonts; and Downloadable Fonts is served by Play Services, which
+  our users do not have. Handing us their own file is the one legitimate path, and Vela never
+  fetches, ships or uploads it. Three details that matter: the file is VALIDATED BY LOADING IT
+  before adoption (a silently-adopted corrupt font renders every screen in the fallback face, and a
+  silently-rejected one reads as a dead button), the picker filters `*/*` on purpose (font files
+  arrive as font/ttf, application/x-font-ttf and octet-stream depending on the file manager - a
+  filter that hides the user's own font is worse than a chooser showing too much), and init falls
+  back to the system face if the stored copy no longer loads. **MAP LABELS ARE NOT AFFECTED** and
+  cannot be by this mechanism: they are drawn by MapLibre from pre-generated SDF glyph atlases (see
+  MapFonts), so an arbitrary TTF would have to be rasterized into glyph-range PBFs on-device - a
+  separate project, not a config. If bundled faces are ever added, they slot in beside these two
+  rows; nothing else changes.
 - **Interface size (2026-07-11):** `UiScale` holder (pref `ui_scale`, chips 90/100/115/130% in
   Settings -> Appearance) applied as a LocalDensity override around VelaRoot's whole tree - all
   Compose UI scales, the map AndroidView keeps native size (built for car/vertical screens).

--- a/app/src/main/java/app/vela/VelaApp.kt
+++ b/app/src/main/java/app/vela/VelaApp.kt
@@ -85,6 +85,7 @@ class VelaApp : Application(), coil.ImageLoaderFactory {
         }
         app.vela.ui.SimLocation.init(this)
         app.vela.ui.UiScale.init(this)
+        app.vela.ui.AppFont.init(this) // user-supplied UI font (issue #252)
         app.vela.ui.MapColors.init(this)
         app.vela.ui.LiveReviews.init(this)
         app.vela.ui.ShowReviews.init(this)

--- a/app/src/main/java/app/vela/ui/AppFont.kt
+++ b/app/src/main/java/app/vela/ui/AppFont.kt
@@ -1,0 +1,103 @@
+package app.vela.ui
+
+import android.content.Context
+import android.net.Uri
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.text.font.FontFamily
+import java.io.File
+
+/**
+ * The typeface Vela's own UI is drawn in (issue #252).
+ *
+ * **Vela ships no branded font and cannot.** The font people usually mean here is Google Sans,
+ * which is proprietary: not on Google Fonts, not licensed for third-party use, and impossible to
+ * redistribute in a GPLv3 app. Android also has no API to list the fonts a user has installed, and
+ * the download-a-font-on-demand mechanism is served by Play Services, which our users do not have.
+ *
+ * What IS possible, and is what this does: the user hands us a font file from their own storage and
+ * we render with it. Vela never distributes it, never fetches it, and never uploads it - the file is
+ * copied into app storage and read locally. Whatever someone is licensed to have on their own
+ * device, they can use here.
+ *
+ * **This changes the app's UI text only, NOT map labels.** Those are drawn by MapLibre from
+ * pre-generated signed-distance-field glyph atlases (see MapFonts - the Roboto-over-Noto set on
+ * Pages), not from a system typeface: turning an arbitrary TTF into those atlases means rendering
+ * every glyph range on-device, which is a different project entirely. So a custom font restyles the
+ * sheets, search, settings and nav cards; the street names on the map stay as they are.
+ */
+object AppFont {
+
+    /** The family to draw UI text in, or null for the platform default. Read in the theme. */
+    val family = mutableStateOf<FontFamily?>(null)
+
+    /** File name the user picked, for display. Null when on the system font. */
+    val customName = mutableStateOf<String?>(null)
+
+    /** A font file is a few hundred KB; anything far past that is not a font we want to load. */
+    private const val MAX_BYTES = 12L * 1024 * 1024
+
+    fun init(context: Context) {
+        val name = prefs(context).getString(KEY_NAME, null) ?: return
+        val f = fontFile(context)
+        if (!f.exists()) { clear(context); return }
+        val fam = load(f)
+        if (fam == null) { clear(context); return } // unreadable now (corrupt copy) - fall back quietly
+        family.value = fam
+        customName.value = name
+    }
+
+    /**
+     * Adopt the font at [uri]. Returns false when it is not a usable font file, in which case
+     * nothing changes - the file is validated by actually LOADING it before it is adopted, because
+     * a rejected font that silently leaves the app in the system face reads as "the button did
+     * nothing", and a corrupt one adopted blind would render every screen in the fallback face.
+     */
+    fun setCustom(context: Context, uri: Uri, displayName: String): Boolean {
+        val tmp = File(context.filesDir, "fonts/incoming.tmp")
+        tmp.parentFile?.mkdirs()
+        val copied = runCatching {
+            context.contentResolver.openInputStream(uri).use { input ->
+                if (input == null) return false
+                var total = 0L
+                tmp.outputStream().use { out ->
+                    val buf = ByteArray(64 * 1024)
+                    while (true) {
+                        val n = input.read(buf)
+                        if (n <= 0) break
+                        total += n
+                        if (total > MAX_BYTES) return@runCatching false
+                        out.write(buf, 0, n)
+                    }
+                }
+                total > 0
+            }
+        }.getOrDefault(false)
+        if (!copied) { tmp.delete(); return false }
+        val fam = load(tmp)
+        if (fam == null) { tmp.delete(); return false }
+        val dest = fontFile(context)
+        dest.delete()
+        if (!tmp.renameTo(dest)) { tmp.delete(); return false }
+        family.value = fam
+        customName.value = displayName
+        prefs(context).edit().putString(KEY_NAME, displayName).apply()
+        return true
+    }
+
+    /** Back to the platform font. */
+    fun clear(context: Context) {
+        family.value = null
+        customName.value = null
+        fontFile(context).delete()
+        prefs(context).edit().remove(KEY_NAME).apply()
+    }
+
+    /** null when the file is not a font the platform can parse. */
+    private fun load(f: File): FontFamily? = runCatching {
+        FontFamily(androidx.compose.ui.text.font.Font(f))
+    }.getOrNull()
+
+    private fun fontFile(c: Context) = File(c.filesDir, "fonts/ui.ttf")
+    private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
+    private const val KEY_NAME = "ui_font_name"
+}

--- a/app/src/main/java/app/vela/ui/settings/sections/AppearanceSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/AppearanceSettings.kt
@@ -2,6 +2,7 @@ package app.vela.ui.settings.sections
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.FlowRow
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -67,6 +68,44 @@ internal fun AppearanceSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
         )
         }
         Hint(stringResource(R.string.settings_appearance_hint))
+
+        // FONT (issue #252). Only two states, and deliberately so: the platform font, or a file the
+        // user supplies. We ship no faces of our own - the one people ask for is proprietary and
+        // cannot be redistributed - so the honest offer is "use what you already have a licence to".
+        Spacer(Modifier.height(8.dp))
+        val fontBad = stringResource(R.string.settings_font_bad)
+        val fontPicker = rememberLauncherForActivityResult(
+            androidx.activity.result.contract.ActivityResultContracts.OpenDocument(),
+        ) { uri ->
+            if (uri != null) {
+                val name = queryDisplayName(context, uri) ?: "Custom"
+                if (!app.vela.ui.AppFont.setCustom(context, uri, name)) {
+                    android.widget.Toast.makeText(context, fontBad, android.widget.Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+        SettingsGroup(title = stringResource(R.string.settings_font)) {
+            SelectableRow(
+                label = stringResource(R.string.settings_font_system),
+                selected = app.vela.ui.AppFont.customName.value == null,
+                onClick = { app.vela.ui.AppFont.clear(context) },
+            )
+            GroupDivider()
+            SelectableRow(
+                label = app.vela.ui.AppFont.customName.value ?: stringResource(R.string.settings_font_choose),
+                selected = app.vela.ui.AppFont.customName.value != null,
+                // Picking the row re-opens the chooser, so swapping fonts is one tap either way -
+                // whether a custom font is already set or not.
+                onClick = {
+                    // Fonts arrive under a pile of MIME types (font/ttf, application/x-font-ttf,
+                    // application/octet-stream from some file managers), so accept anything and let
+                    // AppFont reject what will not load. A filter that hides the user's font file is
+                    // worse than a chooser that shows too much.
+                    fontPicker.launch(arrayOf("*/*"))
+                },
+            )
+        }
+        Hint(stringResource(R.string.settings_font_hint))
 
         Spacer(Modifier.height(8.dp))
         // Interface size: scales every control and sheet (not the map) - for car/tablet
@@ -194,3 +233,10 @@ internal fun AppearanceSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
         Spacer(Modifier.height(24.dp))
     }
 }
+
+
+/** The human file name behind a document [uri], for the settings row. */
+private fun queryDisplayName(context: android.content.Context, uri: android.net.Uri): String? = runCatching {
+    context.contentResolver.query(uri, arrayOf(android.provider.OpenableColumns.DISPLAY_NAME), null, null, null)
+        ?.use { c -> if (c.moveToFirst()) c.getString(0) else null }
+}.getOrNull()

--- a/app/src/main/java/app/vela/ui/theme/Theme.kt
+++ b/app/src/main/java/app/vela/ui/theme/Theme.kt
@@ -95,5 +95,5 @@ fun VelaTheme(
         darkTheme -> DarkColors
         else -> LightColors
     }
-    MaterialTheme(colorScheme = colorScheme, typography = VelaTypography, content = content)
+    MaterialTheme(colorScheme = colorScheme, typography = velaTypography(app.vela.ui.AppFont.family.value), content = content)
 }

--- a/app/src/main/java/app/vela/ui/theme/Type.kt
+++ b/app/src/main/java/app/vela/ui/theme/Type.kt
@@ -17,6 +17,24 @@ private fun TextStyle.scaled(): TextStyle = copy(
     lineHeight = if (lineHeight.isSpecified) lineHeight * SCALE else lineHeight,
 )
 
+/**
+ * The type scale in [family], or the platform font when null (issue #252: a user can point Vela at
+ * a font file of their own - see [app.vela.ui.AppFont]). Applying the family here means one place
+ * decides it, rather than every composable that sets a style having to remember.
+ */
+fun velaTypography(family: androidx.compose.ui.text.font.FontFamily? = null): Typography {
+    fun TextStyle.f(): TextStyle = if (family == null) this else copy(fontFamily = family)
+    return VelaTypography.run {
+        copy(
+            displayLarge = displayLarge.f(), displayMedium = displayMedium.f(), displaySmall = displaySmall.f(),
+            headlineLarge = headlineLarge.f(), headlineMedium = headlineMedium.f(), headlineSmall = headlineSmall.f(),
+            titleLarge = titleLarge.f(), titleMedium = titleMedium.f(), titleSmall = titleSmall.f(),
+            bodyLarge = bodyLarge.f(), bodyMedium = bodyMedium.f(), bodySmall = bodySmall.f(),
+            labelLarge = labelLarge.f(), labelMedium = labelMedium.f(), labelSmall = labelSmall.f(),
+        )
+    }
+}
+
 val VelaTypography: Typography = Typography().run {
     copy(
         displayLarge = displayLarge.scaled(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -714,6 +714,11 @@
     <string name="settings_hub_diagnostics_sub">Crash reports, trips, compatibility</string>
     <string name="settings_hub_about_sub">Version, updates, support</string>
     <string name="settings_theme_amoled">AMOLED black</string>
+    <string name="settings_font">Font</string>
+    <string name="settings_font_system">System font</string>
+    <string name="settings_font_choose">Choose a font file…</string>
+    <string name="settings_font_hint">Vela cannot ship Google Sans: it is proprietary and cannot be redistributed. You can point Vela at any font file on your own device instead. Map labels keep their own font.</string>
+    <string name="settings_font_bad">That file could not be read as a font.</string>
     <string name="settings_traffic_lights">Traffic-light guidance</string>
     <string name="settings_traffic_lights_hint">Spoken landmark cues: pass the light, then turn. English only, off by default.</string>
     <string name="settings_softkeys" translatable="false">Hardware softkeys</string>


### PR DESCRIPTION
Closes #252

**Vela can't ship the font people mean.** Google Sans is proprietary, isn't in the open Google Fonts collection, and can't be redistributed in a GPLv3 app. Android has no API to enumerate a user's installed fonts, and Downloadable Fonts is served by Play Services — which our users deliberately don't have. So there's no version of "hardcode it" that's legal or even technically available.

What *is* available: the user supplies a file they're already licensed to have. Settings → Appearance → Font: system font, or pick any font file on the device. Vela never fetches, ships, or uploads it — it's copied into app storage and read locally.

Three details that would each have been a bug:

- **Validated by actually loading it** before adoption. A corrupt file adopted blind renders every screen in the fallback face; one rejected silently reads as a dead button. Bad file → toast, nothing changes.
- **Picker filters `*/*` deliberately.** Font files arrive as `font/ttf`, `application/x-font-ttf`, or `application/octet-stream` depending on the file manager. A filter that hides the user's own font is worse than a chooser that shows too much.
- **Init falls back to the system face** if the stored copy no longer loads, rather than leaving the app in a broken typeface.

**Map labels are unaffected, and can't be by this mechanism.** They're drawn by MapLibre from pre-generated SDF glyph atlases, so an arbitrary TTF would have to be rasterized into glyph-range PBFs on device — a separate project, not a setting. Worth saying out loud since the issue asks about "the tiles".

No bundled faces in this PR. If we add some later they're two more rows in the same group; I'd rather you pick which ones than have me guess.