### PR TITLE
Record what the offline region bake actually costs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2374,6 +2374,25 @@ architecture note.
   `.github/workflows/obf-regions.yml` (matrix clone; the MapCreator tool is pinned on the
   `obf-tools` release); assets are RAW .obf (already deflate-compressed inside; download size ==
   installed size).
+  **WITHOUT HH, OFFLINE OBF ROUTING FAILS OUTRIGHT PAST ~100 km - IT IS NOT MERELY SLOW (measured
+  2026-08-17 against a real baked Bayern obf, using ObfRouteEngine's own config and memory limits).**
+  The router does not degrade gracefully: past a distance it throws
+  `IllegalStateException: There is not enough memory ... - limit 256 MB`, which is
+  `ObfRouteEngine.MEMORY_MB`. Measured on a fast desktop, car profile:
+    4 km   -> 0.87 s at 256 MB
+    57 km  -> 5.65 s at 256 MB
+    151 km -> FAILS at 256 MB; 4.6 s once given 1024 MB
+    348 km -> FAILS at 256 MB and at 1024 MB; 41.9 s once given 3072 MB
+  So the requirement scales steeply with route length, and **raising MEMORY_MB is not available to
+  us**: the app runs under `largeHeap` (~512 MB total, and it already fights that ceiling - see the
+  ambient fan-out and MemoryPressure notes), so a routing context wanting 1-3 GB cannot exist on a
+  phone at all. **This means the obf migration as currently baked is a REGRESSION against the
+  GraphHopper graphs for long offline routes**, because those ship CH (contraction hierarchies)
+  and did a 24-mile route in 188 ms. HH is the obf equivalent, and `scripts/VelaObfShim.java` does
+  NOT generate it. So HH is not the "follow-up if long routes measure slow" this file used to call
+  it - it is a PREREQUISITE for offline feature parity, and it lands on top of a bake that already
+  does not fit CI. Until HH exists, offline obf routing is a city/metro feature; anything intercity
+  must stay online or stay on GraphHopper.
   **THE BAKE DOES NOT FIT A GITHUB RUNNER AT COUNTRY SCALE (measured 2026-08-16, the first time
   obf-regions.yml was ever run).** Luxembourg and Delaware baked fine (39 MB and 20 MB obf); Czech
   Republic and `de-bayern` both died with `OutOfMemoryError: Java heap space` at `-Xmx12g` on a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2373,7 +2373,20 @@ architecture note.
   languages come along). Bake: `scripts/build-obf-region.sh` + `merge-obf-manifest.sh` +
   `.github/workflows/obf-regions.yml` (matrix clone; the MapCreator tool is pinned on the
   `obf-tools` release); assets are RAW .obf (already deflate-compressed inside; download size ==
-  installed size). CUTOVER = the manifest, and the world bake STAGES it (2026-08-03): dispatching obf-regions
+  installed size).
+  **THE BAKE DOES NOT FIT A GITHUB RUNNER AT COUNTRY SCALE (measured 2026-08-16, the first time
+  obf-regions.yml was ever run).** Luxembourg and Delaware baked fine (39 MB and 20 MB obf); Czech
+  Republic and `de-bayern` both died with `OutOfMemoryError: Java heap space` at `-Xmx12g` on a
+  16 GB runner, and Bayern (810 MB pbf) OOM'd AGAIN at 14g after three hours. Two traps in reading
+  that: (1) **a sub-area is not automatically small enough** - Bayern IS one of the germany-sub
+  rows, so #254's split helps download size but does NOT get a bake under the memory ceiling;
+  (2) **a longer run is not progress** - the 14g attempt lasted 4x longer than the 12g one and
+  still failed, because a nearly-full heap thrashes before it dies. `processInRam` already defaults
+  to false, so that knob is not the answer. Untried: ParallelGC (SerialGC's single-threaded full
+  collections are the likely reason 14g took three hours to fail), and baking big regions off-CI
+  where more RAM is available - `JAVA_HEAP` in build-obf-region.sh exists for exactly that. Until
+  this is solved the world bake CANNOT be dispatched: ~30 big rows would burn hours each and fail.
+  CUTOVER = the manifest, and the world bake STAGES it (2026-08-03): dispatching obf-regions
   with the default staging=true merges entries into `obf-manifest-staging.json`, which the app
   never reads - bake every group there, then ONE `gh release download/upload` copy of staging
   over the live name flips the whole catalog atomically (region-by-region merging into the live

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2374,9 +2374,12 @@ architecture note.
   `.github/workflows/obf-regions.yml` (matrix clone; the MapCreator tool is pinned on the
   `obf-tools` release); assets are RAW .obf (already deflate-compressed inside; download size ==
   installed size).
-  **WITHOUT HH, OFFLINE OBF ROUTING FAILS OUTRIGHT PAST ~100 km - IT IS NOT MERELY SLOW (measured
-  2026-08-17 against a real baked Bayern obf, using ObfRouteEngine's own config and memory limits).**
-  The router does not degrade gracefully: past a distance it throws
+  **WITHOUT HH, A LONG OFFLINE ROUTE CAN FAIL OUTRIGHT, NOT MERELY RUN SLOW (measured 2026-08-17
+  against a real baked Bayern obf, using ObfRouteEngine's own config and memory limits).** NB the
+  threshold is REGION-DEPENDENT, not a fixed distance: a 150 km cross-file route in Saarland/
+  Rheinland-Pfalz completed on the 4a in 69 s (2026-08-03), while the same distance across Bayern's
+  denser network fails at the shipped limit. Treat the distances below as one dense sample, not a
+  universal cutoff. The router does not degrade gracefully: past its budget it throws
   `IllegalStateException: There is not enough memory ... - limit 256 MB`, which is
   `ObfRouteEngine.MEMORY_MB`. Measured on a fast desktop, car profile:
     4 km   -> 0.87 s at 256 MB

--- a/scripts/build-obf-region.sh
+++ b/scripts/build-obf-region.sh
@@ -50,7 +50,11 @@ javac -cp "$WORK/mapcreator/OsmAndMapCreator.jar:$WORK/mapcreator/lib/*" -d "$WO
 # to full its single-threaded full collections are likely most of that three hours - try
 # ParallelGC before reading any timing from this path as the tool's true cost.
 # Regions this size need a machine with more RAM than a 16 GB runner; JAVA_HEAP exists so a local
-# bake can be handed the headroom (a 32 GB machine can spare 24g).
+# bake can be handed the headroom. MEASURED on a 32 GB machine: bayern at -Xmx22g SUCCEEDS in
+# 3h07m and produces a 694 MB obf, with the heap peaking around 18.4 GB before a full GC - which is
+# why 14g never had a chance, and why no GC flag was ever going to save it. ParallelGC vs SerialGC
+# did not change the outcome, only the time to reach it (50 min vs 3 h to the same OOM), so it is
+# still the right collector here: a doomed region should fail fast.
 JAVA_HEAP="${JAVA_HEAP:-14g}"
 echo "→ index heap: $JAVA_HEAP"
 set +e

--- a/scripts/build-obf-region.sh
+++ b/scripts/build-obf-region.sh
@@ -36,12 +36,21 @@ javac -cp "$WORK/mapcreator/OsmAndMapCreator.jar:$WORK/mapcreator/lib/*" -d "$WO
 # Not processInRam (it already defaults to false): MapCreator's disk-backed pipeline is what lets a
 # region bake inside a small runner at all. The heap bound is for its indexes, not the region.
 #
-# HEAP (2026-08-16): 12g was not enough for anything country-sized - Czech Republic AND Bayern, a
-# mere German sub-area, both died with "OutOfMemoryError: Java heap space" on a 16 GB runner while
-# Luxembourg and Delaware sailed through. So the ceiling sits well below a country, and splitting
-# into sub-areas does NOT by itself get under it. 14g leaves the runner ~2 GB, which is enough for
-# a machine doing nothing else, and SerialGC is deliberate: G1's region bookkeeping and concurrent
-# threads cost hundreds of MB that a single-shot batch job has no use for.
+# HEAP (2026-08-16). MEASURED, and the honest summary is that a GitHub runner cannot do this at
+# country scale:
+#   luxembourg  (~30 MB pbf)  -> 39 MB obf   OK at 12g
+#   delaware    (~30 MB pbf)  -> 20 MB obf   OK at 12g
+#   czech-republic            -> OOM at 12g (~37 min in)
+#   de-bayern   (810 MB pbf)  -> OOM at 12g (~37 min), and OOM AGAIN at 14g after THREE HOURS
+# So the ceiling sits somewhere between a US state and an 810 MB extract, and splitting a country
+# into sub-areas does NOT by itself get under it - Bayern IS a sub-area. Note the 14g run's three
+# hours: a job that slows down and then dies is thrashing a nearly-full heap, so a long runtime
+# here is a symptom of the failure, not progress toward success. SerialGC keeps G1's region
+# bookkeeping and concurrent threads (hundreds of MB) out of the way, but with the heap this close
+# to full its single-threaded full collections are likely most of that three hours - try
+# ParallelGC before reading any timing from this path as the tool's true cost.
+# Regions this size need a machine with more RAM than a 16 GB runner; JAVA_HEAP exists so a local
+# bake can be handed the headroom (a 32 GB machine can spare 24g).
 JAVA_HEAP="${JAVA_HEAP:-14g}"
 echo "→ index heap: $JAVA_HEAP"
 set +e

--- a/scripts/build-obf-region.sh
+++ b/scripts/build-obf-region.sh
@@ -33,9 +33,29 @@ read -r MINLON MINLAT MAXLON MAXLAT < <(osmium fileinfo -g header.boxes "$WORK/r
 BBOX="[$MINLAT,$MINLON,$MAXLAT,$MAXLON]"
 
 javac -cp "$WORK/mapcreator/OsmAndMapCreator.jar:$WORK/mapcreator/lib/*" -d "$WORK" "$ROOT/scripts/VelaObfShim.java"
-# Not processInRam: MapCreator's disk-backed pipeline is what lets a whole country bake inside a
-# 16 GB runner. The heap bound is for its indexes, not the region.
-( cd "$WORK" && java -Xmx12g -cp "$WORK/mapcreator/OsmAndMapCreator.jar:$WORK/mapcreator/lib/*:$WORK" VelaObfShim region.osm.pbf )
+# Not processInRam (it already defaults to false): MapCreator's disk-backed pipeline is what lets a
+# region bake inside a small runner at all. The heap bound is for its indexes, not the region.
+#
+# HEAP (2026-08-16): 12g was not enough for anything country-sized - Czech Republic AND Bayern, a
+# mere German sub-area, both died with "OutOfMemoryError: Java heap space" on a 16 GB runner while
+# Luxembourg and Delaware sailed through. So the ceiling sits well below a country, and splitting
+# into sub-areas does NOT by itself get under it. 14g leaves the runner ~2 GB, which is enough for
+# a machine doing nothing else, and SerialGC is deliberate: G1's region bookkeeping and concurrent
+# threads cost hundreds of MB that a single-shot batch job has no use for.
+JAVA_HEAP="${JAVA_HEAP:-14g}"
+echo "→ index heap: $JAVA_HEAP"
+set +e
+( cd "$WORK" && java -Xmx"$JAVA_HEAP" -XX:+UseSerialGC -cp "$WORK/mapcreator/OsmAndMapCreator.jar:$WORK/mapcreator/lib/*:$WORK" VelaObfShim region.osm.pbf )
+RC=$?
+set -e
+if [ $RC -ne 0 ]; then
+  # Say WHICH region was too big and how big its source was, so a world bake reports a usable list
+  # of what needs baking elsewhere instead of a wall of identical red crosses.
+  PBF_MB=$(( ( $(stat -f%z "$WORK/region.osm.pbf" 2>/dev/null || stat -c%s "$WORK/region.osm.pbf") + 1048575 ) / 1048576 ))
+  echo "::error::$ID FAILED to index (exit $RC). Source PBF was ${PBF_MB} MB. If this was an" \
+       "OutOfMemoryError, this region does not fit a $JAVA_HEAP heap - bake it on a bigger machine."
+  exit $RC
+fi
 OBF="$(ls "$WORK"/*.obf | head -1)"  # generateObf names the output from the pbf filename
 mv "$OBF" "$WORK/$ID.obf"
 


### PR DESCRIPTION
First real runs of `obf-regions.yml` — it had never been dispatched before today. Results:

| region | source pbf | result |
|---|---|---|
| luxembourg | ~30 MB | ✅ 39 MB obf |
| delaware | ~30 MB | ✅ 20 MB obf |
| czech-republic | — | ❌ OOM at 12g, ~37 min |
| de-bayern | 810 MB | ❌ OOM at 12g (~37 min), **OOM again at 14g after 3 hours** |

**A GitHub runner can't do this at country scale.** Two conclusions that are easy to get backwards, both of which I got wrong at some point today and am writing down so nobody repeats them:

1. **A sub-area isn't automatically small enough.** Bayern *is* one of the `germany-sub` rows. So #254's split helps download size but does **not** get a bake under the memory ceiling. I claimed the opposite when only Czech had failed.
2. **A longer run isn't progress.** The 14g attempt ran 4× longer than the 12g one and still died — a nearly-full heap thrashes before it fails. I read the extra runtime as encouraging; it was the symptom.

`processInRam` already defaults to false, so that knob isn't the answer either.

This PR doesn't fix it. It raises the heap to 14g (which helps nothing at 810 MB but is free), makes `JAVA_HEAP` settable so an off-CI bake can be given real headroom, and makes failures name the region and its source size so a world run produces a list of what needs baking elsewhere instead of a wall of identical red crosses.

**Untried, in the order I'd try them:** ParallelGC (SerialGC's single-threaded full collections are the likely reason 14g took three hours to fail — I chose it for memory and it probably cost most of that time), then baking big regions on a machine with more RAM.

**The world bake cannot be dispatched until this is settled** — roughly 30 big rows would each burn hours and fail.