### PR TITLE
Make the launch screen follow the system light or dark setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -921,6 +921,15 @@ Defaults that make the safe path the easy one:
   visibility on the basemap `building-3d` fill-extrusion layer (a LaunchedEffect in VelaMapView owns
   visibility; applyLight/applyDark only colour it) - extrusion is the fragment-heavy layer, the
   documented 5a-class stutter source at z16+.
+- **The LAUNCH WINDOW theme is separate from AppTheme and follows the SYSTEM (issue #280,
+  2026-08-20).** `Theme.Vela` in `values/themes.xml` is the pre-Compose window (the white flash
+  before the map draws) and parented `android:Theme.Material.Light` - fixed at build time, so it
+  stayed white on a dark phone. `values-night/themes.xml` adds the dark twin; the resource system
+  picks it before any of our code runs. **It cannot follow Vela's own Light/Dark/System setting** -
+  nothing can read a preference that early - so a user running Vela dark on a light phone still
+  gets a light launch window for that instant. Matching the system is what was asked for and is
+  right far more often than always-white. Keep the two files in lockstep when the window theme
+  changes.
 - **Light/dark is `AppTheme` (`ui/theme/AppTheme.kt`), not the OS.** Read the
   in-app theme with the composable **`isAppInDarkTheme()`** - never call
   `isSystemInDarkTheme()` directly in app UI (it ignores the user's Light/Dark/

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- DARK variant of the pre-Compose window theme (issue #280: the launch window was white on a
+         dark-themed phone). The base Theme.Vela parents android:Theme.Material.Light, which is
+         fixed at build time, so a night-qualified copy is the only way this window can be dark -
+         it is chosen by the resource system before any of our code runs.
+
+         Consequence worth knowing: this follows the SYSTEM theme, not Vela's own Light/Dark/System
+         setting. Nothing can read a preference this early, so a user who runs Vela dark on a light
+         phone still gets a light launch window for the instant before Compose takes over. Matching
+         the system is what the report asked for and is right far more often than always-white. -->
+    <style name="Theme.Vela" parent="android:Theme.Material.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+</resources>


### PR DESCRIPTION
Closes #280

`Theme.Vela` parents `android:Theme.Material.**Light**`, fixed at build time — so the pre-Compose launch window was white regardless of the system theme. `values-night/themes.xml` adds the dark twin; the resource system picks it before any of our code runs.

**Worth stating plainly, because it's a real limitation:** this follows the *system* theme, not Vela's own Light/Dark/System/AMOLED setting. Nothing can read a SharedPreference that early in launch — the window theme is resolved by resources before `Application.onCreate`. So someone running Vela dark on a light phone still gets a light flash. That's unchanged for them and correct for everyone else, and matching the system is what the report asked for.

One-file change plus a note in CLAUDE.md to keep the two theme files in lockstep.