### PR TITLE
Show reviews in your own language instead of forcing English

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1579,6 +1579,21 @@ architecture note.
   `GoogleMapsDataSource.reviews()` anymore; ALL review content comes from the WebReviewsFetcher
   DOM scrape. If reviews ever break, debug the scrape (selectors, virtualized-list
   accumulation), not the RPC, and don't burn time trying to "fix" reviewsPb.
+- **The review page follows the APP'S LANGUAGE now (issue #278, 2026-09-02).** `WebReviewsFetcher`
+  pinned `hl=en&gl=us`, and the page language decides WHICH reviews Google serves - a Chinese reader
+  looking at a Chinese restaurant got the English ones. Reviews are CONTENT and must never be
+  translated for the reader, so the fetch uses `reviewsHl()` (the app locale, with the zh-TW/zh-CN
+  script split, gated to `SUPPORTED_HL`). ⚠️ **Unpinning `hl` ALONE breaks the scraper** - it keyed
+  on English text in four places, all verified live on a zh-TW page: the star SELECTOR
+  (`aria-label*="star"` vs the real `5 顆星`), `num()`'s `/([0-9.]+)\s*star/i` (returned 0 for every
+  review), the reviews TAB (`/^reviews\b/i` vs 評論) and the more-reviews BUTTON. Ratings now read
+  the LEADING NUMBER (every language leads with it) and the labels match `:core`
+  `data/ReviewWords` - kept there, not inline in the JS, so they are unit-tested (`ReviewWordsTest`).
+  The more-reviews button requires a review word AND a "more" word: a bare match hits "Write a
+  review" (zh-TW 撰寫評論) and CLICKS THE COMPOSER, a wrong action rather than a missed one.
+  **`ReviewsPanel` (the full-screen page) stays `hl=en` deliberately** - it carves the page by
+  matching English relative dates, "N stars," histogram labels, the auto-processing disclaimer and
+  the Sort button; localising it needs those four hardened first (open follow-up).
 - **Review scrape accumulation replaces on LONGER TEXT (2026-07-19, issue #181):** a card is
   often harvested on the tick its More toggle was clicked, before Google's async re-render
   swaps in the full body - first-capture-wins turned that race into permanent "…" truncation.

--- a/app/src/main/java/app/vela/web/ReviewsPanel.kt
+++ b/app/src/main/java/app/vela/web/ReviewsPanel.kt
@@ -444,6 +444,12 @@ private fun buildPanelWebView(
             view?.evaluateJavascript(carveScript(dark, fullScreen), null)
         }
     }
+    // DELIBERATELY still English, unlike the inline review SCRAPER, which now follows the app's
+    // language (issue #278). This full-screen page is CARVED by matching English text: the relative
+    // date ("3 months ago"), the "N stars," histogram labels, the "reviews are automatically
+    // processed" disclaimer it strips, and the Sort button. Serving it in another language would
+    // break all four at once and trade one bug for several. Localising it means hardening those
+    // four selectors first; tracked as the follow-up on #278.
     wv.loadUrl("https://www.google.com/maps?cid=$cid&hl=en&gl=us")
     return wv
 }

--- a/app/src/main/java/app/vela/web/WebReviewsFetcher.kt
+++ b/app/src/main/java/app/vela/web/WebReviewsFetcher.kt
@@ -219,6 +219,13 @@ class WebReviewsFetcher @Inject constructor(
      *  DOM nodes as you scroll, so any single snapshot holds only ~10 cards; the union across scroll
      *  positions is the full list). Bridges the accumulated JSON array back once the list is exhausted
      *  or the cap is hit. */
+    /** The :core review-word patterns, quoted for embedding in the scraper's JavaScript. */
+    private fun reviewPatternJs(): String = jsString(app.vela.core.data.ReviewWords.REVIEW_PATTERN)
+    private fun morePatternJs(): String = jsString(app.vela.core.data.ReviewWords.MORE_PATTERN)
+
+    private fun jsString(v: String): String =
+        "\"" + v.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
     private fun extractScript(id: String): String {
         val idj = "\"" + id.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
         return """
@@ -226,7 +233,20 @@ class WebReviewsFetcher @Inject constructor(
               var ID=$idj, tries=0, opened=false, acc={}, accN=0, lastN=0, noGrow=0, atBottom=0;
               var openedAt=-1, lastRep=-1, openedBy='', sawEntry=false, everCards=false, btnReclicks=0;
               var CAP=50;
-              function num(s){ var m=(s||'').match(/([0-9.]+)\s*star/i); return m?Math.round(parseFloat(m[1])):0; }
+              // The rating sits at the FRONT of the star widget's aria-label in every language
+              // ("5 stars", "5 顆星", "5 étoiles"), so read the leading number rather than looking
+              // for the English word - that match returned 0 for every review the moment the page
+              // was not English (issue #278).
+              function num(s){ var m=(s||'').match(/^\s*([1-5])(?:[.,]0)?\b/); return m?parseInt(m[1],10):0; }
+              // "Reviews" across the languages Vela ships, for the TAB (matched only against
+              // role="tab", where the choices are Overview / Reviews / About, so a loose contains
+              // is safe) and for the "more reviews" BUTTON. The button additionally requires a
+              // "more" word: a bare review-word match there would hit "Write a review" (zh-TW
+              // "撰寫評論"), and clicking that opens the review composer instead of the list.
+              // The word lists live in :core ReviewWords so they can be unit-tested; a list that
+              // silently stops matching is invisible until someone reports missing reviews.
+              var REVIEW_WORD=new RegExp(${'$'}{reviewPatternJs()},'i');
+              var MORE_WORD=new RegExp(${'$'}{morePatternJs()},'i');
               function t1(c,sel){ var e=c.querySelector(sel); return e?(e.textContent||'').trim():''; }
               function extract(){
                 // Review cards are `.jJc9Ad`, each with a unique `data-review-id` — far more robust than the
@@ -235,7 +255,17 @@ class WebReviewsFetcher @Inject constructor(
                 var revs=[].slice.call(document.querySelectorAll('.jJc9Ad'));
                 return revs.map(function(c){
                   var idEl=c.querySelector('[data-review-id]'); var rid=idEl?(idEl.getAttribute('data-review-id')||''):'';
-                  var star=c.querySelector('[role="img"][aria-label*="star" i], span[aria-label*=" star" i]');
+                  // Rating: the star widget's aria-label LEADS WITH THE NUMBER in every language
+                  // ("5 stars", "5 顆星", "5 étoiles", "5 звёзд"), so key on that instead of the
+                  // English word. The old `aria-label*="star"` selector matched nothing the moment
+                  // the page was served in the user's own language, and every rating came back
+                  // null (issue #278; verified live on a zh-TW page where the label read "5 顆星").
+                  var star=null;
+                  var cand=[].slice.call(c.querySelectorAll('[role="img"][aria-label],span[aria-label]'));
+                  for(var si=0;si<cand.length;si++){
+                    var sl=(cand[si].getAttribute('aria-label')||'').trim();
+                    if(/^[1-5]([.,]0)?(\s|\u00a0)*\D/.test(sl)){ star=cand[si]; break; }
+                  }
                   // author: Google's review name class, else pull the NAME out of a button aria — the
                   // name is always right before "'s review" (after a "Share "/"Photo N on " prefix) or
                   // after "Photo of ". (Class names rotate; the aria phrasing is stable + semantic.)
@@ -315,7 +345,7 @@ class WebReviewsFetcher @Inject constructor(
                 var ts=[].slice.call(document.querySelectorAll('[role="tab"]'));
                 for(var i=0;i<ts.length;i++){
                   var tl=((ts[i].getAttribute('aria-label')||ts[i].textContent)||'').trim();
-                  if(/^reviews\b/i.test(tl)){
+                  if(REVIEW_WORD.test(tl)){
                     sawEntry=true;
                     if((ts[i].getAttribute('aria-selected')||'')==='true'){ if(!opened){ opened=true; openedAt=tries; openedBy='tab'; } return; }
                     try{ ts[i].click(); }catch(e){}
@@ -328,7 +358,7 @@ class WebReviewsFetcher @Inject constructor(
                 // button silently no-ops, same as the tab).
                 if(opened) return;
                 var bs=[].slice.call(document.querySelectorAll('button'));
-                for(var i=0;i<bs.length;i++){ var l=((bs[i].getAttribute('aria-label')||bs[i].textContent)||''); if(/more reviews/i.test(l)){ sawEntry=true; try{ bs[i].click(); }catch(e){} opened=true; openedAt=tries; openedBy='btn'; return; } }
+                for(var i=0;i<bs.length;i++){ var l=((bs[i].getAttribute('aria-label')||bs[i].textContent)||''); if(REVIEW_WORD.test(l)&&MORE_WORD.test(l)){ sawEntry=true; try{ bs[i].click(); }catch(e){} opened=true; openedAt=tries; openedBy='btn'; return; } }
               }
               function tick(){
                 tries++;
@@ -399,6 +429,11 @@ class WebReviewsFetcher @Inject constructor(
         const val TOTAL_TIMEOUT_MS = 45_000L
         const val REAP_IDLE_MS = 120_000L // destroy the idle WebView after this quiet period (issue #182)
         const val SETTLE_MS = 150L
+
+        /** Languages whose review-page wording the scraper's word lists cover (see `reviewsHl`).
+         *  Outside this set the page stays English: a language the scraper cannot navigate would
+         *  return FEWER reviews than English does. */
+        val SUPPORTED_HL = setOf("en", "fr", "de", "es", "it", "pt", "nl", "ru", "pl", "sv", "uk", "zh", "ja", "he")
         const val MAX_LOAD_MS = 7_000L
         // Offscreen viewport for the headless WebView — tall so the virtualized review list renders a
         // healthy batch per scroll position.

--- a/core/src/main/java/app/vela/core/data/ReviewWords.kt
+++ b/core/src/main/java/app/vela/core/data/ReviewWords.kt
@@ -1,0 +1,64 @@
+package app.vela.core.data
+
+/**
+ * The words that identify Google's review controls in each language Vela ships (issue #278).
+ *
+ * The review scraper used to run the place page in English and match English labels. That forced
+ * Google to serve English reviews to everyone, because the page language decides which reviews you
+ * get - a Chinese reader looking at a Chinese restaurant was shown the English ones. Reviews are
+ * content and must never be translated for the reader, so the page now follows the app's language,
+ * which means every label the scraper keys on has to be recognised in that language too.
+ *
+ * Kept here rather than inline in the scraper's JavaScript so the patterns can be unit-tested: a
+ * word list that silently stops matching is invisible until someone reports missing reviews.
+ */
+object ReviewWords {
+
+    /**
+     * "Reviews", for finding the reviews TAB.
+     *
+     * Matched as a plain substring, which is safe because it is only ever tested against
+     * `role="tab"` elements, where the choices are Overview / Reviews / About.
+     */
+    const val REVIEW_PATTERN =
+        "review|rezension|bewertung|reseña|opini|avis|commentaire|recension|recensioni|" +
+            "avalia|beoordel|отзыв|відгук|" +
+            "omdöme|ביקור|评论|評論|评价|" +
+            "クチコミ|口コミ|レビュー"
+
+    /**
+     * "More" / "all", required IN ADDITION to [REVIEW_PATTERN] when clicking the "more reviews"
+     * BUTTON.
+     *
+     * Without it a bare review-word match hits "Write a review" (zh-TW "撰寫評論"), and clicking that
+     * opens the review composer instead of the list - a wrong click, not merely a missed one.
+     */
+    const val MORE_PATTERN =
+        "more|all|mehr|alle|más|todas|plus|tous|più|tutte|mais|meer|" +
+            "ещё|все|więcej|wszystkie|fler|alla|" +
+            "більше|всі|עוד|כל|" +
+            "更多|全部|もっと|すべて"
+
+    /**
+     * A star widget's rating, read from the FRONT of its aria-label.
+     *
+     * Every language leads with the number ("5 stars", "5 顆星", "5 étoiles", "4,0 Sterne"), so the
+     * leading digit is the one language-neutral signal. The old parser looked for the English word
+     * "star" and returned 0 for every review as soon as the page was not English.
+     */
+    val LEADING_RATING = Regex("""^\s*([1-5])(?:[.,]0)?\b""")
+
+    private val review = Regex(REVIEW_PATTERN, RegexOption.IGNORE_CASE)
+    private val more = Regex(MORE_PATTERN, RegexOption.IGNORE_CASE)
+
+    /** Whether a `role="tab"` label names the reviews tab. */
+    fun isReviewsTab(label: String): Boolean = review.containsMatchIn(label)
+
+    /** Whether a button opens MORE reviews (as opposed to composing one). */
+    fun isMoreReviewsButton(label: String): Boolean =
+        review.containsMatchIn(label) && more.containsMatchIn(label)
+
+    /** The rating in a star widget's aria-label, or null when it carries none. */
+    fun ratingOf(ariaLabel: String): Int? =
+        LEADING_RATING.find(ariaLabel)?.groupValues?.get(1)?.toIntOrNull()
+}

--- a/core/src/test/java/app/vela/core/data/ReviewWordsTest.kt
+++ b/core/src/test/java/app/vela/core/data/ReviewWordsTest.kt
@@ -1,0 +1,73 @@
+package app.vela.core.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The review scraper's language handling ([ReviewWords], issue #278).
+ *
+ * The page is served in the reader's language now, so every label the scraper keys on has to be
+ * recognised in that language. These are the failures that would otherwise be silent: ratings
+ * quietly becoming zero, the reviews tab never opening, and - the one that does damage - clicking
+ * "Write a review" instead of "More reviews".
+ *
+ * The Chinese strings are the real ones captured from a live zh-TW place page.
+ */
+class ReviewWordsTest {
+
+    @Test fun `a rating is read from the front of the label in any language`() {
+        assertEquals(5, ReviewWords.ratingOf("5 stars"))
+        assertEquals(5, ReviewWords.ratingOf("5 顆星"))   // live capture, zh-TW
+        assertEquals(4, ReviewWords.ratingOf("4 顆星"))   // live capture, zh-TW
+        assertEquals(5, ReviewWords.ratingOf("5 étoiles"))
+        assertEquals(5, ReviewWords.ratingOf("5 звёзд"))
+        assertEquals(1, ReviewWords.ratingOf("1 star"))
+    }
+
+    // German writes "4,0 Sterne"; a decimal comma must not read as a different number.
+    @Test fun `a decimal rating keeps its whole-star value`() {
+        assertEquals(4, ReviewWords.ratingOf("4,0 Sterne"))
+        assertEquals(4, ReviewWords.ratingOf("4.0 stars"))
+    }
+
+    @Test fun `a label with no leading rating yields nothing`() {
+        assertNull(ReviewWords.ratingOf("Photo of Jr"))
+        assertNull(ReviewWords.ratingOf(""))
+        assertNull(ReviewWords.ratingOf("Local Guide · 11 reviews"))
+    }
+
+    @Test fun `the reviews tab is recognised in every shipped language`() {
+        listOf(
+            "Reviews", "評論", "评论", "Rezensionen", "Bewertungen", "Avis", "Reseñas",
+            "Recensioni", "Avaliações", "Beoordelingen", "Отзывы", "Opinie", "Omdömen",
+            "Відгуки", "ביקורות", "クチコミ", "レビュー",
+        ).forEach { assertTrue("tab not recognised: $it", ReviewWords.isReviewsTab(it)) }
+    }
+
+    // The one that does real damage: clicking this opens the review composer.
+    @Test fun `write-a-review is never mistaken for more-reviews`() {
+        listOf(
+            "撰寫評論",              // live capture, zh-TW
+            "Write a review",
+            "Rezension schreiben",
+            "Escribir una reseña",
+            "Écrire un avis",
+        ).forEach { assertFalse("would click the composer: $it", ReviewWords.isMoreReviewsButton(it)) }
+    }
+
+    @Test fun `a genuine more-reviews button is still clicked`() {
+        listOf(
+            "More reviews", "Alle Rezensionen", "Más reseñas", "Plus d'avis",
+            "もっとクチコミ", "更多評論", "Все отзывы", "Wszystkie opinie",
+        ).forEach { assertTrue("missed: $it", ReviewWords.isMoreReviewsButton(it)) }
+    }
+
+    // A tab word alone must not be enough for the button, or the composer test above is luck.
+    @Test fun `a bare review word is not a more-reviews button`() {
+        assertFalse(ReviewWords.isMoreReviewsButton("Reviews"))
+        assertFalse(ReviewWords.isMoreReviewsButton("評論"))
+    }
+}


### PR DESCRIPTION
Closes #278 (the reviews half; the sharing half in that report still needs its own repro).

**The cause.** `WebReviewsFetcher` pinned `hl=en&gl=us`, and the page language is what decides which reviews Google returns — so a Chinese reader looking at a Chinese restaurant was served the English ones. Reviews are content people wrote, not UI, so they should arrive as written.

### Unpinning `hl` alone would have broken it worse
The scraper keyed on English text in **four** places. All verified live on a real `zh-TW` place page:

| What | Looked for | Reality on a Chinese page |
|---|---|---|
| star selector | `aria-label*="star"` | `5 顆星` → no match |
| `num()` rating parse | `/([0-9.]+)\s*star/i` | → **0 for every review** |
| reviews tab | `/^reviews\b/i` | tab is `評論` |
| more-reviews button | `/more reviews/i` | localized |

Ratings now read the **leading number**, which every language puts first (`5 stars`, `5 顆星`, `4,0 Sterne`). Labels match a per-language word list.

### The one that does damage, not just nothing
A bare review-word match on a *button* hits **"Write a review"** (zh-TW `撰寫評論`) — clicking that opens the composer. That's a wrong action, not a missed one. The button match now requires a review word **and** a "more" word. There's a test for exactly this.

### Testable on purpose
The word lists live in `:core` `ReviewWords` rather than inline in the scraper's JavaScript, because a word list that silently stops matching is invisible until someone reports missing reviews. `ReviewWordsTest`, 7 passing, using the real captured Chinese strings.

### Deliberately not changed
`ReviewsPanel` (the full-screen "read all reviews" page) stays `hl=en`. It carves the page by matching English relative dates, `N stars,` histogram labels, the auto-processing disclaimer and the Sort button — localising it would break four things to fix one. Hardening those is the follow-up, noted in the code.

Also worth flagging: `.w8nwRe` (the More-toggle hook) was already language-independent and needed nothing, which is why expansion kept working even in the broken state.