### PR TITLE
Only count native crashes toward the compatibility-rendering fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1988,6 +1988,15 @@ architecture note.
   `navSession.onLocation` path - puck/banner/voice keep working, `navStarved` keeps the
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
+  **THE TEXTUREVIEW CRASH SENTINEL MISFIRED ON A HEALTHY PHONE (2026-09-03).** `texture_render`
+  (compatibility rendering, a TextureView map) is meant for GL drivers that kill the process at
+  init; the sentinel counted ANY death between map creation and the first idle render, so two
+  force-stops / swipe-kills / unrelated crashes flipped the Pixel 4a into it for good. Symptom: a
+  `TextureViewRend` thread at ~89% CPU in a trace and judder on every road, reported as puck jitter.
+  Now only `ApplicationExitInfo.REASON_CRASH_NATIVE` counts (`lastExitWasNativeCrash`, API 30+;
+  older devices keep the any-death rule), the flip records `texture_render_auto_ms`, and the
+  Developer row shows "Turned on automatically on <date>" so it can be seen and undone. When a
+  jitter/judder report comes in, check this toggle FIRST.
   Nav zoom range is 18.0→15.5 (2026-07-14, was 17.3→15.0). **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
   dominant cause of the "record needle" swim).** `startDemoDrive` feeds
   `locationProvider.replay(fixes, speedup = 1f)` - REAL-TIME fixes - but it also sets

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -121,8 +121,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   now marks "map initializing" at surface creation and clears it on the first finished render;
   two consecutive launches dying inside that window automatically switch the map to TextureView
   rendering (a different graphics path that avoids most of these driver bugs, slightly slower)
-  and the app just works from then on. Zero configuration, cannot misfire on healthy devices (a
-  successful render resets the counter), and Settings → Developer → Compatibility rendering is
+  and the app just works from then on. Zero configuration. Since 2026-09-03 only deaths the OS
+  recorded as a NATIVE crash count (Android 11+, `ApplicationExitInfo`): a force-stop, a swipe from
+  Recents, a low-memory kill or a Java crash elsewhere no longer count, because two of those had
+  flipped a healthy phone into the slower path for good without anyone noticing. When the sentinel
+  does engage, the setting's row says so with the date, and Settings → Developer → Compatibility rendering is
   the manual override in both directions. Known-fragile chips skip even the two crashes: Unisoc
   devices ON ANDROID 14 (the reported tablet's family + OS, identified from the hardware string;
   the documented driver faults are specific to the Android 14 builds) default straight into

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -561,11 +561,22 @@ fun VelaMapView(
         // A healthy device clears the sentinel every launch and never accumulates a count.
         val prefs = context.getSharedPreferences("vela_settings", android.content.Context.MODE_PRIVATE)
         if (prefs.getBoolean("map_init_inflight", false)) {
-            val n = prefs.getInt("map_init_crashes", 0) + 1
-            if (n >= 2) {
-                prefs.edit().putBoolean("texture_render", true).putInt("map_init_crashes", 0).apply()
+            // Only a death the OS recorded as a NATIVE crash counts (that is what a GL driver
+            // fault is). Anything else that ends a process before its first render used to count
+            // too - a force-stop, a swipe from Recents, a low-memory kill, `adb` during testing,
+            // a Java crash elsewhere in the app - and two of those flipped a healthy Pixel 4a into
+            // TextureView for good, unnoticed: the renderer ran at 89% CPU and the resulting
+            // judder was chased as puck jitter for weeks (2026-09-03).
+            if (lastExitWasNativeCrash(context)) {
+                val n = prefs.getInt("map_init_crashes", 0) + 1
+                if (n >= 2) {
+                    prefs.edit().putBoolean("texture_render", true).putInt("map_init_crashes", 0)
+                        .putLong("texture_render_auto_ms", System.currentTimeMillis()).apply()
+                } else {
+                    prefs.edit().putInt("map_init_crashes", n).apply()
+                }
             } else {
-                prefs.edit().putInt("map_init_crashes", n).apply()
+                prefs.edit().putInt("map_init_crashes", 0).apply()
             }
         }
         prefs.edit().putBoolean("map_init_inflight", true).apply()
@@ -4443,6 +4454,19 @@ private fun applyMapTheme(style: Style, dark: Boolean) {
  *  downgrade on exactly the weakest GPUs. Pre-14 fragile devices are covered by the two-crash
  *  sentinel instead. This only sets the DEFAULT - an explicit Developer-toggle choice (the
  *  "texture_render" pref) beats it either way. */
+/** Whether this process's PREVIOUS life ended in a native crash, per the OS's own exit record
+ *  (`ApplicationExitInfo`): the only kind of death the GPU-driver sentinel is for. Android 11+
+ *  keeps that record; older devices report true (the old any-death behaviour) because the
+ *  fragile-driver class the sentinel exists for is Android 14. */
+internal fun lastExitWasNativeCrash(context: android.content.Context): Boolean {
+    if (android.os.Build.VERSION.SDK_INT < 30) return true
+    val am = context.getSystemService(android.content.Context.ACTIVITY_SERVICE) as? android.app.ActivityManager
+        ?: return true
+    val last = runCatching { am.getHistoricalProcessExitReasons(context.packageName, 0, 1).firstOrNull() }
+        .getOrNull() ?: return true
+    return last.reason == android.app.ApplicationExitInfo.REASON_CRASH_NATIVE
+}
+
 internal fun fragileGpuDefault(): Boolean =
     android.os.Build.VERSION.SDK_INT >= 34 &&
         (

--- a/app/src/main/java/app/vela/ui/settings/sections/DiagnosticsSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/DiagnosticsSettings.kt
@@ -85,13 +85,25 @@ internal fun DiagnosticsSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onC
         // VelaMapView reads when it creates the map; needs an app restart to apply. Also flips
         // itself on via the two-crash sentinel when a GPU driver kills the map at init.
         var textureRender by remember { mutableStateOf(prefs.getBoolean("texture_render", app.vela.ui.map.fragileGpuDefault())) }
+        // When the sentinel flipped it on by itself, SAY SO on the row (with the date): a user who
+        // never touched this must be able to see the app did, and that turning it off is safe to try.
+        var textureAutoMs by remember { mutableStateOf(prefs.getLong("texture_render_auto_ms", 0L)) }
         Spacer(Modifier.height(4.dp))
         SettingsGroup {
         ToggleRow(
             label = stringResource(R.string.settings_texture_render),
             checked = textureRender,
-            onCheckedChange = { on -> textureRender = on; prefs.edit().putBoolean("texture_render", on).apply() },
-            hint = stringResource(R.string.settings_texture_render_hint),
+            onCheckedChange = { on ->
+                textureRender = on
+                prefs.edit().putBoolean("texture_render", on).remove("texture_render_auto_ms").apply()
+                textureAutoMs = 0L
+            },
+            hint = if (textureRender && textureAutoMs > 0L) {
+                stringResource(
+                    R.string.settings_texture_render_auto_hint,
+                    java.text.DateFormat.getDateInstance(java.text.DateFormat.MEDIUM).format(java.util.Date(textureAutoMs)),
+                )
+            } else stringResource(R.string.settings_texture_render_hint),
         )
         GroupDivider()
         // Building-overlay debug badge + fps readout on the map (the runOvlGate probe tooling).

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
     <string name="settings_voice_install_vela_hint">The recommended navigation voice. Reinstall it here any time it goes missing or a download failed.</string>
     <string name="settings_texture_render">Compatibility rendering</string>
     <string name="settings_texture_render_hint">Draws the map through a compatibility path that avoids some devices\' graphics driver bugs. Turns itself on if the map crashed the app at startup. Slightly slower; needs an app restart to apply.</string>
+    <string name="settings_texture_render_auto_hint">Turned on automatically on %1$s after the map crashed at startup twice. If the map works with this off, leave it off: it is slower and can make the map stutter while driving. Needs an app restart to apply.</string>
     <string name="settings_show_reviews">Show reviews</string>
     <string name="settings_show_reviews_hint">Off = place pages show no reviews, and Vela never fetches them.</string>
     <string name="settings_load_photos">Load photos</string>


### PR DESCRIPTION
Found while chasing #251.

The two-crash sentinel that switches the map to TextureView ("Compatibility rendering") counted **any** process death between map creation and the first finished render: a force-stop, a swipe from Recents, a low-memory kill, `adb` during testing, a Java crash elsewhere in the app. Two of those had flipped a healthy Pixel 4a into the slower path for good, silently: a `TextureViewRend` thread at 89% CPU in the trace, judder on every road, reported as puck jitter.

**Fix:** on Android 11+ the sentinel asks the OS how the previous process died (`ApplicationExitInfo`) and counts only `REASON_CRASH_NATIVE`, which is what a GL driver fault is. Older devices keep the old rule (the fragile-driver class this exists for is Android 14).

When the fallback does engage it records the time, and the Developer row reads "Turned on automatically on <date> after the map crashed at startup twice" so a user who never touched it can see the app did, and that switching it off is safe to try. Switching it off clears the note.

Docs: FEATURES.md (the "cannot misfire on healthy devices" claim is gone), CLAUDE.md (check this toggle first on any judder report). Static audit clean.