### PR TITLE
Trim the private ends off a recorded trip before sharing it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,19 @@ Defaults that make the safe path the easy one:
   audit/replay a multi-block trip against a single mashed route - that was the "arrow on another
   street / arrived mid-replay" corruption. NB replays of OLD trips faithfully play back the dirty
   fixes the old pipeline recorded (BeaconDB teleports) - judge the engine on fresh recordings.
+- **Sharing a trip trims its ends** (`core/replay/TripScrub`, 13 tests; Settings → Diagnostics →
+  a trip's Share). A trip leaks its owner's endpoints in SIX places, not one, and all six are
+  handled: the fixes, the `META` destination, the `META` **label** (trips are named after where
+  they went, so it is usually a street address), the maneuvers, the route polyline's start, and
+  the `S` spoken lines ("Arrive at ..."). It TRIMS rather than blurs: every fix within the chosen
+  radius of the start, the end, the destination and the user's Home/Work is deleted and the middle
+  kept at FULL precision, because rounding protects the ends weakly (a 1 km round still names a
+  block) while destroying the geometry the trip exists to diagnose. Timestamps are rebased to zero
+  (replay only ever uses the deltas). **Unknown line kinds are DROPPED, not passed through.** The
+  format is append-only, so a tag added later would otherwise be published by a scrubber written
+  before it existed: **if you add a line kind to `TripLog`, decide in `TripScrub` whether it is
+  safe to share.** The scrub is non-destructive (the on-device trip is never modified) and the
+  raw file is still reachable behind "Share full trace".
 - **Demo / simulate-driving mode** (Settings → Navigation, off by default, pref `demo_drive` in
   `vela_settings`). Drives a planned route as a SYNTHETIC GPS trace so nav can be shown/tested
   **anywhere** with no real fix - this is how the Davis `docs/screenshots/05-navigation.png` was shot

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -224,6 +224,18 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   building-footprint OVERLAY (the layer that fills OSM's gaps) had its colour hardcoded to Modern, so
   in Classic those houses stayed Google-navy while the OSM ones went grey; it now honours the palette
   too. Also, since the two sets currently diverge mostly in dark mode, the Settings hint says so.
+- ✅ **Share a recorded trip without sharing your front door (2026-09-01).** Share on a trip now
+  opens a trim dialog instead of exporting the raw CSV. **Share trimmed** (the default button)
+  deletes every fix within 200 / 400 / 800 m of the start, the end, the recorded destination and
+  your Home and Work, keeping the middle of the drive at full precision, plus the five other
+  places the same fact hides: the trip's *name* (trips are named after where they went), the
+  destination in the file header, the spoken lines at either end ("Arrive at …"), the maneuvers
+  in the trimmed zones, and the start of the saved route line. Timestamps are rebased to zero so
+  the file does not say when you drive. Unknown line kinds are dropped rather than passed through,
+  so a tag added to the format later cannot be published by a scrubber written before it existed.
+  The dialog shows what was removed and the first surviving coordinate before anything leaves the
+  device; **Share full trace** is still there, and the on-device copy is never modified.
+  `core/replay/TripScrub`, 13 tests.
 - ✅ **Google-style nav puck (2026-07-11).** The navigation arrow is a white chevron inside a
   filled bright-navy circle with a soft drop shadow (no white ring, per user feedback); it rotates
   about the exact GPS point. Replaces the bare blue chevron. **Enlarged twice from feedback

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -169,6 +169,19 @@ prompt asks for it on its own line.
   leaves the phone is if *you* tap **Share** on a trip and choose where to send it (the
   same user-initiated FileProvider export as the diagnostics log) - useful for handing a
   drive to a developer to debug a bad route.
+- **Share offers to trim the private ends first, and that is the default button.** A drive
+  starts and ends where you do, so publishing a raw trace publishes your front door. Choosing
+  **Share trimmed** deletes every recorded point within a distance you pick (200 / 400 / 800 m)
+  of the start, the end, the recorded destination, and your **Home and Work** if you have set
+  them, and with them the trip's name (trips are named after where they went, so it is usually
+  an address), the destination coordinate in the file header, the spoken directions at either
+  end, and the start of the saved route line. Timestamps are rebased to zero, so the file does
+  not say *when* you drive either. The middle of the drive is kept at **full precision**, because
+  that is the part a bug lives in. Rounding coordinates instead would protect the ends weakly
+  (a 1 km round still names a block) while destroying what the trace is for. The dialog shows
+  what it removed, and the first surviving coordinate, before anything leaves the device. The
+  untrimmed file is still available behind **Share full trace**, and the copy on your phone is
+  never modified.
 - Manage it in Settings → recorded trips have **Replay**, **Share**, and **Delete**;
   turning the switch off stops new recording. Off by default; you choose to enable it.
 

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -4173,6 +4173,57 @@ class MapViewModel @Inject constructor(
         }.getOrNull()
     }
 
+    /**
+     * Scrub a recorded trip for publication — trim the private ends off, see [TripScrub]. Returns
+     * what the scrub did (including the CSV) so the UI can show it BEFORE anything leaves the
+     * device, or null when the trip can't be read or is shorter than one trim zone.
+     *
+     * Home and Work are added as trim zones automatically when they're set: a drive that merely
+     * PASSES one of them leaks it just as thoroughly as one that starts there, and they're the two
+     * places most worth protecting.
+     */
+    fun scrubTripForSharing(
+        meta: app.vela.replay.TripMeta,
+        radiusM: Double = app.vela.core.replay.TripScrub.DEFAULT_RADIUS_M,
+    ): app.vela.core.replay.TripScrub.Report? {
+        val csv = tripStore.rawCsv(meta.id) ?: return null
+        val zones = listOfNotNull(
+            shortcutStore.get(ShortcutKind.HOME)?.location,
+            shortcutStore.get(ShortcutKind.WORK)?.location,
+        )
+        return runCatching {
+            app.vela.core.replay.TripScrub.scrub(csv, radiusM = radiusM, extraZones = zones)
+        }.getOrNull()
+    }
+
+    /**
+     * A share intent for an already-scrubbed trip. Deliberately separate from [exportTripIntent]:
+     * the filename and the subject line of that one both carry the trip's LABEL and id, and the
+     * label is the destination's own name (trips are named after where they went) while the id is
+     * its start timestamp. Sharing a scrubbed body under a filename that names the address would
+     * defeat the whole thing.
+     */
+    fun shareScrubbedTripIntent(report: app.vela.core.replay.TripScrub.Report): android.content.Intent? =
+        runCatching {
+            val dir = java.io.File(appContext.cacheDir, "export").apply { mkdirs() }
+            val file = java.io.File(dir, "vela-trip-shared.csv")
+            file.writeText(report.csv)
+            val uri = androidx.core.content.FileProvider.getUriForFile(
+                appContext, "${appContext.packageName}.fileprovider", file,
+            )
+            val send = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                type = "text/csv"
+                putExtra(android.content.Intent.EXTRA_STREAM, uri)
+                putExtra(
+                    android.content.Intent.EXTRA_SUBJECT,
+                    appContext.getString(R.string.mapvm_export_trip_scrubbed_subject, report.fixesAfter),
+                )
+                addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            android.content.Intent.createChooser(send, appContext.getString(R.string.mapvm_share_trip_chooser))
+                .apply { addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK) }
+        }.getOrNull()
+
     /** Dismiss the arrival summary and return to a clean map (drops the finished
      *  route + selection). */
     fun finishNav() {

--- a/app/src/main/java/app/vela/ui/settings/sections/DiagnosticsSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/DiagnosticsSettings.kt
@@ -132,6 +132,7 @@ internal fun DiagnosticsSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onC
         // so it's a separate opt-in. Records nav GPS traces for replay testing.
         LaunchedEffect(Unit) { vm.refreshTripRecording() }
         var showTripConsent by remember { mutableStateOf(false) }
+        var shareTrip by remember { mutableStateOf<app.vela.replay.TripMeta?>(null) }
         var trips by remember { mutableStateOf(vm.recordedTrips()) }
         // Re-read on entry so a trip recorded since the app launched shows up without
         // a restart (the list was otherwise only refreshed after a delete).
@@ -165,12 +166,12 @@ internal fun DiagnosticsSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onC
                     // the trio drives its own LEFT/RIGHT (issue #24 pattern).
                     val tripFocus = remember(t.id) { List(3) { FocusRequester() } }
                     TextButton(modifier = Modifier.dpadRowSibling(tripFocus, 0), onClick = { vm.replayTrip(t); onCloseSettings() }) { Text(stringResource(R.string.settings_trip_replay)) }
-                    // Share the raw trace off-device - works on release builds, so a
-                    // drive can be handed over for replay/debug without a dev build.
+                    // Share the trace off-device - works on release builds, so a drive can be
+                    // handed over for replay/debug without a dev build. Opens the trim dialog
+                    // rather than sharing outright: a raw trip starts and ends at its owner's
+                    // front door, and that decision should be made deliberately every time.
                     TextButton(modifier = Modifier.dpadRowSibling(tripFocus, 1), onClick = {
-                        val intent = vm.exportTripIntent(t)
-                        if (intent != null) runCatching { context.startActivity(intent) }
-                        else android.widget.Toast.makeText(context, context.getString(R.string.settings_trip_read_error), android.widget.Toast.LENGTH_SHORT).show()
+                        shareTrip = t
                     }) { Text(stringResource(R.string.settings_trip_share)) }
                     IconButton(modifier = Modifier.dpadHighlight(androidx.compose.foundation.shape.CircleShape).dpadRowSibling(tripFocus, 2), onClick = { vm.deleteTrip(t.id); trips = vm.recordedTrips() }) {
                         Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.settings_trip_delete))
@@ -181,6 +182,7 @@ internal fun DiagnosticsSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onC
             Hint(stringResource(R.string.settings_no_trips_hint))
         }
         }
+        shareTrip?.let { meta -> TripShareDialog(meta, vm, context) { shareTrip = null } }
         if (showTripConsent) {
             app.vela.ui.VelaDialog(
                 onDismissRequest = { showTripConsent = false },
@@ -245,5 +247,105 @@ internal fun DiagnosticsSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onC
             )
         }
         Spacer(Modifier.height(24.dp))
+    }
+}
+
+/**
+ * The trim-before-you-share dialog for one recorded trip.
+ *
+ * A trip CSV is raw GPS whose first and last fixes are, almost always, exactly the places its
+ * owner would least like published. This is the deliberate moment to decide that: the trimmed
+ * share is the prominent button, the full trace stays available but has to be reached for, and
+ * the summary says what is actually being removed *before* anything leaves the device — including
+ * the first surviving coordinate, which is the one thing worth eyeballing yourself.
+ */
+@Composable
+private fun TripShareDialog(
+    meta: app.vela.replay.TripMeta,
+    vm: MapViewModel,
+    context: android.content.Context,
+    onClose: () -> Unit,
+) {
+    var radius by remember { mutableStateOf(app.vela.core.replay.TripScrub.DEFAULT_RADIUS_M) }
+    val report = remember(meta.id, radius) { vm.scrubTripForSharing(meta, radius) }
+    app.vela.ui.VelaDialog(
+        onDismissRequest = onClose,
+        title = stringResource(R.string.settings_trip_share_title),
+        confirmText = stringResource(R.string.settings_trip_share_trimmed),
+        onConfirm = {
+            val r = report
+            val intent = r?.let { vm.shareScrubbedTripIntent(it) }
+            if (intent != null) runCatching { context.startActivity(intent) }
+            else android.widget.Toast.makeText(
+                context, context.getString(R.string.settings_trip_read_error), android.widget.Toast.LENGTH_SHORT,
+            ).show()
+            onClose()
+        },
+        dismissText = stringResource(R.string.settings_cancel),
+        onDismiss = onClose,
+    ) {
+        Column(Modifier.fillMaxWidth()) {
+            Text(
+                stringResource(R.string.settings_trip_share_explain),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                stringResource(R.string.settings_trip_share_radius),
+                style = MaterialTheme.typography.labelLarge,
+            )
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                for (m in listOf(200.0, 400.0, 800.0)) {
+                    if (m == radius) {
+                        FilledTonalButton(onClick = { radius = m }) {
+                            Text(stringResource(R.string.settings_trip_share_radius_m, m.toInt()))
+                        }
+                    } else {
+                        TextButton(onClick = { radius = m }) {
+                            Text(stringResource(R.string.settings_trip_share_radius_m, m.toInt()))
+                        }
+                    }
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+            if (report == null) {
+                Text(
+                    stringResource(R.string.settings_trip_scrub_short),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            } else {
+                Text(
+                    stringResource(
+                        R.string.settings_trip_share_summary,
+                        report.fixesRemoved, report.fixesAfter,
+                        report.trimmedStartM.toInt(), report.trimmedEndM.toInt(),
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(Modifier.height(6.dp))
+                Hint(stringResource(R.string.settings_trip_share_also))
+                report.firstRemaining?.let { p ->
+                    Spacer(Modifier.height(6.dp))
+                    Hint(
+                        stringResource(
+                            R.string.settings_trip_share_first,
+                            String.format(java.util.Locale.US, "%.5f", p.lat),
+                            String.format(java.util.Locale.US, "%.5f", p.lng),
+                        ),
+                    )
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+            // Still reachable, but it is the reach: this is the file that names your front door.
+            TextButton(onClick = {
+                val intent = vm.exportTripIntent(meta)
+                if (intent != null) runCatching { context.startActivity(intent) }
+                else android.widget.Toast.makeText(
+                    context, context.getString(R.string.settings_trip_read_error), android.widget.Toast.LENGTH_SHORT,
+                ).show()
+                onClose()
+            }) { Text(stringResource(R.string.settings_trip_share_full)) }
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,6 +184,18 @@
     <string name="settings_trip_replay">Replay</string>
     <string name="settings_trip_read_error">Couldn\'t read that trip</string>
     <string name="settings_trip_share">Share</string>
+    <string name="settings_trip_share_title">Share this trip</string>
+    <string name="settings_trip_share_explain">A recorded drive starts and ends where you do. Trimming deletes every fix near the start, the end, the destination and your Home and Work, keeping the middle at full precision.</string>
+    <string name="settings_trip_share_radius">Trim distance</string>
+    <string name="settings_trip_share_radius_m">%1$d m</string>
+    <!-- 1: fixes removed, 2: fixes kept, 3: metres off the start, 4: metres off the end -->
+    <string name="settings_trip_share_summary">Removes %1$d of the recorded points, keeping %2$d. That is %3$d m off the start and %4$d m off the end.</string>
+    <string name="settings_trip_share_also">The destination, trip name, spoken directions at either end and the start of the route line go too. Times are rebased so the file does not say when you drove.</string>
+    <!-- 1: latitude, 2: longitude -->
+    <string name="settings_trip_share_first">First remaining point: %1$s, %2$s. Check it is not somewhere that identifies you.</string>
+    <string name="settings_trip_share_trimmed">Share trimmed</string>
+    <string name="settings_trip_share_full">Share full trace</string>
+    <string name="settings_trip_scrub_short">This drive is shorter than the trim distance, so there is no middle left to share. Try a smaller one.</string>
     <string name="settings_trip_delete">Delete trip</string>
     <string name="settings_no_trips_hint">No trips recorded yet. Navigate somewhere with this on and it\'ll show up here to replay.</string>
     <string name="settings_trip_consent_title">Save your trips?</string>
@@ -493,6 +505,7 @@
     <string name="mapvm_export_saved_subject">Vela saved places (%1$d)</string> <!-- format -->
     <string name="mapvm_export_saved_chooser">Export saved places</string>
     <string name="mapvm_export_trip_subject">Vela trip: %1$s (%2$d points)</string> <!-- format -->
+    <string name="mapvm_export_trip_scrubbed_subject">Vela trip: %1$d points, ends trimmed</string> <!-- format -->
     <string name="mapvm_share_trip_chooser">Share trip</string>
     <string name="mapvm_voice_sample">In a quarter mile, turn right onto Main Street.</string>
     <string name="mapvm_not_enough_space">Not enough free space for %1$s (%2$d MB)</string> <!-- format -->

--- a/core/src/main/java/app/vela/core/replay/TripScrub.kt
+++ b/core/src/main/java/app/vela/core/replay/TripScrub.kt
@@ -1,0 +1,226 @@
+package app.vela.core.replay
+
+import app.vela.core.data.google.PolylineCodec
+import app.vela.core.model.LatLng
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Make a recorded trip safe to publish, by removing its ends rather than blurring them.
+ *
+ * A trip CSV is raw GPS, and its first and last fixes are almost always the two places their
+ * owner would least like online — home, work, a friend's house. The MIDDLE of the drive is where
+ * a nav bug lives, and that part is just roads.
+ *
+ * So this **trims**: every fix within [radiusM] of the start, the end, the recorded destination
+ * and any [extraZones] is deleted outright, and everything between is left at FULL precision.
+ * Rounding coordinates instead would protect the endpoints only weakly (a 1 km round still names
+ * a block) while destroying the geometry the trip was recorded to diagnose. Trimming gives up
+ * nothing that matters and gives away nothing that does.
+ *
+ * The other lines leak the same fact in other clothes, and all of them are handled:
+ * - the `META` **destination** is on a drive home exactly the address being protected, and can sit
+ *   outside the radius around the last FIX (recording stops at the curb, or early);
+ * - the `META` **label** is the destination's own name — trips are named after where they went,
+ *   so it is frequently a street address in plain text;
+ * - the route polyline starts at the driveway;
+ * - maneuvers carry a position AND an instruction that names the street it is on;
+ * - `S` lines are what the voice actually SPOKE, which includes "Arrive at …" and the turns onto
+ *   the home street.
+ *
+ * Timestamps are rebased so the first surviving fix is at zero. Replay only ever uses the
+ * *differences* between them, so this costs nothing and stops a published file from saying
+ * exactly when its author drives.
+ *
+ * Unknown line kinds are DROPPED, not passed through. The format is deliberately append-only, so
+ * a tag added later would otherwise be published by a scrubber written before it existed. If you
+ * add a line kind to [TripLog], decide here whether it is safe to share.
+ */
+object TripScrub {
+
+    /** Metres trimmed around each private place by default. */
+    const val DEFAULT_RADIUS_M = 400.0
+
+    /** What a scrub did, so it can be shown before anything leaves the device. */
+    data class Report(
+        val csv: String,
+        val fixesBefore: Int,
+        val fixesAfter: Int,
+        val trimmedStartM: Double,
+        val trimmedEndM: Double,
+        /** The first fix that SURVIVED — the thing to eyeball before publishing. */
+        val firstRemaining: LatLng?,
+        val maneuversDropped: Int,
+        val spokenDropped: Int,
+        val routeTrimmed: Boolean,
+        val otherLinesDropped: Int,
+    ) {
+        val fixesRemoved: Int get() = fixesBefore - fixesAfter
+    }
+
+    /**
+     * Scrub [csv]. Returns null when the trip has no fixes at all, or when *every* fix falls
+     * inside a trim zone — a drive shorter than the radius has no shareable middle, and quietly
+     * emitting an empty file would be the wrong answer to that.
+     */
+    fun scrub(
+        csv: String,
+        radiusM: Double = DEFAULT_RADIUS_M,
+        extraZones: List<LatLng> = emptyList(),
+        label: String = "Shared trip",
+    ): Report? {
+        val lines = csv.split('\n').filter { it.isNotBlank() }
+        val fixes = lines.mapNotNull { line -> parseFix(line)?.let { line to it } }
+        if (fixes.isEmpty()) return null
+
+        val parsed = TripLog.parse(csv)
+        val zones = buildList {
+            add(fixes.first().second.latLng)
+            add(fixes.last().second.latLng)
+            parsed.dest?.let { add(it) }
+            addAll(extraZones)
+        }
+        fun private(p: LatLng) = zones.any { haversine(p, it) <= radiusM }
+
+        val kept = fixes.filterNot { private(it.second.latLng) }
+        if (kept.isEmpty()) return null
+
+        // Everything is expressed against the first SURVIVING fix, so the published file carries
+        // no absolute wall-clock at all.
+        val tZero = kept.first().second.t
+        val keptFrom = kept.first().second.t
+        val keptTo = kept.last().second.t
+
+        var maneuversDropped = 0
+        var spokenDropped = 0
+        var routeTrimmed = false
+        var otherDropped = 0
+        val out = StringBuilder()
+
+        for (line in lines) {
+            val fix = parseFix(line)
+            if (fix != null) {
+                if (private(fix.latLng)) continue
+                out.append(rebaseFix(line, tZero)).append('\n')
+                continue
+            }
+            when (line.substringBefore(',')) {
+                "META" -> {
+                    // Keep the start time slot (rebased to 0) and the version code — which build
+                    // recorded a trip is the single most useful thing about it for diagnosis —
+                    // and drop the label and the destination, which are both the address.
+                    val f = line.split(',')
+                    val version = f.getOrNull(5).orEmpty()
+                    val safeLabel = label.replace(',', ' ').replace('\n', ' ').take(80).ifBlank { "Shared trip" }
+                    out.append("META,$safeLabel,0,,,$version\n")
+                }
+                "RP" -> {
+                    // The route line starts at the driveway. Keep its longest run of vertices that
+                    // is entirely outside every zone, so what is left is contiguous rather than a
+                    // line that teleports across a removed section.
+                    val poly = runCatching { PolylineCodec.decode(line.substring(3)) }.getOrDefault(emptyList())
+                    val run = longestPublicRun(poly, ::private)
+                    if (run.size != poly.size) routeTrimmed = true
+                    if (run.size >= 2) out.append("RP,").append(PolylineCodec.encode(run)).append('\n')
+                }
+                // Distance and duration totals identify nothing on their own and are needed to
+                // make sense of the trace.
+                "RD" -> out.append(line).append('\n')
+                "M" -> {
+                    val f = line.split(',', limit = 6)
+                    val lat = f.getOrNull(2)?.toDoubleOrNull()
+                    val lng = f.getOrNull(3)?.toDoubleOrNull()
+                    if (lat == null || lng == null || private(LatLng(lat, lng))) maneuversDropped++
+                    else out.append(line).append('\n')
+                }
+                "S" -> {
+                    // Spoken lines outside the surviving window are the ones that name the
+                    // destination and the streets at either end.
+                    val t = line.split(',').getOrNull(1)?.toLongOrNull()
+                    if (t == null || t < keptFrom || t > keptTo) spokenDropped++
+                    else out.append(rebaseEvent(line, tZero)).append('\n')
+                }
+                // Frame pacing and battery carry no position.
+                "J", "B" -> {
+                    val t = line.split(',').getOrNull(1)?.toLongOrNull()
+                    if (t == null || t < keptFrom || t > keptTo) otherDropped++
+                    else out.append(rebaseEvent(line, tZero)).append('\n')
+                }
+                else -> otherDropped++
+            }
+        }
+
+        return Report(
+            csv = out.toString(),
+            fixesBefore = fixes.size,
+            fixesAfter = kept.size,
+            trimmedStartM = haversine(fixes.first().second.latLng, kept.first().second.latLng),
+            trimmedEndM = haversine(fixes.last().second.latLng, kept.last().second.latLng),
+            firstRemaining = kept.first().second.latLng,
+            maneuversDropped = maneuversDropped,
+            spokenDropped = spokenDropped,
+            routeTrimmed = routeTrimmed,
+            otherLinesDropped = otherDropped,
+        )
+    }
+
+    /** The longest contiguous run of vertices with no private one in it. */
+    private fun longestPublicRun(poly: List<LatLng>, private: (LatLng) -> Boolean): List<LatLng> {
+        var bestStart = 0
+        var bestLen = 0
+        var start = 0
+        var len = 0
+        for (i in poly.indices) {
+            if (private(poly[i])) {
+                start = i + 1
+                len = 0
+            } else {
+                len++
+                if (len > bestLen) { bestLen = len; bestStart = start }
+            }
+        }
+        return if (bestLen <= 0) emptyList() else poly.subList(bestStart, bestStart + bestLen)
+    }
+
+    private fun parseFix(line: String): TripLog.Point? {
+        val p = line.split(',')
+        if (p.size < 5) return null
+        val lat = p[0].toDoubleOrNull() ?: return null
+        val lng = p[1].toDoubleOrNull() ?: return null
+        if (lat !in -90.0..90.0 || lng !in -180.0..180.0) return null
+        return TripLog.Point(
+            lat, lng, p[2].toLongOrNull() ?: 0L, p[3].toFloatOrNull() ?: 0f, p[4].toFloatOrNull() ?: 0f,
+            offRoute = p.getOrNull(5) == "1",
+            accuracyM = p.getOrNull(6)?.toFloatOrNull(),
+        )
+    }
+
+    /** A fix line with field 2 (its timestamp) rebased; every other field is untouched. */
+    private fun rebaseFix(line: String, tZero: Long): String {
+        val f = line.split(',').toMutableList()
+        f[2] = ((f[2].toLongOrNull() ?: 0L) - tZero).toString()
+        return f.joinToString(",")
+    }
+
+    /** An event line (`S`/`J`/`B`) with field 1 (its timestamp) rebased. The text may hold
+     *  commas, so only the first two fields are touched. */
+    private fun rebaseEvent(line: String, tZero: Long): String {
+        val f = line.split(',', limit = 3)
+        if (f.size < 2) return line
+        val t = ((f[1].toLongOrNull() ?: 0L) - tZero).toString()
+        return if (f.size == 2) "${f[0]},$t" else "${f[0]},$t,${f[2]}"
+    }
+
+    private fun haversine(a: LatLng, b: LatLng): Double {
+        val r = 6_371_000.0
+        val p1 = Math.toRadians(a.lat)
+        val p2 = Math.toRadians(b.lat)
+        val dp = p2 - p1
+        val dl = Math.toRadians(b.lng - a.lng)
+        val h = sin(dp / 2) * sin(dp / 2) + cos(p1) * cos(p2) * sin(dl / 2) * sin(dl / 2)
+        return 2 * r * asin(min(1.0, sqrt(h)))
+    }
+}

--- a/core/src/test/java/app/vela/core/replay/TripScrubTest.kt
+++ b/core/src/test/java/app/vela/core/replay/TripScrubTest.kt
@@ -1,0 +1,168 @@
+package app.vela.core.replay
+
+import app.vela.core.model.LatLng
+import app.vela.core.model.Maneuver
+import app.vela.core.model.ManeuverType
+import app.vela.core.model.Route
+import app.vela.core.model.RouteLeg
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Publishing a recorded drive must not publish where its author lives.
+ *
+ * A trip leaks its endpoints in five different places, not one, and a scrubber that closes only
+ * the obvious one is worse than none — it hands over a file its owner has been told is safe.
+ * Most of the tests here are one of those five.
+ *
+ * Fixtures are the repo's standard Davis / Sacramento box (see the location-hygiene note in
+ * CLAUDE.md): a straight eastward run along a line of latitude, ~28 m between fixes.
+ */
+class TripScrubTest {
+
+    private val originLat = 38.5449
+    private val originLng = -121.7405
+    private val step = 0.00032 // ~28 m of longitude at this latitude
+
+    /** A synthetic drive of [n] fixes heading east from the "home" origin. */
+    private fun trip(
+        n: Int = 200,
+        label: String = "1451 W Covell Blvd",
+    ): String = buildString {
+        val poly = (0 until n).map { LatLng(originLat, originLng + step * it) }
+        val dest = poly.last()
+        append("META,$label,1756700000000,${dest.lat},${dest.lng},2770\n")
+        append(
+            TripLog.encodeRoute(
+                Route(
+                    poly,
+                    listOf(
+                        RouteLeg(
+                            5000.0, 300.0, null,
+                            listOf(
+                                Maneuver(ManeuverType.DEPART, "Head east on Sesame Street", poly.first(), 100.0, 0.0),
+                                Maneuver(ManeuverType.TURN_RIGHT, "Turn right onto Midpoint Road", poly[n / 2], 100.0, 0.0),
+                                Maneuver(ManeuverType.ARRIVE, "Arrive at 1451 W Covell Blvd", poly.last(), 0.0, 0.0),
+                            ),
+                        ),
+                    ),
+                    5000.0, 300.0, null,
+                ),
+                "start",
+            ),
+        )
+        append("S,1756700000000,Head east on Sesame Street\n")
+        append("S,1756700100000,Turn right onto Midpoint Road\n")
+        append("S,1756700199000,Arriving at 1451 W Covell Blvd\n")
+        append("B,1756700100000,84\n")
+        for (i in 0 until n) {
+            append("$originLat,${originLng + step * i},${1756700000000L + i * 1000},90,15,0,4.0\n")
+        }
+    }
+
+    private fun scrub(csv: String = trip(), radius: Double = 400.0) = TripScrub.scrub(csv, radiusM = radius)
+
+    @Test fun `the ends of the drive are gone entirely`() {
+        val r = scrub()!!
+        assertTrue("something must survive", r.fixesAfter > 0)
+        assertTrue("fixes must have been removed", r.fixesRemoved > 0)
+        assertTrue("start trimmed by roughly the radius", r.trimmedStartM > 350.0)
+        assertTrue("end trimmed by roughly the radius", r.trimmedEndM > 350.0)
+        val pts = TripLog.parsePoints(r.csv.split('\n'))
+        val home = LatLng(originLat, originLng)
+        assertTrue("no surviving fix may be near home", pts.none { dist(it.latLng, home) <= 400.0 })
+    }
+
+    @Test fun `the destination coordinate is stripped from the header`() {
+        assertNull(TripLog.parse(scrub()!!.csv).dest)
+    }
+
+    @Test fun `the label is stripped, because trips are named after where they went`() {
+        val r = scrub()!!
+        assertTrue("the address must not survive in the label", !r.csv.contains("1451 W Covell"))
+        assertEquals("Shared trip", TripLog.parse(r.csv).label)
+    }
+
+    @Test fun `spoken lines naming the destination are dropped`() {
+        val r = scrub()!!
+        assertTrue("the arrival announcement names the address", !r.csv.contains("Arriving at"))
+        assertTrue("the departure street is named too", !r.csv.contains("Sesame Street"))
+        assertTrue("but the middle of the drive survives", r.csv.contains("Midpoint Road"))
+        assertTrue(r.spokenDropped >= 2)
+    }
+
+    @Test fun `maneuvers at either end are dropped, the middle one is kept`() {
+        val r = scrub()!!
+        assertEquals(2, r.maneuversDropped)
+        val route = TripLog.parseRoute(r.csv.split('\n'))
+        assertNotNull(route)
+        assertTrue(route!!.maneuvers.none { it.instruction.contains("1451 W Covell") })
+    }
+
+    @Test fun `the route line no longer starts at the door`() {
+        val r = scrub()!!
+        assertTrue(r.routeTrimmed)
+        val poly = TripLog.parseRoute(r.csv.split('\n'))!!.polyline
+        val home = LatLng(originLat, originLng)
+        assertTrue("route must not enter the trim zone", poly.none { dist(it, home) <= 400.0 })
+        assertTrue("...and must still be a usable line", poly.size >= 2)
+    }
+
+    @Test fun `timestamps are rebased so the file does not say when its author drives`() {
+        val r = scrub()!!
+        assertEquals(0L, TripLog.parse(r.csv).startedAt)
+        val pts = TripLog.parsePoints(r.csv.split('\n'))
+        assertEquals("first surviving fix sits at zero", 0L, pts.first().t)
+        assertTrue("later fixes keep their spacing", pts.last().t > 0)
+        assertTrue("no absolute wall-clock survives", !r.csv.contains("17567000"))
+    }
+
+    @Test fun `the scrubbed trip still parses and still replays`() {
+        val p = TripLog.parse(scrub()!!.csv)
+        assertTrue("fixes survive", p.points.size > 10)
+        assertNotNull("a route survives", p.route)
+        val gaps = p.points.zipWithNext { a, b -> b.t - a.t }
+        assertTrue("all gaps stay positive and sane", gaps.all { it in 1..5000 })
+    }
+
+    @Test fun `the build that recorded the trip is preserved`() {
+        assertTrue("versionCode identifies nobody and is diagnosis-critical", scrub()!!.csv.contains(",2770"))
+    }
+
+    @Test fun `a drive entirely inside the radius is refused, not silently emptied`() {
+        assertNull(scrub(trip(n = 10), radius = 400.0))
+    }
+
+    @Test fun `a trip with no fixes is refused`() {
+        assertNull(TripScrub.scrub("META,x,0,,,\n"))
+    }
+
+    @Test fun `an unknown line kind is dropped rather than published`() {
+        val csv = trip().replace("B,1756700100000,84\n", "B,1756700100000,84\nZZ,1756700100000,something new\n")
+        val r = TripScrub.scrub(csv)!!
+        assertTrue("a tag this scrubber predates must not pass through", !r.csv.contains("something new"))
+        assertTrue(r.otherLinesDropped >= 1)
+    }
+
+    @Test fun `an extra private place is trimmed too`() {
+        val mid = LatLng(originLat, originLng + step * 100)
+        val plain = TripScrub.scrub(trip())!!
+        val withWork = TripScrub.scrub(trip(), extraZones = listOf(mid))!!
+        assertTrue("naming a third place must remove more", withWork.fixesAfter < plain.fixesAfter)
+        assertTrue(TripLog.parsePoints(withWork.csv.split('\n')).none { dist(it.latLng, mid) <= 400.0 })
+    }
+
+    private fun dist(a: LatLng, b: LatLng): Double {
+        val r = 6_371_000.0
+        val p1 = Math.toRadians(a.lat)
+        val p2 = Math.toRadians(b.lat)
+        val dp = p2 - p1
+        val dl = Math.toRadians(b.lng - a.lng)
+        val h = Math.sin(dp / 2) * Math.sin(dp / 2) +
+            Math.cos(p1) * Math.cos(p2) * Math.sin(dl / 2) * Math.sin(dl / 2)
+        return 2 * r * Math.asin(Math.min(1.0, Math.sqrt(h)))
+    }
+}


### PR DESCRIPTION
So a recorded drive can be posted publicly. In the app, on trips already saved, which is what #292 could not do from a desktop script.

Share on a trip used to hand over the raw CSV. A drive starts and ends where you do, so that published your front door.

Share now opens a dialog and the trimmed option is the default button. It deletes every fix within a distance you pick (200, 400 or 800 m) of the start, the end, the recorded destination, and your **Home and Work** when they are set. A drive that merely passes one of those leaks it just as thoroughly as one that starts there.

**It trims rather than blurs.** The middle of the drive is kept at full precision, because that is the part a bug lives in. Rounding coordinates instead would protect the ends only weakly, since a 1 km round still names a block, while destroying the geometry the trace was recorded to diagnose.

### The endpoints hide in six places, not one

This is the part worth reviewing. A scrubber that closes only the obvious one is worse than none, because it hands someone a file they have been told is safe.

1. the fixes themselves
2. the destination coordinate in the `META` header
3. **the trip name**, which is `selected?.name`, the destination's own name, so usually a street address in plain text
4. the maneuvers inside a trimmed zone, instruction text and all
5. the start of the saved route polyline
6. **the `S` lines**, which are what the voice actually spoke, including "Arrive at ..." and the turns onto the home street

Items 3 and 6 are the two the script in #292 passes straight through. I only found them by running a real trip through it and reading the output.

Timestamps are rebased so the first surviving fix sits at zero. Replay only uses the differences between them, so this costs nothing and stops a published file saying when its author drives.

**Unknown line kinds are dropped rather than passed through.** The format is append-only, so a tag added later would otherwise be published by a scrubber written before it existed. There is a note on `TripLog` saying so.

### Non-destructive

The copy on the phone is never modified, and the untrimmed file stays reachable behind a quieter "Share full trace" button. The scrubbed export also gets a neutral filename and subject line, since the existing export path puts the trip label and its id (a start timestamp) in both.

### Verification

`TripScrub` lives in `:core` beside the format, with 13 tests, one per leak. 330 core tests pass.

Device-verified end to end on the 4a 5G against a trip built from a real routed drive in the repo's Davis fixture box: dialog renders, all three distances recompute live, and the file the share sheet actually produced was audited afterwards. 257 fixes to 171, no fix within 400 m of either end, route line out of both zones, address absent, arrival announcement absent, no absolute wall clock, version code preserved, still parses and still replays.

Related to #292, which stays open; that script is still the right tool for a trip already pulled off the phone.
