### PR TITLE
Update Flock camera hint to be on by default in strings.xml

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,7 +90,7 @@
     <string name="settings_topography">Terrain shading</string>
     <string name="settings_topography_hint">Shades hills and mountains on the map. Off by default.</string>
     <string name="settings_flock" translatable="false">Surveillance cameras</string>
-    <string name="settings_flock_hint" translatable="false">Shows mapped automated license-plate reader (Flock) cameras, from the community DeFlock project in OpenStreetMap. Off by default.</string>
+    <string name="settings_flock_hint" translatable="false">Shows mapped automated license-plate reader (Flock) cameras, from the community DeFlock project in OpenStreetMap. On by default.</string>
     <string name="settings_speed_cams">Speed cameras</string>
     <string name="settings_speed_cams_hint">Shows fixed radar and speed cameras mapped in OpenStreetMap. Fixed installations only; coverage follows the map, strongest in Europe. Off by default.</string>
     <string name="settings_flock_route_alert" translatable="false">Avoid surveillance cameras</string>


### PR DESCRIPTION
**What this changes and why**
Changed the Flock camera hint in strings.xml to be "on by default" as that's the behavior on a fresh install. Didn't add to the other locales as I see it's not translated anyways and didn't change anything else. Fixes #308 

**Checklist** (see CONTRIBUTING.md)
- [ ] Every real place in the diff (coordinates, addresses, business names, screenshots, commit messages) is there on purpose, not because it's near me; fixtures default to the Davis / Sacramento box (CLAUDE.md, "Location hygiene")
- [ ] Docs updated in this same PR where behaviour changed (README / FEATURES / SPEC / CLAUDE), or the description says why none were needed
- [ ] New user-facing strings added to all 15 locales with matching placeholder types
- [x] No GMS, no static Google keys, no backend calls introduced
- [ ] `:core` stays free of Android UI / MapLibre types
- [ ] Tested on a release build if this touches UI, map or navigation (say which device)
- [ ] `./gradlew :core:test` passes
- [x] Commit subjects read as changelog lines (they become the release notes)
