### PR TITLE
Show subway journeys properly instead of a row of empty walks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2906,6 +2906,26 @@ architecture note.
   end. The auto-advance is **latched** (`maybeAdvanceTransitNav`, `TRANSIT_ARM_M=90`/`TRANSIT_ARRIVE_M=40`):
   a leg only advances once it's been ARMED by being >ARM_M from its end, so a transfer hub can't cascade
   through legs and a short final walk can't fire a premature arrival.
+- **SUBWAY LEGS RENDERED AS EMPTY WALKS (issue #284, fixed 2026-08-31, live NYC capture).** Two
+  independent defects in `TransitParser`, both proven against a real Harlem->Wall St payload:
+  (1) **A line drawn as a BULLET carries no text pill.** `[14]` is a list of tagged entries and
+  tag 5 is the line identity, expressed EITHER as a text badge at `[1]`
+  (`["M101",1,"#1d59b3","#ffffff"]`, buses) OR - with `[1]` NULL - as an agency icon at `[2]`
+  (`[3,"us-ny-mta/2.png",null,"2 Line",...]`, NYC subway). `parseLines` only matched the pill, so
+  a subway leg yielded no line, and `mode = line?.mode ?: WALK` turned every one into an empty
+  walking step. `iconLineName` now reads the name off the icon FILENAME. **The agency prefix is
+  the load-bearing rule**: a line icon is operator-scoped and contains a "/" (`us-ny-mta/2.png`)
+  while the generic vehicle icon is bare (`subway2.png`, `bus2.png`) - without that test a bus
+  would invent a line called "bus2". Filename not the label beside it ("2 Line"), because the
+  label is localized.
+  (2) **`guessMode` matched mode words inside PLACE NAMES.** It scanned every short string in the
+  subtree with "bus" tested first, so a "2" train to **Flat-BUS-h Av** reported as a BUS
+  (device-proven: the live capture guessed BUS for a subway leg). It now reads ICON FILENAMES
+  ONLY, which are language-neutral and per-mode (bus2/subway2/rail/tram/ferry/walk); Columbus,
+  Bushwick and Brisbane were the same trap. The whole LEG is passed in, not just `[14]`, because
+  the generic vehicle icon sits outside the badge node. Subway is now tested before rail.
+  Pinned by `TransitSubwayTest` using the real captured nodes; re-verified by replaying the new
+  rules over the whole live payload (6 trips -> lines 2/3/5 SUBWAY, M101 BUS, walks still WALK).
 - **Live stop departure board (`WebStopDeparturesFetcher` + `core/.../StopDeparturesParser`,
   2026-07-12, keyless + device-verified).** Tapping a transit STATION shows Google's "See departure
   board" in the place sheet. The board is embedded in the station's OWN place page's

--- a/core/src/main/java/app/vela/core/data/google/parse/TransitParser.kt
+++ b/core/src/main/java/app/vela/core/data/google/parse/TransitParser.kt
@@ -168,7 +168,10 @@ object TransitParser {
 
     private fun parseStep(leg: JsonElement): TransitStep {
         val sum = leg.at(0) ?: leg
-        val line = parseLines(sum.at(14)).firstOrNull()
+        // The whole leg is handed over for mode inference: the generic vehicle icon
+        // ("subway2.png") sits OUTSIDE the badge node, so [14] alone cannot tell a subway from
+        // anything else (issue #284, live NYC capture).
+        val line = parseLines(sum.at(14), leg).firstOrNull()
         val stops = leg.at(5) // present on ride legs only
         val board = parseStopTime(stops.at(0))
         val alight = parseStopTime(stops.at(1))
@@ -240,13 +243,18 @@ object TransitParser {
      *  "#fill", "#text"]` — collecting them in document order, de-duplicated by
      *  name. Walk legs carry no such node, so a walk-only segment contributes
      *  nothing here (matching Google's compact card, which shows only the lines). */
-    private fun parseLines(badges: JsonElement?): List<TransitLine> {
+    /** Test seam for [parseLines] - the badge/mode shapes are the part that drifts with Google. */
+    internal fun parseLinesForTest(badges: JsonElement?, leg: JsonElement?) = parseLines(badges, leg)
+
+    /** Test seam for [guessMode]. */
+    internal fun guessModeForTest(leg: JsonElement) = guessMode(leg)
+
+    private fun parseLines(badges: JsonElement?, leg: JsonElement? = null): List<TransitLine> {
         val root = badges.arr() ?: return emptyList()
-        // The mode-icon facet ("bus2.png") sits in a sibling node of the line
-        // facet, not inside it, so derive one dominant vehicle class for the whole
-        // badge subtree and apply it to the lines (correct for single-mode trips,
-        // a sane approximation for mixed ones).
-        val mode = guessMode(root)
+        // The mode-icon facet ("bus2.png") sits in a sibling node of the line facet, not inside
+        // it, so derive one dominant vehicle class for the leg and apply it to the lines
+        // (correct for single-mode trips, a sane approximation for mixed ones).
+        val mode = guessMode(leg ?: root)
         val out = ArrayList<TransitLine>()
         val seen = HashSet<String>()
         fun walk(n: JsonElement) {
@@ -268,7 +276,43 @@ object TransitParser {
             a.forEach(::walk)
         }
         walk(root)
+        // A line drawn as a BULLET rather than a text pill carries no colour badge at all - the
+        // whole identity is an agency-scoped icon. New York's subway is the case that exposed this
+        // (issue #284): every subway leg parsed to no line, which made it fall through to WALK and
+        // render as an empty walking step, while buses (which do get a text pill) were fine.
+        if (out.isEmpty()) iconLineName(root)?.let { name ->
+            out.add(TransitLine(name = name, mode = mode))
+        }
         return out
+    }
+
+    /**
+     * The line name carried as an agency icon, e.g. `us-ny-mta/2.png` -> "2".
+     *
+     * The AGENCY PREFIX is what separates a line bullet from the generic vehicle icon: a line icon
+     * is scoped to its operator ("us-ny-mta/2.png"), while the mode icon is a bare filename
+     * ("subway2.png", "bus2.png", "walk.png"). Without that rule a bus leg would invent a line
+     * called "bus2".
+     *
+     * Read from the filename rather than the human label beside it ("2 Line") because the filename
+     * is language-neutral - the label is localized and would yield "2 Ligne" / "2 Línea".
+     */
+    private fun iconLineName(root: JsonElement): String? {
+        var best: String? = null
+        fun walk(n: JsonElement) {
+            when (n) {
+                is JsonArray -> n.forEach(::walk)
+                else -> {
+                    val v = n.str()
+                    if (best == null && v != null && v.endsWith(".png") && !v.startsWith("//") && "/" in v) {
+                        val name = v.substringAfterLast('/').removeSuffix(".png").trim()
+                        if (name.isNotEmpty() && name.length <= 12) best = name
+                    }
+                }
+            }
+        }
+        walk(root)
+        return best
     }
 
     /** Infer the vehicle class from any icon filename ("bus2.png", "tram.png",
@@ -276,19 +320,31 @@ object TransitParser {
      *  tested before WALK: line nodes only exist for ridden segments, so a trip
      *  whose badges mention both "walk" and "bus" is a bus trip with a walk leg. */
     private fun guessMode(node: JsonElement): TransitMode {
+        // ICON FILENAMES ONLY, never arbitrary strings (issue #284). The old version scanned every
+        // short string in the subtree, so a stop or headsign containing a mode word decided the
+        // vehicle: a New York "2" train to FLATBUSH Av matched "bus" - and bus is tested first -
+        // so a subway leg was reported as a bus. Columbus, Bushwick and Brisbane are the same trap.
+        // Filenames are language-neutral and Google names them per mode: bus2.png, subway2.png,
+        // rail.png, tram.png, ferry.png, walk.png.
         val hay = StringBuilder()
         fun walk(n: JsonElement) {
             when (n) {
                 is JsonArray -> n.forEach(::walk)
-                else -> n.str()?.let { if (it.length < 40) hay.append(it).append(' ') }
+                else -> n.str()?.let {
+                    if (it.endsWith(".png") || it.endsWith(".svg")) {
+                        // Keep only the filename: an agency line icon (us-ny-mta/2.png) must not
+                        // contribute its operator name to the mode guess.
+                        hay.append(it.substringAfterLast('/')).append(' ')
+                    }
+                }
             }
         }
         walk(node)
         val s = hay.toString().lowercase()
         return when {
             "bus" in s -> TransitMode.BUS
-            "tram" in s || "light rail" in s || "streetcar" in s || "lightrail" in s -> TransitMode.TRAM
             "subway" in s || "metro" in s -> TransitMode.SUBWAY
+            "tram" in s || "light rail" in s || "streetcar" in s || "lightrail" in s -> TransitMode.TRAM
             "train" in s || "rail" in s -> TransitMode.TRAIN
             "ferry" in s || "boat" in s -> TransitMode.FERRY
             "walk" in s -> TransitMode.WALK

--- a/core/src/test/java/app/vela/core/data/google/parse/TransitSubwayTest.kt
+++ b/core/src/test/java/app/vela/core/data/google/parse/TransitSubwayTest.kt
@@ -1,0 +1,88 @@
+package app.vela.core.data.google.parse
+
+import app.vela.core.model.TransitMode
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Subway legs from Google's transit payload (issue #284).
+ *
+ * The fixtures are the REAL `[14]` nodes captured live from a Manhattan-to-Wall-Street trip on
+ * 2026-08-31, not invented shapes. Two things were wrong and both are pinned here:
+ *
+ *  1. A subway line is drawn as an agency BULLET, so its `[14]` entry carries `null` where a bus
+ *     carries a text pill and puts the identity in an icon instead. Vela only looked for the pill,
+ *     found no line, and fell through to `mode = WALK` - so every subway leg rendered as an empty
+ *     walking step while buses were fine.
+ *  2. The vehicle class was guessed from every string in the leg, so a "2" train to FLATBUSH Av
+ *     matched "bus" (checked first) and reported a subway as a bus.
+ */
+class TransitSubwayTest {
+
+    private fun node(raw: String): JsonElement = Json.parseToJsonElement(raw)
+
+    // Live capture: an MTA "2" train leg. Note [0][1] is null - no text badge exists.
+    private val subwayBadges = node(
+        """[[5,null,[3,"us-ny-mta/2.png",null,"2 Line",[["//maps.gstatic.com/mapfiles/transit/iw2/svg/us-ny-mta/2.svg",1,[44,44],null,0]]]],[7,["Flatbush Av-Brooklyn College"]]]"""
+    )
+
+    // Live capture: an M101 bus leg on the same trip - a text pill, which always worked.
+    private val busBadges = node(
+        """[[4,null,[3,"bus2.png",null,"Bus",[["//maps.gstatic.com/mapfiles/transit/iw2/svg/bus2.svg",1,[44,44],null,0]]]],[5,["M101",1,"#1d59b3","#ffffff"]],[7,["Limited East Village 3 Av-6 St via Lex"]]]"""
+    )
+
+    /** A whole leg carries the generic vehicle icon, which is what names the mode. */
+    private fun legWith(badges: String, vehicleIcon: String, extraText: String) = node(
+        """[[null,null,null,null,null,null,null,null,null,null,null,null,null,null,$badges],
+            null,null,null,null,
+            [["$extraText",null,null,null,[null,null,40.7,-74.0]],["End",null,null,null,[null,null,40.6,-74.0]],3,null,null,null,null,[]],
+            "$vehicleIcon"]"""
+    )
+
+    @Test fun `a subway line drawn as a bullet is still a line, not a walk`() {
+        val lines = TransitParser.parseLinesForTest(subwayBadges, null)
+        assertTrue("a bullet-only line must still be found", lines.isNotEmpty())
+        assertEquals("the line name comes from the agency icon, not the localized label", "2", lines[0].name)
+    }
+
+    @Test fun `a bus keeps its text pill and its colours`() {
+        val lines = TransitParser.parseLinesForTest(busBadges, null)
+        assertEquals("M101", lines[0].name)
+        assertEquals("#1d59b3", lines[0].colorHex)
+    }
+
+    // The generic vehicle icon must not be mistaken for a line: a bus would become line "bus2".
+    @Test fun `the generic vehicle icon never becomes a line name`() {
+        val lines = TransitParser.parseLinesForTest(busBadges, null)
+        assertTrue("no line may be named after a mode icon", lines.none { it.name.startsWith("bus") })
+    }
+
+    @Test fun `a subway to Flatbush is a subway, not a bus`() {
+        val leg = legWith(subwayBadges.toString(), "subway2.png", "Flatbush Av-Brooklyn College")
+        val mode = TransitParser.guessModeForTest(leg)
+        assertEquals("'Flatbush' must not decide the vehicle", TransitMode.SUBWAY, mode)
+    }
+
+    @Test fun `a bus leg is still a bus`() {
+        val leg = legWith(busBadges.toString(), "bus2.png", "3 Av-6 St")
+        assertEquals(TransitMode.BUS, TransitParser.guessModeForTest(leg))
+    }
+
+    // Place names that merely contain a mode word must not steer the guess at all.
+    @Test fun `place names containing mode words are ignored`() {
+        val leg = legWith(subwayBadges.toString(), "subway2.png", "Columbus Circle")
+        assertEquals(TransitMode.SUBWAY, TransitParser.guessModeForTest(leg))
+        val rail = legWith(subwayBadges.toString(), "rail.png", "Bushwick Av")
+        assertEquals(TransitMode.TRAIN, TransitParser.guessModeForTest(rail))
+    }
+
+    @Test fun `the mode falls back to generic rather than guessing from prose`() {
+        val leg = legWith("""[[7,["Somewhere"]]]""", "unknown-thing.png", "Busy Street")
+        assertNotNull(TransitParser.guessModeForTest(leg))
+        assertEquals(TransitMode.GENERIC, TransitParser.guessModeForTest(leg))
+    }
+}


### PR DESCRIPTION
Closes #284

Diagnosed from a **live capture** of a real Harlem → Wall St transit payload, not from reading code. Two independent defects.

### 1. A subway line has no text badge at all
`[14]` is a list of tagged entries; tag 5 is the line identity, and Google expresses it **two different ways**:

```
bus:     [5, ["M101", 1, "#1d59b3", "#ffffff"]]                          ← text pill
subway:  [5, null, [3, "us-ny-mta/2.png", null, "2 Line", …]]            ← null pill, icon instead
```

Vela only matched the pill. No pill → no line → and `mode = line?.mode ?: WALK` quietly turned **every subway leg into an empty walking step**. Buses have a pill, which is exactly why they worked.

The name now comes off the icon **filename**, because the label next to it ("2 Line") is localized. The load-bearing rule is the **agency prefix**: a line icon is operator-scoped and contains a `/` (`us-ny-mta/2.png`), the generic vehicle icon is bare (`subway2.png`). Without that test a bus would invent a line called "bus2".

### 2. A train to Flatbush was reported as a bus
`guessMode` scanned *every* short string in the leg with `"bus"` tested first — so a **2 train to Flat‑bus‑h Av** came back BUS. The live capture confirmed it: my probe printed `guess: "BUS"` for a subway leg. Columbus, Bushwick and Brisbane are the same trap.

It now reads **icon filenames only** — language-neutral and named per mode (`bus2`/`subway2`/`rail`/`tram`/`ferry`/`walk`). The whole leg is passed in, since the generic vehicle icon sits outside the badge node.

### Verified on real data, twice
- `TransitSubwayTest` (7 passing) uses the **actual captured nodes** as fixtures, not invented shapes.
- The new rules were then replayed over the **entire live payload**: all 6 trips resolve to lines **2, 3, 5** as SUBWAY and **M101** as BUS, with genuine walking legs still WALK. Trip 4 is the good one — a mixed bus + subway journey that previously showed one bus and one empty walk.

Fare and operator were always parsed correctly, which matches the reporter seeing $3.00 and MTA while the legs were blank.