### PR TITLE
Rename saved trips, and share several at once

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,11 @@ Defaults that make the safe path the easy one:
   - `audit_dynamic.sh` - EXHAUSTIVE on-device tour: every surface opens focused, focus is never lost
     across a full traversal, BACK exits. "Nothing escapes the auditor."
 - **Managing saved trips (2026-08-26).** Settings > Diagnostics: every recorded trip can be
-  RENAMED (pencil on the row -> `TripStore.rename`, which rewrites ONLY the META header's first
-  field via a temp file + rename, so a recording can never be half-written), and "Select trips"
+  RENAMED (pencil on the row -> `TripStore.rename`, file IO only; the header surgery itself is
+  **`TripLog.renameHeader` in :core**, beside the format so writer and reader cannot drift, and
+  unit-tested by `TripRenameTest` - a comma or newline in a name would shift/split the header
+  fields and make the whole recording unparseable, and a drive cannot be recorded twice. The
+  write goes to a temp file and is renamed over the original, so it can never be half-written), and "Select trips"
   turns the list into a multi-select whose Share hands the whole set to ACTION_SEND_MULTIPLE
   (`MapViewModel.exportTripsIntent`; one unreadable CSV is skipped, not fatal, and a single pick
   falls through to the existing single-trip intent). Optional pref `trip_name_on_save` (Settings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,17 @@ Defaults that make the safe path the easy one:
     no `isSystemInDarkTheme`; fails on any real violation. Wire it into CI.
   - `audit_dynamic.sh` - EXHAUSTIVE on-device tour: every surface opens focused, focus is never lost
     across a full traversal, BACK exits. "Nothing escapes the auditor."
+- **Managing saved trips (2026-08-26).** Settings > Diagnostics: every recorded trip can be
+  RENAMED (pencil on the row -> `TripStore.rename`, which rewrites ONLY the META header's first
+  field via a temp file + rename, so a recording can never be half-written), and "Select trips"
+  turns the list into a multi-select whose Share hands the whole set to ACTION_SEND_MULTIPLE
+  (`MapViewModel.exportTripsIntent`; one unreadable CSV is skipped, not fatal, and a single pick
+  falls through to the existing single-trip intent). Optional pref `trip_name_on_save` (Settings
+  toggle, shown only while trip recording is on, default OFF) makes `finishTrip` - which now
+  RETURNS the kept `TripMeta` instead of Unit - arm `MapUiState.tripToName`, and MapScreen prompts
+  for a name on the map right after the drive. TRAP: an early `return@forEachIndexed` inside the
+  trip-row composable lambda crashes the Compose compiler ("No mapping for symbol" during IR
+  lowering); the selection branch is if/else for that reason.
 - **Auditing a real drive.** A saved trip stores the navigated route too (`core/replay/TripLog`
   format, shared by `:app`'s `TripStore` writer and the `:core` reader). To diff what the nav
   cards/voice said against the plotted route from a shared trip CSV, call `TripLog.audit(csv)`

--- a/app/src/main/java/app/vela/replay/TripStore.kt
+++ b/app/src/main/java/app/vela/replay/TripStore.kt
@@ -106,11 +106,19 @@ class TripStore @Inject constructor(
     }
 
     /** Close the active trip. Deletes it if it captured too few fixes to be useful. */
-    fun finishTrip() = synchronized(lock) {
-        val f = active ?: return
+    /**
+     * Close the active trip.
+     *
+     * Returns the saved trip when one was KEPT, so a caller can offer to name it; null when
+     * nothing was recording or the trip was too short to be worth keeping (under 5 fixes -
+     * starting nav and immediately ending it should not leave litter in the list).
+     */
+    fun finishTrip(): TripMeta? = synchronized(lock) {
+        val f = active ?: return null
         active = null
-        runCatching { if (countFixes(f) < 5) f.delete() }
-        Unit
+        return runCatching {
+            if (countFixes(f) < 5) { f.delete(); null } else readMeta(f)
+        }.getOrNull()
     }
 
     val isRecording: Boolean get() = active != null
@@ -146,6 +154,38 @@ class TripStore @Inject constructor(
 
     /** The raw CSV for a saved trip, for export/share (or null if missing). */
     fun rawCsv(id: String): String? = runCatching { File(dir, "$id.csv").readText() }.getOrNull()
+
+    /**
+     * Rename a saved trip.
+     *
+     * The label is the FIRST field of the META header, so this rewrites that one line and leaves
+     * every other byte alone - fixes, route and maneuvers untouched. A trip is a recording of
+     * something that happened once and cannot be captured again, so a rename must not put it at
+     * risk: the new content goes to a temp file and is renamed over the original, because a
+     * half-written header makes the whole file unparseable to `TripLog.parse`.
+     *
+     * Sanitised exactly like [startTrip] - a comma would split the header into the wrong fields
+     * and a newline would turn one record into two.
+     *
+     * Returns false when the file is missing or is not a trip (nothing is written then).
+     */
+    fun rename(id: String, label: String): Boolean = synchronized(lock) {
+        val f = File(dir, "$id.csv")
+        return runCatching {
+            if (!f.exists()) return false
+            val lines = f.readLines()
+            val first = lines.firstOrNull() ?: return false
+            if (!first.startsWith("META,")) return false
+            val safe = label.replace(',', ' ').replace('\n', ' ').trim().take(80).ifBlank { "Trip" }
+            val rest = first.removePrefix("META,").split(',').drop(1)
+            val header = (listOf("META", safe) + rest).joinToString(",")
+            val tmp = File(dir, "$id.csv.tmp")
+            tmp.writeText((listOf(header) + lines.drop(1)).joinToString("\n") + "\n")
+            val ok = tmp.renameTo(f)
+            if (!ok) tmp.delete()
+            ok
+        }.getOrDefault(false)
+    }
 
     fun delete(id: String) {
         runCatching { File(dir, "$id.csv").delete() }

--- a/app/src/main/java/app/vela/replay/TripStore.kt
+++ b/app/src/main/java/app/vela/replay/TripStore.kt
@@ -158,29 +158,20 @@ class TripStore @Inject constructor(
     /**
      * Rename a saved trip.
      *
-     * The label is the FIRST field of the META header, so this rewrites that one line and leaves
-     * every other byte alone - fixes, route and maneuvers untouched. A trip is a recording of
-     * something that happened once and cannot be captured again, so a rename must not put it at
-     * risk: the new content goes to a temp file and is renamed over the original, because a
-     * half-written header makes the whole file unparseable to `TripLog.parse`.
+     * The header surgery itself is `TripLog.renameHeader` in :core (beside the format, and unit
+     * tested); this does the file IO. Written to a temp file and renamed over the original,
+     * because a half-written header makes the whole recording unparseable and a drive cannot be
+     * recorded again.
      *
-     * Sanitised exactly like [startTrip] - a comma would split the header into the wrong fields
-     * and a newline would turn one record into two.
-     *
-     * Returns false when the file is missing or is not a trip (nothing is written then).
+     * Returns false when the file is missing or is not a trip - nothing is written then.
      */
     fun rename(id: String, label: String): Boolean = synchronized(lock) {
         val f = File(dir, "$id.csv")
         return runCatching {
             if (!f.exists()) return false
-            val lines = f.readLines()
-            val first = lines.firstOrNull() ?: return false
-            if (!first.startsWith("META,")) return false
-            val safe = label.replace(',', ' ').replace('\n', ' ').trim().take(80).ifBlank { "Trip" }
-            val rest = first.removePrefix("META,").split(',').drop(1)
-            val header = (listOf("META", safe) + rest).joinToString(",")
+            val out = TripLog.renameHeader(f.readLines(), label) ?: return false
             val tmp = File(dir, "$id.csv.tmp")
-            tmp.writeText((listOf(header) + lines.drop(1)).joinToString("\n") + "\n")
+            tmp.writeText(out.joinToString("\n") + "\n")
             val ok = tmp.renameTo(f)
             if (!ok) tmp.delete()
             ok

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -832,6 +832,32 @@ fun MapScreen(
     val onStartNav: () -> Unit = {
         if (!fineGranted() && !vm.demoDriveOn()) showPreciseNeeded = true else proceedStartNav()
     }
+    // Name-this-drive prompt (opt-in, Settings > Diagnostics). Shown on the MAP right after a
+    // recorded drive ends, because that is when you remember what the drive was; a name applied
+    // later from the trips list is the same rename, just harder to recall.
+    state.tripToName?.let { justRecorded ->
+        var draft by remember(justRecorded.id) { mutableStateOf(justRecorded.label) }
+        app.vela.ui.VelaDialog(
+            onDismissRequest = { vm.dismissTripNaming() },
+            title = stringResource(R.string.trip_name_prompt_title),
+            confirmText = stringResource(R.string.trip_name_prompt_save),
+            onConfirm = {
+                val name = draft.trim()
+                // An empty box means "leave it alone", not "call it blank".
+                if (name.isNotEmpty()) vm.nameRecordedTrip(justRecorded.id, name) else vm.dismissTripNaming()
+            },
+            dismissText = stringResource(R.string.trip_name_prompt_skip),
+            onDismiss = { vm.dismissTripNaming() },
+        ) {
+            androidx.compose.material3.OutlinedTextField(
+                value = draft,
+                onValueChange = { draft = it },
+                singleLine = true,
+                label = { Text(stringResource(R.string.settings_trip_rename_hint)) },
+                modifier = Modifier.fillMaxWidth().dpadHighlight(),
+            )
+        }
+    }
     if (showPreciseNeeded) {
         app.vela.ui.VelaDialog(
             onDismissRequest = { showPreciseNeeded = false },

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -231,6 +231,10 @@ data class MapUiState(
     val voiceMuted: Boolean = false,
     val diagnosticsEnabled: Boolean = false,
     val tripRecordingEnabled: Boolean = false, // record nav GPS traces for replay (more invasive)
+    val nameTripsOnSave: Boolean = false, // ask for a name each time a recorded drive is saved
+    // A drive just finished and the user asked to be prompted for its name; the prompt shows on
+    // the map so it is answered while the drive is fresh, not found later in Settings.
+    val tripToName: app.vela.replay.TripMeta? = null,
     val replaying: Boolean = false,            // a recorded trip OR a demo drive is playing (drives the puck)
     val demoDriving: Boolean = false,          // replaying is a Settings→demo synthetic drive (not a recorded trip) — nav chrome only, no "Stop replay" pill
     val arrived: Boolean = false,
@@ -3830,7 +3834,12 @@ class MapViewModel @Inject constructor(
         if (_state.value.replaying && replayOwnsNav) { stopReplay(); return }
         NavigationService.stop(appContext)
         navSession.stop()
-        tripStore.finishTrip() // close + persist the recorded trip (drops too-short ones)
+        val recorded = tripStore.finishTrip() // close + persist the recorded trip (drops too-short ones)
+        // Offer to name it while the drive is still in mind - a trip auto-named after the
+        // destination is fine for one drive and useless once there are twenty of the same one.
+        // Only when the user asked for the prompt, and only for a trip that actually survived
+        // (finishTrip drops ones too short to be worth keeping).
+        if (recorded != null && nameTripsOnSave()) _state.update { it.copy(tripToName = recorded) }
         clearSpeedLimit() // clear the speed-limit badge for the next drive
         clearPersistedNav() // this drive is over → don't offer to resume it next launch
         _state.update {
@@ -3928,7 +3937,12 @@ class MapViewModel @Inject constructor(
 
     /** Reflect the persisted "save my trips" flag into UI state. */
     fun refreshTripRecording() =
-        _state.update { it.copy(tripRecordingEnabled = settingsPrefs.getBoolean("trip_recording_on", false)) }
+        _state.update {
+            it.copy(
+                tripRecordingEnabled = settingsPrefs.getBoolean("trip_recording_on", false),
+                nameTripsOnSave = settingsPrefs.getBoolean("trip_name_on_save", false),
+            )
+        }
 
     /** Opt in/out of recording nav trips (GPS traces) for replay — strictly local,
      *  more invasive than diagnostics, so it's its own toggle. */
@@ -3939,6 +3953,29 @@ class MapViewModel @Inject constructor(
 
     fun recordedTrips(): List<app.vela.replay.TripMeta> = tripStore.list()
     fun deleteTrip(id: String) = tripStore.delete(id)
+
+    /** Rename a saved trip. Returns false when the file could not be rewritten, so the caller
+     *  can say so rather than silently showing the old name again. */
+    fun renameTrip(id: String, label: String): Boolean = tripStore.rename(id, label)
+
+    /** Whether to ask for a name each time a recorded drive is saved (pref `trip_name_on_save`).
+     *  Off by default: a prompt after every drive is the wrong default for someone recording
+     *  continuously, and the trips list can rename after the fact either way. */
+    fun nameTripsOnSave(): Boolean = settingsPrefs.getBoolean("trip_name_on_save", false)
+
+    fun setNameTripsOnSave(on: Boolean) {
+        settingsPrefs.edit().putBoolean("trip_name_on_save", on).apply()
+        _state.update { it.copy(nameTripsOnSave = on) }
+    }
+
+    /** Dismiss the name-this-trip prompt, keeping whatever the trip was auto-named. */
+    fun dismissTripNaming() = _state.update { it.copy(tripToName = null) }
+
+    /** Apply the name from the prompt, then dismiss it. */
+    fun nameRecordedTrip(id: String, label: String) {
+        tripStore.rename(id, label)
+        dismissTripNaming()
+    }
 
     /** Replay a recorded trip's GPS trace through the live pipeline (camera + dot +
      *  nav loop), at 3× so it's quick. Auto-routes to the trip's destination and starts
@@ -4153,6 +4190,43 @@ class MapViewModel @Inject constructor(
     /** A share intent for a recorded trip's raw CSV trace (via the same FileProvider),
      *  so a drive can be pulled off a *release* build — handed to a dev for replay/debug,
      *  or kept as a backup. Null if the trip file is gone. User-initiated, user-routed. */
+    /**
+     * Share SEVERAL trips at once as separate attachments.
+     *
+     * Same files the single-trip share writes, through ACTION_SEND_MULTIPLE. Trips whose CSV
+     * cannot be read are skipped rather than failing the whole share - one unreadable file
+     * should not cost the user the other nine. Returns null only when NOTHING could be read.
+     */
+    fun exportTripsIntent(metas: List<app.vela.replay.TripMeta>): android.content.Intent? {
+        if (metas.size == 1) return exportTripIntent(metas.first())
+        return runCatching {
+            val dir = java.io.File(appContext.cacheDir, "export").apply { mkdirs() }
+            val uris = java.util.ArrayList<android.net.Uri>()
+            var points = 0
+            for (meta in metas) {
+                val csv = tripStore.rawCsv(meta.id) ?: continue
+                val file = java.io.File(dir, "vela-trip-${meta.id}.csv")
+                file.writeText(csv)
+                uris += androidx.core.content.FileProvider.getUriForFile(
+                    appContext, "${appContext.packageName}.fileprovider", file,
+                )
+                points += meta.fixCount
+            }
+            if (uris.isEmpty()) return null
+            val send = android.content.Intent(android.content.Intent.ACTION_SEND_MULTIPLE).apply {
+                type = "text/csv"
+                putParcelableArrayListExtra(android.content.Intent.EXTRA_STREAM, uris)
+                putExtra(
+                    android.content.Intent.EXTRA_SUBJECT,
+                    appContext.getString(R.string.mapvm_export_trips_subject, uris.size, points),
+                )
+                addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            android.content.Intent.createChooser(send, appContext.getString(R.string.mapvm_share_trip_chooser))
+                .apply { addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK) }
+        }.getOrNull()
+    }
+
     fun exportTripIntent(meta: app.vela.replay.TripMeta): android.content.Intent? {
         val csv = tripStore.rawCsv(meta.id) ?: return null
         return runCatching {

--- a/app/src/main/java/app/vela/ui/settings/sections/DiagnosticsSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/DiagnosticsSettings.kt
@@ -18,6 +18,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -133,6 +136,11 @@ internal fun DiagnosticsSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onC
         LaunchedEffect(Unit) { vm.refreshTripRecording() }
         var showTripConsent by remember { mutableStateOf(false) }
         var trips by remember { mutableStateOf(vm.recordedTrips()) }
+        // Multi-select for export. Off until asked for: the common case is one trip, and a
+        // checkbox on every row all the time would be clutter for it.
+        var selecting by remember { mutableStateOf(false) }
+        var selected by remember { mutableStateOf(setOf<String>()) }
+        var renaming by remember { mutableStateOf<app.vela.replay.TripMeta?>(null) }
         // Re-read on entry so a trip recorded since the app launched shows up without
         // a restart (the list was otherwise only refreshed after a delete).
         LaunchedEffect(Unit) { trips = vm.recordedTrips() }
@@ -144,9 +152,59 @@ internal fun DiagnosticsSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onC
             onCheckedChange = { on -> if (on) showTripConsent = true else vm.setTripRecording(false) },
             hint = stringResource(R.string.settings_save_trips_hint),
         )
+        // Naming on save only makes sense while trips are being recorded, so it hides with the
+        // switch above rather than sitting there inert.
+        if (state.tripRecordingEnabled) {
+            ToggleRow(
+                label = stringResource(R.string.settings_name_trips),
+                checked = state.nameTripsOnSave,
+                onCheckedChange = { vm.setNameTripsOnSave(it) },
+                hint = stringResource(R.string.settings_name_trips_hint),
+            )
+        }
         if (trips.isNotEmpty()) {
             GroupDivider()
             Hint(stringResource(R.string.settings_recorded_trips_hint))
+            // Selection bar. Sharing several drives at once is the point of the mode, so the
+            // Share action carries the count and does nothing at zero rather than opening an
+            // empty chooser.
+            Row(
+                Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 2.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (!selecting) {
+                    TextButton(
+                        modifier = Modifier.dpadHighlight(),
+                        onClick = { selecting = true; selected = emptySet() },
+                    ) { Text(stringResource(R.string.settings_trip_select)) }
+                } else {
+                    TextButton(
+                        modifier = Modifier.dpadHighlight(),
+                        onClick = {
+                            selected = if (selected.size == trips.size) emptySet() else trips.map { it.id }.toSet()
+                        },
+                    ) { Text(stringResource(R.string.settings_trip_select_all)) }
+                    Spacer(Modifier.weight(1f))
+                    TextButton(
+                        modifier = Modifier.dpadHighlight(),
+                        enabled = selected.isNotEmpty(),
+                        onClick = {
+                            val picked = trips.filter { it.id in selected }
+                            val intent = vm.exportTripsIntent(picked)
+                            if (intent != null) runCatching { context.startActivity(intent) }
+                            else android.widget.Toast.makeText(
+                                context,
+                                context.getString(R.string.settings_trip_read_error),
+                                android.widget.Toast.LENGTH_SHORT,
+                            ).show()
+                        },
+                    ) { Text(stringResource(R.string.settings_trip_share_selected, selected.size)) }
+                    TextButton(
+                        modifier = Modifier.dpadHighlight(),
+                        onClick = { selecting = false; selected = emptySet() },
+                    ) { Text(stringResource(R.string.settings_trip_select_done)) }
+                }
+            }
             trips.forEachIndexed { ti, t ->
                 if (ti > 0) GroupDivider()
                 Row(
@@ -161,19 +219,40 @@ internal fun DiagnosticsSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onC
                         else null
                         Hint(listOfNotNull(recordedAt, stringResource(R.string.settings_trip_points, t.fixCount)).joinToString(" · "))
                     }
-                    // D-pad: Replay/Share/Delete sit side by side inside the L/R-swallowing Column, so
-                    // the trio drives its own LEFT/RIGHT (issue #24 pattern).
-                    val tripFocus = remember(t.id) { List(3) { FocusRequester() } }
+                    // NB an early `return@forEachIndexed` here crashes the Compose compiler
+                    // ("No mapping for symbol" during IR lowering) - a composable lambda cannot
+                    // return early past later composable calls. Keep this as if/else.
+                    if (selecting) {
+                        // In selection mode the row IS the checkbox - tapping it toggles, which is
+                        // how every list of this shape behaves.
+                        Checkbox(
+                            modifier = Modifier.dpadHighlight(androidx.compose.foundation.shape.CircleShape),
+                            checked = t.id in selected,
+                            onCheckedChange = { on ->
+                                selected = if (on) selected + t.id else selected - t.id
+                            },
+                        )
+                    } else {
+                    // D-pad: Replay/Rename/Share/Delete sit side by side inside the L/R-swallowing
+                    // Column, so the group drives its own LEFT/RIGHT (issue #24 pattern).
+                    val tripFocus = remember(t.id) { List(4) { FocusRequester() } }
                     TextButton(modifier = Modifier.dpadRowSibling(tripFocus, 0), onClick = { vm.replayTrip(t); onCloseSettings() }) { Text(stringResource(R.string.settings_trip_replay)) }
+                    IconButton(
+                        modifier = Modifier.dpadHighlight(androidx.compose.foundation.shape.CircleShape).dpadRowSibling(tripFocus, 1),
+                        onClick = { renaming = t },
+                    ) {
+                        Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.settings_trip_rename))
+                    }
                     // Share the raw trace off-device - works on release builds, so a
                     // drive can be handed over for replay/debug without a dev build.
-                    TextButton(modifier = Modifier.dpadRowSibling(tripFocus, 1), onClick = {
+                    TextButton(modifier = Modifier.dpadRowSibling(tripFocus, 2), onClick = {
                         val intent = vm.exportTripIntent(t)
                         if (intent != null) runCatching { context.startActivity(intent) }
                         else android.widget.Toast.makeText(context, context.getString(R.string.settings_trip_read_error), android.widget.Toast.LENGTH_SHORT).show()
                     }) { Text(stringResource(R.string.settings_trip_share)) }
-                    IconButton(modifier = Modifier.dpadHighlight(androidx.compose.foundation.shape.CircleShape).dpadRowSibling(tripFocus, 2), onClick = { vm.deleteTrip(t.id); trips = vm.recordedTrips() }) {
+                    IconButton(modifier = Modifier.dpadHighlight(androidx.compose.foundation.shape.CircleShape).dpadRowSibling(tripFocus, 3), onClick = { vm.deleteTrip(t.id); trips = vm.recordedTrips() }) {
                         Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.settings_trip_delete))
+                    }
                     }
                 }
             }
@@ -181,6 +260,42 @@ internal fun DiagnosticsSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onC
             Hint(stringResource(R.string.settings_no_trips_hint))
         }
         }
+        renaming?.let { target ->
+            // Seeded with the current name and remembered per trip, so opening the dialog on a
+            // different row does not carry the previous row's text across.
+            var draft by remember(target.id) { mutableStateOf(target.label) }
+            app.vela.ui.VelaDialog(
+                onDismissRequest = { renaming = null },
+                title = stringResource(R.string.settings_trip_rename_title),
+                confirmText = stringResource(R.string.settings_trip_rename),
+                onConfirm = {
+                    val name = draft.trim()
+                    if (name.isNotEmpty()) {
+                        val ok = vm.renameTrip(target.id, name)
+                        // A rewrite can fail (missing file, unwritable) and the list would just
+                        // redraw the old name, which reads as the button doing nothing.
+                        if (!ok) android.widget.Toast.makeText(
+                            context,
+                            context.getString(R.string.settings_trip_rename_failed),
+                            android.widget.Toast.LENGTH_SHORT,
+                        ).show()
+                        trips = vm.recordedTrips()
+                    }
+                    renaming = null
+                },
+                dismissText = stringResource(android.R.string.cancel),
+                onDismiss = { renaming = null },
+            ) {
+                OutlinedTextField(
+                    value = draft,
+                    onValueChange = { draft = it },
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.settings_trip_rename_hint)) },
+                    modifier = Modifier.fillMaxWidth().dpadHighlight(),
+                )
+            }
+        }
+
         if (showTripConsent) {
             app.vela.ui.VelaDialog(
                 onDismissRequest = { showTripConsent = false },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,19 @@
     <string name="settings_trip_read_error">Couldn\'t read that trip</string>
     <string name="settings_trip_share">Share</string>
     <string name="settings_trip_delete">Delete trip</string>
+    <string name="settings_trip_rename">Rename</string>
+    <string name="settings_trip_rename_title">Name this trip</string>
+    <string name="settings_trip_rename_hint">Trip name</string>
+    <string name="settings_trip_rename_failed">Could not rename that trip</string>
+    <string name="settings_trip_select">Select trips</string>
+    <string name="settings_trip_select_done">Done</string>
+    <string name="settings_trip_share_selected">Share %1$d</string> <!-- format -->
+    <string name="settings_trip_select_all">Select all</string>
+    <string name="settings_name_trips">Name each trip when it is saved</string>
+    <string name="settings_name_trips_hint">After a recorded drive ends, Vela asks what to call it. Off by default; you can always rename a trip later in the list below.</string>
+    <string name="trip_name_prompt_title">Name this drive</string>
+    <string name="trip_name_prompt_save">Save name</string>
+    <string name="trip_name_prompt_skip">Not now</string>
     <string name="settings_no_trips_hint">No trips recorded yet. Navigate somewhere with this on and it\'ll show up here to replay.</string>
     <string name="settings_trip_consent_title">Save your trips?</string>
     <string name="settings_trip_consent_body">Vela will record the GPS trace of each navigation on this phone, so a drive can be replayed for testing without driving it again. This is more revealing than diagnostics (it captures your exact routes) but it stays on the phone and is never uploaded. Turn it off any time.</string>
@@ -493,6 +506,7 @@
     <string name="mapvm_export_saved_subject">Vela saved places (%1$d)</string> <!-- format -->
     <string name="mapvm_export_saved_chooser">Export saved places</string>
     <string name="mapvm_export_trip_subject">Vela trip: %1$s (%2$d points)</string> <!-- format -->
+    <string name="mapvm_export_trips_subject">Vela trips: %1$d drives (%2$d points)</string> <!-- format -->
     <string name="mapvm_share_trip_chooser">Share trip</string>
     <string name="mapvm_voice_sample">In a quarter mile, turn right onto Main Street.</string>
     <string name="mapvm_not_enough_space">Not enough free space for %1$s (%2$d MB)</string> <!-- format -->

--- a/core/src/main/java/app/vela/core/replay/TripLog.kt
+++ b/core/src/main/java/app/vela/core/replay/TripLog.kt
@@ -180,4 +180,29 @@ object TripLog {
         }
         return NavReplay.Report(cards, maneuvers)
     }
+    /** Longest a trip label may be. Long enough for a real description, short enough that the
+     *  header stays a header. */
+    private const val MAX_LABEL = 80
+
+    /**
+     * Rewrite a trip's label, returning the new file lines, or null when [lines] is not a trip
+     * (no META header) - the caller must then leave the file alone rather than write something
+     * unreadable over a recording.
+     *
+     * Lives here, beside the format it edits, so the rename can never drift from what the parser
+     * expects; `:app`'s TripStore does the file IO around it.
+     *
+     * The label is sanitised the same way the writer sanitises it: a comma would shift every
+     * later field of the header by one (the destination would be read as the start time), and a
+     * newline would turn the header into two records, the second of which parses as garbage.
+     * Only field 0 changes; the start time, destination and version code are carried through
+     * untouched, and every line after the header is untouched.
+     */
+    fun renameHeader(lines: List<String>, label: String): List<String>? {
+        val first = lines.firstOrNull() ?: return null
+        if (!first.startsWith("META,")) return null
+        val safe = label.replace(',', ' ').replace('\n', ' ').trim().take(MAX_LABEL).ifBlank { "Trip" }
+        val rest = first.removePrefix("META,").split(',').drop(1)
+        return listOf((listOf("META", safe) + rest).joinToString(",")) + lines.drop(1)
+    }
 }

--- a/core/src/test/java/app/vela/core/replay/TripRenameTest.kt
+++ b/core/src/test/java/app/vela/core/replay/TripRenameTest.kt
@@ -1,0 +1,68 @@
+package app.vela.core.replay
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Renaming a saved trip ([TripLog.renameHeader]).
+ *
+ * A recorded drive cannot be captured again, so what is worth pinning is that a rename touches the
+ * label and NOTHING else: the header's other fields keep their positions, and every recorded fix,
+ * route and maneuver line survives byte for byte.
+ */
+class TripRenameTest {
+
+    private val trip = listOf(
+        "META,Old name,1755000000,38.5449,-121.7405,2955",
+        "RD,3000,300,320",
+        "M,DEPART,38.54490,-121.74050,1500,Head east",
+        "38.54490,-121.74050,1755000000,90.0,13.4",
+        "38.54491,-121.73990,1755000001,90.0,13.5",
+    )
+
+    @Test fun `renaming changes only the label`() {
+        val out = TripLog.renameHeader(trip, "Morning commute")!!
+        assertEquals("META,Morning commute,1755000000,38.5449,-121.7405,2955", out[0])
+        assertEquals("every line after the header is untouched", trip.drop(1), out.drop(1))
+    }
+
+    // A comma would shift every later field along by one - the start time would be read as a
+    // coordinate - so it is replaced, not kept.
+    @Test fun `a comma in the name cannot shift the header fields`() {
+        val fields = TripLog.renameHeader(trip, "Home, then work")!![0].split(',')
+        assertEquals("META", fields[0])
+        assertEquals("Home  then work", fields[1])
+        assertEquals("1755000000", fields[2])
+        assertEquals("38.5449", fields[3])
+        assertEquals("-121.7405", fields[4])
+        assertEquals("2955", fields[5])
+    }
+
+    // A newline would split the header into two records, the second of which parses as junk.
+    @Test fun `a newline in the name cannot split the header`() {
+        val out = TripLog.renameHeader(trip, "Line one\nline two")!!
+        assertEquals(trip.size, out.size)
+        assertTrue(out[0].startsWith("META,Line one line two,"))
+    }
+
+    @Test fun `a blank name falls back rather than leaving the trip nameless`() {
+        assertEquals("META,Trip,1755000000,38.5449,-121.7405,2955", TripLog.renameHeader(trip, "   ")!![0])
+    }
+
+    @Test fun `an over-long name is trimmed to something a header can hold`() {
+        assertEquals(80, TripLog.renameHeader(trip, "x".repeat(500))!![0].split(',')[1].length)
+    }
+
+    // Refusing is what protects a file that is not a trip: the caller then writes nothing at all.
+    @Test fun `a file with no trip header is refused`() {
+        assertNull(TripLog.renameHeader(listOf("38.5449,-121.7405,1,0,0"), "Nope"))
+        assertNull(TripLog.renameHeader(emptyList(), "Nope"))
+    }
+
+    // Still parsing afterwards is the whole reason this lives beside the format.
+    @Test fun `a renamed trip still parses`() {
+        assertEquals(2, TripLog.parsePoints(TripLog.renameHeader(trip, "Renamed")!!).size)
+    }
+}


### PR DESCRIPTION
All three asks.

**Rename** — pencil on every row in Settings → Diagnostics. Recorded drives all arrive named after the destination, which is fine for one drive and useless once there are twenty to the same place.

**Multi-select export** — a "Select trips" mode with checkboxes and one Share that hands the whole set over as separate attachments. A single pick still uses the existing single-trip path, and one unreadable file is skipped rather than costing you the other nine.

**Name on save** — optional prompt right after a recorded drive ends, which is when you actually remember what it was. Off by default, and only offered while recording is on; renaming later from the list does the same thing.

### The rename is careful on purpose
A recorded drive cannot be captured a second time, so:
- the header surgery moved into **`TripLog.renameHeader` in `:core`**, beside the format, so the writer and the reader cannot drift apart (and so it is testable);
- only field 0 of the header changes — start time, destination and version code are carried through, and every fix/route/maneuver line after it is untouched;
- the write goes to a temp file and is renamed over the original, so a recording can never be left half-written;
- a comma or newline in a name is replaced, because either would shift or split the header fields and make the whole file unparseable.

`TripRenameTest`, 7 passing, pins exactly those properties including "a renamed trip still parses".

### Device-verified what could be
On the 4a, installed in place at the existing versionCode: turning on trip recording revealed the new **"Name each trip when it is saved"** toggle, and turning recording back off hid it again — the gating works. I could not exercise rename end to end there because the phone has no recorded trips and **demo drives cannot create one** (the live collector drops fixes while replaying, so no trip is recorded). That is why the header logic moved somewhere it could be tested for real rather than shipped on inspection. Both settings I flipped are back off.

**Trap worth knowing:** an early `return@forEachIndexed` inside the trip-row composable crashes the Compose compiler ("No mapping for symbol" during IR lowering); the selection branch is if/else for that reason.