### PR TITLE
Publish the signing certificate so downloads can be checked

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,15 @@ Defaults that make the safe path the easy one:
   probe would evict its cache and every install falls back to Noto). Site edits: `site/**` is
   in CI's paths-ignore (no nightly for copy tweaks) and is a push trigger on `fdroid-repo.yml`
   (the deploy still needs release APKs to exist, which they always do).
+  **The APP SIGNING CERTIFICATE is published (issue #294, 2026-08-26):** SHA-256
+  `29938b4858063e42e677ff95c901cd48248a7f032a3ae85f9b9e5617568b0d36`, in README ("Check you got
+  the real thing") + FDROID.md. Read it out of any signed release with
+  `apksigner verify --print-certs <apk>` - NO keystore password needed, the certificate is public;
+  verified identical on stable and canary, so every channel shares the one key. NB `keytool -list`
+  needs the password AND the keystore is `~/.vela-signing/vela-release.jks` (not `vela.keystore` -
+  a wrong path makes keytool print its error to stderr, so a `| grep SHA256` pipeline looks
+  silently empty). Do NOT confuse this with the F-Droid fingerprint in FDROID.md
+  (`F374920F...`), which signs the repo INDEX, not the app.
   Release signing uses repo secrets `VELA_KEYSTORE_BASE64`,
   `VELA_KEYSTORE_PASSWORD`, `VELA_KEY_ALIAS` (set; keystore at `~/.vela-signing/`,
   outside the repo - back it up). Without them the APK is debug-signed. Version

--- a/FDROID.md
+++ b/FDROID.md
@@ -47,6 +47,19 @@ signed with a dedicated repo key; the APKs carry the same Vela signing key as
 the GitHub releases and the in-app updater, so switching install sources never
 forces a reinstall.
 
+**Two different fingerprints, do not mix them up.** The one in the repo URL
+above signs the repo INDEX, which is what tells your F-Droid client the listing
+is genuine. The APKs themselves are signed with the Vela app key, whose
+certificate fingerprint is:
+
+```
+SHA-256  29:93:8B:48:58:06:3E:42:E6:77:FF:95:C9:01:CD:48:24:8A:7F:03:2A:3A:E8:5F:9B:9E:56:17:56:8B:0D:36
+```
+
+That is the one to check an APK against (`apksigner verify --print-certs`), and
+it is identical on every channel, which is why moving between install sources
+never asks you to uninstall first.
+
 ## Why not the official f-droid.org catalog?
 
 The main F-Droid catalog builds every app from source on their own servers,

--- a/README.md
+++ b/README.md
@@ -58,6 +58,30 @@ the same signed APKs, weekly stable by default (fingerprint and nightly-channel
 setup in [FDROID.md](FDROID.md)). Or grab an APK straight from
 [Releases](https://github.com/PimpinPumpkin/Vela/releases).
 
+### Check you got the real thing
+
+Every Vela APK, from any channel, is signed with the same key. Its certificate
+fingerprint is:
+
+```
+SHA-256  29:93:8B:48:58:06:3E:42:E6:77:FF:95:C9:01:CD:48:24:8A:7F:03:2A:3A:E8:5F:9B:9E:56:17:56:8B:0D:36
+```
+
+Check a downloaded file against it before installing:
+
+```bash
+apksigner verify --print-certs vela-maps-*.apk
+```
+
+Android enforces this for you after the first install: an update signed with a
+different key is refused, so a build that installs over your existing Vela came
+from the same place this one did.
+
+This is the certificate the app is signed with, and it stays the same across
+releases. It is not a checksum of a particular APK, and it is not the same as
+the F-Droid repo fingerprint in [FDROID.md](FDROID.md), which signs the repo
+index rather than the app.
+
 There's also a one-page tour at
 **[pimpinpumpkin.github.io/Vela](https://pimpinpumpkin.github.io/Vela/)**.
 


### PR DESCRIPTION
Closes #294

The reporter wanted the **signing certificate** hash, and pre-empted the usual confusion by noting it is not a per-APK checksum. Both distinctions are now spelled out in the docs.

```
SHA-256  29:93:8B:48:58:06:3E:42:E6:77:FF:95:C9:01:CD:48:24:8A:7F:03:2A:3A:E8:5F:9B:9E:56:17:56:8B:0D:36
```

Read straight out of the signed releases with `apksigner verify --print-certs` (no keystore password involved, the certificate is public), and **verified identical on both stable v0.4.955 and the canary**, so the claim that every channel shares one key is checked rather than assumed.

Also worth separating, and now done in FDROID.md: the fingerprint already on that page (`F374920F…`) signs the **repo index**, not the app. Someone verifying an APK against it would get a mismatch and reasonably conclude something was wrong.