### PR TITLE
Add a Start button to place pages and tidy the nav bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -585,6 +585,21 @@ Defaults that make the safe path the easy one:
   maneuvers[liveStep-1].ref; the exit fold adopts the folded branch's road/ref so it survives
   on-ramps). Rerouting plays a two-note earcon (VoiceGuide.reroutingChime, in-process synth,
   muted-gated) before the throttled spoken word.
+  **Place sheet has START beside Directions; the nav bar is END | figures | STEPS (issues
+  #272/#273, 2026-08-17).** Directions opens the picker whose own Start sits BELOW the route list,
+  so with three routes on a large-font screen the commonest action (just take me there) needed a
+  scroll - the START pill routes and launches in one tap (`MapViewModel.startNavToSelected` sets
+  `autoStartOnRoute`; MapScreen consumes it ONCE when a route lands). **It fires through
+  MapScreen's `onStartNav`, never straight at the VM** - a one-tap Start must not become a way
+  around the precise-location and notification gates the picker's Start honours; and the flag is
+  consume-once + cleared by `clearRoute`/`startNav` so a later refetch (mode change, added stop)
+  cannot silently launch a drive. Not offered for the parked car (you are already at the start of
+  that walk). The nav bottom bar swapped End's labelled Button for a 54dp X icon on the LEFT with
+  the trip figures CENTRED and Steps on the right: two controls of the same size doing the same
+  job should be the same shape, and this is the arrangement where they cannot be mistaken for
+  each other. End keeps `errorContainer` colouring - it is the one control that throws the drive
+  away, and an unlabelled X must not read as just another button; its label lives on as the
+  content description.
   **Nav UI style (2026-07-08):** ManeuverBanner + NavControls are RoundedCornerShape(24/28dp)
   Cards with elevation 6dp, 54dp turn glyph, headlineMedium-bold distance, titleMedium-medium road
   name, FilledTonalIconButton for mute/steps. Keep new nav chrome on this treatment (no flat

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -832,6 +832,14 @@ fun MapScreen(
     val onStartNav: () -> Unit = {
         if (!fineGranted() && !vm.demoDriveOn()) showPreciseNeeded = true else proceedStartNav()
     }
+    // START from the place sheet (issue #272): the pill routes, and guidance begins the moment a
+    // route exists. It goes through onStartNav, NOT straight to the ViewModel, so the precise-
+    // location and notification gates still get their say - a one-tap Start must not be a way to
+    // skip the permission prompts that the picker's Start button honours. Consumed once, so a
+    // later refetch (mode change, added stop) cannot silently launch a drive.
+    LaunchedEffect(state.activeRoute, state.navigating) {
+        if (state.activeRoute != null && !state.navigating && vm.consumeAutoStart()) onStartNav()
+    }
     if (showPreciseNeeded) {
         app.vela.ui.VelaDialog(
             onDismissRequest = { showPreciseNeeded = false },
@@ -1840,6 +1848,7 @@ fun MapScreen(
                 onClose = vm::clearSelection,
                 onToggleSave = vm::toggleSave,
                 onDirections = vm::routeToSelected,
+                onStartNavigation = { vm.startNavToSelected() },
                 onStreetView = { vm.openStreetView(state.selected!!) },
                 onOpenPlace = vm::selectPlace,
                 onOpenSimilar = vm::openSimilar,

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -2638,6 +2638,7 @@ class MapViewModel @Inject constructor(
     /** Back out of the directions preview to the place sheet: drop the route,
      *  keep the place selected (so back peels one layer at a time). */
     fun clearRoute() {
+        autoStartOnRoute = false // backing out of directions cancels a pending auto-start (issue #272)
         destination = null
         routeJob?.cancel() // an in-flight directions fetch must not repopulate the route we're backing out of
         _state.update {
@@ -3018,6 +3019,26 @@ class MapViewModel @Inject constructor(
     fun quickSearch(category: String) {
         _state.update { it.copy(query = category) }
         search()
+    }
+
+    /**
+     * Set when Directions was entered via the place sheet's START pill (issue #272): the moment a
+     * route lands, begin guidance instead of parking on the picker. Consumed once - a later route
+     * refetch (a mode change, an added stop) must not re-launch nav behind the user.
+     */
+    @Volatile var autoStartOnRoute = false
+        private set
+
+    fun consumeAutoStart(): Boolean {
+        if (!autoStartOnRoute) return false
+        autoStartOnRoute = false
+        return true
+    }
+
+    /** Directions for the selected place, launching guidance as soon as a route exists. */
+    fun startNavToSelected() {
+        autoStartOnRoute = true
+        routeToSelected()
     }
 
     fun routeToSelected() {
@@ -3647,6 +3668,7 @@ class MapViewModel @Inject constructor(
     private var navStartJob: kotlinx.coroutines.Job? = null
 
     fun startNav() {
+        autoStartOnRoute = false // an explicit Start supersedes any pending auto-start
         val route = _state.value.activeRoute ?: return
         // RE-ENTRANCY GUARD (user 2026-07-16: multiple "Starting navigation" from double-tapping
         // while start was slow): ignore Start while a start is already in flight or nav is running.

--- a/app/src/main/java/app/vela/ui/nav/NavOverlays.kt
+++ b/app/src/main/java/app/vela/ui/nav/NavOverlays.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.VolumeOff
 import androidx.compose.material.icons.filled.VolumeUp
@@ -703,12 +704,34 @@ fun NavControls(
             contentColor = SheetPalette.ink(dark),
         ),
     ) {
+        // LAYOUT (issue #273): End on the LEFT as an icon, the trip figures CENTRED, Steps on the
+        // right. Previously the figures sat left with two controls crowded right, one an icon and
+        // one a labelled button - two different shapes doing the same job at the same size. As
+        // icons they read as a matched pair with the numbers between them, which is also the one
+        // arrangement where the two 54dp targets cannot be hit by mistake for each other.
         Row(
             Modifier.fillMaxWidth().padding(horizontal = 18.dp, vertical = 14.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Column(Modifier.weight(1f)) {
+            // End keeps a DESTRUCTIVE colour rather than the tonal fill Steps uses: it is the one
+            // control here that throws the drive away, and an unlabelled X must not look like just
+            // another button. The label survives as its accessibility name.
+            FilledTonalIconButton(
+                onClick = onStop,
+                modifier = Modifier.size(54.dp),
+                colors = androidx.compose.material3.IconButtonDefaults.filledTonalIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                ),
+            ) {
+                Icon(Icons.Default.Close, contentDescription = stringResource(R.string.nav_end), modifier = Modifier.size(26.dp))
+            }
+            Spacer(Modifier.width(8.dp))
+            Column(
+                Modifier.weight(1f),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
                 // Both lines SHRINK to fit rather than wrap or ellipsise: the 54dp buttons (and
                 // any Interface-size scale) squeezed the column and "1 hr 25 min" wrapped rough,
                 // while ellipsis on the second line cut off the arrival TIME (user 2026-07-11).
@@ -726,17 +749,9 @@ fun NavControls(
                 )
             }
             Spacer(Modifier.width(8.dp))
-            // Steps is icon-only so the row stays compact (the left ETA column can
-            // grow with a longer "X mi · 7:42 PM"); End keeps its label.
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-                // Bigger driving targets (user 2026-07-11, car-screen use): 54dp buttons,
-                // 26dp glyphs; End matches the height so the row reads as one control set.
-                FilledTonalIconButton(onClick = onSteps, modifier = Modifier.size(54.dp)) {
-                    Icon(Icons.AutoMirrored.Filled.List, contentDescription = stringResource(R.string.nav_steps), modifier = Modifier.size(26.dp))
-                }
-                Button(onClick = onStop, modifier = Modifier.height(54.dp)) {
-                    Text(stringResource(R.string.nav_end), maxLines = 1, softWrap = false)
-                }
+            // Bigger driving targets (user 2026-07-11, car-screen use): 54dp buttons, 26dp glyphs.
+            FilledTonalIconButton(onClick = onSteps, modifier = Modifier.size(54.dp)) {
+                Icon(Icons.AutoMirrored.Filled.List, contentDescription = stringResource(R.string.nav_steps), modifier = Modifier.size(26.dp))
             }
         }
     }

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -253,6 +253,8 @@ fun PlaceSheet(
     onClose: () -> Unit,
     onToggleSave: () -> Unit,
     onDirections: () -> Unit,
+    // Route AND begin guidance in one tap (issue #272). Null hides the pill.
+    onStartNavigation: (() -> Unit)? = null,
     onStreetView: () -> Unit = {},
     onOpenPlace: (Place) -> Unit = {},
     onOpenSimilar: (app.vela.core.model.SimilarPlace) -> Unit = {},
@@ -921,6 +923,14 @@ fun PlaceSheet(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 ActionPill(Icons.Default.Directions, stringResource(R.string.place_directions), emphasized = true, onClick = onDirections)
+                // START, right beside Directions (issue #272). Directions opens the picker, whose
+                // own Start sits BELOW the route list - with three routes on a large-font screen
+                // that is off the bottom of the sheet, so the common case (just take me there)
+                // needed a scroll. Not offered for the parked car, where you are already at the
+                // start of the walk and "Directions" is the useful verb.
+                if (onStartNavigation != null && !isParking) {
+                    ActionPill(Icons.Filled.Navigation, stringResource(R.string.place_start), onClick = onStartNavigation)
+                }
                 if (isParking) {
                     ActionPill(Icons.Default.Delete, stringResource(R.string.place_clear_parking), onClick = onClearParking)
                 }


### PR DESCRIPTION
Closes #272
Closes #273

**#272 — Start beside Directions.** The reporter's point is concrete: Directions opens the picker, whose Start sits *below* the route list, so with three routes on a large-font screen the commonest action needs a scroll. The pill routes and launches in one tap.

Two things I was careful about:
- **It fires through MapScreen's `onStartNav`, not straight at the ViewModel.** A one-tap Start must not become a way around the precise-location and notification gates that the picker's Start honours.
- **Consume-once**, and cleared by `clearRoute`/`startNav`. Otherwise a later refetch — changing travel mode, adding a stop — would silently launch a drive behind the user.

Not offered for the parked car: you're already at the start of that walk, and "Directions" is the useful verb there.

**#273 — nav bar reorganised** to End | figures | Steps, per the mockup. Two controls of the same size doing the same kind of job should be the same shape, and this is the arrangement where the two 54dp targets can't be mistaken for each other mid-drive.

One deviation from the mockup: **End keeps a destructive colour** (`errorContainer`) rather than matching Steps' tonal fill. It's the one control on that bar that throws the drive away, and an unlabelled X shouldn't read as just another button. The "End" label survives as its content description, so screen readers and the D-pad still announce it.

D-pad audit clean, core tests pass. Both want a device look — that's next.