### PR TITLE
Stop accelerometer noise from shaking the nav puck

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1988,7 +1988,22 @@ architecture note.
   `navSession.onLocation` path - puck/banner/voice keep working, `navStarved` keeps the
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
-  Nav zoom range is 18.0→15.5 (2026-07-14, was 17.3→15.0). **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
+  Nav zoom range is 18.0→15.5 (2026-07-14, was 17.3→15.0).
+  **ACCELEROMETER NOISE WAS REACHING THE PUCK (issue #251, 2026-08-20 - the jitter that survived
+  the two fixes below, still reported on a P9).** Archaeology settled it: the ORIGINAL puck
+  (498e7f49, 2026-06-21, the version remembered as smooth) took its speed STRAIGHT off the GPS fix
+  and held it constant between fixes - twelve lines, no Kalman, no boxcar. `SpeedKalman.predict`
+  now runs once per FRAME, so ~60 accelerometer samples are integrated into the speed between two
+  1 Hz fixes, and the puck ADVANCES AT THAT SPEED - so road texture, engine and mount resonance
+  became visible movement. `SpeedKalman.denoise` applies an `a^2/(a^2+n^2)` suppression gain
+  (`ACCEL_NOISE` 0.5) before integrating. **NOT a subtract-the-floor shrinkage** - that was tried
+  first and broke `brakingCollapsesThePredictionBetweenFixes`, because shrinking every sample taxes
+  a REAL brake by the floor, weakening the exact behaviour the filter exists for (the puck must
+  decelerate with a stopping car). The gain leaves a 4 m/s2 brake within ~1.5% of itself while
+  cutting 0.3 m/s2 of vibration to about a quarter. A steady bias is attenuated, not erased (~0.08
+  m/s after a second), which the next fix corrects. **Rule: anything integrated per-frame from a
+  phone sensor in a car needs a noise model, or it becomes puck motion.**
+  **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
   dominant cause of the "record needle" swim).** `startDemoDrive` feeds
   `locationProvider.replay(fixes, speedup = 1f)` - REAL-TIME fixes - but it also sets
   `replaying`, and MapScreen keyed `replaySpeedup` off that flag alone, so a demo drive

--- a/core/src/main/java/app/vela/core/location/SpeedKalman.kt
+++ b/core/src/main/java/app/vela/core/location/SpeedKalman.kt
@@ -31,7 +31,7 @@ class SpeedKalman {
      *  + = speeding up along the travel bearing). Call per frame; no-op until the first fix. */
     fun predict(accel: Double, dt: Double) {
         if (!seeded || dt <= 0.0) return
-        val a = accel.coerceIn(-MAX_ACCEL, MAX_ACCEL) // a spike can't teleport the model
+        val a = denoise(accel).coerceIn(-MAX_ACCEL, MAX_ACCEL) // a spike can't teleport the model
         speed = (speed + a * dt).coerceAtLeast(0.0)
         // Uncertainty grows with time; faster when the (noisy) accelerometer is actively
         // steering the model, so the next GPS fix pulls harder after a hard brake/launch.
@@ -70,6 +70,33 @@ class SpeedKalman {
         seeded = false
     }
 
+    /**
+     * Shrink small accelerations toward zero before they are integrated (issue #251, the nav puck
+     * jitter that survived two other fixes).
+     *
+     * A phone in a car reads road texture, engine and mount resonance as acceleration along the
+     * travel bearing. This runs ONCE PER FRAME, so between two 1 Hz GPS fixes about sixty of those
+     * samples are integrated into the speed - and the puck advances at that speed, so the noise
+     * becomes visible movement. A steady 0.3 m/s2 of vibration bias is 0.3 m/s of phantom speed
+     * after one second, which is a few tenths of a metre of shimmer, repeatedly.
+     *
+     * The gain is `a^2 / (a^2 + noise^2)` - the standard suppression shape, and specifically NOT a
+     * subtract-the-floor shrinkage, which was tried first and BROKE an existing test:
+     * `brakingCollapsesThePredictionBetweenFixes` pins a 2 s brake at -4 m/s2, and shrinking every
+     * sample by the floor taxes a real brake by exactly that floor - weakening the one behaviour
+     * this filter exists for (the puck must decelerate WITH a stopping car). This shape leaves a
+     * 4 m/s2 brake within ~1.5% of itself while cutting a 0.3 m/s2 vibration to about a quarter,
+     * and it is smooth, so nothing chatters across a threshold the way a hard gate would.
+     *
+     * Residual: a STEADY small bias is attenuated, not erased (0.3 m/s2 leaves ~0.08 m/s after a
+     * second), which the next GPS fix corrects. Erasing it entirely was the shrinkage version, and
+     * it cost more than it bought.
+     */
+    private fun denoise(accel: Double): Double {
+        val a2 = accel * accel
+        return accel * (a2 / (a2 + ACCEL_NOISE * ACCEL_NOISE))
+    }
+
     private companion object {
         // Tuned so that with NO accelerometer (predict a=0) a fix still pulls ~2/3 of the way to
         // the GPS speed — the old code snapped to each fix outright, so the fallback must stay
@@ -78,6 +105,10 @@ class SpeedKalman {
         const val Q_BASE = 0.75   // variance growth per second, coasting
         const val Q_ACCEL = 0.5   // extra growth per (m/s²) of applied accel — accel is noisy
         const val MAX_ACCEL = 8.0 // beyond ±8 m/s² is sensor junk, not driving
+        // Accelerometer noise scale in a moving car (road texture, engine, mount resonance). Sets
+        // where [denoise]'s gain turns over: well below a real brake, at the level of the vibration
+        // that was reaching the puck 60 times a second.
+        const val ACCEL_NOISE = 0.5
         const val INIT_VAR = 4.0
         const val P_FLOOR = 0.05
     }

--- a/core/src/test/java/app/vela/core/SpeedKalmanNoiseTest.kt
+++ b/core/src/test/java/app/vela/core/SpeedKalmanNoiseTest.kt
@@ -1,0 +1,70 @@
+package app.vela.core
+
+import app.vela.core.location.SpeedKalman
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Accelerometer noise must not reach the puck (issue #251, the jitter that survived two other
+ * fixes).
+ *
+ * predict() runs once per FRAME, so ~60 accelerometer samples are integrated between two 1 Hz GPS
+ * fixes. Whatever vibration survives into the speed estimate becomes visible puck movement, because
+ * the puck advances at that speed. These drive a second of frames the way a real drive does.
+ */
+class SpeedKalmanNoiseTest {
+
+    private val dt = 1.0 / 60.0
+
+    private fun seeded(at: Double = 20.0) = SpeedKalman().apply { update(at) }
+
+    @Test fun `a second of road vibration does not move the speed`() {
+        val k = seeded()
+        // Alternating +/-0.3 m/s2: vibration, not driving. It averages to zero, but the point is
+        // that it must not wander even transiently - every frame of it moves the drawn puck.
+        repeat(60) { i -> k.predict(if (i % 2 == 0) 0.3 else -0.3, dt) }
+        assertEquals("vibration must not accumulate", 20.0, k.speed, 0.001)
+    }
+
+    @Test fun `a steady vibration BIAS does not accumulate either`() {
+        // The nastier case: a mount that rings slightly forward reads as a constant small accel,
+        // and integrating that for a second is a phantom 0.3 m/s - which is the shimmer.
+        val k = seeded()
+        repeat(60) { k.predict(0.3, dt) }
+        // Attenuated, not erased - erasing it entirely meant taxing real braking by the same
+        // amount (see denoise). A tenth of a m/s over a whole second is well under what shows.
+        assertTrue("bias must be strongly attenuated, got ${k.speed - 20.0}", k.speed - 20.0 < 0.12)
+    }
+
+    @Test fun `a real brake still slows the puck`() {
+        // The whole reason this filter exists: without it the puck sails on at the last fix's speed
+        // while the car stops. That must survive the noise rejection.
+        val k = seeded(20.0)
+        repeat(60) { k.predict(-3.0, dt) }
+        assertTrue("a 3 m/s2 brake for 1 s should shed most of 3 m/s, got ${20.0 - k.speed}", 20.0 - k.speed > 2.5)
+    }
+
+    @Test fun `hard braking to a stop still reaches zero and never goes negative`() {
+        val k = seeded(8.0)
+        repeat(120) { k.predict(-6.0, dt) }
+        assertEquals(0.0, k.speed, 0.0001)
+    }
+
+    @Test fun `the threshold is continuous, so noise cannot chatter across it`() {
+        // A hard gate would jump between 0 and the full value as noise crossed the threshold,
+        // swapping a shimmer for a chatter. Just above the floor must give just above zero.
+        val a = seeded()
+        val b = seeded()
+        repeat(60) { a.predict(0.36, dt) }
+        repeat(60) { b.predict(0.34, dt) }
+        assertTrue("just-above-floor must be small, not a step", a.speed - 20.0 < 0.2)
+        assertTrue("just-below-floor must be smaller still", b.speed - 20.0 < a.speed - 20.0 + 0.01)
+    }
+
+    @Test fun `genuine acceleration still registers`() {
+        val k = seeded(5.0)
+        repeat(60) { k.predict(2.0, dt) }
+        assertTrue("2 m/s2 for 1 s should add most of 2 m/s, got ${k.speed - 5.0}", k.speed - 5.0 > 1.5)
+    }
+}


### PR DESCRIPTION
Third attempt at #251, and this time from the archaeology you asked for rather than a hunch.

**The original puck (`498e7f49`, 2026-06-21 — the version you remember as smooth) was twelve lines.** It took its speed *straight off the GPS fix* and held it constant between fixes. No Kalman, no boxcar, no accelerometer.

Today `SpeedKalman.predict` runs **once per frame**, so ~60 accelerometer samples get integrated into the speed between two 1 Hz fixes — and the puck advances at that speed. In a car that sensor reads road texture, engine, and mount resonance. That noise was becoming visible movement.

It also explains why my last fix didn't finish the job: I changed how *corrections* are applied but left the puck advancing at a noisy rate.

`SpeedKalman.denoise` now applies an `a²/(a²+n²)` suppression gain before integrating.

**A pre-existing test caught my first attempt and was right to.** I started with subtract-the-floor shrinkage, which broke `brakingCollapsesThePredictionBetweenFixes` — because shrinking every sample taxes a *real* brake by the floor, weakening the one behaviour this filter exists for (the puck must decelerate with a stopping car). The gain shape doesn't have that problem:

| input | effect |
|---|---|
| 4 m/s² brake | within ~1.5% of itself |
| 0.3 m/s² vibration | cut to ~a quarter |

A steady bias is attenuated, not erased (~0.08 m/s after a second), which the next GPS fix corrects. Erasing it entirely was the version that cost more than it bought.

6 new tests driving a second of frames the way a real drive does, plus the existing suite green.

Still unverified on a real drive — that's the only test that counts here, and I've been wrong twice.