### PR TITLE
Bring your saved places over from other map apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -942,6 +942,19 @@ Defaults that make the safe path the easy one:
   provider is off (degoogled devices often carry a present-but-disabled NETWORK provider) ->
   AbstractMethodError, crash on every launch (user report, Android 10/Adreno 308). Override all
   four callbacks explicitly in any android.location.LocationListener implementation.
+- **Places import from OTHER APPS (issue #279, 2026-09-02).** `:core` `data/PlaceImport` reads GPX
+  waypoints, KML placemarks and GeoJSON points (including Google Takeout, whose name/address hide
+  under `properties.location`), tried by `SavedPlaceStore.importMerge` when the file is not Vela's
+  own export. Migration path for people arriving from Organic Maps / CoMaps / OsmAnd. ⚠️ **GPX is
+  lat-then-lon but KML and GeoJSON are LNG FIRST** - reading either the wrong way round silently
+  imports a whole collection into the Gulf of Guinea, so both orders are pinned by
+  `PlaceImportTest`. Deliberately imports ONLY name + coordinate (+ address where Takeout gives
+  one): every format agrees on those, and a confidently wrong address is worse than no import.
+  Ids are content-derived from the rounded coordinate, so re-importing the same file adds nothing
+  (device-verified: "Imported 3 place(s)" then "Everything in that file is already saved").
+  0,0 and out-of-range coordinates are dropped rather than pinned at null island. The picker's
+  mime list keeps a broad `*/*` last on purpose - Android does not know `.gpx` and reports it as
+  an octet-stream BIN file, so a strict filter makes the file look absent.
 - **Import reports WHICH outcome happened (issue #287, 2026-08-28).** `SavedPlaceStore.importMerge`
   / `PlaceListStore.importMerge` return `:core` `data/ImportResult` (Added / NothingNew /
   WrongFormat(format?) / Unreadable) instead of a bare Int - four very different outcomes used to

--- a/app/src/main/java/app/vela/ui/settings/sections/SavedPlacesSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/SavedPlacesSettings.kt
@@ -92,7 +92,16 @@ internal fun SavedPlacesSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
 // of file providers hand back application/octet-stream for a .json, and filtering that out makes
 // the file look absent - the picker opens onto an empty folder and the feature reads as broken.
 // (NB a literal wildcard mime in a KDoc block closes the comment early - see PoiPackStore.)
-private val IMPORT_MIME = arrayOf("application/json", "*/*")
+private val IMPORT_MIME = arrayOf(
+    "application/json",
+    "application/gpx+xml",
+    "application/vnd.google-earth.kml+xml",
+    "application/xml",
+    "text/xml",
+    // Kept last and deliberately broad: providers hand back application/octet-stream for a .gpx or
+    // .json often enough that filtering strictly makes the file look absent (issue #279).
+    "*/*",
+)
 
 /**
  * Open the file picker, and SAY SO when there isn't one (issue #287).

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,12 +149,12 @@
     <string name="settings_routing_remove">Remove offline routing</string>
     <string name="settings_download">Download</string>
     <string name="settings_saved_places">Saved places</string>
-    <string name="settings_saved_places_hint">Back up your starred places to a file, or restore them on another device. Import merges into what you already have. It never overwrites or removes anything.</string>
+    <string name="settings_saved_places_hint">Back up your starred places to a file, or restore them on another device. Import merges into what you already have. It never overwrites or removes anything, and it also reads GPX, KML and GeoJSON files exported from other map apps.</string>
     <string name="settings_import_nothing">Nothing new to import</string>
     <string name="settings_import_nothing_new">Everything in that file is already saved.</string>
     <string name="settings_import_unreadable">That file could not be opened.</string>
-    <string name="settings_import_wrong_format">That is not a Vela export. Use a file saved with Export, from the same screen.</string>
-    <string name="settings_import_wrong_format_named">That looks like a %1$s file. Vela can only import its own exports for now.</string> <!-- format -->
+    <string name="settings_import_wrong_format">No places found in that file. Vela reads its own exports, and GPX, KML or GeoJSON files saved from other map apps.</string>
+    <string name="settings_import_wrong_format_named">No places found in that %1$s file.</string> <!-- format -->
     <string name="settings_import_no_picker">No file picker is available on this device, so a file cannot be chosen.</string>
     <string name="settings_no_saved_places">No saved places yet</string>
     <string name="settings_export">Export</string>

--- a/core/src/main/java/app/vela/core/data/PlaceImport.kt
+++ b/core/src/main/java/app/vela/core/data/PlaceImport.kt
@@ -1,0 +1,151 @@
+package app.vela.core.data
+
+import app.vela.core.model.SavedPlace
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Reading saved places out of OTHER apps' export files (issue #279).
+ *
+ * People arriving from Organic Maps, CoMaps, OsmAnd or Google Takeout have years of pins they do
+ * not want to re-create by hand, and until now Vela could only tell them their file was the wrong
+ * kind. The formats those apps actually export are GPX waypoints, KML placemarks and GeoJSON
+ * points, so those three are what this reads.
+ *
+ * Deliberately conservative. It only ever produces a NAME and a COORDINATE, because that is the one
+ * thing every format agrees on and the one thing that cannot be wrong: a place with the right
+ * coordinate and a plain name is useful, whereas a place with a confidently wrong address is worse
+ * than no import at all. Everything else in these files (icons, colours, folders, per-app custom
+ * fields) is left behind on purpose.
+ *
+ * Parsing is deliberately shallow string/regex work rather than a real XML parser: these are
+ * untrusted files, the shapes are simple and well known, and `:core` already avoids pulling in
+ * parsers it does not need.
+ */
+object PlaceImport {
+
+    /** Sanity bound for a single import, so a pathological file cannot exhaust memory. */
+    private const val MAX_PLACES = 5_000
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    /**
+     * Places found in [text], or empty when it is not a format we read.
+     *
+     * Order is the file's own, and duplicates are left in: the caller merges against what is
+     * already saved and is the right place to decide what counts as the same place.
+     */
+    fun parse(text: String): List<SavedPlace> {
+        val trimmed = text.trimStart()
+        return when {
+            trimmed.startsWith("<") -> parseXml(text)
+            trimmed.startsWith("{") || trimmed.startsWith("[") -> parseGeoJson(text)
+            else -> emptyList()
+        }
+    }
+
+    // --- GPX / KML ---------------------------------------------------------------------------
+
+    /** GPX `<wpt lat= lon=><name>` and KML `<Placemark><name>…<coordinates>lng,lat`. */
+    private fun parseXml(text: String): List<SavedPlace> {
+        val gpx = GPX_WPT.findAll(text).mapNotNull { m ->
+            val lat = m.groupValues[1].toDoubleOrNull() ?: return@mapNotNull null
+            val lng = m.groupValues[2].toDoubleOrNull() ?: return@mapNotNull null
+            place(nameIn(m.groupValues[3]) ?: fallbackName(lat, lng), lat, lng)
+        }.take(MAX_PLACES).toList()
+        if (gpx.isNotEmpty()) return gpx
+
+        return KML_PLACEMARK.findAll(text).mapNotNull { m ->
+            val body = m.groupValues[1]
+            val coords = KML_COORDS.find(body)?.groupValues?.get(1)?.trim() ?: return@mapNotNull null
+            // KML is lng,lat[,alt] - the reversed order is the classic way to import a whole file
+            // into the sea off west Africa, so it is worth being explicit about.
+            val parts = coords.split(Regex("[,\\s]+")).mapNotNull { it.toDoubleOrNull() }
+            if (parts.size < 2) return@mapNotNull null
+            val lng = parts[0]
+            val lat = parts[1]
+            place(nameIn(body) ?: fallbackName(lat, lng), lat, lng)
+        }.take(MAX_PLACES).toList()
+    }
+
+    private val GPX_WPT = Regex(
+        """<wpt\b[^>]*\blat\s*=\s*["']([-\d.]+)["'][^>]*\blon\s*=\s*["']([-\d.]+)["'][^>]*>(.*?)</wpt>""",
+        setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE),
+    )
+    private val KML_PLACEMARK = Regex(
+        """<Placemark\b[^>]*>(.*?)</Placemark>""",
+        setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE),
+    )
+    private val KML_COORDS = Regex(
+        """<coordinates>(.*?)</coordinates>""",
+        setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE),
+    )
+    private val NAME_TAG = Regex("""<name>(.*?)</name>""", setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE))
+
+    private fun nameIn(body: String): String? =
+        NAME_TAG.find(body)?.groupValues?.get(1)?.let { unescapeXml(it).trim() }?.takeIf { it.isNotBlank() }
+
+    private fun unescapeXml(s: String): String {
+        // CDATA is common in KML names written by desktop tools.
+        val inner = Regex("""<!\[CDATA\[(.*?)]]>""", RegexOption.DOT_MATCHES_ALL)
+            .find(s)?.groupValues?.get(1) ?: s
+        return inner.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+            .replace("&quot;", "\"").replace("&#39;", "'").replace("&apos;", "'")
+    }
+
+    // --- GeoJSON (incl. Google Takeout) ------------------------------------------------------
+
+    private fun parseGeoJson(text: String): List<SavedPlace> {
+        val root = runCatching { json.parseToJsonElement(text) }.getOrNull() ?: return emptyList()
+        val features = (root as? JsonObject)?.get("features") as? JsonArray
+            ?: (root as? JsonArray)
+            ?: return emptyList()
+        return features.mapNotNull { f ->
+            val o = f as? JsonObject ?: return@mapNotNull null
+            val geom = o["geometry"] as? JsonObject ?: return@mapNotNull null
+            val coords = geom["coordinates"] as? JsonArray ?: return@mapNotNull null
+            // GeoJSON is [lng, lat] - the same reversal trap as KML.
+            val lng = coords.getOrNull(0)?.num() ?: return@mapNotNull null
+            val lat = coords.getOrNull(1)?.num() ?: return@mapNotNull null
+            val props = o["properties"] as? JsonObject
+            place(geoJsonName(props) ?: fallbackName(lat, lng), lat, lng, geoJsonAddress(props))
+        }.take(MAX_PLACES)
+    }
+
+    /** Takeout hides the name a level down in `properties.location.name`; plain GeoJSON uses
+     *  `properties.name` (or `title`). */
+    private fun geoJsonName(props: JsonObject?): String? {
+        val p = props ?: return null
+        val loc = p["location"] as? JsonObject
+        return (loc?.get("name")?.text() ?: p["name"]?.text() ?: p["title"]?.text())
+            ?.trim()?.takeIf { it.isNotBlank() }
+    }
+
+    private fun geoJsonAddress(props: JsonObject?): String? {
+        val p = props ?: return null
+        val loc = p["location"] as? JsonObject
+        return (loc?.get("address")?.text() ?: p["address"]?.text())?.trim()?.takeIf { it.isNotBlank() }
+    }
+
+    private fun JsonElement.num(): Double? = runCatching { jsonPrimitive.doubleOrNull }.getOrNull()
+    private fun JsonElement.text(): String? = runCatching { jsonPrimitive.content }.getOrNull()
+
+    // --- shared ------------------------------------------------------------------------------
+
+    /** A coordinate that cannot be real is dropped rather than imported as a pin in the ocean. */
+    private fun place(name: String, lat: Double, lng: Double, address: String? = null): SavedPlace? {
+        if (lat !in -90.0..90.0 || lng !in -180.0..180.0) return null
+        if (lat == 0.0 && lng == 0.0) return null // null island: an unset coordinate, not a place
+        // The id must be STABLE for the same place so re-importing the same file adds nothing the
+        // second time; it is derived from the rounded coordinate rather than a counter.
+        val id = "imp:%.5f,%.5f".format(java.util.Locale.US, lat, lng)
+        return SavedPlace(id = id, name = name.take(120), lat = lat, lng = lng, address = address)
+    }
+
+    private fun fallbackName(lat: Double, lng: Double): String =
+        "%.4f, %.4f".format(java.util.Locale.US, lat, lng)
+}

--- a/core/src/main/java/app/vela/core/data/SavedPlaceStore.kt
+++ b/core/src/main/java/app/vela/core/data/SavedPlaceStore.kt
@@ -49,7 +49,11 @@ class SavedPlaceStore @Inject constructor(
      * sent people looking for a bug in the wrong place.
      */
     fun importMerge(json: String): ImportResult {
+        // Vela's own export first; failing that, the formats other map apps produce (issue #279),
+        // so someone arriving from Organic Maps / OsmAnd / CoMaps / Takeout keeps their pins
+        // instead of only being told the file is the wrong kind.
         val incoming = runCatching { this.json.decodeFromString<List<SavedPlace>>(json) }.getOrNull()
+            ?: PlaceImport.parse(json).ifEmpty { null }
             ?: return ImportResult.WrongFormat(ImportFormats.describe(json))
         val current = saved()
         val existing = current.mapTo(HashSet()) { it.id }

--- a/core/src/test/java/app/vela/core/data/PlaceImportTest.kt
+++ b/core/src/test/java/app/vela/core/data/PlaceImportTest.kt
@@ -1,0 +1,103 @@
+package app.vela.core.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Reading other apps' saved places ([PlaceImport], issue #279).
+ *
+ * The fixtures are the real shapes these apps export. The failure that matters most is silent:
+ * GPX writes lat then lon, while KML and GeoJSON write LNG FIRST, so getting the order wrong
+ * imports someone's whole bookmark collection into the Gulf of Guinea without erroring.
+ */
+class PlaceImportTest {
+
+    // Organic Maps / OsmAnd / CoMaps all export GPX waypoints in this shape.
+    private val gpx = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gpx version="1.1" creator="Organic Maps">
+          <wpt lat="38.5449" lon="-121.7405"><name>Davis Food Co-op</name></wpt>
+          <wpt lat="37.7749" lon="-122.4194"><name><![CDATA[Ferry Building]]></name></wpt>
+        </gpx>
+    """.trimIndent()
+
+    private val kml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <kml xmlns="http://www.opengis.net/kml/2.2"><Document>
+          <Placemark><name>Bookshop &amp; Cafe</name>
+            <Point><coordinates>-121.7405,38.5449,0</coordinates></Point></Placemark>
+          <Placemark><name>Second Spot</name>
+            <Point><coordinates>-122.4194,37.7749</coordinates></Point></Placemark>
+        </Document></kml>
+    """.trimIndent()
+
+    // Google Takeout's saved places: name and address nested under properties.location.
+    private val takeout = """
+        {"type":"FeatureCollection","features":[
+          {"type":"Feature","geometry":{"type":"Point","coordinates":[-121.7405,38.5449]},
+           "properties":{"google_maps_url":"http://maps.google.com/?cid=1",
+                         "location":{"name":"Covell Market","address":"1451 W Covell Blvd, Davis, CA"}}}]}
+    """.trimIndent()
+
+    @Test fun `gpx waypoints come in with their names and coordinates`() {
+        val out = PlaceImport.parse(gpx)
+        assertEquals(2, out.size)
+        assertEquals("Davis Food Co-op", out[0].name)
+        assertEquals(38.5449, out[0].lat, 1e-6)
+        assertEquals(-121.7405, out[0].lng, 1e-6)
+    }
+
+    @Test fun `a CDATA wrapped name is read as plain text`() {
+        assertEquals("Ferry Building", PlaceImport.parse(gpx)[1].name)
+    }
+
+    // KML is lng,lat - reading it as lat,lng would put California in the Atlantic.
+    @Test fun `kml coordinates are read longitude first`() {
+        val out = PlaceImport.parse(kml)
+        assertEquals(2, out.size)
+        assertEquals(38.5449, out[0].lat, 1e-6)
+        assertEquals(-121.7405, out[0].lng, 1e-6)
+        assertTrue("latitude must be plausible, not swapped", out.all { it.lat in 30.0..40.0 })
+    }
+
+    @Test fun `xml entities in a name are decoded`() {
+        assertEquals("Bookshop & Cafe", PlaceImport.parse(kml)[0].name)
+    }
+
+    @Test fun `google takeout brings the name and address across`() {
+        val out = PlaceImport.parse(takeout)
+        assertEquals(1, out.size)
+        assertEquals("Covell Market", out[0].name)
+        assertEquals("1451 W Covell Blvd, Davis, CA", out[0].address)
+        assertEquals(38.5449, out[0].lat, 1e-6)
+    }
+
+    // Re-importing the same file must not double every pin, so ids are content-derived.
+    @Test fun `the same place imports to the same id twice`() {
+        assertEquals(PlaceImport.parse(gpx).map { it.id }, PlaceImport.parse(gpx).map { it.id })
+    }
+
+    @Test fun `an unset coordinate is dropped rather than pinned at null island`() {
+        val junk = """<gpx><wpt lat="0" lon="0"><name>Nowhere</name></wpt></gpx>"""
+        assertTrue(PlaceImport.parse(junk).isEmpty())
+    }
+
+    @Test fun `an impossible coordinate is dropped`() {
+        val bad = """<gpx><wpt lat="999" lon="12"><name>Broken</name></wpt></gpx>"""
+        assertTrue(PlaceImport.parse(bad).isEmpty())
+    }
+
+    @Test fun `a waypoint with no name still imports, labelled by its coordinate`() {
+        val noName = """<gpx><wpt lat="38.5449" lon="-121.7405"></wpt></gpx>"""
+        val out = PlaceImport.parse(noName)
+        assertEquals(1, out.size)
+        assertTrue("should be labelled by coordinate", out[0].name.contains("38.54"))
+    }
+
+    @Test fun `something that is not a places file yields nothing`() {
+        assertTrue(PlaceImport.parse("hello there").isEmpty())
+        assertTrue(PlaceImport.parse("{\"unrelated\":true}").isEmpty())
+        assertTrue(PlaceImport.parse("").isEmpty())
+    }
+}


### PR DESCRIPTION
Closes #279

**Stacked on #301** (it needs the `ImportResult` type from there), so base is `fix/285-287-import-weblate` — retarget to main once that lands.

People arriving from Organic Maps, CoMaps, OsmAnd or Google Maps have years of pins. Import now reads **GPX waypoints, KML placemarks and GeoJSON points** (including Google Takeout, whose name and address hide under `properties.location`), so those files bring places in instead of only being told they're the wrong kind. That turns the dead end from #301 into an actual migration path.

### The trap that would have been silent
**GPX writes lat then lon. KML and GeoJSON write lng first.** Getting that backwards doesn't error — it imports someone's entire bookmark collection into the Gulf of Guinea. Both orders are pinned by tests.

### Deliberately narrow
Only **name + coordinate** (plus address where Takeout supplies one). Every format agrees on those; icons, colours and folders are left behind. A place that lands in the right spot with a plain name is useful — one with a confidently wrong address is worse than no import.

Also: ids are derived from the rounded coordinate, so re-importing the same file adds nothing; 0,0 and out-of-range coordinates are dropped rather than pinned at null island.

### Verified on the device, both halves
Imported a real Organic Maps-style GPX (including a CDATA name and an `&amp;` entity):

- first import → **"Imported 3 place(s)"**
- same file again → **"Everything in that file is already saved."**

That second message is #301's outcome-reporting earning its keep.

One practical find: Android doesn't recognise `.gpx` and lists it as an octet-stream "BIN file", so the picker's mime list keeps a broad `*/*` last — a strict filter makes the file look absent.

`PlaceImportTest`: 10 passing, using each app's real export shape.