### PR TITLE
Stop the driving puck swimming side to side on bends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2001,7 +2001,20 @@ architecture note.
   motion 6x the bottom band = rotation, not translation). After gating the scaling on
   `!demoDriving`: 0% stalled, chord wiggle **0.53**, camera wiggle **0.29** deg, on-screen top-band
   motion halved. The gate is `state.replaying && !state.demoDriving` - a genuine trip REPLAY still
-  emits fixes at 3x and MUST keep the scaling. **Nav-camera eases also use a CAPPED time
+  emits fixes at 3x and MUST keep the scaling.
+  **THE PUCK BOXCAR WINDOW IS LOW-PASSED (issue #251, 2026-08-28 - a POSITION-swim source the
+  earlier bearing-only work missed).** `win = speed*0.7` sizes the position+bearing boxcar, but
+  `navPuck.speed` is the KALMAN speed and `kalman.predict(accel, dt)` runs EVERY FRAME integrating
+  the raw forward accelerometer - so `win` rippled at accel-noise frequency, 60 fps. On any curve a
+  rippling boxcar half-width pulses the AVERAGED point sideways (~win^2/2R), and the same ripple
+  slid the chord endpoints (`progressM +/- win`) across vertices and hopped the BEARING too - a
+  record-needle swim geometry smoothing cannot cancel, because the smoother's own window is what
+  shakes. `navPuck.smoothWinM` low-passes the half-width toward its speed-target (tau 0.8 s, seeded
+  on the first frame, reset to NaN on route re-anchor), so the window follows MEAN speed not accel
+  ripple. Measured on a synthetic crinkly road: per-frame bearing jitter 0.82 -> 0.23 deg, lateral
+  swim on R=150 m 8.5 -> 0.14 cm. NB a DEMO drive cannot verify this (clean synthetic fixes, no
+  accel ripple) - needs a real drive; the demo only proves no regression.
+  **Nav-camera eases also use a CAPPED time
   step (`dtEase` <= 65 ms, same issue, video-diagnosed):** a main-thread hitch (the
   400 m road-label pass lands near junctions) used to deliver one frame whose exponential eases
   jumped 45-70% of their error at once - the map lurched sideways under a rock-steady puck.

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1503,6 +1503,7 @@ fun VelaMapView(
         }
         wasNavRef[0] = true
         navPuck.engaged = false
+        navPuck.smoothWinM = Double.NaN // fresh route = re-seed the boxcar window from the first frame's speed
         val navWin = doubleArrayOf(Double.NaN) // route-split window end (m); relaunch = fresh route = re-anchor
         var lastNanos = 0L
         while (true) {
@@ -1583,7 +1584,15 @@ fun VelaMapView(
                 // so wiggle shorter than the window CANCELS instead of shrinking. Pure geometry
                 // smoothing, no temporal lag; corners round by a couple of metres at speed,
                 // which is what Google's puck does too.
-                val win = (navPuck.speed * 0.7).coerceIn(5.0, 14.0)
+                // The window follows MEAN speed, not the Kalman's per-frame accel ripple: ease
+                // the half-width toward its speed-target with a slow (~0.8 s) tau. Without this,
+                // `win` jitters every frame and on any curve the boxcar centre jitters laterally
+                // with it - a swim source the earlier bearing-only work never addressed. Seeded
+                // on the first frame so it does not ramp from 5 m at nav start.
+                val winTarget = (navPuck.speed * 0.7).coerceIn(5.0, 14.0)
+                navPuck.smoothWinM = if (navPuck.smoothWinM.isNaN()) winTarget
+                    else navPuck.smoothWinM + (winTarget - navPuck.smoothWinM) * (1f - kotlin.math.exp(-dtEase / 0.8f))
+                val win = navPuck.smoothWinM
                 var sLat = 0.0
                 var sLng = 0.0
                 for (k in 0 until PUCK_SMOOTH_SAMPLES) {
@@ -4968,6 +4977,13 @@ private class NavPuck {
                                    // runs in a recomposing scope, and kalman.update/reckonedM=0 are
                                    // NOT idempotent: re-running them on a mere recomposition re-injects
                                    // a stale speed and re-opens the blind reckoning window
+    var smoothWinM = Double.NaN    // LOW-PASSED half-width (m) of the position/bearing boxcar. The
+                                   // raw target win = speed*0.7, but speed is the KALMAN speed,
+                                   // which the per-frame accelerometer predict ripples at 60 fps -
+                                   // and on a curve a rippling boxcar width pulses the averaged
+                                   // point sideways (record-needle swim that geometry smoothing
+                                   // cannot cancel, because the smoother's own window is shaking).
+                                   // Eased slowly so the window follows MEAN speed, not accel noise.
     var displayBearing = Float.NaN // smoothed heading actually drawn (NaN = not yet seeded)
     var drawn: LatLng? = null     // last point actually drawn — the camera follows THIS, not the raw fix
     var raw: LatLng? = null       // off-route fallback position


### PR DESCRIPTION
A genuinely different angle on the residual jitter. All the prior work chased *bearing* noise; this is a *position* source none of it touched.

**The mechanism.** The puck smooths its position and heading by averaging a short stretch of road around it, and that stretch's length is `speed*0.7`. But that speed is the Kalman speed, and the Kalman integrates the phone's accelerometer **every frame** — so the averaging window was quietly growing and shrinking 60 times a second. On a curve, a window that keeps changing length drags the averaged point side to side (`~win²/2R`), and the same ripple slides the window's endpoints across polyline vertices and hops the bearing too. That's a record-needle swim the earlier smoothing couldn't remove, because the thing doing the smoothing was itself shaking.

**The fix.** Low-pass the window width toward its speed target (tau 0.8 s) so it follows *mean* speed, holding steady on a straight steady road and breathing gently only as you speed up or slow down.

**Measured** on a synthetic crinkly road:

| | rippling window | low-passed |
|---|---|---|
| per-frame bearing jitter | 0.82° | 0.23° |
| per-frame lateral swim, R=150m | 8.5 cm | 0.14 cm |

The 0.82° is right in the range earlier work measured as the visible wiggle — so this may be a large part of what you're still seeing.

**Honest caveat:** a demo drive **cannot** confirm this. Demo mode feeds perfectly clean synthetic fixes, so the accelerometer ripple this targets doesn't exist there — I verified it doesn't crash or regress, but the actual reduction only shows on your real drive on the P9. If it's still swimming after this, the trace toggle (Settings → Diagnostics → Nav smoothness trace) will now capture it with no location data, safe to attach.