### PR TITLE
Stop the UI thread stalling once per GPS fix during navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1988,6 +1988,26 @@ architecture note.
   `navSession.onLocation` path - puck/banner/voice keep working, `navStarved` keeps the
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
+  **THE UI THREAD STALLED ONCE PER GPS FIX (issue #251, the "jitter" on a demo drive, fixed
+  2026-09-03).** A demo drive has ZERO GPS noise, yet the puck still froze and lurched once a
+  second. Measured, not guessed: a screen recording showed one 65-84 ms frame every 1.02 s
+  followed by a 3.5x catch-up step, and a Perfetto trace named it: `Compose:recompose` 50-74 ms
+  in the fix's `doFrame`, "App Deadline Missed", exactly at the fix cadence. Trace markers
+  bisected it to the ARGUMENTS of the `ManeuverBanner` call in MapScreen: `navRomanize` ->
+  `SpokenScript.forDisplay` sorted the WHOLE road-name dict (`roadNameLatin`, a downloaded
+  region's entire `names.tsv.gz`) and scanned every entry, twice per fix, for an English string
+  that could never match. Fix in `SpokenScript.applyDict`: return in O(length) when the text has
+  no character the reader can't read (every matchable entry contains one), and digest the dict
+  once per instance (`preparedFor`, identity-keyed, two slots for the UI-language and
+  voice-language maps). Second cost in the same frame: `NavEngine.update` rebuilt
+  `cumulative(polyline)` and projected EVERY maneuver over the remaining line per fix (~19 ms,
+  over a frame budget by itself) - now cached per route identity (`geomFor`). On-device after:
+  recompose 7 ms max, banner 0.9 ms, onLocation 0.2 ms, the 1 Hz stall gone. **Rule: a puck
+  "jitter" report is measured with a screen recording (frame-to-frame timestamps + pixel diff)
+  and a Perfetto trace BEFORE any physics is touched; a hitch at the fix cadence is main-thread
+  work, and no filter can smooth a dropped frame.** Trace app sections with
+  `atrace_apps: "app.vela"` in the perfetto config; `android.os.Trace.beginSection` works in the
+  release build, and `Compose:recompose` slices are emitted by the runtime already.
   Nav zoom range is 18.0→15.5 (2026-07-14, was 17.3→15.0). **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
   dominant cause of the "record needle" swim).** `startDemoDrive` feeds
   `locationProvider.replay(fixes, speedup = 1f)` - REAL-TIME fixes - but it also sets

--- a/core/src/main/java/app/vela/core/nav/NavEngine.kt
+++ b/core/src/main/java/app/vela/core/nav/NavEngine.kt
@@ -160,7 +160,8 @@ object NavEngine {
         // [offDist], the perpendicular distance of the projection we ADOPTED (or the best seen
         // while holding) — the off-route check below keys on it, NOT on the whole-polyline
         // minimum, so "near the RETURN leg of an out-and-back" can't mask a genuine exit.
-        val cum = cumulative(route.polyline)
+        val geom = geomFor(route)
+        val cum = geom.cum
         val total = cum.lastOrNull() ?: 0.0
         var reacquireHits = state.reacquireHits
         val traveled: Double
@@ -280,20 +281,8 @@ object NavEngine {
         // tile the polyline (Google's abbreviated fallback; old trip recordings made before via
         // distances were folded carry km-wrong step lengths). A location that can't be found on
         // the polyline at all (damaged data) falls back to the anchored global match.
-        val manAlong = DoubleArray(maneuvers.size)
-        run {
-            var fromM = 0.0
-            for (k in maneuvers.indices) {
-                // +0.5 nudge past the previous position: a segment ENDING exactly at fromM still
-                // overlaps the window and its (earlier) projection would win the strict-less tie.
-                val (wm, wd) = projectAlong(route.polyline, cum, maneuvers[k].location, fromM + 0.5, total)
-                manAlong[k] = (
-                    if (wd <= ON_ROUTE_M) wm
-                    else projectNearAnchor(route.polyline, cum, maneuvers[k].location, fromM).first
-                    ).coerceAtLeast(fromM)
-                fromM = manAlong[k]
-            }
-        }
+        // Computed once per ROUTE in [geomFor] (it depends on nothing but the route), not per fix.
+        val manAlong = geom.manAlong
         fun maneuverAlong(k: Int): Double = manAlong[k]
 
         var spoken = state.spoken
@@ -515,6 +504,35 @@ object NavEngine {
     }
 
     /** Cumulative geometric length (m) of [path] at each vertex (cum[0] = 0). */
+    /** The per-route geometry every [update] needs: cumulative metres at each vertex, and each
+     *  maneuver's along-route mark. Both depend on the ROUTE alone, yet were rebuilt on every fix:
+     *  a full-polyline pass plus a windowed projection of EVERY maneuver over the remaining line,
+     *  once a second on the main thread, ~19 ms on a long route (measured 2026-09-03: over a
+     *  frame budget by itself, so the puck dropped a frame per fix even with the banner fixed).
+     *  One slot keyed by route identity: nav follows a single route and a reroute is a new object. */
+    private class RouteGeom(val route: Route, val cum: DoubleArray, val manAlong: DoubleArray)
+    @Volatile private var geomCache: RouteGeom? = null
+
+    private fun geomFor(route: Route): RouteGeom {
+        geomCache?.let { if (it.route === route) return it }
+        val cum = cumulative(route.polyline)
+        val total = cum.lastOrNull() ?: 0.0
+        val maneuvers = route.maneuvers
+        val manAlong = DoubleArray(maneuvers.size)
+        var fromM = 0.0
+        for (k in maneuvers.indices) {
+            // +0.5 nudge past the previous position: a segment ENDING exactly at fromM still
+            // overlaps the window and its (earlier) projection would win the strict-less tie.
+            val (wm, wd) = projectAlong(route.polyline, cum, maneuvers[k].location, fromM + 0.5, total)
+            manAlong[k] = (
+                if (wd <= ON_ROUTE_M) wm
+                else projectNearAnchor(route.polyline, cum, maneuvers[k].location, fromM).first
+                ).coerceAtLeast(fromM)
+            fromM = manAlong[k]
+        }
+        return RouteGeom(route, cum, manAlong).also { geomCache = it }
+    }
+
     internal fun cumulative(path: List<LatLng>): DoubleArray {
         val cum = DoubleArray(path.size)
         for (i in 1 until path.size) cum[i] = cum[i - 1] + path[i - 1].distanceTo(path[i])

--- a/core/src/main/java/app/vela/core/voice/SpokenScript.kt
+++ b/core/src/main/java/app/vela/core/voice/SpokenScript.kt
@@ -86,13 +86,44 @@ object SpokenScript {
         if (dict.isEmpty()) return text
         val code = lang?.lowercase()?.substringBefore('-')?.substringBefore('_')
         val voiceScript = VOICE_SCRIPT[code] ?: Character.UnicodeScript.LATIN
+        // Nothing can match unless the text itself carries a script this reader can't read: every
+        // entry that survives [preparedFor] contains such a character. So a plain-English
+        // instruction leaves here in O(length). It used to sort the WHOLE road-name table and scan
+        // every entry on every call, and the nav banner calls this twice per GPS fix on the main
+        // thread: with a downloaded region's names loaded that was ~60 ms once a second, four
+        // dropped frames and a visible lurch of the puck (the "jitter" of issue #251, 2026-09-03).
+        if (text.none { needsRomanizing(it, voiceScript) }) return text
         var s = text
-        for ((local, latin) in dict.entries.sortedByDescending { it.key.length }) {
-            if (local.isBlank() || latin.isBlank() || local == latin) continue
-            if (local.none { needsRomanizing(it, voiceScript) }) continue // reads this script itself
+        for ((local, latin) in preparedFor(dict, voiceScript)) {
             if (s.contains(local)) s = s.replace(local, latin)
         }
         return s
+    }
+
+    /** [dict] digested for [applyDict]: only the entries that can ever match for a reader of
+     *  [script] (a local name in a script it can't read, with a real, different Latin form),
+     *  longest first. Keyed by the dict INSTANCE: the road-name map is replaced wholesale when it
+     *  changes and never mutated in place, so identity is both cheap and exact. Two slots because
+     *  the banner (UI language) and the voice (voice language) hold their own map instances. */
+    private class Prepared(val dict: Map<String, String>, val script: Character.UnicodeScript, val entries: List<Pair<String, String>>)
+    private val prepared = arrayOfNulls<Prepared>(2)
+
+    private fun preparedFor(dict: Map<String, String>, script: Character.UnicodeScript): List<Pair<String, String>> {
+        synchronized(prepared) {
+            prepared.firstOrNull { it != null && it.dict === dict && it.script == script }?.let { return it.entries }
+        }
+        val entries = dict.entries.asSequence()
+            .filter { (local, latin) ->
+                local.isNotBlank() && latin.isNotBlank() && local != latin && local.any { needsRomanizing(it, script) }
+            }
+            .sortedByDescending { it.key.length }
+            .map { it.key to it.value }
+            .toList()
+        synchronized(prepared) {
+            prepared[1] = prepared[0]
+            prepared[0] = Prepared(dict, script, entries)
+        }
+        return entries
     }
 
     /** Testable core: the ICU call is injected as [romanize] so the run-splitting, voice gating and

--- a/core/src/test/java/app/vela/core/voice/SpokenScriptTest.kt
+++ b/core/src/test/java/app/vela/core/voice/SpokenScriptTest.kt
@@ -84,4 +84,34 @@ class SpokenScriptTest {
     @Test fun `a hebrew UI keeps hebrew even when the dict has a latin name`() {
         assertEquals("פנה אל רחוב הרצל", SpokenScript.forDisplay("פנה אל רחוב הרצל", "he", dict))
     }
+
+    // The dict path (issue #251 stall, 2026-09-03): the road-name table can hold a whole region's
+    // names, and the banner applies it twice per GPS fix on the main thread.
+    @Test fun `display dict swaps a local name for its latin form, longest name first`() {
+        val dict = mapOf("רחוב" to "Rehov", "רחוב הרצל" to "Rehov Herzl")
+        assertEquals("Turn right onto Rehov Herzl", SpokenScript.forDisplay("Turn right onto רחוב הרצל", "en", dict))
+    }
+
+    @Test fun `plain-script text returns as-is without touching a big dict`() {
+        // Every matchable entry carries a foreign-script character, so text without one can never
+        // match: it must come back identical (and, by construction, without a sort of the table).
+        val big = HashMap<String, String>()
+        for (i in 0 until 200_000) big["רחוב $i"] = "Rehov $i"
+        val text = "Turn right onto Elm Street"
+        assertEquals(text, SpokenScript.forDisplay(text, "en", big))
+        val t0 = System.nanoTime()
+        repeat(200) { SpokenScript.forDisplay(text, "en", big) }
+        val perCallMs = (System.nanoTime() - t0) / 200 / 1e6
+        org.junit.Assert.assertTrue("plain text took ${perCallMs} ms per call", perCallMs < 1.0)
+    }
+
+    @Test fun `a replaced dict instance is honoured, not the cached digest of the old one`() {
+        val a = mapOf("רחוב" to "Rehov")
+        val b = mapOf("רחוב" to "Street")
+        assertEquals("onto Rehov", SpokenScript.forDisplay("onto רחוב", "en", a))
+        assertEquals("onto Street", SpokenScript.forDisplay("onto רחוב", "en", b))
+        assertEquals("onto Rehov", SpokenScript.forDisplay("onto רחוב", "en", a))
+        // A reader of the name's own script keeps it, whatever the dict says.
+        assertEquals("onto רחוב", SpokenScript.forDisplay("onto רחוב", "he", b))
+    }
 }


### PR DESCRIPTION
Relates to #251.

A demo drive has no GPS noise at all, yet the puck still froze and lurched once a second. Measured rather than guessed: a screen recording showed one 65 to 84 ms frame every 1.02 s followed by a 3.5x catch-up step, and a Perfetto trace named it: `Compose:recompose` at 50 to 74 ms inside the fix's `doFrame`, "App Deadline Missed", exactly at the fix cadence. Trace markers bisected it to the arguments of the `ManeuverBanner` call.

**Cause 1 (60 ms):** `SpokenScript.forDisplay` sorted the whole road-name dictionary and scanned every entry on every call, and the banner calls it twice per fix. With a downloaded region's names loaded, that is the region's entire names table, twice a second, on the main thread, for an English instruction that can never match.

Fix: `applyDict` returns in O(length) when the text has no character the reader can't read (every entry that could match contains one), and the dictionary is digested once per instance (identity keyed, two slots for the UI-language and voice-language maps).

**Cause 2 (19 ms):** `NavEngine.update` rebuilt `cumulative(polyline)` and projected every maneuver over the remaining line on every fix. Both depend only on the route, so they are now cached per route identity.

**On the Pixel 4a after:** recompose 7 ms max (was 60 to 74), banner 0.9 ms (was 59.5), `onLocation` 0.2 ms (was 19). The once-a-second main-thread stall is gone from the trace and the recording.

Tests: fast path, longest-name-first swap, and a replaced dictionary instance. All core tests pass, static audit clean. CLAUDE.md records the cause and the rule that a jitter report gets a recording and a trace before any physics is touched.