### PR TITLE
Show what is coming up on the road ahead

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2834,6 +2834,26 @@ architecture note.
   single transfer) and the ambient fan-out takes the LEAN path (8 terms at `!7i30` instead of
   15 at `!7i60`) - the same trade LowRamMode makes, for bytes rather than heap. NOT verifiable
   without a real satellite link; the plumbing is what was tested.
+- **Route bar (issue #228, 2026-08-28, Settings > Navigation "Road ahead bar", OFF by default).**
+  A strip down the LEFT edge during nav (opposite the FAB stack) showing the road AHEAD:
+  congestion bands from `Route.trafficSpans` plus the static furniture already fetched along the
+  corridor (lights, stops, level crossings, speed humps, ALPR cameras). Model is pure + tested in
+  `:core` `nav/RouteBar` (`RouteBarTest`); the strip is `app/ui/nav/RouteBarStrip`.
+  **It shows a 5 km WINDOW, not the whole route (`RouteBar.WINDOW_M`) - the first cut scaled to
+  the entire remaining trip and was device-proven useless:** on a 769 mi demo drive every nearby
+  mark collapsed into the bottom pixel and the bar read as a plain grey stick. Near the end the
+  window shrinks to the destination (`reachesDestination`). TomTom's original also carries live
+  HAZARDS; ours deliberately cannot (every keyless incident source is a proven dead end), so it
+  draws only what the map already knows. Two clocks: marks are projected onto the polyline ONCE
+  per route (`RouteBar.alongMeters`, 40 m corridor so a parallel street is not claimed as yours),
+  the model is rebuilt per nav tick from that cache. Portrait only + never in PiP, deliberately -
+  issue #297 is already about landscape being crowded.
+  ⚠️ **INIT-ORDER TRAP (cost a launch crash, device-caught):** `refreshRouteBar()` was first called
+  from the main `init` block, but `settingsPrefs` is declared ~3400 lines further down the class,
+  and Kotlin runs property initializers + init blocks in DECLARATION order - so it read a null
+  SharedPreferences and every launch died with an NPE before the map drew. It now lives in its own
+  `init { }` placed immediately AFTER the `settingsPrefs` property. Any future pref read that must
+  happen at construction goes there too, not in the main init block.
 - **Nav smoothness trace (`app/diag/NavTrace`, Settings > Diagnostics, OFF by default, issue #251
   2026-08-10).** One row per nav frame - t, along-route progress, speed, bearing WINDOW, chordBrg,
   displayBearing, live camera bearing, frame dt - into a bounded 72k ring (oldest dropped), written

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
@@ -1249,6 +1250,21 @@ fun MapScreen(
         }
 
         // --- top overlay: nav banner while navigating, else search ----------
+        // Route bar (issue #228): the road ahead as a strip down the LEFT edge, opposite the
+        // right-edge FAB stack so it competes with nothing. Portrait only and never in PiP - issue
+        // #297 is already about landscape being crowded, and adding a permanent strip there would
+        // make that worse rather than better.
+        state.routeBar?.let { bar ->
+            if (state.navigating && !landscapeChrome && !bar.isEmpty) {
+                app.vela.ui.nav.RouteBarStrip(
+                    model = bar,
+                    modifier = Modifier
+                        .align(Alignment.CenterStart)
+                        .padding(start = 10.dp)
+                        .fillMaxHeight(0.42f),
+                )
+            }
+        }
         if (state.navigating) {
             val mans = state.activeRoute?.maneuvers
             val liveStep = state.nav.stepIndex

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -169,6 +169,11 @@ data class MapUiState(
                                                       // .pmtiles — rendered beneath OSM to fill gaps
     val trafficControls: List<app.vela.core.data.TrafficControl> = emptyList(), // OSM lights+stop signs drawn at high zoom
     val flockCameras: List<app.vela.core.data.AlprCamera> = emptyList(), // ALPR/Flock cameras (DeFlock/OSM), high zoom
+    // The route bar's model (issue #228): what is on the road AHEAD - congestion bands plus the
+    // static road furniture already fetched along the corridor. Recomputed on progress, not per
+    // frame; empty whenever the bar has nothing honest to show.
+    val routeBar: app.vela.core.nav.RouteBar.Model? = null,
+    val routeBarEnabled: Boolean = false,
     val speedCameras: List<app.vela.core.data.SpeedCamera> = emptyList(), // fixed radar cameras (OSM), opt-in layer
     val transitStops: List<app.vela.core.data.transit.Transitous.MapStop> = emptyList(), // canonical GTFS stops (Transitous), high zoom
     val directionsOpen: Boolean = false,
@@ -596,6 +601,13 @@ class MapViewModel @Inject constructor(
                 // what the nav engine did — the tuning signal that pairs with the raw GPS trip
                 // trace. Rides the existing opt-in; never uploaded.
                 if (navStarted) diag.record("nav", "start → ${ns.destinationLabel.ifBlank { "destination" }}")
+                // Route bar (issue #228). Two clocks on purpose: the MARKS are projected onto the
+                // route once per route (O(marks x polyline), far too heavy for a progress tick),
+                // while the model itself is rebuilt from the cached marks every tick, which is
+                // just arithmetic. Nav-end clears both.
+                if (_state.value.routeBarEnabled) updateRouteBar(ns) else if (_state.value.routeBar != null) {
+                    _state.update { it.copy(routeBar = null) }
+                }
                 // Heartbeat the resume timestamp while a REAL drive is under way (skip replay/demo, which
                 // don't persist) so the resume window measures time since the INTERRUPTION, not since nav
                 // start — else a drive longer than RESUME_MAX_AGE_MS could never be resumed (audit 2026-07-06).
@@ -3926,7 +3938,18 @@ class MapViewModel @Inject constructor(
 
     private val settingsPrefs = appContext.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
 
+    // Seeded HERE, not in the main init block above: Kotlin runs property initializers and init
+    // blocks in DECLARATION order, and `settingsPrefs` is declared this far down the class, so an
+    // early caller reads it as null and the app dies on launch before the map ever draws. Any
+    // future pref read that has to happen at construction belongs after this line too.
+    init { refreshRouteBar() }
+
     /** Reflect the persisted "save my trips" flag into UI state. */
+    /** Reflect the persisted route-bar flag into UI state (pref `route_bar`, default off - it is
+     *  extra chrome on the nav screen, so it should be asked for, not imposed). */
+    fun refreshRouteBar() =
+        _state.update { it.copy(routeBarEnabled = settingsPrefs.getBoolean("route_bar", false)) }
+
     fun refreshTripRecording() =
         _state.update { it.copy(tripRecordingEnabled = settingsPrefs.getBoolean("trip_recording_on", false)) }
 
@@ -5269,6 +5292,69 @@ class MapViewModel @Inject constructor(
      * cached box edge, and the churn (against mirrors that are sometimes down) made the icons appear
      * rarely and vanish quickly during nav. Same cluster-per-intersection pass as the box path.
      */
+    // Marks projected onto the CURRENT route, cached by that route's identity so a progress tick
+    // never re-walks the polyline. Null route key = nothing cached.
+    private var routeBarKey: String? = null
+    private var routeBarMarks: List<Pair<app.vela.core.nav.RouteBar.Mark, Double>> = emptyList()
+
+    /** Recompute the route bar for this nav tick (see the call site for why the work is split). */
+    private fun updateRouteBar(ns: app.vela.core.nav.NavSession.State) {
+        val route = ns.route
+        if (!ns.navigating || route == null || route.polyline.size < 2) {
+            if (_state.value.routeBar != null || routeBarKey != null) {
+                routeBarKey = null
+                routeBarMarks = emptyList()
+                _state.update { it.copy(routeBar = null) }
+            }
+            return
+        }
+        // Identity = the same key shape the corridor fetch uses, so a steps/traffic heal on the
+        // same course does not throw the projection away.
+        val key = "${route.polyline.first()}|${route.polyline.last()}|${route.distanceMeters.toInt()}|" +
+            "${_state.value.trafficControls.size}|${_state.value.flockCameras.size}"
+        if (key != routeBarKey) {
+            routeBarKey = key
+            val poly = route.polyline
+            val cum = app.vela.core.nav.RouteBar.cumulative(poly)
+            val controls = _state.value.trafficControls
+            val cams = _state.value.flockCameras
+            viewModelScope.launch(Dispatchers.Default) {
+                val marks = buildList {
+                    for (c in controls) {
+                        val m = app.vela.core.nav.RouteBar.alongMeters(poly, cum, c.loc) ?: continue
+                        add(
+                            when (c.kind) {
+                                app.vela.core.data.TrafficControl.Kind.SIGNAL -> app.vela.core.nav.RouteBar.Mark.SIGNAL
+                                app.vela.core.data.TrafficControl.Kind.STOP -> app.vela.core.nav.RouteBar.Mark.STOP
+                                app.vela.core.data.TrafficControl.Kind.RAIL_CROSSING -> app.vela.core.nav.RouteBar.Mark.RAIL_CROSSING
+                                app.vela.core.data.TrafficControl.Kind.SPEED_HUMP -> app.vela.core.nav.RouteBar.Mark.SPEED_HUMP
+                            } to m,
+                        )
+                    }
+                    for (c in cams) {
+                        val m = app.vela.core.nav.RouteBar.alongMeters(poly, cum, c.loc) ?: continue
+                        add(app.vela.core.nav.RouteBar.Mark.CAMERA to m)
+                    }
+                }
+                withContext(Dispatchers.Main) {
+                    // Guard against a route swap landing while this was computing.
+                    if (routeBarKey == key) {
+                        routeBarMarks = marks
+                        _state.update { it.copy(routeBar = app.vela.core.nav.RouteBar.build(route, ns.nav.traveledM, marks)) }
+                    }
+                }
+            }
+            return
+        }
+        _state.update { it.copy(routeBar = app.vela.core.nav.RouteBar.build(route, ns.nav.traveledM, routeBarMarks)) }
+    }
+
+    /** Show or hide the route bar (pref `route_bar`). */
+    fun setRouteBar(on: Boolean) {
+        settingsPrefs.edit().putBoolean("route_bar", on).apply()
+        _state.update { it.copy(routeBarEnabled = on, routeBar = if (on) it.routeBar else null) }
+    }
+
     private fun refreshNavRouteControls(route: app.vela.core.model.Route) {
         val poly = route.polyline
         if (poly.size < 2) return

--- a/app/src/main/java/app/vela/ui/nav/RouteBarStrip.kt
+++ b/app/src/main/java/app/vela/ui/nav/RouteBarStrip.kt
@@ -1,0 +1,112 @@
+package app.vela.ui.nav
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.unit.dp
+import app.vela.core.nav.RouteBar
+
+/**
+ * The route bar (issue #228): a thin vertical strip showing the road AHEAD - you at the bottom,
+ * the destination at the top, congestion painted along it and the road furniture ahead marked on
+ * it.
+ *
+ * TomTom's original also carries live hazards; Vela's deliberately does not, because every keyless
+ * live-incident source is a proven dead end. What it draws is exactly what the map already knows,
+ * so the bar can never imply knowledge the app does not have.
+ *
+ * Sized and positioned by the caller. Everything here is a pure function of [model] - no state, no
+ * animation - because it sits on the nav screen where a per-frame recomposition is expensive.
+ */
+@Composable
+fun RouteBarStrip(model: RouteBar.Model, modifier: Modifier = Modifier) {
+    if (model.isEmpty) return
+    val track = MaterialTheme.colorScheme.surfaceVariant
+    Box(
+        modifier
+            .width(10.dp)
+            .clip(RoundedCornerShape(5.dp))
+            .background(track),
+    ) {
+        // Bottom-anchored fractions: 0 is you, 1 is the destination, which is how the strip reads
+        // when it stands beside a map with the puck low on the screen.
+        Layout(content = {
+            for (b in model.bands) {
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .background(congestionColor(b.level))
+                        .layoutId(b.from, b.to),
+                )
+            }
+            for (p in model.pins) {
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(3.dp)
+                        .background(pinColor(p.kind))
+                        .layoutId(p.at, p.at),
+                )
+            }
+        }) { measurables, constraints ->
+            val h = constraints.maxHeight
+            val placeables = measurables.map { m ->
+                val (from, to) = m.parentData as? Pair<*, *> ?: (0.0 to 0.0)
+                val f = (from as? Double) ?: 0.0
+                val t = (to as? Double) ?: 0.0
+                val bandH = ((t - f) * h).toInt()
+                m.measure(
+                    constraints.copy(
+                        minWidth = constraints.maxWidth,
+                        maxWidth = constraints.maxWidth,
+                        minHeight = 0,
+                        maxHeight = if (bandH > 0) bandH else constraints.maxHeight,
+                    ),
+                ) to f
+            }
+            layout(constraints.maxWidth, h) {
+                placeables.forEach { (p, f) ->
+                    // y grows downward, so a fraction near 1 (the destination) sits at the TOP.
+                    val y = (h - (f * h).toInt() - p.height).coerceIn(0, (h - p.height).coerceAtLeast(0))
+                    p.place(0, y)
+                }
+            }
+        }
+    }
+}
+
+/** Same grading the route line and the ETA colour use, so the bar agrees with the map. */
+private fun congestionColor(level: Int): Color = when {
+    level >= 3 -> Color(0xFF9C1C1C) // severe
+    level == 2 -> Color(0xFFD93025) // heavy
+    else -> Color(0xFFF9AB00)       // moderate
+}
+
+private fun pinColor(kind: RouteBar.Mark): Color = when (kind) {
+    RouteBar.Mark.CAMERA -> Color(0xFF8E24AA)        // the purple the camera badge uses
+    RouteBar.Mark.RAIL_CROSSING -> Color(0xFF37474F)
+    RouteBar.Mark.SPEED_HUMP -> Color(0xFFFFA000)
+    RouteBar.Mark.STOP -> Color(0xFFD32F2F)
+    RouteBar.Mark.SIGNAL -> Color(0xFF388E3C)
+}
+
+/** Carries a child's (from, to) fractions through measurement. */
+private fun Modifier.layoutId(from: Double, to: Double) =
+    this.then(RouteBarParentData(from to to))
+
+private data class RouteBarParentData(val span: Pair<Double, Double>) :
+    androidx.compose.ui.layout.ParentDataModifier, Modifier.Element {
+    override fun androidx.compose.ui.unit.Density.modifyParentData(parentData: Any?) = span
+}

--- a/app/src/main/java/app/vela/ui/settings/SettingsHub.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsHub.kt
@@ -315,6 +315,7 @@ private val SEARCH_INDEX: List<Pair<Int, SettingsSection>> = listOf(
     R.string.settings_hide_external_links to SettingsSection.PLACE_PAGES,
     // Navigation
     R.string.settings_keep_screen_on to SettingsSection.NAVIGATION,
+    R.string.settings_route_bar to SettingsSection.NAVIGATION,
     R.string.settings_traffic_lights to SettingsSection.NAVIGATION,
     R.string.settings_vibrate_on_turns to SettingsSection.NAVIGATION,
     R.string.settings_demo_drive to SettingsSection.NAVIGATION,

--- a/app/src/main/java/app/vela/ui/settings/sections/NavigationSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/NavigationSettings.kt
@@ -71,6 +71,17 @@ internal fun NavigationSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
             switchModifier = topRow,
         )
 
+        // Route bar (issue #228). Off by default: it is extra chrome on the nav screen, and the
+        // congestion colour already on the route line covers some of the same ground.
+        var routeBar by remember { mutableStateOf(prefs.getBoolean("route_bar", false)) }
+        GroupDivider()
+        ToggleRow(
+            label = stringResource(R.string.settings_route_bar),
+            checked = routeBar,
+            onCheckedChange = { routeBar = it; vm.setRouteBar(it) },
+            hint = stringResource(R.string.settings_route_bar_hint),
+        )
+
         var trafficLights by remember { mutableStateOf(prefs.getBoolean("nav_traffic_lights", false)) }
         GroupDivider()
         ToggleRow(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -714,6 +714,8 @@
     <string name="settings_hub_diagnostics_sub">Crash reports, trips, compatibility</string>
     <string name="settings_hub_about_sub">Version, updates, support</string>
     <string name="settings_theme_amoled">AMOLED black</string>
+    <string name="settings_route_bar">Road ahead bar</string>
+    <string name="settings_route_bar_hint">A strip beside the map showing traffic and what is coming up on the rest of your route. Shows only what Vela actually knows: congestion, lights, stop signs, level crossings, speed bumps and surveillance cameras. Portrait only.</string>
     <string name="settings_traffic_lights">Traffic-light guidance</string>
     <string name="settings_traffic_lights_hint">Spoken landmark cues: pass the light, then turn. English only, off by default.</string>
     <string name="settings_softkeys" translatable="false">Hardware softkeys</string>

--- a/core/src/main/java/app/vela/core/nav/RouteBar.kt
+++ b/core/src/main/java/app/vela/core/nav/RouteBar.kt
@@ -1,0 +1,161 @@
+package app.vela.core.nav
+
+import app.vela.core.model.LatLng
+import app.vela.core.model.Route
+import app.vela.core.model.distanceTo
+
+/**
+ * The model behind the route bar (issue #228) - a strip showing the road AHEAD of you at a glance:
+ * where the traffic is, and what is coming up on it.
+ *
+ * TomTom's version of this also carries live hazards. Vela's cannot: every keyless live-incident
+ * source has been probed and is dead (Google serves binary vector tiles, Waze is reCAPTCHA-gated).
+ * So this shows only what Vela genuinely knows - the congestion spans Google gives us for the
+ * route, and the static road furniture already fetched along the corridor for the map. Showing a
+ * confident bar with nothing real behind it would be worse than not having one.
+ *
+ * Pure and unit-tested on purpose: it decides positions, which is the part that can be wrong in
+ * ways a screenshot will not reveal.
+ */
+object RouteBar {
+
+    /** What a mark on the bar represents. The kinds are exactly the ones Vela already draws on the
+     *  map, so the bar can never claim knowledge the map does not have. */
+    enum class Mark { SIGNAL, STOP, RAIL_CROSSING, SPEED_HUMP, CAMERA }
+
+    /** A congestion band, as a fraction of the REMAINING trip: 0 = where you are, 1 = destination.
+     *  [level] is Google's grade (1 moderate, 2 heavy, 3+ severe). */
+    data class Band(val level: Int, val from: Double, val to: Double)
+
+    /** One mark placed on the bar, again as a fraction of the remaining trip. */
+    data class Pin(val kind: Mark, val at: Double)
+
+    data class Model(
+        val bands: List<Band>,
+        val pins: List<Pin>,
+        /** Metres of road the bar's full height represents (the window, not the whole trip). */
+        val spanM: Double,
+        /** True when the window reaches the end of the route, so the top of the bar is the
+         *  destination and can be capped as such rather than implying more road. */
+        val reachesDestination: Boolean,
+    ) {
+        val isEmpty: Boolean get() = bands.isEmpty() && pins.isEmpty()
+    }
+
+    /** Marks closer together than this along the route collapse into one, so a junction with a
+     *  light and a stop line does not stack two glyphs on the same pixel. */
+    private const val PIN_MERGE_M = 60.0
+
+    /** Below this the bar would be a sliver of noise; the banner already covers the last stretch. */
+    private const val MIN_REMAINING_M = 400.0
+
+    /**
+     * How much road the bar shows: the next 5 km, not the whole trip.
+     *
+     * Scaling the strip to the entire remaining route was the first cut and it is useless on any
+     * long drive - on a 700 mile trip everything within the next few miles lands inside one pixel
+     * at the bottom and the bar reads as a plain grey stick (device-checked, that is exactly what
+     * it looked like). TomTom's bar has the same property and solves it the same way: show the
+     * near road at a scale you can actually read. When less than this is left, the bar covers the
+     * rest of the trip and its top IS the destination.
+     */
+    const val WINDOW_M = 5_000.0
+
+    /** Cumulative distance to each vertex, so a point can be placed along the line without
+     *  re-walking it per lookup. Computed once per route, never per frame. */
+    fun cumulative(poly: List<LatLng>): DoubleArray {
+        val cum = DoubleArray(poly.size)
+        for (i in 1 until poly.size) cum[i] = cum[i - 1] + poly[i - 1].distanceTo(poly[i])
+        return cum
+    }
+
+    /**
+     * How far along the route [p] sits, or null when it is further than [maxOffRouteM] from the
+     * line - a corridor fetch returns things near the road, including some on a parallel street,
+     * and those must not be drawn as if they were ahead of you.
+     */
+    fun alongMeters(
+        poly: List<LatLng>,
+        cum: DoubleArray,
+        p: LatLng,
+        maxOffRouteM: Double = 40.0,
+    ): Double? {
+        if (poly.size < 2) return null
+        var bestD = Double.MAX_VALUE
+        var bestAlong = 0.0
+        for (i in 0 until poly.size - 1) {
+            val a = poly[i]
+            val b = poly[i + 1]
+            val segLen = cum[i + 1] - cum[i]
+            if (segLen <= 0.0) continue
+            // Project onto the segment in a local flat frame; over a segment this is exact enough
+            // and avoids trigonometry per vertex on a polyline with thousands of points.
+            val latScale = Math.cos(Math.toRadians(a.lat))
+            val ax = 0.0
+            val ay = 0.0
+            val bx = (b.lng - a.lng) * latScale
+            val by = (b.lat - a.lat)
+            val px = (p.lng - a.lng) * latScale
+            val py = (p.lat - a.lat)
+            val len2 = bx * bx + by * by
+            val t = if (len2 <= 0.0) 0.0 else (((px - ax) * bx + (py - ay) * by) / len2).coerceIn(0.0, 1.0)
+            val cx = bx * t
+            val cy = by * t
+            val dDeg = Math.hypot(px - cx, py - cy)
+            val dM = dDeg * 111_320.0
+            if (dM < bestD) {
+                bestD = dM
+                bestAlong = cum[i] + segLen * t
+            }
+        }
+        return if (bestD <= maxOffRouteM) bestAlong else null
+    }
+
+    /**
+     * Build the bar for [route] given how far along it you are.
+     *
+     * [markMeters] is each mark's own distance along the route (from [alongMeters]); anything
+     * already behind you, or past the destination, is dropped rather than clamped to an end - a
+     * pin pinned at your own position reads as "right here" and would be a lie.
+     */
+    fun build(
+        route: Route,
+        traveledM: Double,
+        markMeters: List<Pair<Mark, Double>> = emptyList(),
+        windowM: Double = WINDOW_M,
+    ): Model {
+        val total = route.distanceMeters
+        val done = traveledM.coerceIn(0.0, total)
+        val remaining = total - done
+        if (remaining < MIN_REMAINING_M) return Model(emptyList(), emptyList(), remaining, true)
+
+        // The bar covers the next [windowM] of road, or the rest of the trip when that is nearer.
+        val end = minOf(total, done + windowM)
+        val span = end - done
+        val reaches = end >= total - 1.0
+
+        fun frac(m: Double) = ((m - done) / span).coerceIn(0.0, 1.0)
+
+        val bands = route.trafficSpans
+            .mapNotNull { s ->
+                val sEnd = s.startMeters + s.lengthMeters
+                // Keep a span overlapping the WINDOW, trimmed to it.
+                if (sEnd <= done || s.startMeters >= end) null
+                else Band(s.level, frac(maxOf(s.startMeters, done)), frac(minOf(sEnd, end)))
+            }
+            .filter { it.to > it.from }
+
+        val pins = markMeters
+            .filter { (_, m) -> m > done && m <= end }
+            .sortedBy { it.second }
+            .fold(mutableListOf<Pair<Mark, Double>>()) { acc, item ->
+                // Collapse a cluster to its first member: the point is "something is coming up
+                // here", and two glyphs a pixel apart carry no more information than one.
+                if (acc.isEmpty() || item.second - acc.last().second >= PIN_MERGE_M) acc += item
+                acc
+            }
+            .map { (kind, m) -> Pin(kind, frac(m)) }
+
+        return Model(bands, pins, span, reaches)
+    }
+}

--- a/core/src/test/java/app/vela/core/nav/RouteBarTest.kt
+++ b/core/src/test/java/app/vela/core/nav/RouteBarTest.kt
@@ -1,0 +1,117 @@
+package app.vela.core.nav
+
+import app.vela.core.model.LatLng
+import app.vela.core.model.Route
+import app.vela.core.model.RouteLeg
+import app.vela.core.model.TrafficSpan
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The route bar's positioning ([RouteBar]).
+ *
+ * The bar's whole job is to say WHERE something sits on the road ahead, so the failures worth
+ * pinning are the ones a screenshot would not reveal: a jam you already drove through still being
+ * drawn, something on a parallel street counted as being on your route, or a mark landing at the
+ * wrong height on the strip.
+ */
+class RouteBarTest {
+
+    // A straight 10 km run east from the Davis fixture, roughly one vertex per kilometre.
+    private val poly = (0..10).map { LatLng(38.5449, -121.7405 + it * 0.0115) }
+
+    private fun route(distanceM: Double, spans: List<TrafficSpan> = emptyList()) = Route(
+        polyline = poly,
+        legs = listOf(RouteLeg(distanceM, 600.0, null, emptyList())),
+        distanceMeters = distanceM,
+        durationSeconds = 600.0,
+        durationInTrafficSeconds = null,
+        trafficSpans = spans,
+    )
+
+    @Test fun `a jam ahead is placed by how far ahead it is`() {
+        // 10 km trip, 2 km driven, jam from 6 km to 8 km: half to three quarters of the 8 km left.
+        val m = RouteBar.build(route(10_000.0, listOf(TrafficSpan(2, 6_000.0, 2_000.0))), traveledM = 2_000.0, windowM = 20_000.0)
+        assertEquals(1, m.bands.size)
+        assertEquals(0.5, m.bands[0].from, 0.001)
+        assertEquals(0.75, m.bands[0].to, 0.001)
+        assertEquals(8_000.0, m.spanM, 0.1)
+    }
+
+    @Test fun `a jam already driven through is dropped`() {
+        val m = RouteBar.build(route(10_000.0, listOf(TrafficSpan(2, 1_000.0, 500.0))), traveledM = 4_000.0, windowM = 20_000.0)
+        assertTrue("nothing behind you belongs on a bar of the road ahead", m.bands.isEmpty())
+    }
+
+    @Test fun `a jam you are sitting in starts at your own position, not before it`() {
+        val m = RouteBar.build(route(10_000.0, listOf(TrafficSpan(3, 1_000.0, 4_000.0))), traveledM = 2_000.0, windowM = 20_000.0)
+        assertEquals("trimmed to the road ahead", 0.0, m.bands[0].from, 0.001)
+        assertEquals(0.375, m.bands[0].to, 0.001) // ends at 5 km = 3 km into the remaining 8
+    }
+
+    @Test fun `marks behind you and past the destination are dropped`() {
+        val marks = listOf(
+            RouteBar.Mark.SIGNAL to 500.0,      // behind
+            RouteBar.Mark.STOP to 5_000.0,      // ahead
+            RouteBar.Mark.CAMERA to 12_000.0,   // past the end
+        )
+        val m = RouteBar.build(route(10_000.0), traveledM = 2_000.0, markMeters = marks, windowM = 20_000.0)
+        assertEquals(1, m.pins.size)
+        assertEquals(RouteBar.Mark.STOP, m.pins[0].kind)
+        assertEquals(0.375, m.pins[0].at, 0.001)
+    }
+
+    @Test fun `marks at the same junction collapse to one`() {
+        val marks = listOf(
+            RouteBar.Mark.SIGNAL to 5_000.0,
+            RouteBar.Mark.STOP to 5_020.0,
+            RouteBar.Mark.SIGNAL to 5_040.0,
+            RouteBar.Mark.STOP to 7_000.0, // a genuinely separate junction
+        )
+        val m = RouteBar.build(route(10_000.0), traveledM = 0.0, markMeters = marks, windowM = 20_000.0)
+        assertEquals("one glyph per junction", 2, m.pins.size)
+    }
+
+    @Test fun `the bar stands down near the destination`() {
+        val m = RouteBar.build(route(10_000.0, listOf(TrafficSpan(2, 9_950.0, 50.0))), traveledM = 9_800.0, windowM = 20_000.0)
+        assertTrue("a 200 m sliver is noise, the banner covers that stretch", m.isEmpty)
+    }
+
+    @Test fun `a point on the route is placed at its distance along it`() {
+        val cum = RouteBar.cumulative(poly)
+        assertEquals(cum[3], RouteBar.alongMeters(poly, cum, poly[3])!!, 5.0)
+    }
+
+    @Test fun `a point on a parallel street is not counted as being on the route`() {
+        val cum = RouteBar.cumulative(poly)
+        // ~330 m north of the line: a different road, not this one.
+        assertNull(RouteBar.alongMeters(poly, cum, LatLng(poly[3].lat + 0.003, poly[3].lng)))
+    }
+
+    @Test fun `a point just off the kerb still counts`() {
+        val cum = RouteBar.cumulative(poly)
+        val kerb = LatLng(poly[3].lat + 0.0001, poly[3].lng) // ~11 m
+        assertEquals(cum[3], RouteBar.alongMeters(poly, cum, kerb)!!, 20.0)
+    }
+
+    // The whole point of the window: on a long trip the near road must stay readable.
+    @Test fun `on a long trip the bar shows the near road, not the whole route`() {
+        val far = TrafficSpan(2, 400_000.0, 10_000.0)   // hundreds of km away
+        val near = TrafficSpan(3, 3_000.0, 1_000.0)     // 3 km ahead
+        val m = RouteBar.build(route(1_200_000.0, listOf(far, near)), traveledM = 0.0)
+        assertEquals("only what is inside the window is drawn", 1, m.bands.size)
+        assertEquals(0.6, m.bands[0].from, 0.001) // 3 km into a 5 km window
+        assertEquals(0.8, m.bands[0].to, 0.001)
+        assertEquals(RouteBar.WINDOW_M, m.spanM, 0.1)
+        assertTrue("a 1200 km trip does not end inside the window", !m.reachesDestination)
+    }
+
+    @Test fun `near the end the window shrinks to the destination`() {
+        val m = RouteBar.build(route(10_000.0, listOf(TrafficSpan(2, 9_000.0, 500.0))), traveledM = 8_000.0)
+        assertEquals("2 km left, so the bar spans 2 km", 2_000.0, m.spanM, 0.1)
+        assertTrue("the top of the bar is the destination", m.reachesDestination)
+        assertEquals(0.5, m.bands[0].from, 0.001)
+    }
+}


### PR DESCRIPTION
Closes #228

A strip down the left edge during nav (opposite the FAB stack) showing the road ahead: congestion bands plus the lights, stop signs, level crossings, speed humps and ALPR cameras you're about to reach. **Off by default**, Settings → Navigation → "Road ahead bar".

**What it deliberately does not do.** TomTom's bar carries live hazards; ours can't, since every keyless incident source is a proven dead end. It draws only what the map already knows, because a bar that looks confident while knowing nothing is worse than no bar.

### Device testing changed the design
I built it scaled to the whole remaining route first. On a 769-mile demo drive that was **useless** — every nearby mark collapsed into the bottom pixel and it read as a plain grey stick. So it now shows a **5 km window** (shrinking to the destination near the end), which is what TomTom actually does and why.

Before → after, same drive: one mark crushed at the bottom → two camera marks spread legibly up the strip.

### And it caught a launch crash
`refreshRouteBar()` initially sat in the main `init` block, but `settingsPrefs` is declared ~3,400 lines further down, and Kotlin runs initializers in declaration order — so it read a null SharedPreferences and **every launch died with an NPE before the map drew**. Compiled clean, tested clean, crashed instantly on the phone. It now has its own `init` block after that property, with a note for the next person.

### Honest state of the visuals
It works and is legible, but it's minimal: a grey track with coloured marks. No "you" anchor at the bottom, no destination cap, no per-kind icons — the marks are colour-coded only. If you want it to look designed rather than functional, that's a follow-up I'd rather you steer.

`RouteBarTest`: 11 passing, covering the positioning that a screenshot wouldn't reveal — a jam you've already driven through is dropped, a jam you're sitting in starts at your position rather than behind you, marks on a parallel street aren't claimed as being on your route, and marks at one junction collapse to a single glyph.