### PR TITLE
Say what went wrong when importing places, and stop pointing translators at a page that does not exist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -942,6 +942,21 @@ Defaults that make the safe path the easy one:
   provider is off (degoogled devices often carry a present-but-disabled NETWORK provider) ->
   AbstractMethodError, crash on every launch (user report, Android 10/Adreno 308). Override all
   four callbacks explicitly in any android.location.LocationListener implementation.
+- **Import reports WHICH outcome happened (issue #287, 2026-08-28).** `SavedPlaceStore.importMerge`
+  / `PlaceListStore.importMerge` return `:core` `data/ImportResult` (Added / NothingNew /
+  WrongFormat(format?) / Unreadable) instead of a bare Int - four very different outcomes used to
+  collapse into "0" and the UI could only say "Nothing to import", which is actively misleading
+  when the real problem is that the file came from another app (a reporter hit exactly that with
+  Google Takeout data). `ImportFormats.describe` names a recognisable foreign file (Takeout,
+  GeoJSON, GPX, KML, Organic Maps) so the message says what it IS; unit-tested
+  (`ImportFormatsTest` - the Takeout matcher was written wrong first and the test caught it, real
+  Takeout URLs are `maps.google.com/?cid=`, not `google.com/maps`). **AND the actual "button does
+  nothing" bug: `importLauncher.launch(...)` was wrapped in a bare `runCatching`**, so on a device
+  with no documents provider the ActivityNotFoundException was swallowed and the button genuinely
+  did nothing - no picker, no message. `launchImport` toasts instead. Device-verified end to end
+  with a Takeout-shaped file. NB importing another app's format is issue #279, still open.
+  ⚠️ A literal wildcard mime in a KDoc block ENDS THE COMMENT (same trap as PoiPackStore's
+  `del_*/ins_*`) - the mime array's comment is a line comment for that reason.
 - **SavedPlace carries an optional address (2026-07-10).** `SavedPlace.address` (defaulted null, so
   pre-existing payloads decode; every store's Json sets ignoreUnknownKeys so downgrades survive too)
   is filled by `SavedPlace.of(Place)` - recents rows show it as a sublabel and the Home/Work rows
@@ -1396,11 +1411,15 @@ Defaults that make the safe path the easy one:
   strings that double as a logic key (place "Open"/"Closed" → status-colour parser, the map category chips /
   search-along-route chips are also the query, review sort/tab labels branch a `when`) are NOT in strings.xml;
   they localize only once display text is split from the logic key. **Names/addresses/reviews are DATA - never
-  translated.** **Translations flow through WEBLATE now (2026-07-14, docs/TRANSLATING.md):** adding a
-  user-facing string means adding it to the ENGLISH base `values/strings.xml` only - translators fill the
-  locales via hosted Weblate (its PRs are reviewed like any other; the em-dash + placeholder rules are the
-  review checklist) and a missing translation falls back to English. Hand-filling every `values-<lang>/` in
-  the same commit (the old rule) is still fine for small batches but no longer required. Match the
+  translated.** **Translations come in as PULL REQUESTS (docs/TRANSLATING.md; issue #285):** adding a
+  user-facing string means adding it to the ENGLISH base `values/strings.xml` only - contributors fill
+  the locales by editing `values-<lang>/strings.xml` (the em-dash + placeholder rules are the review
+  checklist) and a missing translation falls back to English. Hand-filling every `values-<lang>/` in
+  the same commit (the old rule) is still fine for small batches but no longer required.
+  ⚠️ **WEBLATE IS NOT LIVE and its link 404s - do not point anyone at it** (issue #285, 2026-08-28):
+  hosted Weblate asks that a project be established before it takes it on, and Vela does not qualify
+  yet. README/CONTRIBUTING/FEATURES/TRANSLATING were corrected to describe the PR flow; the README
+  roadmap keeps it as an open item. Rewrite those four the day the project is actually approved. Match the
   `%1$s`/`%2$d` placeholder TYPE to the arg (Int → `%d`, else `%s`; a `%d` fed a String crashes).
   **Count strings use `<plurals>`, not a bare `%d X` (2026-07-11, issue #56 "1 results"):** the
   results-count bar is a `<plurals name="mapscreen_results_count">` read via `pluralStringResource(...,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1417,7 +1417,7 @@ Defaults that make the safe path the easy one:
   checklist) and a missing translation falls back to English. Hand-filling every `values-<lang>/` in
   the same commit (the old rule) is still fine for small batches but no longer required.
   ⚠️ **WEBLATE IS NOT LIVE and its link 404s - do not point anyone at it** (issue #285, 2026-08-28):
-  hosted Weblate asks that a project be established before it takes it on, and Vela does not qualify
+  hosted Weblate requires a project to be at least THREE MONTHS OLD to qualify and Vela is not there
   yet. README/CONTRIBUTING/FEATURES/TRANSLATING were corrected to describe the PR flow; the README
   roadmap keeps it as an open item. Rewrite those four the day the project is actually approved. Match the
   `%1$s`/`%2$d` placeholder TYPE to the arg (Int → `%d`, else `%s`; a `%d` fed a String crashes).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,12 @@ too).
    commit message.
 6. **Every user-facing string is translatable** (the 15-language matrix is in
    [docs/LANGUAGES.md](docs/LANGUAGES.md)). Add new strings to the English base
-   `res/values/strings.xml`; translations flow in through **Weblate** (see
+   `res/values/strings.xml`; translations come in as pull requests against `values-<lang>/strings.xml` (see
    [docs/TRANSLATING.md](docs/TRANSLATING.md)), and an untranslated string falls
    back to English until they do. Match placeholder types to the arguments (an Int
    needs `%d`; a `%d` fed a String crashes). Place names, addresses and reviews are
-   data and are never translated. Want to translate rather than code? Weblate is
-   the place, no git needed.
+   data and are never translated. Want to translate rather than code? That guide
+   is the place to start; a one-file edit in the GitHub web editor is enough.
 
 ## Practical rules you will hit quickly
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -2211,12 +2211,14 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   the old code on-device). RTL is automatic: the app already declares `android:supportsRtl` and
   re-creates the Activity with a Hebrew config, so Compose's `LayoutDirection` flips (a whole-app scan
   found no hardcoded left/right, `Absolute` arrangements or forced `LayoutDirection`). Unit-tested.
-- ✅ **Community translations via Weblate (2026-07-14).** UI-string translation moved to hosted
-  Weblate so anyone can translate or fix strings in a web editor, no git required - see
-  [docs/TRANSLATING.md](docs/TRANSLATING.md) for the project link, the rules (placeholders, CLDR
-  plural categories, no em dashes) and the maintainer component config. New strings are added to
-  the English base only; Weblate opens PRs to fill the locales, and untranslated strings fall
-  back to English in the meantime.
+- ✅ **Community translations by pull request (2026-07-14; Weblate still pending, see issue #285).**
+  Anyone can translate or fix UI strings by editing one `values-<lang>/strings.xml` in the GitHub
+  web editor and opening a PR - no git client, no Android toolchain. See
+  [docs/TRANSLATING.md](docs/TRANSLATING.md) for the flow and the rules (placeholders, CLDR plural
+  categories, no em dashes). New strings are added to the English base only, and an untranslated
+  string falls back to English, so partial contributions are safe. **Hosted Weblate is the intended
+  home and is NOT live**: it asks that a project be established before taking it on and Vela is too
+  young to qualify yet, so the docs describe the PR flow until that changes.
 
 ## Added 2026-07-17 (offline routing on pre-Android-14 devices)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Live traffic, real place data and turn-by-turn navigation, with zero Google on y
 [![Stable release](https://img.shields.io/github/v/release/PimpinPumpkin/Vela?label=stable&color=149387)](https://github.com/PimpinPumpkin/Vela/releases/latest)
 [![Build](https://img.shields.io/github/actions/workflow/status/PimpinPumpkin/Vela/ci.yml?branch=main&label=build)](https://github.com/PimpinPumpkin/Vela/actions/workflows/ci.yml)
 [![License: GPL v3](https://img.shields.io/github/license/PimpinPumpkin/Vela?color=blue)](LICENSE)
-[![Translated on Weblate](https://img.shields.io/badge/translations-Weblate-2ecccf)](https://hosted.weblate.org/projects/vela-maps/)
 [![Stars](https://img.shields.io/github/stars/PimpinPumpkin/Vela?style=flat&color=ffd43b)](https://github.com/PimpinPumpkin/Vela/stargazers)
 
 [Install](#install) · [What you get](#what-you-get) · [Privacy](#privacy) · [How it works](docs/HOW-IT-WORKS.md) · [Build](#build) · [Discussions](https://github.com/PimpinPumpkin/Vela/discussions) · [Translate](docs/TRANSLATING.md)
@@ -186,7 +185,7 @@ Deeper still is [`SPEC.md`](SPEC.md).
 | [`docs/HOW-IT-WORKS.md`](docs/HOW-IT-WORKS.md) | Every capability, the keyless method behind it, and the file to read first |
 | [`docs/BUILDING.md`](docs/BUILDING.md) | Building from source, module architecture, and the release pipeline |
 | [`docs/LANGUAGES.md`](docs/LANGUAGES.md) | The 15 supported languages, layer by layer (UI, spoken nav, neural voice, dictation), and how to add one |
-| [`docs/TRANSLATING.md`](docs/TRANSLATING.md) | Translating Vela on Weblate - no git needed |
+| [`docs/TRANSLATING.md`](docs/TRANSLATING.md) | Translating Vela - edit one file, open a PR |
 | [`FEATURES.md`](FEATURES.md) | The full, categorised list of every shipped capability (the encyclopaedia) |
 | [`SPEC.md`](SPEC.md) | The authoritative **rebuild spec** - architecture, extractor contract (pb layouts + response indices), resilience layer, hard constraints |
 | [`ROADMAP.md`](ROADMAP.md) | Planned work + big bets (opt-in telemetry, a Vela-own traffic layer, giant-country graph splits, …) |

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -4130,24 +4130,24 @@ class MapViewModel @Inject constructor(
     }
 
     /** Import lists from a picked file [uri]; returns how many lists were newly added. */
-    fun importListsFromUri(uri: android.net.Uri): Int {
+    fun importListsFromUri(uri: android.net.Uri): app.vela.core.data.ImportResult {
         val json = runCatching {
             appContext.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
-        }.getOrNull() ?: return 0
-        val added = listStore.importMerge(json)
-        if (added > 0) _state.update { it.copy(lists = listStore.lists()) }
-        return added
+        }.getOrNull() ?: return app.vela.core.data.ImportResult.Unreadable
+        val res = listStore.importMerge(json)
+        if (res is app.vela.core.data.ImportResult.Added) _state.update { it.copy(lists = listStore.lists()) }
+        return res
     }
 
-    /** Import saved places from a picked file [uri]; returns how many were newly added
-     *  (refreshes the saved list in state). 0 on a read/parse failure or nothing new. */
-    fun importSavedFromUri(uri: android.net.Uri): Int {
+    /** Import saved places from a picked file [uri]. Reports WHICH outcome happened so the UI can
+     *  tell "that is another app's file" from "you already have all of these" (issue #287). */
+    fun importSavedFromUri(uri: android.net.Uri): app.vela.core.data.ImportResult {
         val json = runCatching {
             appContext.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
-        }.getOrNull() ?: return 0
-        val added = savedStore.importMerge(json)
-        if (added > 0) _state.update { it.copy(saved = savedStore.saved()) }
-        return added
+        }.getOrNull() ?: return app.vela.core.data.ImportResult.Unreadable
+        val res = savedStore.importMerge(json)
+        if (res is app.vela.core.data.ImportResult.Added) _state.update { it.copy(saved = savedStore.saved()) }
+        return res
     }
 
     /** A share intent for a recorded trip's raw CSV trace (via the same FileProvider),

--- a/app/src/main/java/app/vela/ui/settings/sections/SavedPlacesSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/SavedPlacesSettings.kt
@@ -33,14 +33,7 @@ internal fun SavedPlacesSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
         val importLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
             ActivityResultContracts.OpenDocument(),
         ) { uri ->
-            if (uri != null) {
-                val n = vm.importSavedFromUri(uri)
-                android.widget.Toast.makeText(
-                    context,
-                    if (n > 0) context.getString(R.string.settings_places_imported, n) else context.getString(R.string.settings_import_nothing),
-                    android.widget.Toast.LENGTH_SHORT,
-                ).show()
-            }
+            if (uri != null) toastImport(context, vm.importSavedFromUri(uri), places = true)
         }
         SettingsGroup {
         Row(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp)) {
@@ -59,9 +52,7 @@ internal fun SavedPlacesSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
             Spacer(Modifier.width(8.dp))
             FilledTonalButton(
                 modifier = Modifier.dpadRowSibling(savedFocus, 1),
-                onClick = {
-                    runCatching { importLauncher.launch(arrayOf("application/json", "*/*")) }
-                },
+                onClick = { launchImport(context) { importLauncher.launch(IMPORT_MIME) } },
             ) { Text(stringResource(R.string.settings_import)) }
         }
         }
@@ -71,14 +62,7 @@ internal fun SavedPlacesSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
         val listImportLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
             ActivityResultContracts.OpenDocument(),
         ) { uri ->
-            if (uri != null) {
-                val n = vm.importListsFromUri(uri)
-                android.widget.Toast.makeText(
-                    context,
-                    if (n > 0) context.getString(R.string.settings_lists_imported, n) else context.getString(R.string.settings_import_nothing),
-                    android.widget.Toast.LENGTH_SHORT,
-                ).show()
-            }
+            if (uri != null) toastImport(context, vm.importListsFromUri(uri), places = false)
         }
         SettingsGroup(title = stringResource(R.string.mapscreen_section_lists)) {
         app.vela.ui.settings.Hint(stringResource(R.string.settings_lists_export_hint))
@@ -96,12 +80,53 @@ internal fun SavedPlacesSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
             Spacer(Modifier.width(8.dp))
             FilledTonalButton(
                 modifier = Modifier.dpadRowSibling(listsFocus, 1),
-                onClick = {
-                    runCatching { listImportLauncher.launch(arrayOf("application/json", "*/*")) }
-                },
+                onClick = { launchImport(context) { listImportLauncher.launch(IMPORT_MIME) } },
             ) { Text(stringResource(R.string.settings_import)) }
         }
         }
         Spacer(Modifier.height(24.dp))
     }
+}
+
+// Mime filter for a picked export. The wildcard type is kept alongside the JSON one because a lot
+// of file providers hand back application/octet-stream for a .json, and filtering that out makes
+// the file look absent - the picker opens onto an empty folder and the feature reads as broken.
+// (NB a literal wildcard mime in a KDoc block closes the comment early - see PoiPackStore.)
+private val IMPORT_MIME = arrayOf("application/json", "*/*")
+
+/**
+ * Open the file picker, and SAY SO when there isn't one (issue #287).
+ *
+ * The launch used to be wrapped in a bare `runCatching`, so on a device with no documents provider
+ * the exception was swallowed and the button genuinely did nothing at all - no picker, no message,
+ * which is exactly what was reported. A stripped-down or degoogled ROM without DocumentsUI is a
+ * realistic case for this app's users.
+ */
+private fun launchImport(context: android.content.Context, launch: () -> Unit) {
+    runCatching { launch() }.onFailure {
+        android.widget.Toast.makeText(
+            context,
+            context.getString(R.string.settings_import_no_picker),
+            android.widget.Toast.LENGTH_LONG,
+        ).show()
+    }
+}
+
+/** One message per real outcome, instead of "nothing to import" for all of them. */
+private fun toastImport(
+    context: android.content.Context,
+    result: app.vela.core.data.ImportResult,
+    places: Boolean,
+) {
+    val msg = when (result) {
+        is app.vela.core.data.ImportResult.Added ->
+            if (places) context.getString(R.string.settings_places_imported, result.count)
+            else context.getString(R.string.settings_lists_imported, result.count)
+        app.vela.core.data.ImportResult.NothingNew -> context.getString(R.string.settings_import_nothing_new)
+        app.vela.core.data.ImportResult.Unreadable -> context.getString(R.string.settings_import_unreadable)
+        is app.vela.core.data.ImportResult.WrongFormat ->
+            result.format?.let { context.getString(R.string.settings_import_wrong_format_named, it) }
+                ?: context.getString(R.string.settings_import_wrong_format)
+    }
+    android.widget.Toast.makeText(context, msg, android.widget.Toast.LENGTH_LONG).show()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,6 +151,11 @@
     <string name="settings_saved_places">Saved places</string>
     <string name="settings_saved_places_hint">Back up your starred places to a file, or restore them on another device. Import merges into what you already have. It never overwrites or removes anything.</string>
     <string name="settings_import_nothing">Nothing new to import</string>
+    <string name="settings_import_nothing_new">Everything in that file is already saved.</string>
+    <string name="settings_import_unreadable">That file could not be opened.</string>
+    <string name="settings_import_wrong_format">That is not a Vela export. Use a file saved with Export, from the same screen.</string>
+    <string name="settings_import_wrong_format_named">That looks like a %1$s file. Vela can only import its own exports for now.</string> <!-- format -->
+    <string name="settings_import_no_picker">No file picker is available on this device, so a file cannot be chosen.</string>
     <string name="settings_no_saved_places">No saved places yet</string>
     <string name="settings_export">Export</string>
     <string name="settings_import">Import</string>

--- a/core/src/main/java/app/vela/core/data/ImportResult.kt
+++ b/core/src/main/java/app/vela/core/data/ImportResult.kt
@@ -1,0 +1,53 @@
+package app.vela.core.data
+
+/**
+ * What actually happened when a user tried to import a file (issue #287).
+ *
+ * The stores used to answer with a bare `Int`, which collapsed four very different outcomes into
+ * "0": the file could not be read, it was not Vela's format at all, it was Vela's format but held
+ * nothing new, and it held nothing. The UI could then only say "Nothing to import", which is
+ * actively misleading when the real problem is that you exported the file from a different app.
+ */
+sealed interface ImportResult {
+    /** [count] entries were new and have been merged in. */
+    data class Added(val count: Int) : ImportResult
+
+    /** Valid Vela data, but every entry was already saved - importing a backup twice. */
+    data object NothingNew : ImportResult
+
+    /** Readable, but not Vela's own export. [format] names it when recognisable, so the message
+     *  can say what the file actually is instead of shrugging. */
+    data class WrongFormat(val format: String?) : ImportResult
+
+    /** The file could not be opened or read at all. */
+    data object Unreadable : ImportResult
+}
+
+/**
+ * Best-effort naming of a file the importer cannot use, so the app can say "that looks like a
+ * Google Takeout file" rather than "nothing to import".
+ *
+ * Deliberately shallow: it matches on distinctive markers rather than parsing, because the point
+ * is only to write a better sentence, never to decide whether an import succeeds.
+ */
+object ImportFormats {
+    fun describe(json: String): String? {
+        val head = json.take(4000)
+        return when {
+            // Google Takeout saved places: a GeoJSON FeatureCollection whose properties carry
+            // Google's own place fields.
+            // Takeout's distinctive markers: its own property name, and the two URL spellings
+            // Google actually emits (maps.google.com/?cid=... and google.com/maps/...).
+            head.contains("\"FeatureCollection\"") && (
+                head.contains("google_maps_url") ||
+                    head.contains("maps.google.com") ||
+                    head.contains("google.com/maps")
+                ) -> "Google Takeout"
+            head.contains("\"FeatureCollection\"") || head.contains("\"features\"") -> "GeoJSON"
+            head.trimStart().startsWith("<?xml") || head.contains("<gpx") -> "GPX"
+            head.contains("<kml") || head.contains("<Placemark") -> "KML"
+            head.contains("\"bookmarks\"") || head.contains("\"organicmaps\"") -> "Organic Maps"
+            else -> null
+        }
+    }
+}

--- a/core/src/main/java/app/vela/core/data/PlaceListStore.kt
+++ b/core/src/main/java/app/vela/core/data/PlaceListStore.kt
@@ -70,14 +70,17 @@ class PlaceListStore @Inject constructor(
 
     /** Merge exported [json] lists in, de-duped by list id (existing lists keep their
      *  places; a brand-new list is appended whole). Returns how many lists were added. */
-    fun importMerge(json: String): Int {
-        val incoming = runCatching { this.json.decodeFromString<List<PlaceList>>(json) }.getOrNull() ?: return 0
+    /** Merge lists from an exported file; reports which outcome happened (issue #287, see
+     *  [ImportResult] - "not our format" and "nothing new" are different answers). */
+    fun importMerge(json: String): ImportResult {
+        val incoming = runCatching { this.json.decodeFromString<List<PlaceList>>(json) }.getOrNull()
+            ?: return ImportResult.WrongFormat(ImportFormats.describe(json))
         val current = lists()
         val existingIds = current.mapTo(HashSet()) { it.id }
         val added = incoming.filterNot { it.id in existingIds }
-        if (added.isEmpty()) return 0
+        if (added.isEmpty()) return ImportResult.NothingNew
         write(current + added)
-        return added.size
+        return ImportResult.Added(added.size)
     }
 
     private companion object {

--- a/core/src/main/java/app/vela/core/data/SavedPlaceStore.kt
+++ b/core/src/main/java/app/vela/core/data/SavedPlaceStore.kt
@@ -41,14 +41,22 @@ class SavedPlaceStore @Inject constructor(
     /** Merge a previously-exported [json] list into the saved set, de-duped by id
      *  (existing entries kept, new ones appended). Returns how many were newly added;
      *  0 on a parse failure or nothing new. */
-    fun importMerge(json: String): Int {
-        val incoming = runCatching { this.json.decodeFromString<List<SavedPlace>>(json) }.getOrNull() ?: return 0
+    /**
+     * Merge saved places from an exported file.
+     *
+     * Reports WHICH outcome happened (issue #287): a file from another app and a re-imported
+     * backup both used to come back as 0, and the app could only say "nothing to import", which
+     * sent people looking for a bug in the wrong place.
+     */
+    fun importMerge(json: String): ImportResult {
+        val incoming = runCatching { this.json.decodeFromString<List<SavedPlace>>(json) }.getOrNull()
+            ?: return ImportResult.WrongFormat(ImportFormats.describe(json))
         val current = saved()
         val existing = current.mapTo(HashSet()) { it.id }
         val added = incoming.filterNot { it.id in existing }
-        if (added.isEmpty()) return 0
+        if (added.isEmpty()) return ImportResult.NothingNew
         prefs.edit().putString(KEY, this.json.encodeToString(current + added)).apply()
-        return added.size
+        return ImportResult.Added(added.size)
     }
 
     private companion object {

--- a/core/src/test/java/app/vela/core/data/ImportFormatsTest.kt
+++ b/core/src/test/java/app/vela/core/data/ImportFormatsTest.kt
@@ -1,0 +1,47 @@
+package app.vela.core.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Naming a file the importer cannot use ([ImportFormats]).
+ *
+ * This exists only to write a better sentence: someone who exported from Google Takeout or Organic
+ * Maps should be told what their file is, instead of "nothing to import", which sends them looking
+ * for a bug in Vela (issue #287 - a reporter hit exactly that with Takeout data).
+ */
+class ImportFormatsTest {
+
+    // The shape Google Takeout actually produces for saved places.
+    private val takeout = """
+        {"type":"FeatureCollection","features":[{"type":"Feature",
+        "geometry":{"type":"Point","coordinates":[-121.7405,38.5449]},
+        "properties":{"google_maps_url":"http://maps.google.com/?cid=123","location":{"name":"Somewhere"}}}]}
+    """.trimIndent()
+
+    @Test fun `google takeout is named specifically`() {
+        assertEquals("Google Takeout", ImportFormats.describe(takeout))
+    }
+
+    @Test fun `plain geojson is named as geojson`() {
+        val geo = """{"type":"FeatureCollection","features":[]}"""
+        assertEquals("GeoJSON", ImportFormats.describe(geo))
+    }
+
+    @Test fun `gpx and kml are recognised`() {
+        assertEquals("GPX", ImportFormats.describe("""<?xml version="1.0"?><gpx version="1.1"></gpx>"""))
+        assertEquals("KML", ImportFormats.describe("""<kml><Placemark></Placemark></kml>"""))
+    }
+
+    // Vela's own export must never be mistaken for someone else's format.
+    @Test fun `vela's own export is not named as foreign`() {
+        val ours = """[{"id":"g:1","name":"Somewhere","lat":38.5449,"lng":-121.7405}]"""
+        assertNull(ImportFormats.describe(ours))
+    }
+
+    @Test fun `unrecognised junk simply has no name`() {
+        assertNull(ImportFormats.describe("not json at all"))
+        assertNull(ImportFormats.describe("{}"))
+    }
+}

--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -4,11 +4,10 @@ Vela ships in 15 languages (the canonical layer-by-layer table is in
 [LANGUAGES.md](LANGUAGES.md)). Translations are community-maintained, and today
 they come in as ordinary pull requests.
 
-> **Weblate is not up yet.** Hosted Weblate is free for open-source projects but
-> asks that a project be established before it takes it on, and Vela is still too
-> young to qualify. Until that changes there is no Weblate project to sign in to,
-> so please use the pull-request flow below. This page will be rewritten the day
-> it is running.
+> **Weblate is not up yet.** Hosted Weblate is free for open-source projects, but
+> a project has to be at least three months old to qualify and Vela is not there
+> yet. Until it is, there is no Weblate project to sign in to, so please use the
+> pull-request flow below. This page gets rewritten the day it is running.
 
 ## Translate by pull request
 

--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -1,31 +1,43 @@
 # Translating Vela
 
 Vela ships in 15 languages (the canonical layer-by-layer table is in
-[LANGUAGES.md](LANGUAGES.md)). Translations are community-maintained through
-**Weblate**, a web editor where you can translate without touching git at all.
+[LANGUAGES.md](LANGUAGES.md)). Translations are community-maintained, and today
+they come in as ordinary pull requests.
 
-## Translate on Weblate
+> **Weblate is not up yet.** Hosted Weblate is free for open-source projects but
+> asks that a project be established before it takes it on, and Vela is still too
+> young to qualify. Until that changes there is no Weblate project to sign in to,
+> so please use the pull-request flow below. This page will be rewritten the day
+> it is running.
 
-Project: https://hosted.weblate.org/projects/vela-maps/
+## Translate by pull request
 
-1. Make a free account (GitHub sign-in works).
-2. Pick your language and start suggesting or translating strings.
-3. Weblate batches the work and opens a pull request against this repo; a
-   maintainer reviews and merges it. You get commit credit for your strings.
+1. Find your language file: `app/src/main/res/values-<lang>/strings.xml`
+   (for example `values-de` for German, `values-zh-rTW` for Traditional
+   Chinese). The English original is `app/src/main/res/values/strings.xml`.
+2. Edit or add the strings you want to fix. You can do this entirely in the
+   GitHub web editor: open the file, press the pencil, and commit to a new
+   branch. No git client and no Android toolchain needed.
+3. Open a pull request. A maintainer reviews it against the rules below and
+   merges. You keep commit credit for your strings.
 
-Missing your language entirely? Open the project page and hit "Start new
-translation", or open an issue here. A new language needs the UI strings
-first; spoken directions and the open/closed keyword table are separate
-layers a maintainer wires up afterwards (see below).
+Anything you do not translate simply falls back to English, so a partial
+contribution is genuinely useful and never breaks the app.
+
+Missing your language entirely? Open an issue and say which one, or copy
+`values/strings.xml` to a new `values-<lang>/` folder and translate what you
+can. A new language needs the UI strings first; spoken directions and the
+open/closed keyword table are separate layers a maintainer wires up afterwards
+(see below).
 
 ## What lives where
 
-Only the first layer is on Weblate. The rest is code or config and changes
-through normal pull requests:
+The UI strings above are the layer that is open to everyone. The rest is code
+or config and changes through pull requests too, but needs a maintainer:
 
 | Layer | Where | How to change |
 |---|---|---|
-| App UI strings (~350) | `app/src/main/res/values-<lang>/strings.xml` | Weblate |
+| App UI strings (~350) | `app/src/main/res/values-<lang>/strings.xml` | PR (the flow above) |
 | Spoken turn-by-turn | `core/src/main/java/app/vela/core/i18n/` (a `NavStrings` table per language) | PR, needs native review |
 | Open/closed status keywords | `calibration.json` (`statusClosedWords`/`statusOpenWords`) + compiled tables in `SearchParser` | PR or a signed calibration push |
 | Neural voice | Piper voice catalog (`PiperCatalog`) | depends on an upstream Piper voice existing |
@@ -38,8 +50,8 @@ through normal pull requests:
   silently doesn't show.
 - **Plurals need the right CLDR categories for your language.** Russian,
   Ukrainian and Polish need `one`/`few`/`many`/`other`; Hebrew needs
-  `one`/`two`/`many`/`other`; Chinese and Japanese only `other`. Weblate
-  shows the right set automatically.
+  `one`/`two`/`many`/`other`; Chinese and Japanese only `other`. Copy the
+  category set from an existing file in your language if you are unsure.
 - **No em dashes.** Use a comma, a colon, or rephrase. The one legitimate
   dash is a numeric range. (House style across the whole repo.)
 - **Escape apostrophes** as `\'` in strings.xml. A raw one fails the release


### PR DESCRIPTION
Closes #287, closes #285.

## #287 — two separate bugs, not one

**The button could genuinely do nothing.** `importLauncher.launch(...)` was wrapped in a bare `runCatching`, so on a device with no documents provider the `ActivityNotFoundException` was swallowed: no picker, no message, nothing — exactly as reported. A stripped-down or degoogled ROM without DocumentsUI is a realistic case for this app's users. It now says so.

**And four outcomes collapsed into one message.** `importMerge` returned a bare `Int`, so *couldn't read it*, *not our format*, *nothing new*, and *empty* all became 0 → "Nothing to import". That's actively misleading when the real answer is "that file came from another app" — which is what the second reporter in the thread hit with Google Takeout data.

Stores now return `ImportResult` (Added / NothingNew / WrongFormat / Unreadable), and recognisable foreign files are **named**: Takeout, GeoJSON, GPX, KML, Organic Maps.

**Device-verified with a real Takeout-shaped file** — screenshot in the thread: *"That looks like a Google Takeout file. Vela can only import its own exports for now."*

A test caught my own bug here: I matched Takeout on `google.com/maps`, but real exports use `maps.google.com/?cid=`.

Actually *importing* other apps' formats remains #279 — this only stops the dead end.

## #285 — the link was never going to work

The docs sent translators to a Weblate project that doesn't exist. Per you: the hosting application hasn't been accepted because the project isn't old enough yet. So this isn't a broken link to repair, it's a claim to correct.

- Dead badge removed from the README
- `docs/TRANSLATING.md` now documents what works **today**: edit one `values-<lang>/strings.xml` in the GitHub web editor, open a PR, no git client or Android toolchain needed
- CONTRIBUTING and FEATURES corrected (FEATURES claimed it as ✅ shipped)
- README roadmap keeps Weblate as the intended home
- CLAUDE.md warns not to point anyone at it until it's real

`ImportFormatsTest`: 5 passing. `check-translations.py`: 707 keys, no placeholder drift.