### PR TITLE
Explain properly when avoiding tolls cannot be applied

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1913,7 +1913,16 @@ architecture note.
   online chain produced while a toggle was on carry `Route.avoidNotHonored` (set in both the
   single-dest and multi-stop paths, never on the on-device result) - DirectionsPanel shows
   `place_avoid_not_honored` under the chips when EVERY route carries it, so a toggled avoid is
-  never silently ignored. PLUMBING: `MapDataSource.directions`/`nameRoute` + `RouteEngine.route`
+  never silently ignored.
+  **RE-PROBED 2026-08-24 (issue #286, a new user: "Avoid tolls doesn't appear to do anything"):
+  the public FOSSGIS OSRM STILL rejects `exclude=` for EVERY value** (`toll`, `motorway`, `ferry`
+  all return `InvalidValue: Exclude flag combination is not supported`), and Google's keyless
+  endpoint has no avoid parameter - online avoid remains IMPOSSIBLE, do not re-chase it without a
+  self-hosted OSRM. That makes the honesty note the entire user-facing answer, so it was upgraded
+  from dim `bodySmall` under the chips (it read as decoration; the reporter never registered it)
+  to an info-glyph row at `bodyMedium` in ink, worded to say what to DO (download the area) rather
+  than only what went wrong.
+  PLUMBING: `MapDataSource.directions`/`nameRoute` + `RouteEngine.route`
   carry the flags end to end. The public FOSSGIS OSRM REJECTS `exclude=` (probed 2026-07-11:
   InvalidValue - its profiles lack excludable classes; routeOsrm bails on any 4xx instead
   of retrying, AND `OSRM_SUPPORTS_EXCLUDE=false` keeps the param OFF entirely - sending it

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -83,6 +83,7 @@ import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Directions
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.filled.DirectionsBoat
 import androidx.compose.material.icons.automirrored.filled.DirectionsBike
 import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
@@ -1566,12 +1567,31 @@ fun DirectionsPanel(
                 // anyway - say so instead of pretending (the "still routed me through the motorway"
                 // report). Keyed on the routes' own tag so it never shows when avoid worked.
                 if ((avoidTolls || avoidHighways) && routes.isNotEmpty() && routes.all { it.avoidNotHonored }) {
-                    Text(
-                        stringResource(R.string.place_avoid_not_honored),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = dim,
-                        modifier = Modifier.padding(top = 6.dp),
-                    )
+                    // Treatment upgraded (issue #286): this is the EXPLANATION for a control that
+                    // otherwise looks broken - a new user flips Avoid tolls, gets routed down the
+                    // toll road, and concludes the button does nothing. As dim bodySmall under the
+                    // chips it read as decoration. It is the same weight as any other advisory now,
+                    // with a glyph so the eye lands on it, and the text says what to DO rather than
+                    // only what went wrong. (Online avoid is not a missing feature to add later:
+                    // re-probed 2026-08-24, the public OSRM still rejects `exclude=` for every
+                    // value, and Google's keyless endpoint has no avoid parameter at all.)
+                    Row(
+                        Modifier.fillMaxWidth().padding(top = 8.dp),
+                        verticalAlignment = Alignment.Top,
+                    ) {
+                        Icon(
+                            Icons.Outlined.Info,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(16.dp).padding(top = 2.dp),
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            stringResource(R.string.place_avoid_not_honored),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = ink,
+                        )
+                    }
                 }
             }
             if (currentMode == TravelMode.TRANSIT) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -625,7 +625,7 @@
     <string name="settings_voice_volume_louder">Louder</string>
     <string name="settings_voice_volume_loudest">Loudest</string>
     <string name="settings_voice_volume_hint">How loud spoken directions play over your media. Louder tiers apply to the Vela voice; system voices can only be made softer.</string>
-    <string name="place_avoid_not_honored">Avoiding tolls and highways needs an offline region for this trip. These routes may still use them.</string>
+    <string name="place_avoid_not_honored">These routes may still use tolls and highways. Avoiding them works on downloaded areas only, so download this area in Settings, Offline maps.</string>
     <string name="settings_lists_export_hint">Back up your lists to a file, or restore them on another device.</string>
     <string name="settings_lists_imported">Imported %1$d list(s)</string>
     <string name="settings_places_imported">Imported %1$d place(s)</string> <!-- format -->


### PR DESCRIPTION
Closes #286

**Re-probed the router before touching anything.** The public FOSSGIS OSRM still rejects `exclude=` for every value:

```
exclude=toll      InvalidValue  Exclude flag combination is not supported
exclude=motorway  InvalidValue  Exclude flag combination is not supported
exclude=ferry     InvalidValue  Exclude flag combination is not supported
no exclude        Ok            dur=1528s
```

Google's keyless endpoint has no avoid parameter either. So for a route with no downloaded area — which is every new user — the toggle genuinely cannot change the result. This is a limitation to be honest about, not a routing bug to fix (short of self-hosting OSRM).

There *was* already a note saying so, but it sat under the chips as dim `bodySmall`, the quietest treatment available, and read as decoration. Which is why the reporter flipped the switch, got routed onto the toll road, and reasonably concluded the button was broken.

It's now an info-glyph row at `bodyMedium` in ink, and the wording says what to **do** (download the area) rather than only what went wrong.

Follow-up worth doing: make it tappable, deep-linking to Settings → Offline maps. That crosses three files of callback plumbing so I left it out of a fix that should be easy to review.