### PR TITLE
Stop the nav puck jittering by filtering where it is, not just how fast it is going

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1988,7 +1988,22 @@ architecture note.
   `navSession.onLocation` path - puck/banner/voice keep working, `navStarved` keeps the
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
-  Nav zoom range is 18.0→15.5 (2026-07-14, was 17.3→15.0). **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
+  Nav zoom range is 18.0→15.5 (2026-07-14, was 17.3→15.0).
+  **ACCELEROMETER NOISE WAS REACHING THE PUCK (issue #251, 2026-08-20 - the jitter that survived
+  the two fixes below, still reported on a P9).** Archaeology settled it: the ORIGINAL puck
+  (498e7f49, 2026-06-21, the version remembered as smooth) took its speed STRAIGHT off the GPS fix
+  and held it constant between fixes - twelve lines, no Kalman, no boxcar. `SpeedKalman.predict`
+  now runs once per FRAME, so ~60 accelerometer samples are integrated into the speed between two
+  1 Hz fixes, and the puck ADVANCES AT THAT SPEED - so road texture, engine and mount resonance
+  became visible movement. `SpeedKalman.denoise` applies an `a^2/(a^2+n^2)` suppression gain
+  (`ACCEL_NOISE` 0.5) before integrating. **NOT a subtract-the-floor shrinkage** - that was tried
+  first and broke `brakingCollapsesThePredictionBetweenFixes`, because shrinking every sample taxes
+  a REAL brake by the floor, weakening the exact behaviour the filter exists for (the puck must
+  decelerate with a stopping car). The gain leaves a 4 m/s2 brake within ~1.5% of itself while
+  cutting 0.3 m/s2 of vibration to about a quarter. A steady bias is attenuated, not erased (~0.08
+  m/s after a second), which the next fix corrects. **Rule: anything integrated per-frame from a
+  phone sensor in a car needs a noise model, or it becomes puck motion.**
+  **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
   dominant cause of the "record needle" swim).** `startDemoDrive` feeds
   `locationProvider.replay(fixes, speedup = 1f)` - REAL-TIME fixes - but it also sets
   `replaying`, and MapScreen keyed `replaySpeedup` off that flag alone, so a demo drive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2003,7 +2003,22 @@ architecture note.
   cutting 0.3 m/s2 of vibration to about a quarter. A steady bias is attenuated, not erased (~0.08
   m/s after a second), which the next fix corrects. **Rule: anything integrated per-frame from a
   phone sensor in a car needs a noise model, or it becomes puck motion.**
-  **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
+  **THE CAMERA BEARING IS ADAPTIVELY DAMPED (issue #251, 2026-08-24 - the "crinkly roads"
+  residual, and the LARGEST of the four causes).** Measured on a synthetic road that is physically
+  STRAIGHT but digitized with half-metre vertex scatter (what "crinkly" means in the data): the
+  chord bearing the puck derives swings **7.3 deg at a 5 m window, 2.3 deg at 14 m** - several
+  times the 0.83 deg camera wiggle the earlier fixes chased. The camera is anchored to the puck,
+  so that rotates the WHOLE MAP under a steady arrow. **Window WIDTH is the only lever on chord
+  noise** (angular noise ~ sigma/baseline): a least-squares fit over the same window was measured
+  NO BETTER (slightly worse at short windows) because the noise lives in the VERTICES, so interior
+  samples are correlated with the endpoints and add no information. And curvature-adaptive width
+  was measured UNWORKABLE - crinkle reads 3.0 deg median / 7.6 p90 short-vs-long disagreement, a
+  genuine 40 m bend reads 3.9, so no threshold separates them. What DOES separate cleanly is
+  AMPLITUDE at the camera: geometry noise is a couple of degrees, a turn is tens. So the camera's
+  bearing time constant follows the size of its own error - `CAM_BRG_TAU_STILL` 1.6 s when small
+  (keeps ~24% of the wiggle vs 59% at the old flat 0.55), `CAM_BRG_TAU_TURN` 0.35 s past
+  `CAM_BRG_TURN_DEG` (25 deg), which is QUICKER around a real corner than before. Tilt keeps the
+  old constant - it is not part of this. **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
   dominant cause of the "record needle" swim).** `startDemoDrive` feeds
   `locationProvider.replay(fixes, speedup = 1f)` - REAL-TIME fixes - but it also sets
   `replaying`, and MapScreen keyed `replaySpeedup` off that flag alone, so a demo drive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1989,8 +1989,58 @@ architecture note.
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
   Nav zoom range is 18.0→15.5 (2026-07-14, was 17.3→15.0).
-  **ACCELEROMETER NOISE WAS REACHING THE PUCK (issue #251, 2026-08-20 - the jitter that survived
-  the two fixes below, still reported on a P9).** Archaeology settled it: the ORIGINAL puck
+  **PUCK JITTER (issue #251) HAS FIVE SEPARATE CAUSES, ALL FIXED. READ THIS BEFORE TOUCHING THE
+  PUCK.** It was re-diagnosed from scratch four times because each pass found a real cause, fixed
+  it, and the symptom persisted - two of those passes then derived the SAME window fix
+  independently. The list, largest first: (1) the along-route POSITION was never filtered; (2) the
+  progress rule stalled and surged; (3) the camera bearing followed digitization wiggle; (4) the
+  smoothing window's own width rippled; (5) demo drives ran the clocks at 3x. If jitter is
+  reported again, the next thing to suspect is something NOT on this list - do not re-derive one
+  of these.
+  **(1) THE ALONG-ROUTE POSITION WAS NEVER FILTERED (2026-09-01, the biggest single cause).** The
+  puck's SPEED had been Kalman-filtered since June; its POSITION never was. The snapped fix went
+  straight into `targetM` and the puck was drawn from it, so every metre of along-route GPS noise
+  was a metre the puck genuinely had to travel, once a second, for the whole drive. **No amount of
+  downstream smoothing can fix that** - a smoother makes the movement gentler, it does not make it
+  stop happening, which is precisely why four passes of smoothing work left the symptom alive.
+  `AlongRouteFilter` (`:core`, unit-tested) is the missing measurement update: the estimate
+  dead-reckons at the modelled speed and grows variance, and each accepted fix folds in weighted by
+  its OWN reported accuracy (`Location.getAccuracy` is a 68% radius; snapping discards the lateral
+  component, so the along-route sigma is ~0.66x it). A clean 4 m fix pulls most of the way, a 25 m
+  urban-canyon one barely moves the estimate. `targetM` still exists and still takes the raw fix -
+  the plausibility gate and the snap window are built on it and keep their behaviour - but what the
+  puck DRAWS is now `navPuck.along`. Genuine discontinuities (engage, re-acquire, a persistent
+  over-cap jump) call `reseed` instead, because a teleport is not noise to average down.
+  Simulated against the old rule, 1 Hz fixes at 60 fps: along-road wobble 7.2 -> 2.8 px at cruise
+  with clean GPS, 27.1 -> 5.5 px in an urban canyon.
+  **(2) THE PROGRESS RULE STALLED AND SURGED AT THE FIX CADENCE.** The puck eased toward
+  `targetM + reckonedM` and was then clamped monotonic. Each half is individually sensible;
+  together they fight. Every fix reset the reckoning, so the target JUMPED by however much the dead
+  reckoning had over- or under-shot; an overshoot put the target BEHIND the puck, the ease pulled
+  backward, and the monotonic clamp FROZE the puck until the reckoning caught up. A few metres of
+  ordinary GPS noise did that once a second, forever. Now corrected in the RATE domain: the puck
+  always advances at the modelled speed and the estimate error enters as a BOUNDED nudge to that
+  rate (`PUCK_CORRECT_TIME_S`, catch-up capped at 0.5x speed + 1 m/s, hold-back at 0.25x + 0.5).
+  Cannot stall, cannot lurch, still monotonic. Stalled frames 2.7% -> 0% at cruise, 27.8% -> 0% in
+  a canyon; frame-to-frame speed error 36% -> 3%.
+  **(4) THE SMOOTHING WINDOW'S WIDTH RIPPLED.** `win = speed*0.7` sizes the position+bearing
+  boxcar, but that is the KALMAN speed, which the per-frame accelerometer predict ripples. On a
+  curve the averaged point sits inside the arc by ~`win^2/(6R)`, so **the width is a lateral
+  position** and speed noise became sideways movement. `navPuck.smoothWin` now eases the
+  half-width toward its speed target with a long time constant (`PUCK_WIN_TAU_S` 2.5 s): still
+  tracks town-vs-motorway, which is all it was for, but per-fix wobble cannot reach it. **Rule: a
+  fast-moving smoother is not a smoother.** Measured honestly this one is SMALL on real OSRM
+  geometry - a +/-1 m width ripple moves the drawn point ~1 cm, sub-pixel - so it is worth keeping
+  and not worth re-deriving a third time.
+  **Route geometry is requested at `polyline6`, not `polyline` (2026-09-01).** OSRM's default
+  encoding is 1e5-scaled: a 1.11 m latitude grid, so every vertex of a physically straight road
+  arrives snapped to a metre-ish step and the puck has to smooth back out scatter Vela itself
+  introduced. `geometries=polyline6` + `PolylineCodec.decode(s, 6)` removes it at the source -
+  verified on the FOSSGIS server (same vertex count, same distance, 10x the resolution). Worth
+  ~20-25% of the chord-bearing noise on real routes; the rest of the crinkle is genuinely in OSM.
+  NB `TripLog` still encodes saved routes at 1e5 (changing it would misread every existing trip
+  file by 10x), so a REPLAY sees slightly coarser geometry than the live drive did.
+  **(3a) ACCELEROMETER NOISE WAS REACHING THE PUCK (2026-08-20).** Archaeology settled it: the ORIGINAL puck
   (498e7f49, 2026-06-21, the version remembered as smooth) took its speed STRAIGHT off the GPS fix
   and held it constant between fixes - twelve lines, no Kalman, no boxcar. `SpeedKalman.predict`
   now runs once per FRAME, so ~60 accelerometer samples are integrated into the speed between two
@@ -2003,8 +2053,7 @@ architecture note.
   cutting 0.3 m/s2 of vibration to about a quarter. A steady bias is attenuated, not erased (~0.08
   m/s after a second), which the next fix corrects. **Rule: anything integrated per-frame from a
   phone sensor in a car needs a noise model, or it becomes puck motion.**
-  **THE CAMERA BEARING IS ADAPTIVELY DAMPED (issue #251, 2026-08-24 - the "crinkly roads"
-  residual, and the LARGEST of the four causes).** Measured on a synthetic road that is physically
+  **(3) THE CAMERA BEARING IS ADAPTIVELY DAMPED (2026-08-24, the "crinkly roads" residual).** Measured on a synthetic road that is physically
   STRAIGHT but digitized with half-metre vertex scatter (what "crinkly" means in the data): the
   chord bearing the puck derives swings **7.3 deg at a 5 m window, 2.3 deg at 14 m** - several
   times the 0.83 deg camera wiggle the earlier fixes chased. The camera is anchored to the puck,

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -224,6 +224,15 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   building-footprint OVERLAY (the layer that fills OSM's gaps) had its colour hardcoded to Modern, so
   in Classic those houses stayed Google-navy while the OSM ones went grey; it now honours the palette
   too. Also, since the two sets currently diverge mostly in dark mode, the Settings hint says so.
+- ✅ **Nav puck: the position is filtered too (2026-09-01).** The puck's speed had been Kalman
+  filtered since June; its *position* never was, so every metre of along-route GPS noise was a
+  metre the arrow actually travelled, once a second, all drive - and no amount of smoothing
+  downstream could stop it, only soften it. `AlongRouteFilter` folds each fix in weighted by the
+  fix's own reported accuracy, so a clean fix pulls hard and an urban-canyon one barely moves the
+  puck; progress advances in the rate domain, so it can neither stall nor lurch. Route geometry is
+  now requested from OSRM at `polyline6` as well, since the default encoding quantises every vertex
+  to a ~1.1 m grid and made straight roads arrive kinked. Simulated end to end: along-road wobble
+  7.2 → 2.8 px at cruise, 27 → 5.5 px in a canyon, stalled frames 2.7-28% → 0%.
 - ✅ **Google-style nav puck (2026-07-11).** The navigation arrow is a white chevron inside a
   filled bright-navy circle with a soft drop shadow (no white ring, per user feedback); it rotates
   about the exact GPS point. Replaces the bare blue chevron. **Enlarged twice from feedback

--- a/SPEC.md
+++ b/SPEC.md
@@ -515,16 +515,22 @@ itself shows the traffic, not the whole map.
 - **Nav puck motion model** (`VelaMapView`, `NavPuck`): the displayed position during
   nav is decoupled from the raw GPS fix. A `withFrameNanos` ticker glides the puck
   **monotonically forward along the route** by metres-along (`cumLengths`/`pointAtMeters`),
-  **dead-reckoned** and **eased** (τ≈0.25 s), with **heading smoothed** (`smoothBearing`,
-  τ≈0.2 s). The dead-reckoned speed is a **1-D Kalman fusion** (`core/location/SpeedKalman`,
+  advancing in the **rate domain** - it always moves at the modelled speed, with the position
+  error folded in as a *bounded nudge to that rate* (`PUCK_CORRECT_TIME_S`) rather than an ease
+  toward a target, which is what used to stall and surge at the fix cadence - and with **heading
+  smoothed** (`smoothBearing`, τ≈0.2 s). BOTH halves of the motion are filtered: the
+  **position** by `core/location/AlongRouteFilter` (1-D Kalman over metres-along; dead-reckons
+  at the modelled speed, folds each accepted fix in weighted by that fix's own reported accuracy,
+  and `reseed`s on a genuine discontinuity) and the **speed** by a **1-D Kalman fusion**
+  (`core/location/SpeedKalman`,
   pure + unit-tested): each GPS fix is the measurement update, and between fixes the
   **accelerometer steers the prediction** - `MotionProvider` (`core/location`, raw
   `TYPE_LINEAR_ACCELERATION` + `TYPE_ROTATION_VECTOR`, no GMS) emits world-frame horizontal
   acceleration, `forwardAccel()` projects it onto the travel bearing, and the ticker runs
   `kalman.predict(a, dt)` per frame - so braking collapses the modelled speed immediately
   instead of the puck gliding at the stale fix speed into the monotonic-progress trap (the
-  "puck sits ahead of me when I stop" bug). The advance is the **integral** of that speed
-  (`reckonedM += v·dt`, reset per fix, blind-capped at 2 s). Missing sensor → `a = 0` →
+  "puck sits ahead of me when I stop" bug). Between fixes the position estimate is the
+  **integral** of that speed, blind-capped at `DEAD_RECKON_S` (3 s). Missing sensor → `a = 0` →
   the old constant-speed reckoning. Each fix is snapped (`snapToRoute`, §honest-snap) then
   its metres-along advance is **plausibility-clamped** (`speed·Δt·2.5 + 60 m`) so a
   self-approaching route can't teleport the puck to a far leg. The **follow-camera targets the puck's smoothed point** (`NavPuck.drawn`), not

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -193,6 +193,14 @@ private const val ME_ARROW_IMG = "vela-arrow"
 private const val NAV_PUCK_IMG = "vela-nav-puck"
 private const val PREVIEW_SRC = "vela-preview-src"
 private const val PREVIEW_LAYER = "vela-preview"
+/** Camera-bearing damping (issue #251). Heavy while the camera is essentially tracking a straight
+ *  road, so digitization wiggle does not rotate the map; quick once the error is turn-sized. */
+private const val CAM_BRG_TAU_STILL = 1.6
+private const val CAM_BRG_TAU_TURN = 0.35
+/** Error at which the damping is fully in "this is a real turn" mode. Well above the few degrees
+ *  of geometry noise, well below a junction turn. */
+private const val CAM_BRG_TURN_DEG = 25.0
+
 private const val DEM_SRC = "vela-dem"
 private const val HILLSHADE_LAYER = "vela-hillshade"
 // Keyless open elevation tiles (AWS Open Data, terrarium-encoded) — no key, and
@@ -1663,7 +1671,25 @@ fun VelaMapView(
                     // then rotates on the north-up map instead of the map rotating under it.
                     val brgTgt = if (navNorthUpHolder.value) 0.0 else navPuck.displayBearing.toDouble()
                     val db = ((brgTgt - camState[2] + 540.0) % 360.0) - 180.0 // shortest arc
-                    camState[2] = (camState[2] + db * kBrg + 360.0) % 360.0
+                    // CAMERA BEARING IS ADAPTIVELY DAMPED (issue #251, the "crinkly roads" residual).
+                    // A road digitized from imagery wiggles even where it is physically straight, and
+                    // the bearing drawn off that geometry swings 2-7 degrees - measured, and several
+                    // times bigger than anything the earlier fixes addressed. The camera is anchored
+                    // to the puck, so that rotation swings the WHOLE MAP under a steady arrow.
+                    //
+                    // A flat heavier damping would fix the wiggle and make real turns sluggish, so the
+                    // time constant follows the SIZE of the error instead. That discriminator works
+                    // here precisely where the crinkle-vs-curve one failed: geometry noise is a couple
+                    // of degrees and a turn is tens, an order of magnitude apart, whereas a real bend
+                    // and a crinkle both read ~3-4 degrees and could not be told apart at all.
+                    // Small error -> tau 1.6 s (keeps ~24% of the wiggle, vs 59% before); a genuine
+                    // turn -> tau 0.35 s, which is actually QUICKER around a corner than the old flat
+                    // 0.55. Tilt keeps its own constant - it is not part of this problem.
+                    val brgTau = (CAM_BRG_TAU_STILL +
+                        (CAM_BRG_TAU_TURN - CAM_BRG_TAU_STILL) *
+                        (kotlin.math.abs(db) / CAM_BRG_TURN_DEG).coerceAtMost(1.0)).toFloat()
+                    val kBrgAdaptive = (1f - kotlin.math.exp(-dtEase / brgTau)).toDouble()
+                    camState[2] = (camState[2] + db * kBrgAdaptive + 360.0) % 360.0
                     camState[3] += (tgtZoom - camState[3]) * kZoom
                     // Tilt: north-up = flat; else a shove-set override wins over the 55 default.
                     val tiltTgt = when {

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1570,16 +1570,42 @@ fun VelaMapView(
                 // that cadence. 3 s still bounds a dropped-signal runaway to ~100 m at highway
                 // speed, and the decay below shaves the model right after it.
                 val sinceFix = (android.os.SystemClock.elapsedRealtime() - navPuck.targetAtMs) / 1000.0 * ts
-                val tEnd = sinceFix.coerceIn(0.0, 3.0)
-                val tStart = (sinceFix - dtT).coerceIn(0.0, 3.0)
-                if (tEnd > tStart) navPuck.reckonedM += navPuck.kalman.speed * (tEnd - tStart)
                 // Past the dead-reckon window with no accepted fix = a measurement outage: decay
                 // the modelled speed toward 0 (there's no evidence we're still moving) so the
                 // zoom/look-ahead don't ride a stale speed forever. A resumed fix re-measures.
-                if (sinceFix > 3.0) navPuck.kalman.decay(dtT.coerceAtMost(0.5))
-                val predicted = navPuck.targetM + navPuck.reckonedM
-                val eased = navPuck.progressM + (predicted - navPuck.progressM) * (1f - kotlin.math.exp(-dtEase / 0.25f))
-                navPuck.progressM = maxOf(navPuck.progressM, eased) // monotonic — never backward
+                if (sinceFix > DEAD_RECKON_S) navPuck.kalman.decay(dtT.coerceAtMost(0.5))
+                // ALONG-ROUTE POSITION FILTER, predict step (issue #251). The puck's SPEED has
+                // been Kalman-filtered since June; its POSITION never was — `targetM` took the
+                // snapped fix RAW, so every metre of along-route GPS noise was a metre the puck
+                // actually had to travel, once a second, for the whole drive. Here the estimate
+                // dead-reckons forward at the modelled speed and its variance grows with time;
+                // the fix folds in at the ingest site below as a MEASUREMENT weighted against
+                // that variance, rather than replacing the estimate outright. The reckoning is
+                // bounded by the same blind window as before, so a dropped signal still can't
+                // run the puck away down the route.
+                val tEnd = sinceFix.coerceIn(0.0, DEAD_RECKON_S)
+                val tStart = (sinceFix - dtT).coerceIn(0.0, DEAD_RECKON_S)
+                navPuck.along.predict(
+                    if (tEnd > tStart) navPuck.kalman.speed * (tEnd - tStart) else 0.0,
+                    dtT,
+                )
+                // FRONT-TO-BACK SMOOTHNESS (issue #251). The puck used to ease toward the predicted
+                // position and then get clamped monotonic. Both halves are individually reasonable
+                // and together they surge and stall at exactly the fix cadence: every fix reset the
+                // reckoning, so the target JUMPED by however much it had over- or under-shot. An
+                // overshoot put the target BEHIND the puck, the ease pulled backward, and the
+                // monotonic clamp FROZE the puck until the reckoning caught up. A few metres of
+                // ordinary GPS noise did that once a second, forever.
+                //
+                // Corrected in the RATE domain instead: the puck always advances at the modelled
+                // speed, and the estimate error enters as a BOUNDED nudge to that rate. It cannot
+                // stall (the floor is 0 only when the model says stopped), it cannot lurch (the
+                // nudge is capped as a fraction of speed), and it is still monotonic.
+                val err = navPuck.along.alongM - navPuck.progressM
+                val maxCatchUp = navPuck.speed * 0.5 + 1.0   // m/s of extra closing speed
+                val maxHoldBack = navPuck.speed * 0.25 + 0.5 // ...and of braking, so it never reverses
+                val corr = (err / PUCK_CORRECT_TIME_S).coerceIn(-maxHoldBack, maxCatchUp)
+                navPuck.progressM += ((navPuck.speed + corr) * dtT.coerceAtMost(0.5)).coerceAtLeast(0.0)
                 val (ptC, segBrg) = pointAtMeters(routePolyline, routeCum, navPuck.progressM)
                 // Lateral de-jitter: drawn straight off the polyline, the puck traced every
                 // lane-level micro-kink of the dense OSM geometry - side-to-side wiggle "like a
@@ -1591,7 +1617,16 @@ fun VelaMapView(
                 // so wiggle shorter than the window CANCELS instead of shrinking. Pure geometry
                 // smoothing, no temporal lag; corners round by a couple of metres at speed,
                 // which is what Google's puck does too.
-                val win = (navPuck.speed * 0.7).coerceIn(5.0, 14.0)
+                // ...but the window WIDTH must not follow the LIVE speed (issue #251). On a curve
+                // the averaged point sits inside the arc by about win^2/(6R), so the width IS a
+                // lateral position, and `navPuck.speed` is the Kalman speed, which the per-frame
+                // accelerometer predict ripples. The width now eases with a long time constant: it
+                // still tracks town-vs-motorway, which is all it was ever for, but per-fix speed
+                // wobble cannot reach it. Rule: a fast-moving smoother is not a smoother.
+                val winTarget = (navPuck.speed * 0.7).coerceIn(5.0, 14.0)
+                navPuck.smoothWin = if (navPuck.smoothWin.isNaN()) winTarget
+                    else navPuck.smoothWin + (winTarget - navPuck.smoothWin) * (1f - kotlin.math.exp(-dtEase / PUCK_WIN_TAU_S))
+                val win = navPuck.smoothWin
                 var sLat = 0.0
                 var sLng = 0.0
                 for (k in 0 until PUCK_SMOOTH_SAMPLES) {
@@ -2448,7 +2483,8 @@ fun VelaMapView(
         // Feed this fix to the puck motion model (the frame ticker above does the gliding).
         // Gated on the fix being NEW (identity — the ViewModel makes a fresh LatLng per fix and
         // recompositions re-pass the same instance): this block runs in a recomposing scope, and
-        // kalman.update / reckonedM=0 / targetAtMs=now / missCount++ are NOT idempotent — an
+        // kalman.update / the position-filter step / targetAtMs=now / missCount++ are NOT
+        // idempotent — an
         // unrelated recomposition (stale-flag flip, mute toggle) would re-inject a stale GPS
         // speed at high gain (undoing the accelerometer's braking) and re-open the blind
         // reckoning window; the miss branch would count phantom misses toward disengage.
@@ -2458,9 +2494,12 @@ fun VelaMapView(
             val m = snap.third
             val now = android.os.SystemClock.elapsedRealtime()
             var accepted = false
+            var reanchor = false // a genuine discontinuity — reseed the filter rather than average it in
             if (!navPuck.engaged) {
                 navPuck.progressM = m; navPuck.targetM = m; navPuck.engaged = true
+                navPuck.smoothWin = Double.NaN // re-seed the boxcar window from the first real speed
                 navPuck.fwdRejects = 0
+                reanchor = true
                 accepted = true
             } else {
                 // Monotonic forward only: ease in a plausible advance (speed × elapsed × 2.5 +
@@ -2494,6 +2533,11 @@ fun VelaMapView(
                         navPuck.fwdRejects += 1
                         if (navPuck.fwdRejects >= 2) {
                             navPuck.targetM = m
+                            // A persistent over-cap jump is a genuine discontinuity (a long fix
+                            // gap at speed), not noise to be averaged down — snap the position
+                            // filter to it, or the bounded correction would spend many seconds
+                            // walking the puck across a gap it should simply be on the far side of.
+                            reanchor = true
                             accepted = true
                         }
                     }
@@ -2509,9 +2553,17 @@ fun VelaMapView(
             navPuck.missCount = 0
             if (accepted) {
                 navPuck.targetAtMs = now // anchor for dead reckoning
-                navPuck.reckonedM = 0.0  // a fresh ACCEPTED fix re-anchors — the integral restarts
-                // (a REJECTED fix must NOT re-open the 2 s blind window: at a standstill that
+                // (a REJECTED fix must NOT re-open the blind window: at a standstill that
                 // re-armed the creep every second; the old anchor stays until a fix is accepted)
+                // ALONG-ROUTE POSITION FILTER, measurement step (issue #251). `targetM` above is
+                // still the raw accepted fix — the plausibility gate and the snap window are built
+                // on it and keep their hard-won behaviour. What the puck DRAWS now comes from
+                // `alongM`, which takes this fix as a measurement weighted by the fix's own
+                // reported accuracy against the estimate's grown variance. A clean 4 m fix pulls
+                // most of the way; a 25 m urban-canyon one barely moves it, which is exactly the
+                // fix that used to throw the puck a car-length down the road and back.
+                if (reanchor) navPuck.along.reseed(m, myAccuracyM)
+                else navPuck.along.update(m, myAccuracyM)
             }
             // The fix's OWN (spike-filtered) measurement is the Kalman MEASUREMENT; the
             // accelerometer steers between fixes (predict step in the frame ticker). Feeding the
@@ -4989,9 +5041,17 @@ private class NavPuck {
     var targetAtMs = 0L           // elapsedRealtime() the target was set — for dead reckoning
     var speed = 0.0               // m/s — the KALMAN speed (GPS ⊕ accelerometer), see [kalman]
     val kalman = app.vela.core.location.SpeedKalman() // GPS-fix measurement + accel prediction
-    var reckonedM = 0.0           // ∫speed·dt since the last fix — the dead-reckoned advance
+    // The puck's POSITION estimate (see AlongRouteFilter). Dead-reckons at the modelled speed each
+    // frame and takes each accepted fix as a variance-weighted MEASUREMENT, so along-route GPS
+    // noise is averaged down instead of driven straight into the puck — which is what writing the
+    // snapped fix into `targetM` and drawing from it used to do.
+    val along = app.vela.core.location.AlongRouteFilter()
+    var smoothWin = Double.NaN    // the along-route smoothing half-window ACTUALLY in use, eased —
+                                  // see the note at its use site: tying it straight to the live
+                                  // speed made speed noise into sideways puck movement
     var lastFixLoc: LatLng? = null // identity of the last INGESTED fix — the fix-processing block
-                                   // runs in a recomposing scope, and kalman.update/reckonedM=0 are
+                                   // runs in a recomposing scope, and kalman.update / the
+                                   // position-filter measurement step are
                                    // NOT idempotent: re-running them on a mere recomposition re-injects
                                    // a stale speed and re-opens the blind reckoning window
     var displayBearing = Float.NaN // smoothed heading actually drawn (NaN = not yet seeded)
@@ -5076,6 +5136,20 @@ private fun indexAtMeters(cum: DoubleArray, m: Double): Int {
 // Samples in the puck's along-route boxcar average; the half-window itself is speed-scaled at the
 // call site (5-14 m). Odd so the current position is one of the samples.
 private const val PUCK_SMOOTH_SAMPLES = 7
+
+/** Seconds the puck takes to absorb an along-route position error, spread over its own speed
+ *  rather than applied as a jump. Short enough that a real correction is not visibly late, long
+ *  enough that one noisy fix is not a lurch. */
+private const val PUCK_CORRECT_TIME_S = 0.6
+
+/** Time constant for the smoothing window's WIDTH. Deliberately long: the width is meant to track
+ *  the difference between town and motorway, not the difference between two consecutive fixes. */
+private const val PUCK_WIN_TAU_S = 2.5f
+
+/** How long the puck may dead-reckon on a stale fix. 3 s (was 2): some chipsets deliver fixes
+ *  2.5-3.5 s apart under canopy, and a 2 s cap made the puck glide-stall-lurch at exactly that
+ *  cadence. Still bounds a dropped-signal runaway to ~100 m at highway speed. */
+private const val DEAD_RECKON_S = 3.0
 
 private fun pointAtMeters(poly: List<LatLng>, cum: DoubleArray, meters: Double): Pair<LatLng, Float> {
     if (poly.size < 2) return (poly.firstOrNull() ?: LatLng(0.0, 0.0)) to 0f

--- a/core/src/main/java/app/vela/core/data/RouteGeometry.kt
+++ b/core/src/main/java/app/vela/core/data/RouteGeometry.kt
@@ -40,6 +40,11 @@ import okhttp3.Request
  */
 object RouteGeometry {
     private const val OSRM_BASE = "https://routing.openstreetmap.de"
+    /** We ask OSRM for `geometries=polyline6`. The default `polyline` is 1e5-scaled, i.e. a
+     *  1.11 m latitude grid — every vertex of a physically straight road snapped to a metre-ish
+     *  step, which the nav puck then has to smooth back out (issue #251). Verified supported by
+     *  the FOSSGIS community server: same vertex count, same distance, ten times the resolution. */
+    private const val OSRM_PRECISION = 6
     private const val OSRM_TRIES = 3 // FOSSGIS community server blips on mobile; a miss = nameless Google fallback
     // Max gap (m) between an exit ramp and a following fork/merge for them to count as ONE exit complex
     // (consolidateExits). Generous enough for a long ramp, short enough that a genuine km-away fork isn't folded.
@@ -82,7 +87,7 @@ object RouteGeometry {
         val backend = backend(mode) ?: return emptyList()
         val url = "$OSRM_BASE/$backend/route/v1/driving/" +
             "${origin.lng},${origin.lat};${dest.lng},${dest.lat}" +
-            "?overview=full&geometries=polyline" + if (alternatives) "&alternatives=3" else ""
+            "?overview=full&geometries=polyline6" + if (alternatives) "&alternatives=3" else ""
         val req = Request.Builder()
             .url(url)
             .header("User-Agent", VelaConfig.USER_AGENT)
@@ -92,7 +97,7 @@ object RouteGeometry {
             json.parseToJsonElement(resp.body?.string().orEmpty())
                 .jsonObject["routes"]?.jsonArray
                 ?.mapNotNull { it.jsonObject["geometry"]?.jsonPrimitive?.contentOrNull }
-                ?.map { PolylineCodec.decode(it) }
+                ?.map { PolylineCodec.decode(it, OSRM_PRECISION) }
                 ?.filter { it.size >= 2 }
                 ?: emptyList()
         }
@@ -183,7 +188,7 @@ object RouteGeometry {
         val backend = backend(mode) ?: return emptyList()
         val coords = points.joinToString(";") { "${it.lng},${it.lat}" }
         val url = "$OSRM_BASE/$backend/route/v1/driving/$coords" +
-            "?overview=full&geometries=polyline&steps=true" +
+            "?overview=full&geometries=polyline6&steps=true" +
             (if (alternatives) "&alternatives=3" else "") +
             excludeParam(mode, avoidTolls, avoidHighways)
         val req = Request.Builder().url(url).header("User-Agent", VelaConfig.USER_AGENT).build()
@@ -232,7 +237,7 @@ object RouteGeometry {
     }
 
     private fun parseOsrmRoute(r: JsonObject): Route? {
-        val poly = r["geometry"]?.jsonPrimitive?.contentOrNull?.let { PolylineCodec.decode(it) }
+        val poly = r["geometry"]?.jsonPrimitive?.contentOrNull?.let { PolylineCodec.decode(it, OSRM_PRECISION) }
             ?.takeIf { it.size >= 2 } ?: return null
         val dist = r["distance"]?.jsonPrimitive?.doubleOrNull ?: return null
         val dur = r["duration"]?.jsonPrimitive?.doubleOrNull ?: 0.0

--- a/core/src/main/java/app/vela/core/data/google/PolylineCodec.kt
+++ b/core/src/main/java/app/vela/core/data/google/PolylineCodec.kt
@@ -3,14 +3,21 @@ package app.vela.core.data.google
 import app.vela.core.model.LatLng
 
 /**
- * Google's Encoded Polyline Algorithm Format (1e5 precision). A stable, fully
- * specified format — the geometry inside a directions response is encoded
- * exactly this way, so [decode] is one of the few pieces here that needs no
- * calibration.
+ * Google's Encoded Polyline Algorithm Format. A stable, fully specified format — the geometry
+ * inside a directions response is encoded exactly this way, so [decode] is one of the few pieces
+ * here that needs no calibration.
+ *
+ * [precision] is the number of decimal places the coordinates were scaled by. Google always uses
+ * 5, which is the default and what every Google call site wants. OSRM can emit either, and Vela
+ * asks it for **6** — at 5, a latitude step is 1.11 m, so every route vertex is snapped to a
+ * metre-ish grid and a physically straight road arrives visibly kinked. That quantization is
+ * scatter the nav puck then has to smooth back out; asking for the extra digit removes it at the
+ * source and costs nothing (same vertex count, ~15% more characters).
  */
 object PolylineCodec {
 
-    fun decode(encoded: String): List<LatLng> {
+    fun decode(encoded: String, precision: Int = 5): List<LatLng> {
+        val scale = Math.pow(10.0, precision.toDouble())
         val path = ArrayList<LatLng>()
         var index = 0
         var lat = 0
@@ -35,7 +42,7 @@ object PolylineCodec {
             } while (b >= 0x20)
             lng += if (result and 1 != 0) (result shr 1).inv() else result shr 1
 
-            path.add(LatLng(lat / 1e5, lng / 1e5))
+            path.add(LatLng(lat / scale, lng / scale))
         }
         return path
     }

--- a/core/src/main/java/app/vela/core/location/AlongRouteFilter.kt
+++ b/core/src/main/java/app/vela/core/location/AlongRouteFilter.kt
@@ -1,0 +1,108 @@
+package app.vela.core.location
+
+/**
+ * 1-D Kalman filter over the nav puck's **along-route position** (metres travelled along the
+ * navigated polyline), the other half of [SpeedKalman].
+ *
+ * The puck's SPEED has been filtered since June; its POSITION never was. The snapped fix was
+ * written straight into the motion model, so every metre of along-route GPS noise was a metre the
+ * puck genuinely had to travel — once a second, for the whole drive. Smoothing downstream of that
+ * cannot help: a smoother makes the movement gentler, it does not make it stop happening. This is
+ * the missing measurement update (issue #251).
+ *
+ * The model is deliberately the simple one: the position is dead-reckoned forward at the modelled
+ * speed ([predict]) and its variance grows; a fix folds in ([update]) weighted by that variance
+ * against the fix's own reported accuracy. A clean 4 m fix pulls most of the way; a 25 m
+ * urban-canyon one barely moves the estimate, which is exactly the fix that used to throw the
+ * puck a car length down the road and back.
+ *
+ * The speed is NOT part of the state here — [SpeedKalman] already owns it, tuned and tested, and
+ * folding the two into one 2-state filter measured only marginally better than driving this one
+ * from that one, for a much larger change. Genuine DISCONTINUITIES (nav start, a re-acquire after
+ * an outage, a persistent over-cap jump) are not noise to be averaged down: the caller calls
+ * [reseed] and the estimate snaps.
+ *
+ * Pure math, no Android — unit-tested in `:core`. Units: seconds, metres, m/s.
+ */
+class AlongRouteFilter {
+
+    /** Filtered metres along the route. Meaningless until the first [reseed]. */
+    var alongM = 0.0
+        private set
+
+    /** Current estimate variance (m²) — how much doubt the estimate carries. */
+    var variance = 0.0
+        private set
+
+    var seeded = false
+        private set
+
+    /**
+     * Dead-reckon [advanceM] metres forward (the modelled speed integrated over this frame) and
+     * grow the doubt by [dt] seconds' worth. No-op until seeded.
+     */
+    fun predict(advanceM: Double, dt: Double) {
+        if (!seeded) return
+        if (advanceM > 0.0) alongM += advanceM
+        if (dt > 0.0) variance += Q * dt
+    }
+
+    /** Fold in a fix at [m] metres along the route, reported to [accuracyM] metres. */
+    fun update(m: Double, accuracyM: Float?) {
+        if (!seeded) return reseed(m, accuracyM)
+        val r = measurementVariance(accuracyM)
+        val k = variance / (variance + r)
+        alongM += k * (m - alongM)
+        variance = ((1.0 - k) * variance).coerceAtLeast(VAR_FLOOR)
+    }
+
+    /**
+     * Snap the estimate to [m] — for a genuine discontinuity (nav start, re-acquire after an
+     * outage, a persistent over-cap jump), which must NOT be averaged down like noise.
+     */
+    fun reseed(m: Double, accuracyM: Float?) {
+        alongM = m
+        variance = measurementVariance(accuracyM)
+        seeded = true
+    }
+
+    /** Forget everything (nav ended). */
+    fun reset() {
+        alongM = 0.0
+        variance = 0.0
+        seeded = false
+    }
+
+    companion object {
+        /**
+         * Measurement variance (m²) for one fix's along-route position, from its reported accuracy.
+         *
+         * `Location.getAccuracy` is a 68% horizontal RADIUS; for an isotropic 2-D error that puts
+         * the per-axis sigma at about `acc / 1.51`. Snapping to the route throws the LATERAL
+         * component away entirely, so what is left to filter is the along-route projection — hence
+         * the 0.66 factor rather than the raw radius. Floored at 2.5 m, because no fix deserves
+         * more trust than the road geometry it is being snapped onto, and the accuracy itself is
+         * clamped so one absurd reading can neither freeze nor blow up the estimate.
+         */
+        fun measurementVariance(accuracyM: Float?): Double {
+            val acc = (accuracyM ?: DEFAULT_ACC_M).toDouble().coerceIn(1.0, 60.0)
+            val sigma = (acc * 0.66).coerceAtLeast(2.5)
+            return sigma * sigma
+        }
+
+        /** Assumed accuracy (m) when a fix reports none — matches `NavEngine.DEFAULT_ACC_M`. */
+        const val DEFAULT_ACC_M = 12.0f
+
+        /**
+         * Variance growth while dead-reckoning (m² per second). Set from the speed estimate's own
+         * uncertainty — [SpeedKalman] settles around ±0.7 m/s, so a second of blind reckoning is
+         * worth about 0.5 m² of position doubt. Larger makes each fix pull harder (jumpier);
+         * smaller trusts the reckoning further (smoother, but slower to admit it was wrong).
+         */
+        const val Q = 0.5
+
+        /** Floor on the variance, so the estimate can never get so confident that a genuine
+         *  correction is locked out — the same guard [SpeedKalman] keeps on its own. */
+        const val VAR_FLOOR = 0.25
+    }
+}

--- a/core/src/main/java/app/vela/core/location/SpeedKalman.kt
+++ b/core/src/main/java/app/vela/core/location/SpeedKalman.kt
@@ -31,7 +31,7 @@ class SpeedKalman {
      *  + = speeding up along the travel bearing). Call per frame; no-op until the first fix. */
     fun predict(accel: Double, dt: Double) {
         if (!seeded || dt <= 0.0) return
-        val a = accel.coerceIn(-MAX_ACCEL, MAX_ACCEL) // a spike can't teleport the model
+        val a = denoise(accel).coerceIn(-MAX_ACCEL, MAX_ACCEL) // a spike can't teleport the model
         speed = (speed + a * dt).coerceAtLeast(0.0)
         // Uncertainty grows with time; faster when the (noisy) accelerometer is actively
         // steering the model, so the next GPS fix pulls harder after a hard brake/launch.
@@ -70,6 +70,33 @@ class SpeedKalman {
         seeded = false
     }
 
+    /**
+     * Shrink small accelerations toward zero before they are integrated (issue #251, the nav puck
+     * jitter that survived two other fixes).
+     *
+     * A phone in a car reads road texture, engine and mount resonance as acceleration along the
+     * travel bearing. This runs ONCE PER FRAME, so between two 1 Hz GPS fixes about sixty of those
+     * samples are integrated into the speed - and the puck advances at that speed, so the noise
+     * becomes visible movement. A steady 0.3 m/s2 of vibration bias is 0.3 m/s of phantom speed
+     * after one second, which is a few tenths of a metre of shimmer, repeatedly.
+     *
+     * The gain is `a^2 / (a^2 + noise^2)` - the standard suppression shape, and specifically NOT a
+     * subtract-the-floor shrinkage, which was tried first and BROKE an existing test:
+     * `brakingCollapsesThePredictionBetweenFixes` pins a 2 s brake at -4 m/s2, and shrinking every
+     * sample by the floor taxes a real brake by exactly that floor - weakening the one behaviour
+     * this filter exists for (the puck must decelerate WITH a stopping car). This shape leaves a
+     * 4 m/s2 brake within ~1.5% of itself while cutting a 0.3 m/s2 vibration to about a quarter,
+     * and it is smooth, so nothing chatters across a threshold the way a hard gate would.
+     *
+     * Residual: a STEADY small bias is attenuated, not erased (0.3 m/s2 leaves ~0.08 m/s after a
+     * second), which the next GPS fix corrects. Erasing it entirely was the shrinkage version, and
+     * it cost more than it bought.
+     */
+    private fun denoise(accel: Double): Double {
+        val a2 = accel * accel
+        return accel * (a2 / (a2 + ACCEL_NOISE * ACCEL_NOISE))
+    }
+
     private companion object {
         // Tuned so that with NO accelerometer (predict a=0) a fix still pulls ~2/3 of the way to
         // the GPS speed — the old code snapped to each fix outright, so the fallback must stay
@@ -78,6 +105,10 @@ class SpeedKalman {
         const val Q_BASE = 0.75   // variance growth per second, coasting
         const val Q_ACCEL = 0.5   // extra growth per (m/s²) of applied accel — accel is noisy
         const val MAX_ACCEL = 8.0 // beyond ±8 m/s² is sensor junk, not driving
+        // Accelerometer noise scale in a moving car (road texture, engine, mount resonance). Sets
+        // where [denoise]'s gain turns over: well below a real brake, at the level of the vibration
+        // that was reaching the puck 60 times a second.
+        const val ACCEL_NOISE = 0.5
         const val INIT_VAR = 4.0
         const val P_FLOOR = 0.05
     }

--- a/core/src/test/java/app/vela/core/AlongRouteFilterTest.kt
+++ b/core/src/test/java/app/vela/core/AlongRouteFilterTest.kt
@@ -1,0 +1,142 @@
+package app.vela.core
+
+import app.vela.core.location.AlongRouteFilter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+import kotlin.random.Random
+
+/**
+ * The along-route POSITION filter (issue #251). The puck used to take each snapped fix as its
+ * position outright, so along-route GPS noise was distance the puck actually travelled, once a
+ * second, all drive. These pin that the noise is averaged down without the estimate going deaf to
+ * a real correction.
+ */
+class AlongRouteFilterTest {
+
+    private val fps = 60
+    private val dt = 1.0 / fps
+
+    /** Drive [seconds] at [speed] m/s, one fix a second with Gaussian along-route noise. */
+    private fun drive(
+        seconds: Int,
+        speed: Double = 15.0,
+        noise: Double = 3.0,
+        accuracy: Float? = 4f,
+        seed: Int = 7,
+    ): Pair<Double, Double> { // (RMS error of the filtered estimate, RMS error of the raw fixes)
+        val rnd = Random(seed)
+        val f = AlongRouteFilter()
+        var truth = 0.0
+        var sumF = 0.0
+        var sumR = 0.0
+        var n = 0
+        f.reseed(0.0, accuracy)
+        repeat(seconds * fps) { i ->
+            truth += speed * dt
+            f.predict(speed * dt, dt)
+            if (i % fps == fps - 1) {
+                val z = truth + rnd.nextGaussian() * noise
+                f.update(z, accuracy)
+                sumR += (z - truth) * (z - truth)
+                sumF += (f.alongM - truth) * (f.alongM - truth)
+                n++
+            }
+        }
+        return Math.sqrt(sumF / n) to Math.sqrt(sumR / n)
+    }
+
+    private fun Random.nextGaussian(): Double {
+        var u = 0.0
+        var v = 0.0
+        var s = 0.0
+        while (s <= 0.0 || s >= 1.0) {
+            u = nextDouble() * 2 - 1; v = nextDouble() * 2 - 1; s = u * u + v * v
+        }
+        return u * Math.sqrt(-2.0 * Math.log(s) / s)
+    }
+
+    @Test fun `fix noise is averaged down, not driven into the puck`() {
+        val (filtered, raw) = drive(seconds = 120)
+        // The whole point: the estimate must be substantially steadier than the fixes feeding it.
+        assertTrue("filtered $filtered should be well under raw $raw", filtered < raw * 0.6)
+    }
+
+    @Test fun `a noisier fix stream is filtered harder`() {
+        val clean = drive(seconds = 120, noise = 3.0, accuracy = 4f).first
+        val canyon = drive(seconds = 120, noise = 12.0, accuracy = 20f).first
+        // Absolute error grows with the noise, but nothing like proportionally: 4x the noise
+        // must not be 4x the wobble, because the wider accuracy tells the filter to trust it less.
+        assertTrue("canyon $canyon vs clean $clean", canyon < clean * 4.0)
+    }
+
+    @Test fun `a wide accuracy moves the estimate less than a tight one`() {
+        fun pull(acc: Float): Double {
+            val f = AlongRouteFilter()
+            f.reseed(100.0, 4f)
+            f.predict(0.0, 1.0) // let a second of doubt build
+            f.update(120.0, acc) // a fix 20 m ahead
+            return f.alongM - 100.0
+        }
+        val tight = pull(3f)
+        val wide = pull(40f)
+        assertTrue("tight $tight should out-pull wide $wide", tight > wide * 2)
+        assertTrue("even a tight fix should not teleport the estimate", tight < 20.0)
+    }
+
+    @Test fun `dead reckoning carries the estimate between fixes`() {
+        val f = AlongRouteFilter()
+        f.reseed(0.0, 4f)
+        repeat(fps) { f.predict(15.0 * dt, dt) }
+        assertEquals(15.0, f.alongM, 0.001)
+    }
+
+    @Test fun `reseed snaps, because a discontinuity is not noise`() {
+        val f = AlongRouteFilter()
+        f.reseed(0.0, 4f)
+        repeat(10) { f.update(0.0, 4f) } // get confident
+        f.reseed(500.0, 4f)
+        assertEquals(500.0, f.alongM, 0.0)
+    }
+
+    @Test fun `the estimate never goes deaf to a real correction`() {
+        val f = AlongRouteFilter()
+        f.reseed(0.0, 4f)
+        // A long confident stretch, then the truth is genuinely 30 m ahead.
+        repeat(300) { f.predict(0.0, 1.0); f.update(0.0, 4f) }
+        assertTrue("variance floored", f.variance >= AlongRouteFilter.VAR_FLOOR)
+        var moved = 0.0
+        repeat(5) { f.predict(0.0, 1.0); f.update(30.0, 4f); moved = f.alongM }
+        assertTrue("should have closed most of a real 30 m error in 5 fixes, got $moved", moved > 20.0)
+    }
+
+    @Test fun `a steady drive tracks the truth closely`() {
+        val f = AlongRouteFilter()
+        var truth = 0.0
+        f.reseed(0.0, 4f)
+        repeat(60 * fps) { i ->
+            truth += 20.0 * dt
+            f.predict(20.0 * dt, dt)
+            if (i % fps == fps - 1) f.update(truth, 4f) // noiseless fixes
+        }
+        assertTrue("no drift on clean fixes: ${abs(f.alongM - truth)}", abs(f.alongM - truth) < 0.5)
+    }
+
+    @Test fun `measurement variance handles a missing or absurd accuracy`() {
+        val none = AlongRouteFilter.measurementVariance(null)
+        val typical = AlongRouteFilter.measurementVariance(AlongRouteFilter.DEFAULT_ACC_M)
+        assertEquals("null must fall back to the typical-GPS default", typical, none, 1e-9)
+        // A nonsense 0 m accuracy must not make the fix infinitely trusted.
+        assertTrue(AlongRouteFilter.measurementVariance(0f) >= 2.5 * 2.5)
+        // ...nor a 5 km one make it infinitely distrusted.
+        assertTrue(AlongRouteFilter.measurementVariance(5000f) <= 60.0 * 60.0)
+    }
+
+    @Test fun `predict is a no-op before the first seed`() {
+        val f = AlongRouteFilter()
+        f.predict(100.0, 1.0)
+        assertEquals(0.0, f.alongM, 0.0)
+        assertTrue(!f.seeded)
+    }
+}

--- a/core/src/test/java/app/vela/core/SpeedKalmanNoiseTest.kt
+++ b/core/src/test/java/app/vela/core/SpeedKalmanNoiseTest.kt
@@ -1,0 +1,70 @@
+package app.vela.core
+
+import app.vela.core.location.SpeedKalman
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Accelerometer noise must not reach the puck (issue #251, the jitter that survived two other
+ * fixes).
+ *
+ * predict() runs once per FRAME, so ~60 accelerometer samples are integrated between two 1 Hz GPS
+ * fixes. Whatever vibration survives into the speed estimate becomes visible puck movement, because
+ * the puck advances at that speed. These drive a second of frames the way a real drive does.
+ */
+class SpeedKalmanNoiseTest {
+
+    private val dt = 1.0 / 60.0
+
+    private fun seeded(at: Double = 20.0) = SpeedKalman().apply { update(at) }
+
+    @Test fun `a second of road vibration does not move the speed`() {
+        val k = seeded()
+        // Alternating +/-0.3 m/s2: vibration, not driving. It averages to zero, but the point is
+        // that it must not wander even transiently - every frame of it moves the drawn puck.
+        repeat(60) { i -> k.predict(if (i % 2 == 0) 0.3 else -0.3, dt) }
+        assertEquals("vibration must not accumulate", 20.0, k.speed, 0.001)
+    }
+
+    @Test fun `a steady vibration BIAS does not accumulate either`() {
+        // The nastier case: a mount that rings slightly forward reads as a constant small accel,
+        // and integrating that for a second is a phantom 0.3 m/s - which is the shimmer.
+        val k = seeded()
+        repeat(60) { k.predict(0.3, dt) }
+        // Attenuated, not erased - erasing it entirely meant taxing real braking by the same
+        // amount (see denoise). A tenth of a m/s over a whole second is well under what shows.
+        assertTrue("bias must be strongly attenuated, got ${k.speed - 20.0}", k.speed - 20.0 < 0.12)
+    }
+
+    @Test fun `a real brake still slows the puck`() {
+        // The whole reason this filter exists: without it the puck sails on at the last fix's speed
+        // while the car stops. That must survive the noise rejection.
+        val k = seeded(20.0)
+        repeat(60) { k.predict(-3.0, dt) }
+        assertTrue("a 3 m/s2 brake for 1 s should shed most of 3 m/s, got ${20.0 - k.speed}", 20.0 - k.speed > 2.5)
+    }
+
+    @Test fun `hard braking to a stop still reaches zero and never goes negative`() {
+        val k = seeded(8.0)
+        repeat(120) { k.predict(-6.0, dt) }
+        assertEquals(0.0, k.speed, 0.0001)
+    }
+
+    @Test fun `the threshold is continuous, so noise cannot chatter across it`() {
+        // A hard gate would jump between 0 and the full value as noise crossed the threshold,
+        // swapping a shimmer for a chatter. Just above the floor must give just above zero.
+        val a = seeded()
+        val b = seeded()
+        repeat(60) { a.predict(0.36, dt) }
+        repeat(60) { b.predict(0.34, dt) }
+        assertTrue("just-above-floor must be small, not a step", a.speed - 20.0 < 0.2)
+        assertTrue("just-below-floor must be smaller still", b.speed - 20.0 < a.speed - 20.0 + 0.01)
+    }
+
+    @Test fun `genuine acceleration still registers`() {
+        val k = seeded(5.0)
+        repeat(60) { k.predict(2.0, dt) }
+        assertTrue("2 m/s2 for 1 s should add most of 2 m/s, got ${k.speed - 5.0}", k.speed - 5.0 > 1.5)
+    }
+}


### PR DESCRIPTION
Real-drive report again on the canary, so I went back to the start rather than adding a fifth filter.

**The puck's speed has been Kalman filtered since June. Its position never was.** The snapped fix went straight into `targetM` and the puck was drawn from it, so every metre of along-route GPS noise was a metre the arrow genuinely had to travel, once a second, for the whole drive.

That is why four rounds of work on this did not fix it. A smoother makes that movement gentler; it cannot make it stop happening. The tell was that two of those rounds (#270 and #299) independently derived the same window fix without noticing each other.

### The fix

`AlongRouteFilter` (`:core`, 9 tests) is the missing measurement update. The estimate dead-reckons at the modelled speed and grows variance; each accepted fix folds in weighted by its **own reported accuracy**. `Location.getAccuracy` is a 68% radius and snapping throws the lateral component away, so the along-route sigma is about 0.66 of it. A clean 4 m fix pulls most of the way, a 25 m urban-canyon one barely moves the estimate.

`targetM` still takes the raw fix. The plausibility gate and the snap window are built on it and keep their hard-won behaviour. What the puck *draws* is now the filtered estimate. A genuine discontinuity (engage, re-acquire, a persistent over-cap jump) calls `reseed` instead, because a teleport is not noise to average down.

Progress is drawn in the **rate domain**. It used to ease toward a target and then get clamped monotonic, and those two fight: every fix reset the reckoning, an overshoot put the target *behind* the puck, the ease pulled backward, and the clamp froze it until the reckoning caught up. The puck now always advances at the modelled speed with the error as a bounded nudge to that rate, so it can neither stall nor lurch, and it is still monotonic.

Simulated against the old rule, 1 Hz fixes with 3 m noise at 60 fps:

| | stalled frames | frame-to-frame speed error | along-road wobble |
|---|---|---|---|
| main | 2.7% | 36% | 7.2 px |
| main, urban canyon | 27.8% | 111% | 27.1 px |
| this | **0%** | **3%** | **2.8 px** |
| this, urban canyon | **0%** | **8%** | **5.5 px** |

### Also folded in

Includes #282 (accelerometer noise model) and #291 (adaptive camera bearing damping) unchanged, and the window low-pass from #270. Supersedes #270, #282, #291 and #299.

Route geometry is now requested at `geometries=polyline6`. The default encoding is 1e5 scaled, a 1.11 m latitude grid, so Vela was manufacturing the kinks in straight roads that it then had to smooth back out. Verified on the FOSSGIS server: same vertex count, same distance, ten times the resolution. `TripLog` deliberately stays at 1e5, since changing it would misread every existing trip file by a factor of ten.

### Two things I expected to matter, and measured not to

Both were previously written up as major causes, so they are worth recording as closed:

- **Route vertex scatter.** Once the boxcar runs, geometry contributes about 0.02 px per frame of lateral swim on real OSRM routes. Measured on a highway and a town route.
- **The smoothing window's width ripple.** A one metre ripple moves the drawn point about 1 cm, which is sub-pixel at nav zoom. Worth keeping, not worth deriving a third time.

The honest reading is that the geometry was never the problem. The position estimate was.

### Verification

332 core tests pass. Canary built and installed on the 4a 5G. **Still needs a real drive**, which is the only thing that counts here; a demo drive cannot confirm it because its synthetic fixes have no GPS noise, which is precisely what this filters. The nav smoothness trace in Settings will show it numerically if anything is still off.

Closes #251.
