### PR TITLE
Make the facing beam easier to see, and move Your lists next to Settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1646,6 +1646,16 @@ architecture note.
   COMMERCIAL/RETAIL blocks cream #fdf9ef via the `vela-commercial` twin (Liberty ships no
   layer for those classes; dark paints the twin #1c2638 = the other-landuse navy so dark
   is unchanged).
+- **Heading beam + Your lists placement (issues #289 / #290, 2026-09-03).** The browse heading
+  beam (`arrowBitmap`) ran a TWO-stop gradient from alpha 150 at the APEX to 0 at the tip - but
+  the apex sits UNDER the location dot, so the strongest part was hidden and everything visible
+  had already faded most of the way out. Three stops now (210 / 165 at 30% / 0), holding real
+  opacity across the span that actually clears the dot: mean alpha over the VISIBLE part goes
+  53 -> 84, and 105 -> 165 right where the cone emerges. Slightly wider too. When tuning this,
+  reason about the visible span, not the peak. **Your lists moved OUT of the category-chip row
+  into the search bar** beside the mic and gear: leading the chip row it competed with the
+  quick-category chips, which are a different kind of control. Bare map + empty query only, so it
+  never crowds the clear button.
 - **Glyph ink rule (2026-07-11): leading/functional GLYPHS wear the SOFT ink, text keeps
   the strong ink.** Solid Material icons read heavier than text at the same colour, and
   several sites were outright BLACK (an untinted Icon on a non-Surface container falls

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1393,6 +1393,11 @@ fun MapScreen(
                         offline = state.offline,
                         dpadMode = dpadMode,
                         onMic = onMic,
+                        // Your lists sits beside the gear now (issue #290). Bare map only: with a
+                        // place or results on screen the bar has other work to do.
+                        onOpenLists = if (state.selected == null && state.results.isEmpty()) {
+                            { listsSheetOpen = true }
+                        } else null,
                     )
                     }
                     if (landscapeOneLine) {
@@ -1409,7 +1414,6 @@ fun MapScreen(
                                 Spacer(Modifier.width(10.dp))
                                 CategoryChips(
                                     onPick = vm::quickSearch,
-                                    onOpenLists = { listsSheetOpen = true },
                                     modifier = Modifier.weight(1f),
                                 )
                             }
@@ -1505,7 +1509,6 @@ fun MapScreen(
                         // beside the bar above).
                         !landscapeOneLine && state.selected == null && state.results.isEmpty() -> CategoryChips(
                             onPick = vm::quickSearch,
-                            onOpenLists = { listsSheetOpen = true },
                             modifier = Modifier.padding(top = 8.dp),
                         )
                     }
@@ -3103,7 +3106,7 @@ private fun SearchResults(
 }
 
 @Composable
-private fun CategoryChips(onPick: (String) -> Unit, onOpenLists: () -> Unit = {}, modifier: Modifier = Modifier) {
+private fun CategoryChips(onPick: (String) -> Unit, modifier: Modifier = Modifier) {
     // (localized label, STABLE English search query, icon) — the query is the logic key sent to Google
     // search (works in any locale), the label is what the user sees, so the chips localize without
     // changing what's searched.
@@ -3122,24 +3125,9 @@ private fun CategoryChips(onPick: (String) -> Unit, onOpenLists: () -> Unit = {}
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        // Ribbon shortcut to Your lists — leads the row, a round icon button. Light mode keeps
-        // the subtle green secondaryContainer (user liked it); dark mode matches the chips'
-        // neutral elevated grey — the green container read "too green" against the dark map.
-        val dark = isAppInDarkTheme()
-        Surface(
-            onClick = onOpenLists,
-            shape = CircleShape,
-            color = if (dark) MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp) else MaterialTheme.colorScheme.secondaryContainer,
-            // Soft glyph ink both modes - onSecondaryContainer read near-black next to the
-            // grey chip glyphs (user 2026-07-11).
-            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            shadowElevation = 2.dp,
-            modifier = Modifier.dpadHighlight(CircleShape).size(40.dp),
-        ) {
-            Box(contentAlignment = Alignment.Center) {
-                Icon(Icons.Default.Bookmarks, contentDescription = stringResource(R.string.mapscreen_section_lists), modifier = Modifier.size(20.dp))
-            }
-        }
+        // Your lists used to lead this row as a round button. It moved into the search bar beside
+        // the settings gear (issue #290): on the far left it competed with the quick-category
+        // chips, which are a different kind of control, and the reach was awkward.
         categories.forEach { (labelRes, query, icon) ->
             ElevatedAssistChip(
                 onClick = { onPick(query) },

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -5674,17 +5674,30 @@ private fun arrowBitmap(): Bitmap {
     val tipY = 8f
     val path = Path().apply {
         moveTo(cx, cx)               // apex at centre (under the dot)
-        lineTo(cx - 36f, tipY)
-        quadTo(cx, tipY - 7f, cx + 36f, tipY)
+        lineTo(cx - 44f, tipY)
+        quadTo(cx, tipY - 8f, cx + 44f, tipY)
         close()
     }
     canvas.drawPath(
         path,
         Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            // Issue #289: the beam was hard to see, and the reason was WHERE its opacity sat, not
+            // just how much of it there was. A two-stop gradient ran from alpha 150 at the APEX to
+            // 0 at the tip - but the apex is underneath the location dot, so the strongest part
+            // was hidden and everything actually visible had already faded most of the way out.
+            // Three stops instead, holding real opacity across the part that clears the dot and
+            // only dying at the very tip, which is how Google's reads (the reporter attached
+            // Google's beam as the reference).
             shader = android.graphics.LinearGradient(
                 cx, cx, cx, tipY,
-                android.graphics.Color.argb(150, 66, 133, 244),
-                android.graphics.Color.argb(0, 66, 133, 244),
+                intArrayOf(
+                    android.graphics.Color.argb(210, 66, 133, 244),
+                    android.graphics.Color.argb(165, 66, 133, 244),
+                    android.graphics.Color.argb(0, 66, 133, 244),
+                ),
+                // 0.30 is roughly where the dot's edge is, so the mid stop is the first thing the
+                // eye actually sees; the long run to the tip keeps the soft fade.
+                floatArrayOf(0f, 0.30f, 1f),
                 android.graphics.Shader.TileMode.CLAMP,
             )
         },

--- a/app/src/main/java/app/vela/ui/search/SearchBar.kt
+++ b/app/src/main/java/app/vela/ui/search/SearchBar.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.PublicOff
 import androidx.compose.material.icons.filled.Search
@@ -73,6 +74,8 @@ fun SearchBar(
     // Voice search: shown only when there's a way to service it (a voice-input app, and later an
     // on-device model). Null = no mic. Sits at the right when the field is empty, Google-style.
     onMic: (() -> Unit)? = null,
+    /** Opens Your lists. Null hides the button (issue #290 moved it here from the chip row). */
+    onOpenLists: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     // D-pad (docs/dpad.md): mere focus traversal must NOT fall into the text field (its
@@ -241,6 +244,19 @@ fun SearchBar(
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                     modifier = Modifier.padding(end = 4.dp),
                 )
+            }
+            // Your lists, moved here from the head of the category-chip row (issue #290): there it
+            // sat on the far left competing with the quick-category chips, which is a different
+            // kind of thing. Only on the bare map (onOpenLists != null) and only with the field
+            // empty, so it never crowds the clear button while typing.
+            if (onOpenLists != null && query.isEmpty()) {
+                IconButton(onClick = onOpenLists, modifier = Modifier.size(40.dp)) {
+                    Icon(
+                        Icons.Default.Bookmarks,
+                        contentDescription = stringResource(R.string.mapscreen_section_lists),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
             // Voice search mic: only with the field empty (the clear "X" owns the typing state,
             // Google-style) and only when something can service it (onMic != null). Sits just


### PR DESCRIPTION
Closes #289, closes #290. Same reporter's UI batch, paired like #272/#273 were.

### #289 — the beam
The reporter attached a **Google Maps** screenshot as the reference for what a visible beam looks like.

The problem wasn't how much opacity the cone had, it was **where that opacity sat**. A two-stop gradient ran from alpha 150 at the apex to 0 at the tip — but the apex is *underneath the location dot*, so the strongest part was hidden and everything you could actually see had already faded most of the way out.

Three stops now (210 → 165 at 30% → 0), holding real weight across the span that clears the dot:

| along the cone | old | new |
|---|---|---|
| where it clears the dot (30%) | 105 | **165** |
| mean over the whole visible span | 53 | **84** (1.6×) |

Verified on device with simulate-location (the dot needs a live fix to draw a beam at all) — it now reads clearly against the dark basemap.

### #290 — Your lists
It led the category-chip row on the far left, competing with the quick-category chips, which are a different kind of control. Moved into the search bar beside the mic and gear. Bare map with an empty query only, so it never crowds the clear button while typing. Chip row now starts cleanly with Restaurants.

Both verified on the 4a;  clean. Simulate-location was toggled on to photograph the beam and put back off.