### PR TITLE
Show the road you are on under the arrow while driving

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2834,6 +2834,17 @@ architecture note.
   single transfer) and the ambient fan-out takes the LEAN path (8 terms at `!7i30` instead of
   15 at `!7i60`) - the same trade LowRamMode makes, for bytes rather than heap. NOT verifiable
   without a real satellite link; the plumbing is what was tested.
+- **Current-road pill under the puck (issue #288, 2026-09-03).** Google's treatment: a rounded
+  label directly beneath the nav puck naming the road you are ON. The road is the one entered by
+  the LAST MANEUVER PASSED (`maneuvers[stepIndex - 1]`) - the same source the banner's shield
+  already uses - preferring its `ref` ("US-23 S", what the reporter's mockup showed) and falling
+  back to the street name; romanized through `SpokenScript.forDisplay` like the banner. Hidden
+  while PREVIEWING a step (previewing must not change where you "are"), in PiP, and until a puck
+  position exists. Positioned from `VelaMapView`'s new `onPuckScreen` callback, which projects the
+  drawn puck to screen px - **reported only when it moves >2 px**, because the follow camera parks
+  the puck at essentially one spot and pushing it per frame would recompose the label 60x a second.
+  The pill is width-capped and CLAMPED into the viewport so a long name near a screen edge cannot
+  run off it.
 - **Nav smoothness trace (`app/diag/NavTrace`, Settings > Diagnostics, OFF by default, issue #251
   2026-08-10).** One row per nav frame - t, along-route progress, speed, bearing WINDOW, chordBrg,
   displayBearing, live camera bearing, frame dt - into a bounded 72k ring (oldest dropped), written

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -223,6 +223,10 @@ private const val USE_MAPTILER = false
 private val SIDE_PANEL_WIDTH_MIN = 400.dp
 private val SIDE_PANEL_WIDTH_MAX = 520.dp
 
+/** Gap in px between the puck glyph's centre and the current-road pill below it (issue #288).
+ *  The nav puck bitmap is 202px drawn at ~half that on screen, so this clears its lower edge. */
+private const val PUCK_LABEL_GAP_PX = 62
+
 @Composable
 private fun sidePanelWidth(): androidx.compose.ui.unit.Dp {
     val w = LocalConfiguration.current.screenWidthDp
@@ -481,6 +485,9 @@ fun MapScreen(
     // Measured screen-Y of the maneuver banner's bottom edge → so VelaMapView can sit the compass just below
     // it during nav (the banner's height varies with lane guidance + a "then" row, so it can't be guessed).
     var navBannerBottomPx by remember { mutableStateOf(0) }
+    // Where the nav puck sits on screen, for the current-road label under it (issue #288).
+    // Null until the nav ticker reports one; reset when a drive ends.
+    var puckScreen by remember { mutableStateOf<Offset?>(null) }
     // The endpoints card's bottom edge, so the notification column can sit under it in
     // directions mode instead of printing over it (user 2026-07-13).
     var topCardBottomPx by remember { mutableStateOf(0) }
@@ -1038,6 +1045,7 @@ fun MapScreen(
             navOverviewTick = navOverviewTick,
             navRecenterTick = navRecenterTick,
             onNavZoomOverride = { navZoomOverride = it },
+            onPuckScreen = { x, y -> puckScreen = Offset(x, y) },
             onPoiTap = vm::onPoiTap,
             onMarkerTap = { i -> displayedPlaces(state).getOrNull(i)?.let(vm::selectPlace) },
             parkingSpot = state.parkingSpot,
@@ -1249,6 +1257,58 @@ fun MapScreen(
         }
 
         // --- top overlay: nav banner while navigating, else search ----------
+        // Current road, in a pill under the puck (issue #288) - Google's treatment. The road you
+        // are ON is the one entered by the last maneuver you passed, which is what the banner's
+        // shield already uses; prefer its ref ("US-23 S") and fall back to the street name.
+        // Hidden while previewing a step (previewing must not change where you "are"), in PiP,
+        // and until the ticker has reported a puck position.
+        if (state.navigating && !pipUi && state.previewStepIndex == null) {
+            val liveIdx = state.nav.stepIndex
+            val onRoad = state.activeRoute?.maneuvers?.getOrNull(liveIdx - 1)
+                ?.let { it.ref?.takeIf { r -> r.isNotBlank() } ?: it.road?.takeIf { r -> r.isNotBlank() } }
+            val at = puckScreen
+            if (onRoad != null && at != null) {
+                val uiLang = app.vela.ui.AppLocale.effective().language
+                val shownRoad =
+                    if (state.roadNameLatin.isEmpty()) onRoad
+                    else app.vela.core.voice.SpokenScript.forDisplay(onRoad, uiLang, state.roadNameLatin)
+                Surface(
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.surface,
+                    shadowElevation = 3.dp,
+                    modifier = Modifier
+                        // Long names ("Snohomish Cascade Drive Southeast") would otherwise run off
+                        // the screen when the puck sits near an edge.
+                        .widthIn(max = 260.dp)
+                        // Centred under the puck, then CLAMPED into the viewport: measured so the
+                        // pill can be any width and still sit centred, offset below the puck glyph
+                        // rather than over it.
+                        .layout { measurable, constraints ->
+                            val placeable = measurable.measure(constraints)
+                            layout(placeable.width, placeable.height) {
+                                val margin = 8.dp.roundToPx()
+                                val maxX = (constraints.maxWidth - placeable.width - margin)
+                                    .coerceAtLeast(margin)
+                                placeable.place(
+                                    (at.x - placeable.width / 2f).roundToInt()
+                                        .coerceIn(margin, maxX),
+                                    (at.y + PUCK_LABEL_GAP_PX).roundToInt(),
+                                )
+                            }
+                        },
+                ) {
+                    Text(
+                        shownRoad,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 6.dp),
+                    )
+                }
+            }
+        }
         if (state.navigating) {
             val mans = state.activeRoute?.maneuvers
             val liveStep = state.nav.stepIndex

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -374,6 +374,9 @@ fun VelaMapView(
     // Reports whether a manual pinch/shove override is active during nav (true on set, false on
     // clear) so the screen can show Re-center for a zoomed-but-still-following camera (issue #238).
     onNavZoomOverride: (Boolean) -> Unit = {},
+    /** The drawn puck's position in SCREEN px while navigating, so the caller can hang the
+     *  current-road label off it (issue #288). Reported only when it actually moves. */
+    onPuckScreen: (Float, Float) -> Unit = { _, _ -> },
     onPoiTap: (name: String, location: LatLng, poiKind: String?) -> Unit,
     onMarkerTap: (index: Int) -> Unit,
     parkingSpot: LatLng? = null, // saved "parked here" pin; tap → onParkingTap
@@ -464,6 +467,11 @@ fun VelaMapView(
     val addrLabelTap = rememberUpdatedState(onAddressLabelTap)
     val navPanned = rememberUpdatedState(onNavPanned)
     val zoomOverride = rememberUpdatedState(onNavZoomOverride)
+    val puckScreenCb = rememberUpdatedState(onPuckScreen)
+    // Last reported puck screen position, so the label is not re-laid-out 60x a second: the
+    // follow camera holds the puck at essentially ONE screen spot, so this fires a handful of
+    // times per drive instead of per frame.
+    val lastPuckScreen = remember { floatArrayOf(Float.NaN, Float.NaN) }
     val userPan = rememberUpdatedState(onUserPan)
     val scaleChanged = rememberUpdatedState(onScaleChanged)
     val overlayState = rememberUpdatedState(onOverlayState)
@@ -1619,6 +1627,21 @@ fun VelaMapView(
                 }
                 navPuck.drawn = pt // the camera follows this smoothed point, not the raw fix
                 setMeSource(style, pt, navPuck.displayBearing)
+                // Where the puck landed on screen, for the current-road label beneath it
+                // (issue #288). Projection is a cheap matrix op, but the REPORT is gated on real
+                // movement - the follow camera parks the puck at one spot, so pushing this into
+                // compose every frame would recompose the label 60x a second for nothing.
+                runCatching { mapRef?.projection?.toScreenLocation(MLLatLng(pt.lat, pt.lng)) }
+                    .getOrNull()?.let { sp ->
+                        if (lastPuckScreen[0].isNaN() ||
+                            kotlin.math.abs(sp.x - lastPuckScreen[0]) > 2f ||
+                            kotlin.math.abs(sp.y - lastPuckScreen[1]) > 2f
+                        ) {
+                            lastPuckScreen[0] = sp.x
+                            lastPuckScreen[1] = sp.y
+                            puckScreenCb.value(sp.x, sp.y)
+                        }
+                    }
                 // Drive the follow-camera HERE, per frame (60 fps) with a continuous ease, instead
                 // of the recomposition-driven block below (which re-pointed only ~1-3×/s in
                 // throttled 550 ms eases — the "stiff" feel). Ease the camera toward the smooth


### PR DESCRIPTION
Closes #288

The reporter attached a mockup of Google's treatment: a rounded pill directly under the puck reading `US-23 S`. That's what this adds.

**Where the road name comes from:** the maneuver you last passed (`maneuvers[stepIndex - 1]`) — the same source the turn card's shield already uses, so the two can never disagree. Prefers its `ref` (route numbers are what road signs show, and what the mockup had) and falls back to the street name. Romanized through `SpokenScript.forDisplay` like the banner, so a Hebrew or Japanese road reads the same way there.

**Hidden while previewing a step** — flicking ahead through upcoming turns must not change where the app says you are — plus in PiP, and until a puck position exists.

**Positioning:** a new `onPuckScreen` callback projects the drawn puck to screen pixels. It only fires when the position moves more than 2px, because the follow camera parks the puck at essentially one spot and the map slides underneath it — reporting per frame would recompose the label 60 times a second for nothing.

The pill is width-capped and clamped inside the viewport, so a long multi-word street name near a screen edge can't run off it.

Device-verified on a demo drive — screenshot in the thread shows it reading "134th Place Southeast" under the arrow.

Kept the `VelaMapView` footprint to one callback and one small block, since #300 and #305 are also open against that file.
