### PR TITLE
Stop rerouting sending you back the way you came

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1968,6 +1968,21 @@ architecture note.
   ladders inside directions() could hold the single-flight latch for a minute on a flaky cell
   link, silently dropping every new RerouteNeeded (a real-drive hang); past the deadline it
   fails into the same retry-while-deviated path so the next fix fires a fresh request. And
+  **A REROUTE PINS ITS DEPARTURE HEADING (real-drive report 2026-08-17: "it keeps rerouting me the
+  way I was going before").** After a wrong turn, an unconstrained reroute is perfectly entitled to
+  answer "U-turn and rejoin" - from a point a few tens of metres down the wrong road, going back
+  often IS the fastest path - so the driver is told to turn around, carries on anyway, and is told
+  to turn around again. `RouteGeometry.departBearingParam` sends OSRM `bearings=<heading>,65` for
+  the FIRST waypoint only (every later waypoint gets an empty entry; the count MUST match the
+  coordinates or OSRM rejects the whole request and the reroute dies with it), so the router answers
+  "given that I am going this way, what now" - which is what Google does. Threaded
+  NavSession.onLocation's `bearingDeg` -> reroute -> `MapDataSource.directions(departBearingDeg=)`.
+  **Planning fetches send NOTHING**: which way a parked car happens to face is not a routing
+  constraint. Null heading (stationary, or a fix without one) also sends nothing - a stale heading
+  is worse than none. Unit-tested on the STRING (`DepartBearingTest`) because a malformed parameter
+  is not an error: OSRM ignores it and routes as before, so the fix would silently do nothing.
+  Note the related gate this does NOT change: off-route detection needs `movingFloorMps` = 2.0, so
+  inching away from a junction is not counted as deviating until the 90 m far-off rule fires.
   since 2026-08-04 the reroute fetch is URGENT (`directions(urgent = true)`, issues #185/#236):
   single-shot OSRM + Google (no 3x ladders), no divergence snap - the full planning ladder
   regularly outlived the deadline on a weak link, so the timeout cancelled fetches that were

--- a/core/src/main/java/app/vela/core/data/MapDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/MapDataSource.kt
@@ -94,6 +94,12 @@ interface MapDataSource {
         // Mid-drive reroute: single-shot fetches, no divergence snap — a fast usable route now
         // beats a polished one after the reroute deadline (the recheck loop upgrades it later).
         urgent: Boolean = false,
+        // The direction the car is ACTUALLY pointing, for a mid-drive reroute (real-drive report
+        // 2026-08-17). Without it a reroute a few tens of metres down a wrong road is free to
+        // answer "U-turn and rejoin" - which is often genuinely the fastest path, so the driver is
+        // told to turn around, carries on anyway, and is told to turn around again. Null on a
+        // planning fetch: which way a parked car happens to face is not a routing constraint.
+        departBearingDeg: Double? = null,
     ): List<Route>
 
     /** Name a PROVISIONAL alternate ([Route.provisional]) — the user picked it to drive, so turn its

--- a/core/src/main/java/app/vela/core/data/MockMapDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/MockMapDataSource.kt
@@ -63,6 +63,7 @@ class MockMapDataSource @Inject constructor() : MapDataSource {
         avoidTolls: Boolean,
         avoidHighways: Boolean,
         urgent: Boolean,
+        departBearingDeg: Double?,
     ): List<Route> {
         delay(220)
         // A simple L-shaped path: straight, one turn, arrive. Enough geometry

--- a/core/src/main/java/app/vela/core/data/RouteGeometry.kt
+++ b/core/src/main/java/app/vela/core/data/RouteGeometry.kt
@@ -156,8 +156,9 @@ object RouteGeometry {
         avoidTolls: Boolean = false,
         avoidHighways: Boolean = false,
         tries: Int = OSRM_TRIES,
+        departBearingDeg: Double? = null,
     ): List<Route> =
-        routeOsrm(http, listOf(origin, dest), mode, alternatives = true, avoidTolls, avoidHighways, tries)
+        routeOsrm(http, listOf(origin, dest), mode, alternatives = true, avoidTolls, avoidHighways, tries, departBearingDeg)
 
     /** OSRM forced THROUGH [waypoints] (origin, vias…, dest) — used to follow Google's
      *  traffic-smart path with OSRM's full street-named steps (option 3: traffic-aware routing).
@@ -171,6 +172,30 @@ object RouteGeometry {
     ): List<Route> =
         if (waypoints.size < 2) emptyList() else routeOsrm(http, waypoints, mode, alternatives = false, avoidTolls, avoidHighways)
 
+    /**
+     * OSRM `bearings=`, constraining only the FIRST waypoint to the direction the car is actually
+     * pointing (real-drive report, 2026-08-17: after a wrong turn the reroute kept answering "go
+     * back the way you came").
+     *
+     * Unconstrained, a reroute computed a few tens of metres down the wrong road is perfectly
+     * entitled to reply with a U-turn - from there, rejoining the old route often IS the fastest
+     * path - so the driver is told to turn around, carries on instead, and gets told to turn around
+     * again. Pinning the departure heading makes the router answer the question the driver is
+     * actually asking: given that I am going THIS way, what now. Google does the same.
+     *
+     * [TOLERANCE_DEG] either side: wide enough to absorb GPS heading noise and a car mid-turn, narrow
+     * enough that a 180 degree answer is excluded. Every later waypoint is left unconstrained (an
+     * empty entry) - only the departure is a fact about the car; the stops are just places.
+     * Null bearing (stationary, no fix heading) sends nothing at all.
+     */
+    internal fun departBearingParam(bearingDeg: Double?, waypoints: Int): String {
+        if (bearingDeg == null || waypoints < 2) return ""
+        val b = ((bearingDeg % 360.0) + 360.0) % 360.0
+        return "&bearings=${b.toInt()},$BEARING_TOLERANCE_DEG" + ";".repeat(waypoints - 1)
+    }
+
+    private const val BEARING_TOLERANCE_DEG = 65
+
     private fun routeOsrm(
         http: OkHttpClient,
         points: List<LatLng>,
@@ -179,12 +204,14 @@ object RouteGeometry {
         avoidTolls: Boolean = false,
         avoidHighways: Boolean = false,
         tries: Int = OSRM_TRIES,
+        departBearingDeg: Double? = null,
     ): List<Route> {
         val backend = backend(mode) ?: return emptyList()
         val coords = points.joinToString(";") { "${it.lng},${it.lat}" }
         val url = "$OSRM_BASE/$backend/route/v1/driving/$coords" +
             "?overview=full&geometries=polyline&steps=true" +
             (if (alternatives) "&alternatives=3" else "") +
+            departBearingParam(departBearingDeg, points.size) +
             excludeParam(mode, avoidTolls, avoidHighways)
         val req = Request.Builder().url(url).header("User-Agent", VelaConfig.USER_AGENT).build()
         // The FOSSGIS community OSRM transiently 5xx/429/resets on mobile, and each miss otherwise drops

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -454,6 +454,7 @@ class GoogleMapsDataSource @Inject constructor(
         avoidTolls: Boolean,
         avoidHighways: Boolean,
         urgent: Boolean,
+        departBearingDeg: Double?,
     ): List<Route> = io {
         // Mid-drive reroutes are URGENT: one shot per source, no divergence snap, no alternates
         // polish. The retry ladders below (3x OSRM + 3x Google with backoff) are right for a
@@ -499,7 +500,7 @@ class GoogleMapsDataSource @Inject constructor(
             // Google's keyless directions endpoint hands back ABBREVIATED steps for longer routes
             // (a 6-mi route came back with 2 of ~10 turns), so Google is only the FALLBACK + the
             // live-traffic source. Fetch both in parallel so the traffic round-trip is free.
-            val openD = async { RouteGeometry.route(http, origin, destination, mode, avoidTolls, avoidHighways, tries) }
+            val openD = async { RouteGeometry.route(http, origin, destination, mode, avoidTolls, avoidHighways, tries, departBearingDeg) }
             val googleD = async { googleDirectionsRetried(origin, destination, mode, tries) }
             val open = openD.await()
             val google = googleD.await()

--- a/core/src/main/java/app/vela/core/nav/NavSession.kt
+++ b/core/src/main/java/app/vela/core/nav/NavSession.kt
@@ -342,8 +342,8 @@ class NavSession @Inject constructor(
                     }
                 }
                 NavEvent.RerouteNeeded -> {
-                    diag.record("nav", "off-route → rerouting from ${loc.lat},${loc.lng}")
-                    reroute(loc)
+                    diag.record("nav", "off-route → rerouting from ${loc.lat},${loc.lng} heading ${bearingDeg?.toInt()}")
+                    reroute(loc, bearingDeg)
                 }
             }
         }
@@ -594,7 +594,7 @@ class NavSession @Inject constructor(
         }
     }
 
-    private fun reroute(loc: LatLng) {
+    private fun reroute(loc: LatLng, headingDeg: Double? = null) {
         if (replayMode) {
             diag.record("nav", "replay: live reroute suppressed (recorded swaps play back instead)")
             return
@@ -641,7 +641,15 @@ class NavSession @Inject constructor(
             // repeated attempts. A lean route lands in seconds; the recheck loop restores
             // traffic/steps quality afterwards.
             val r = kotlinx.coroutines.withTimeoutOrNull(REROUTE_FETCH_TIMEOUT_MS) {
-                runCatching { dataSource.directions(loc, dest, mode, remainingStops.map { it.location }, urgent = true) }
+                runCatching {
+                    dataSource.directions(
+                        loc, dest, mode, remainingStops.map { it.location },
+                        urgent = true,
+                        // Pin the departure to where the car is pointing, so the answer is "given
+                        // that you are going this way, what now" instead of "turn around".
+                        departBearingDeg = headingDeg,
+                    )
+                }
                     .getOrNull()?.firstOrNull()?.takeIf { it.reaches(dest) }
             }
             if (gen != sessionGen) return@launch // session ended / restarted while fetching — drop it

--- a/core/src/test/java/app/vela/core/data/DepartBearingTest.kt
+++ b/core/src/test/java/app/vela/core/data/DepartBearingTest.kt
@@ -1,0 +1,51 @@
+package app.vela.core.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The OSRM departure-bearing constraint (real-drive report 2026-08-17: after a wrong turn the
+ * reroute kept answering "go back the way you came"). The whole feature is one query parameter, and
+ * a malformed one is not an error - OSRM ignores it and routes exactly as before, so the fix would
+ * silently do nothing. Hence tests on the string itself.
+ */
+class DepartBearingTest {
+
+    private fun p(b: Double?, n: Int) = RouteGeometry.departBearingParam(b, n)
+
+    @Test fun `a two point route constrains only the departure`() {
+        // One entry per waypoint, semicolon separated; the trailing empty entry leaves the
+        // destination unconstrained - a destination is a place, not a direction of travel.
+        assertEquals("&bearings=90,65;", p(90.0, 2))
+    }
+
+    @Test fun `every extra waypoint gets its own empty entry`() {
+        // OSRM REJECTS the whole request when the count does not match the coordinates, which
+        // would take the reroute down with it - so a multi-stop reroute must pad exactly.
+        assertEquals("&bearings=90,65;;", p(90.0, 3))
+        assertEquals("&bearings=90,65;;;;", p(90.0, 5))
+    }
+
+    @Test fun `bearings are normalized into 0-359`() {
+        assertEquals("&bearings=10,65;", p(370.0, 2))
+        assertEquals("&bearings=350,65;", p(-10.0, 2))
+        assertEquals("&bearings=0,65;", p(360.0, 2))
+    }
+
+    @Test fun `no heading sends nothing at all`() {
+        // Stationary, or a fix with no bearing: constraining to a stale or invented heading would
+        // be worse than not constraining, so the request is left exactly as it was.
+        assertEquals("", p(null, 2))
+    }
+
+    @Test fun `a degenerate point count sends nothing`() {
+        assertEquals("", p(90.0, 1))
+        assertEquals("", p(90.0, 0))
+    }
+
+    @Test fun `the tolerance excludes a u-turn but allows real heading noise`() {
+        // The one thing this must never do is permit a 180 degree answer, which is the bug.
+        val tol = p(0.0, 2).substringAfter(",").substringBefore(";").toInt()
+        assert(tol in 30..89) { "tolerance $tol should absorb GPS noise without allowing a U-turn" }
+    }
+}


### PR DESCRIPTION
Real-drive report on a Pixel 9: after wrong turns, "it keeps rerouting me to the way I was going before."

**Cause: we send no heading constraint.** OSRM supports `bearings`, we sent nothing. So a reroute computed a few tens of metres down the wrong road is free to answer "U-turn and rejoin" — and from there that often genuinely *is* the fastest path. Driver is told to turn around, carries on, gets told again. Google avoids this by pinning the departure to the direction the car is pointing; now so do we.

`RouteGeometry.departBearingParam` sends `bearings=<heading>,65` for the **first waypoint only**, threaded from `NavSession.onLocation`'s `bearingDeg` through `MapDataSource.directions(departBearingDeg=)`.

Deliberate limits:
- **Planning fetches send nothing.** Which way a parked car faces isn't a routing constraint.
- **Null heading sends nothing.** A stale heading is worse than none.
- **±65°** — absorbs GPS heading noise and a car mid-turn, while excluding a 180° answer, which is the actual bug.

**Unit-tested on the string**, which matters more than usual here: a malformed parameter isn't an error. OSRM ignores it and routes exactly as before, so a typo would leave the fix silently doing nothing. The tests also pin that the entry count matches the coordinate count — get that wrong and OSRM rejects the whole request, taking the reroute down with it.

**What this does NOT fix**, from the same report: off-route detection needs 2 m/s before a deviation counts, so inching away from a junction isn't registered until the 90 m far-off rule fires. That's why detection felt late. I've left it alone — loosening it makes reroutes fire *earlier*, when "go back" looks even more attractive, so it wants its own thought.

Also unaddressed: the third-reroute hang. I'm not guessing at that one; the diagnostics breadcrumbs will show it.