### PR TITLE
Say when a speed camera is coming up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2714,6 +2714,26 @@ architecture note.
   branch, which would blank the layer at the 15.5 nav zoom floor); a FAILED corridor fetch leaves the
   key unset so the viewport path stays the fallback, and nav-end (`clearNavRouteControls`) nulls
   `controlsBox` so the next browse settle repaints. Needs a real-drive glance to confirm density/size feel.
+- **Speed cameras + SPOKEN approach warning (issue #229).** The LAYER (`OverpassSpeedCameras`,
+  `SpeedCams` holder, Settings > Map "Speed cameras", OFF by default) already shipped: OSM
+  `highway=speed_camera`, keyless, viewport-box + area-cached, `out body` (never `out tags` - the
+  ALPR empty-layer trap). The 2026-08-28 addition is the WARNING the reporter actually asked for
+  ("informed about an incoming radar control" - a dot does nothing while driving):
+  `OverpassSpeedCameras.fetchAlongCorridor` runs ONCE per driven route (sibling of the controls
+  corridor fetch, keyed identically so a same-course heal never refetches or re-arms warnings
+  already heard), each hit is projected onto the route by `:core` `nav/RouteProjection` and
+  anything not genuinely on it is dropped (a corridor returns the parallel street too), and
+  `:core` `nav/CameraAlerts.due` decides when to speak. Timing is SPEED-SCALED (12 s of lead,
+  floored 150 m / capped 600 m) because a fixed distance is ample in town and ~2 s on a motorway;
+  one announcement per camera per route; never for a camera behind you; silent below 2 m/s so
+  sitting beside one is not narrated. Unit-tested (`CameraAlertsTest`, `RouteProjectionTest`).
+  **The spoken half is its own nested opt-in** (`SpeedCamWarn`, "Warn me out loud", shown only
+  while the layer is on): being spoken to is a different ask from seeing a marker, and warning
+  about cameras while driving is legally restricted in some countries. Respects the global
+  spoken-directions mute like every other prompt. STILL fixed installations only - mobile speed
+  traps need a live crowd feed the keyless model has no source for.
+  NB `nav/RouteProjection` duplicates the projection in `nav/RouteBar` (issue #228, open in
+  parallel); whichever merges second should delegate rather than keep two copies.
 - **Surveillance-camera (Flock / ALPR) layer (`OverpassAlprCameras` + `refreshFlock` + `FLOCK_LAYER`, device-verified
   2026-07-12).** Settings > Map > "Surveillance cameras" (`app.vela.ui.Flock` holder, **ON by default since 2026-07-13** -
   it's a headline feature and the bundled dataset makes it free to draw; `FlockRouteAlert` route-avoid stays

--- a/app/src/main/java/app/vela/VelaApp.kt
+++ b/app/src/main/java/app/vela/VelaApp.kt
@@ -75,6 +75,7 @@ class VelaApp : Application(), coil.ImageLoaderFactory {
         app.vela.ui.Topography.init(this)
         app.vela.ui.Flock.init(this) // load the persisted surveillance-camera toggle (else it read false every launch)
         app.vela.ui.SpeedCams.init(this) // same init-or-it-reads-false trap as Flock
+        app.vela.ui.SpeedCamWarn.init(this) // spoken camera warning (issue #229), off by default
         app.vela.ui.FlockRouteAlert.init(this) // load the persisted "warn about cameras on route" toggle
         // Parse the bundled on-device ALPR/Flock camera dataset off the main thread (map layer draws
         // instantly, route counts are reliable), then refresh from the hosted manifest so the data updates

--- a/app/src/main/java/app/vela/ui/SpeedCamWarn.kt
+++ b/app/src/main/java/app/vela/ui/SpeedCamWarn.kt
@@ -1,0 +1,30 @@
+package app.vela.ui
+
+import android.content.Context
+import androidx.compose.runtime.mutableStateOf
+
+/**
+ * Whether an approaching speed camera is announced OUT LOUD during navigation (issue #229).
+ *
+ * Separate from [SpeedCams], which only draws them on the map, for two reasons. Seeing a marker
+ * and being spoken to are different enough that wanting one is not wanting the other. And warning
+ * about speed cameras while driving is treated differently country to country - some ban devices
+ * that do it - so the spoken half is its own deliberate opt-in rather than something that arrives
+ * with a map layer. Nested under the camera toggle in Settings, and it respects the global spoken
+ * -directions mute like every other prompt.
+ */
+object SpeedCamWarn {
+    val on = mutableStateOf(false)
+
+    fun init(context: Context) {
+        on.value = prefs(context).getBoolean(KEY, false)
+    }
+
+    fun set(context: Context, value: Boolean) {
+        on.value = value
+        prefs(context).edit().putBoolean(KEY, value).apply()
+    }
+
+    private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
+    private const val KEY = "speed_cam_warn"
+}

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -569,9 +569,19 @@ class MapViewModel @Inject constructor(
                     // as real nav and does live fetches (device-caught 2026-08-08: the bare !replaying
                     // guard silently skipped the fetch on every simulated drive).
                     val vs = _state.value
-                    if (!vs.replaying || vs.demoDriving) refreshNavRouteControls(nsRoute)
+                    if (!vs.replaying || vs.demoDriving) {
+                        refreshNavRouteControls(nsRoute)
+                        refreshRouteSpeedCams(nsRoute) // spoken camera warnings (issue #229)
+                    }
                 }
-                if (!ns.navigating) { lastRecordedRoute = null; clearNavRouteControls() }
+                if (!ns.navigating) {
+                    lastRecordedRoute = null
+                    clearNavRouteControls()
+                    routeCamMeters = emptyList(); routeCamKey = null; spokenCams = emptySet()
+                }
+                // Speak an approach warning for a camera coming up (issue #229). Cheap per tick:
+                // a scan of a short list; the projection was done once when the route landed.
+                if (ns.navigating) maybeWarnCamera(ns)
                 _state.update {
                     it.copy(
                         navigating = ns.navigating,
@@ -5269,6 +5279,65 @@ class MapViewModel @Inject constructor(
      * cached box edge, and the churn (against mirrors that are sometimes down) made the icons appear
      * rarely and vanish quickly during nav. Same cluster-per-intersection pass as the box path.
      */
+    // Speed cameras projected onto the CURRENT route, in ascending along-route metres, plus the
+    // indices already announced. Keyed like the controls corridor fetch so a same-course heal does
+    // not refetch or re-arm warnings the driver already heard.
+    private var routeCamKey: String? = null
+    private var routeCamMeters: List<Double> = emptyList()
+    private var spokenCams: Set<Int> = emptySet()
+    private var routeCamJob: kotlinx.coroutines.Job? = null
+
+    /** One corridor fetch of speed cameras per driven route, projected onto it for the spoken
+     *  approach warning (issue #229). No-op unless the layer AND the spoken warning are on. */
+    private fun refreshRouteSpeedCams(route: app.vela.core.model.Route) {
+        if (!app.vela.ui.SpeedCams.on.value || !app.vela.ui.SpeedCamWarn.on.value) {
+            routeCamKey = null; routeCamMeters = emptyList(); spokenCams = emptySet()
+            return
+        }
+        val poly = route.polyline
+        if (poly.size < 2) return
+        val f = poly.first(); val l = poly.last()
+        val key = String.format(
+            java.util.Locale.US, "%.4f,%.4f|%.4f,%.4f|%d",
+            f.lat, f.lng, l.lat, l.lng, (route.distanceMeters / 500).toInt(),
+        )
+        if (key == routeCamKey) return
+        routeCamKey = key
+        spokenCams = emptySet() // a genuinely new route: nothing has been announced on it yet
+        routeCamJob?.cancel()
+        routeCamJob = viewModelScope.launch {
+            val cams = runCatching {
+                withContext(Dispatchers.IO) {
+                    app.vela.core.data.OverpassSpeedCameras.fetchAlongCorridor(http, poly)
+                }
+            }.getOrNull() ?: run {
+                // Leave the key set: a failed fetch means no warnings this route rather than a
+                // retry storm mid-drive. The map layer still draws from the viewport path.
+                android.util.Log.i("VelaSpeedCam", "route corridor camera fetch FAILED (all endpoints)")
+                return@launch
+            }
+            val meters = withContext(Dispatchers.Default) {
+                val cum = app.vela.core.nav.RouteProjection.cumulative(poly)
+                cams.mapNotNull { app.vela.core.nav.RouteProjection.alongMeters(poly, cum, it.loc) }.sorted()
+            }
+            if (routeCamKey == key) {
+                routeCamMeters = meters
+                diag.record("speedcam", "${meters.size} camera(s) on route", "corridor")
+            }
+        }
+    }
+
+    /** Announce the camera coming up, once each. Timing lives in :core [CameraAlerts]. */
+    private fun maybeWarnCamera(ns: app.vela.core.nav.NavSession.State) {
+        if (routeCamMeters.isEmpty()) return
+        if (!app.vela.ui.SpeedCams.on.value || !app.vela.ui.SpeedCamWarn.on.value) return
+        val i = app.vela.core.nav.CameraAlerts.due(
+            routeCamMeters, ns.nav.traveledM, (_state.value.mySpeed ?: 0f).toDouble(), spokenCams,
+        ) ?: return
+        spokenCams = spokenCams + i
+        voice.speak(appContext.getString(R.string.nav_speed_camera_ahead))
+    }
+
     private fun refreshNavRouteControls(route: app.vela.core.model.Route) {
         val poly = route.polyline
         if (poly.size < 2) return

--- a/app/src/main/java/app/vela/ui/settings/SettingsHub.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsHub.kt
@@ -299,6 +299,7 @@ private val SEARCH_INDEX: List<Pair<Int, SettingsSection>> = listOf(
     R.string.settings_layers_button to SettingsSection.MAP,
     R.string.settings_flock to SettingsSection.MAP,
     R.string.settings_speed_cams to SettingsSection.MAP,
+    R.string.settings_speed_cam_warn to SettingsSection.MAP,
     R.string.settings_flock_route_alert to SettingsSection.MAP,
     R.string.settings_buildings_3d to SettingsSection.MAP,
     R.string.settings_building_overlay to SettingsSection.MAP,

--- a/app/src/main/java/app/vela/ui/settings/sections/MapSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/MapSettings.kt
@@ -76,6 +76,17 @@ internal fun MapSettingsScreen(onBack: () -> Unit) {
             onCheckedChange = { app.vela.ui.SpeedCams.set(context, it) },
             hint = stringResource(R.string.settings_speed_cams_hint),
         )
+        // The spoken warning is nested: it only means anything once the cameras are being tracked,
+        // and it is its own opt-in because being spoken to is a different ask from seeing a marker
+        // (and is restricted in some countries).
+        if (app.vela.ui.SpeedCams.on.value) {
+            ToggleRow(
+                label = stringResource(R.string.settings_speed_cam_warn),
+                checked = app.vela.ui.SpeedCamWarn.on.value,
+                onCheckedChange = { app.vela.ui.SpeedCamWarn.set(context, it) },
+                hint = stringResource(R.string.settings_speed_cam_warn_hint),
+            )
+        }
         GroupDivider()
         ToggleRow(
             label = stringResource(R.string.settings_flock_route_alert),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,6 +92,9 @@
     <string name="settings_flock" translatable="false">Surveillance cameras</string>
     <string name="settings_flock_hint" translatable="false">Shows mapped automated license-plate reader (Flock) cameras, from the community DeFlock project in OpenStreetMap. Off by default.</string>
     <string name="settings_speed_cams">Speed cameras</string>
+    <string name="settings_speed_cam_warn">Warn me out loud</string>
+    <string name="settings_speed_cam_warn_hint">Says \"Speed camera ahead\" as you approach one while navigating, timed to give about twelve seconds\' notice. Follows your spoken-directions setting. Warning about cameras while driving is restricted in some countries, so this is off unless you turn it on.</string>
+    <string name="nav_speed_camera_ahead">Speed camera ahead</string>
     <string name="settings_speed_cams_hint">Shows fixed radar and speed cameras mapped in OpenStreetMap. Fixed installations only; coverage follows the map, strongest in Europe. Off by default.</string>
     <string name="settings_flock_route_alert" translatable="false">Avoid surveillance cameras</string>
     <string name="settings_flock_route_alert_hint" translatable="false">Counts the license-plate reader (Flock) cameras on each route and auto-picks a lower-camera one when it costs only a little longer. It never sends you far out of the way, so where cameras are unavoidable it just shows the counts and leaves the choice to you. Long-press the map to route through a point yourself. Off by default.</string>

--- a/core/src/main/java/app/vela/core/data/OverpassSpeedCameras.kt
+++ b/core/src/main/java/app/vela/core/data/OverpassSpeedCameras.kt
@@ -59,4 +59,40 @@ object OverpassSpeedCameras {
             }
         }
     }
+
+    /**
+     * Speed cameras within a corridor around a driven route (issue #229, the spoken approach
+     * warning). Sibling of `OverpassTrafficSignals.fetchControlsAlongCorridor` and fetched the same
+     * way: ONE query per route rather than per viewport, because during a drive the moving camera
+     * crosses a cached box constantly and refetches against sometimes-dead mirrors.
+     *
+     * [radiusM] is wider than the controls corridor (a camera can sit on a gantry or a verge set
+     * back from the centreline, and a missed warning is the failure that matters here); the caller
+     * still projects each hit onto the route and drops anything not genuinely on it.
+     */
+    @OptIn(ExperimentalSerializationApi::class)
+    fun fetchAlongCorridor(
+        http: OkHttpClient,
+        polyline: List<LatLng>,
+        radiusM: Int = 150,
+        maxPts: Int = 250,
+        limit: Int = 2000,
+    ): List<SpeedCamera>? {
+        if (polyline.size < 2) return emptyList()
+        // Sampled to bound the GET URL - an unsampled polyline makes a URL the mirrors reject.
+        val pts = if (polyline.size <= maxPts) polyline else {
+            val stride = (polyline.size - 1).toDouble() / (maxPts - 1)
+            (0 until maxPts).map { polyline[Math.round(it * stride).toInt().coerceAtMost(polyline.size - 1)] }
+        }
+        val coords = pts.joinToString(",") { String.format(java.util.Locale.US, "%.5f,%.5f", it.lat, it.lng) }
+        val around = "(around:$radiusM,$coords)"
+        val query = "[out:json][timeout:25];node[\"highway\"=\"speed_camera\"]$around;out body $limit;"
+        return OverpassEndpoints.run(slow(http), query) { body ->
+            json.decodeFromStream<SpeedCamResp>(body.byteStream()).elements.mapNotNull { n ->
+                val lat = n.lat ?: return@mapNotNull null
+                val lng = n.lon ?: return@mapNotNull null
+                SpeedCamera(LatLng(lat, lng))
+            }
+        }
+    }
 }

--- a/core/src/main/java/app/vela/core/nav/CameraAlerts.kt
+++ b/core/src/main/java/app/vela/core/nav/CameraAlerts.kt
@@ -1,0 +1,64 @@
+package app.vela.core.nav
+
+/**
+ * Deciding WHEN to warn about a speed camera coming up (issue #229).
+ *
+ * The reporter's ask was to be "informed about an incoming radar control", which a dot on the map
+ * does not do while you are driving. This is the timing half, kept pure so the awkward cases are
+ * testable: warning too late is useless, warning twice is nagging, and warning at all while you
+ * are stopped beside one is just noise.
+ */
+object CameraAlerts {
+
+    /**
+     * Seconds of warning aimed for. Distance-based alone is wrong: 200 m is ample in town and
+     * about two seconds on a motorway, which is not time to react.
+     */
+    const val LEAD_SECONDS = 12.0
+
+    /** Floors and caps the speed-scaled lead. The floor keeps a warning useful at low speed; the
+     *  cap stops a motorway warning arriving so early it is forgotten before the camera. */
+    const val MIN_LEAD_M = 150.0
+    const val MAX_LEAD_M = 600.0
+
+    /** Below this we are not meaningfully driving toward anything - parked, queuing or crawling -
+     *  and a spoken camera warning would be noise. */
+    const val MOVING_FLOOR_MPS = 2.0
+
+    /** How far the lead distance is for [speedMps]. */
+    fun leadDistanceM(speedMps: Double): Double =
+        (speedMps * LEAD_SECONDS).coerceIn(MIN_LEAD_M, MAX_LEAD_M)
+
+    /**
+     * The index of the camera to announce now, or null.
+     *
+     * [cameraMeters] are distances along the route, ascending. [spoken] are indices already
+     * announced on this route - a camera is warned about ONCE; passing it, or creeping toward it
+     * in traffic, must not re-trigger.
+     *
+     * Returns the NEAREST unannounced camera inside the lead window and still ahead. A camera
+     * already behind you is never announced, even if it was missed: a warning about something you
+     * have passed is worse than silence.
+     */
+    fun due(
+        cameraMeters: List<Double>,
+        traveledM: Double,
+        speedMps: Double,
+        spoken: Set<Int>,
+    ): Int? {
+        if (speedMps < MOVING_FLOOR_MPS) return null
+        val lead = leadDistanceM(speedMps)
+        var best: Int? = null
+        var bestAhead = Double.MAX_VALUE
+        for (i in cameraMeters.indices) {
+            if (i in spoken) continue
+            val ahead = cameraMeters[i] - traveledM
+            if (ahead <= 0.0 || ahead > lead) continue
+            if (ahead < bestAhead) {
+                bestAhead = ahead
+                best = i
+            }
+        }
+        return best
+    }
+}

--- a/core/src/main/java/app/vela/core/nav/RouteProjection.kt
+++ b/core/src/main/java/app/vela/core/nav/RouteProjection.kt
@@ -1,0 +1,61 @@
+package app.vela.core.nav
+
+import app.vela.core.model.LatLng
+import app.vela.core.model.distanceTo
+
+/**
+ * Placing a point on a route: how far along the line it sits, and whether it is genuinely on it.
+ *
+ * Anything fetched in a CORRIDOR around a route comes back with things near the road but not on
+ * it - the parallel street, the service road, the far carriageway. Turning those into "coming up
+ * ahead of you" would be wrong, so every consumer needs the same two operations: cumulative
+ * distances once per route, then a bounded projection per point.
+ *
+ * NB `nav/RouteBar` (issue #228, open in parallel) carries an identical pair; whichever merges
+ * second should delegate here rather than keep a second copy of this maths.
+ */
+object RouteProjection {
+
+    /** Cumulative distance to each vertex, computed once per route so a lookup never re-walks it. */
+    fun cumulative(poly: List<LatLng>): DoubleArray {
+        val cum = DoubleArray(poly.size)
+        for (i in 1 until poly.size) cum[i] = cum[i - 1] + poly[i - 1].distanceTo(poly[i])
+        return cum
+    }
+
+    /**
+     * How far along the route [p] sits, or null when it is further than [maxOffRouteM] from the
+     * line - i.e. near the road but not on it.
+     */
+    fun alongMeters(
+        poly: List<LatLng>,
+        cum: DoubleArray,
+        p: LatLng,
+        maxOffRouteM: Double = 40.0,
+    ): Double? {
+        if (poly.size < 2) return null
+        var bestD = Double.MAX_VALUE
+        var bestAlong = 0.0
+        for (i in 0 until poly.size - 1) {
+            val a = poly[i]
+            val b = poly[i + 1]
+            val segLen = cum[i + 1] - cum[i]
+            if (segLen <= 0.0) continue
+            // Local flat frame per segment: exact enough over one segment, and avoids trigonometry
+            // per vertex on a polyline with thousands of points.
+            val latScale = Math.cos(Math.toRadians(a.lat))
+            val bx = (b.lng - a.lng) * latScale
+            val by = b.lat - a.lat
+            val px = (p.lng - a.lng) * latScale
+            val py = p.lat - a.lat
+            val len2 = bx * bx + by * by
+            val t = if (len2 <= 0.0) 0.0 else (((px * bx) + (py * by)) / len2).coerceIn(0.0, 1.0)
+            val dM = Math.hypot(px - bx * t, py - by * t) * 111_320.0
+            if (dM < bestD) {
+                bestD = dM
+                bestAlong = cum[i] + segLen * t
+            }
+        }
+        return if (bestD <= maxOffRouteM) bestAlong else null
+    }
+}

--- a/core/src/test/java/app/vela/core/nav/CameraAlertsTest.kt
+++ b/core/src/test/java/app/vela/core/nav/CameraAlertsTest.kt
@@ -1,0 +1,62 @@
+package app.vela.core.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * When a speed-camera warning fires ([CameraAlerts]).
+ *
+ * The cases worth pinning are the ones that make a warning system annoying rather than useful:
+ * firing twice for one camera, firing about a camera already behind you, or talking at you while
+ * you sit stationary next to one.
+ */
+class CameraAlertsTest {
+
+    private val cams = listOf(1_000.0, 5_000.0, 5_400.0)
+
+    // 25 m/s (~56 mph) -> 300 m of lead, so the warning lands about 12 s out.
+    @Test fun `warns once inside the lead window`() {
+        assertNull("too far out to warn yet", CameraAlerts.due(cams, traveledM = 600.0, speedMps = 25.0, spoken = emptySet()))
+        assertEquals(0, CameraAlerts.due(cams, traveledM = 750.0, speedMps = 25.0, spoken = emptySet()))
+    }
+
+    @Test fun `a camera already warned about is not repeated`() {
+        assertNull(CameraAlerts.due(cams, traveledM = 900.0, speedMps = 25.0, spoken = setOf(0)))
+    }
+
+    // Creeping toward a camera in traffic must not re-arm it once spoken.
+    @Test fun `crawling toward an already-warned camera stays silent`() {
+        for (t in 800..990 step 10) {
+            assertNull(CameraAlerts.due(cams, traveledM = t.toDouble(), speedMps = 3.0, spoken = setOf(0)))
+        }
+    }
+
+    @Test fun `a camera behind you is never announced`() {
+        assertNull("no warning about something passed", CameraAlerts.due(cams, traveledM = 1_200.0, speedMps = 25.0, spoken = emptySet()))
+    }
+
+    @Test fun `stationary means silence`() {
+        assertNull(CameraAlerts.due(cams, traveledM = 900.0, speedMps = 0.5, spoken = emptySet()))
+    }
+
+    @Test fun `the nearest unannounced camera wins when two are close together`() {
+        val i = CameraAlerts.due(cams, traveledM = 4_900.0, speedMps = 50.0, spoken = emptySet())
+        assertEquals("the closer one is the one you need to hear about", 1, i)
+        // Having announced it, the next one becomes due.
+        assertEquals(2, CameraAlerts.due(cams, traveledM = 4_900.0, speedMps = 50.0, spoken = setOf(1)))
+    }
+
+    // Lead scales with speed, which is the whole reason it is not a fixed distance.
+    @Test fun `lead distance scales with speed but stays bounded`() {
+        assertEquals(CameraAlerts.MIN_LEAD_M, CameraAlerts.leadDistanceM(5.0), 0.01)  // town: floored
+        assertEquals(300.0, CameraAlerts.leadDistanceM(25.0), 0.01)                   // 12 s at 25 m/s
+        assertEquals(CameraAlerts.MAX_LEAD_M, CameraAlerts.leadDistanceM(80.0), 0.01) // capped
+        assertTrue(CameraAlerts.leadDistanceM(40.0) > CameraAlerts.leadDistanceM(20.0))
+    }
+
+    @Test fun `no cameras means nothing to say`() {
+        assertNull(CameraAlerts.due(emptyList(), traveledM = 100.0, speedMps = 25.0, spoken = emptySet()))
+    }
+}

--- a/core/src/test/java/app/vela/core/nav/RouteProjectionTest.kt
+++ b/core/src/test/java/app/vela/core/nav/RouteProjectionTest.kt
@@ -1,0 +1,39 @@
+package app.vela.core.nav
+
+import app.vela.core.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** Placing corridor-fetched points on the route ([RouteProjection]) - the guard that stops
+ *  something on a parallel street being announced as coming up on yours. */
+class RouteProjectionTest {
+
+    // A straight run east from the Davis fixture, ~1 vertex per km.
+    private val poly = (0..10).map { LatLng(38.5449, -121.7405 + it * 0.0115) }
+    private val cum = RouteProjection.cumulative(poly)
+
+    @Test fun `a point on the route is placed at its distance along it`() {
+        assertEquals(cum[3], RouteProjection.alongMeters(poly, cum, poly[3])!!, 5.0)
+    }
+
+    @Test fun `a point just off the kerb still counts`() {
+        val kerb = LatLng(poly[3].lat + 0.0001, poly[3].lng) // ~11 m
+        assertEquals(cum[3], RouteProjection.alongMeters(poly, cum, kerb)!!, 20.0)
+    }
+
+    @Test fun `a point on a parallel street is rejected`() {
+        // ~330 m north: a different road, not this one.
+        assertNull(RouteProjection.alongMeters(poly, cum, LatLng(poly[3].lat + 0.003, poly[3].lng)))
+    }
+
+    @Test fun `midway along a segment projects proportionally`() {
+        val mid = LatLng(poly[2].lat, (poly[2].lng + poly[3].lng) / 2)
+        val along = RouteProjection.alongMeters(poly, cum, mid)!!
+        assertEquals((cum[2] + cum[3]) / 2, along, 30.0)
+    }
+
+    @Test fun `a degenerate route places nothing`() {
+        assertNull(RouteProjection.alongMeters(listOf(poly[0]), doubleArrayOf(0.0), poly[0]))
+    }
+}


### PR DESCRIPTION
Closes #229

**The layer already shipped** — I nearly rebuilt it before a name collision caught that `SpeedCams`, `OverpassSpeedCameras` and the Settings toggle were all already on main. What was missing is what the reporter actually asked for: *"informed about an incoming radar control"*. A dot on a map does nothing while you're driving.

### The warning
One corridor fetch per driven route (sibling of the traffic-controls corridor fetch, keyed identically so a same-course steps/traffic heal never refetches or re-arms warnings you already heard). Each camera is projected onto the route and anything not genuinely on it is dropped — a corridor returns the parallel street and the far carriageway too.

**Timed, not placed.** 12 s of lead, floored at 150 m and capped at 600 m. A fixed distance is ample in town and about two seconds on a motorway, which isn't time to react.

Announced once per camera, never for one behind you (a warning about something you've passed is worse than silence), and silent below 2 m/s so sitting beside one isn't narrated.

### Its own opt-in
"Warn me out loud" is nested under Speed cameras and shown only when that's on. Being spoken to is a different ask from seeing a marker, and **warning drivers about cameras is legally restricted in some countries** — so it's a deliberate second choice rather than something that arrives with a map layer. Respects the global spoken-directions mute.

### Verified on device
Toggle correctly hidden when the layer is off, appears nested when on, disappears again when off; both restored to defaults afterward. Screenshot in the thread. I did **not** get a warning to fire on a real drive — that needs a route that actually passes a mapped camera, and reaching camera-dense areas on the test phone kept surfacing the owner's real location, so I stopped. The timing logic is unit-tested instead.

`CameraAlertsTest` (8) + `RouteProjectionTest` (5) — including that crawling toward an already-warned camera stays silent, and that the nearer of two close cameras is the one you hear about.

⚠️ **Overlaps [#298](https://github.com/PimpinPumpkin/Vela/pull/298):** `nav/RouteProjection` here and `nav/RouteBar`'s `alongMeters` are the same maths. Whichever merges second should delegate to the other rather than keep two copies — noted in both.