### PR TITLE
Steady the map on roads that are drawn with a wobble

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1988,7 +1988,23 @@ architecture note.
   `navSession.onLocation` path - puck/banner/voice keep working, `navStarved` keeps the
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
-  Nav zoom range is 18.0→15.5 (2026-07-14, was 17.3→15.0). **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
+  Nav zoom range is 18.0→15.5 (2026-07-14, was 17.3→15.0).
+  **THE CAMERA BEARING IS ADAPTIVELY DAMPED (issue #251, 2026-08-24 - the "crinkly roads"
+  residual, and the LARGEST of the four causes).** Measured on a synthetic road that is physically
+  STRAIGHT but digitized with half-metre vertex scatter (what "crinkly" means in the data): the
+  chord bearing the puck derives swings **7.3 deg at a 5 m window, 2.3 deg at 14 m** - several
+  times the 0.83 deg camera wiggle the earlier fixes chased. The camera is anchored to the puck,
+  so that rotates the WHOLE MAP under a steady arrow. **Window WIDTH is the only lever on chord
+  noise** (angular noise ~ sigma/baseline): a least-squares fit over the same window was measured
+  NO BETTER (slightly worse at short windows) because the noise lives in the VERTICES, so interior
+  samples are correlated with the endpoints and add no information. And curvature-adaptive width
+  was measured UNWORKABLE - crinkle reads 3.0 deg median / 7.6 p90 short-vs-long disagreement, a
+  genuine 40 m bend reads 3.9, so no threshold separates them. What DOES separate cleanly is
+  AMPLITUDE at the camera: geometry noise is a couple of degrees, a turn is tens. So the camera's
+  bearing time constant follows the size of its own error - `CAM_BRG_TAU_STILL` 1.6 s when small
+  (keeps ~24% of the wiggle vs 59% at the old flat 0.55), `CAM_BRG_TAU_TURN` 0.35 s past
+  `CAM_BRG_TURN_DEG` (25 deg), which is QUICKER around a real corner than before. Tilt keeps the
+  old constant - it is not part of this. **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
   dominant cause of the "record needle" swim).** `startDemoDrive` feeds
   `locationProvider.replay(fixes, speedup = 1f)` - REAL-TIME fixes - but it also sets
   `replaying`, and MapScreen keyed `replaySpeedup` off that flag alone, so a demo drive

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -193,6 +193,14 @@ private const val ME_ARROW_IMG = "vela-arrow"
 private const val NAV_PUCK_IMG = "vela-nav-puck"
 private const val PREVIEW_SRC = "vela-preview-src"
 private const val PREVIEW_LAYER = "vela-preview"
+/** Camera-bearing damping (issue #251). Heavy while the camera is essentially tracking a straight
+ *  road, so digitization wiggle does not rotate the map; quick once the error is turn-sized. */
+private const val CAM_BRG_TAU_STILL = 1.6
+private const val CAM_BRG_TAU_TURN = 0.35
+/** Error at which the damping is fully in "this is a real turn" mode. Well above the few degrees
+ *  of geometry noise, well below a junction turn. */
+private const val CAM_BRG_TURN_DEG = 25.0
+
 private const val DEM_SRC = "vela-dem"
 private const val HILLSHADE_LAYER = "vela-hillshade"
 // Keyless open elevation tiles (AWS Open Data, terrarium-encoded) — no key, and
@@ -1663,7 +1671,25 @@ fun VelaMapView(
                     // then rotates on the north-up map instead of the map rotating under it.
                     val brgTgt = if (navNorthUpHolder.value) 0.0 else navPuck.displayBearing.toDouble()
                     val db = ((brgTgt - camState[2] + 540.0) % 360.0) - 180.0 // shortest arc
-                    camState[2] = (camState[2] + db * kBrg + 360.0) % 360.0
+                    // CAMERA BEARING IS ADAPTIVELY DAMPED (issue #251, the "crinkly roads" residual).
+                    // A road digitized from imagery wiggles even where it is physically straight, and
+                    // the bearing drawn off that geometry swings 2-7 degrees - measured, and several
+                    // times bigger than anything the earlier fixes addressed. The camera is anchored
+                    // to the puck, so that rotation swings the WHOLE MAP under a steady arrow.
+                    //
+                    // A flat heavier damping would fix the wiggle and make real turns sluggish, so the
+                    // time constant follows the SIZE of the error instead. That discriminator works
+                    // here precisely where the crinkle-vs-curve one failed: geometry noise is a couple
+                    // of degrees and a turn is tens, an order of magnitude apart, whereas a real bend
+                    // and a crinkle both read ~3-4 degrees and could not be told apart at all.
+                    // Small error -> tau 1.6 s (keeps ~24% of the wiggle, vs 59% before); a genuine
+                    // turn -> tau 0.35 s, which is actually QUICKER around a corner than the old flat
+                    // 0.55. Tilt keeps its own constant - it is not part of this problem.
+                    val brgTau = (CAM_BRG_TAU_STILL +
+                        (CAM_BRG_TAU_TURN - CAM_BRG_TAU_STILL) *
+                        (kotlin.math.abs(db) / CAM_BRG_TURN_DEG).coerceAtMost(1.0)).toFloat()
+                    val kBrgAdaptive = (1f - kotlin.math.exp(-dtEase / brgTau)).toDouble()
+                    camState[2] = (camState[2] + db * kBrgAdaptive + 360.0) % 360.0
                     camState[3] += (tgtZoom - camState[3]) * kZoom
                     // Tilt: north-up = flat; else a shove-set override wins over the 55 default.
                     val tiltTgt = when {


### PR DESCRIPTION
The remaining half of #251, found from your "especially crinkly roads" clue — which localised it precisely.

**Measured.** On a synthetic road that is *physically straight* but digitized with half-metre vertex scatter (what "crinkly" means in the data), the bearing the puck derives swings:

| smoothing window | bearing swing |
|---|---|
| 5 m (low speed) | **7.3°** |
| 14 m (highway) | **2.3°** |

The camera wiggle chased in the two earlier fixes was **0.83°**. This is several times larger, and since the camera is anchored to the puck it rotates the whole map under a steady arrow.

**Two cleverer fixes measured and rejected — worth recording so nobody retries them:**

1. **Least-squares fit** over the same window: *no better*, slightly worse at short windows. The noise lives in the vertices, so interior samples are correlated with the endpoints and add no independent information. Angular noise goes as σ/baseline — width is the only lever, and width costs corner accuracy.
2. **Curvature-adaptive width**: unworkable. Crinkle reads 3.0° median / 7.6° p90 short-vs-long disagreement; a genuine 40 m bend reads 3.9°. No threshold separates them.

**What does separate cleanly is amplitude at the camera** — geometry noise is a couple of degrees, a turn is tens. So the camera's bearing time constant follows the size of its own error:

- small error → **1.6 s** (keeps ~24% of the wiggle, vs 59% at the old flat 0.55)
- past 25° → **0.35 s**, which is *quicker* around a real corner than before

Tilt keeps the old constant; it isn't part of this problem.

Needs a drive on crinkly roads — that's the only test that counts, and I've been wrong on this bug before.