### PR TITLE
Draw the navigation puck as a screen overlay so it cannot jitter against the map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1988,6 +1988,8 @@ architecture note.
   `navSession.onLocation` path - puck/banner/voice keep working, `navStarved` keeps the
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
+  **Read `docs/puck-jitter.md` first: the eight causes, the measurement scripts in `scripts/jitter/`, and
+  the order to run them. Do not start from a theory.**
   **THE PUCK ITSELF JITTERED BECAUSE IT WAS A MAP SYMBOL (issue #251, fixed 2026-09-03). In
   follow mode the puck is now a COMPOSE OVERLAY, not the `ME_ARROW_LAYER` symbol.** Measured the
   pixel that matters: the white chevron's centroid in an `adb screenrecord` (`puck2.py`: threshold

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1988,6 +1988,24 @@ architecture note.
   `navSession.onLocation` path - puck/banner/voice keep working, `navStarved` keeps the
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
+  **THE PUCK ITSELF JITTERED BECAUSE IT WAS A MAP SYMBOL (issue #251, fixed 2026-09-03). In
+  follow mode the puck is now a COMPOSE OVERLAY, not the `ME_ARROW_LAYER` symbol.** Measured the
+  pixel that matters: the white chevron's centroid in an `adb screenrecord` (`puck2.py`: threshold
+  the white glyph in a 200 px box around the puck, centroid per frame) moved 1-2 px on 95% of
+  frames on a dead-straight highway with the map calm, in a saw-tooth (1683.3, 1682.1, 1683.2,
+  1684.3, 1686.8...). Cause: `setMeSource` is a GeoJSON source update that goes through
+  MapLibre's async worker tiling, while `moveCamera` is synchronous, so the symbol landed on time
+  or one frame late at random - one frame of travel (0.3 m, ~1 px at nav zoom) of vibration, on
+  every road, independent of physics, geometry or frame pacing. The overlay is drawn at
+  `projection.toScreenLocation(pt)` computed right after the camera move from the same camera
+  state, rotated by `displayBearing - camera bearing`, squashed by `cos(tilt)` (two
+  graphicsLayers: inner rotates, outer squashes+translates - order matters), from the same
+  `navPuckBitmap()`. Per-frame writes go to `mutableFloatStateOf` holders read in the DRAW phase,
+  so no recomposition per frame. `ME_ARROW_LAYER` is hidden while the overlay is on and restored
+  (via `lastMeLayerKey = null`) when following stops, the puck disengages or the style reloads.
+  After: chevron motion 0.07 px/frame, 2% of frames >0.5 px (was 1.39 px, 91%). The GeoJSON
+  puck is still used when not following (panned map) and in browse. Rule: anything that must
+  sit still on screen while the map moves cannot be a per-frame GeoJSON symbol.
   Nav zoom range is 18.0→15.5 (2026-07-14, was 17.3→15.0). **DEMO DRIVES RAN THE PUCK CLOCKS AT 3x (issue #251, fixed 2026-08-10 - the
   dominant cause of the "record needle" swim).** `startDemoDrive` feeds
   `locationProvider.replay(fixes, speedup = 1f)` - REAL-TIME fixes - but it also sets

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1262,6 +1262,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   DISPLAYED speed is smoothed with a stop deadband (raw 1 Hz doppler flickered 59/60/61 at cruise), and
   speed derivation requires two GPS fixes past an accuracy-scaled floor (a BeaconDB hop minted phantom
   16 mph readouts at red lights).
+  **The puck sits still (2026-09-03):** in follow mode the arrow is drawn as a screen overlay at
+  the projection of its smoothed point through the camera state just set, instead of as a map
+  symbol whose per-frame update could land a frame late. Measured on a straight highway, the
+  chevron moved 1 to 2 px on 95% of frames before and 0.07 px on average after. Same look:
+  rotated relative to the camera, foreshortened by the tilt.
   **Route line ("the gradient when you zoom in"):** the driven/ahead cut is now a GEOMETRY split - a
   traversed-grey full line (theme-aware, dimmer than the alternates' grey) under an ahead-suffix layer cut
   exactly at the puck, updated at sub-pixel granularity for the current zoom, with traffic spans remapped

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -56,6 +56,9 @@ import org.maplibre.geojson.Feature
 import org.maplibre.geojson.FeatureCollection
 import org.maplibre.geojson.LineString
 import org.maplibre.geojson.Point
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import org.maplibre.android.geometry.LatLng as MLLatLng
 import org.maplibre.android.geometry.LatLngBounds as MLLatLngBounds
 
@@ -598,6 +601,23 @@ fun VelaMapView(
         }
     }
     var styleRef by remember { mutableStateOf<Style?>(null) }
+    // The follow-mode puck OVERLAY (see the ticker): screen position + transform, written per
+    // frame by the ticker and read in the DRAW phase (graphicsLayer lambdas), so a frame costs
+    // one layer redraw and no recomposition.
+    val puckOverlayOn = remember { mutableStateOf(false) }
+    val puckOverlayX = remember { androidx.compose.runtime.mutableFloatStateOf(Float.NaN) }
+    val puckOverlayY = remember { androidx.compose.runtime.mutableFloatStateOf(Float.NaN) }
+    val puckOverlayRot = remember { androidx.compose.runtime.mutableFloatStateOf(0f) }
+    val puckOverlaySquash = remember { androidx.compose.runtime.mutableFloatStateOf(1f) }
+    val puckOverlayHidLayer = remember { booleanArrayOf(false) } // ME_ARROW_LAYER hidden for the overlay
+    fun dropPuckOverlay() {
+        if (puckOverlayOn.value) puckOverlayOn.value = false
+        if (puckOverlayHidLayer[0]) {
+            puckOverlayHidLayer[0] = false
+            lastMeLayerKey = null // applyData re-derives the symbol puck's visibility on its next pass
+            styleRef?.getLayer(ME_ARROW_LAYER)?.setProperties(PropertyFactory.visibility(Property.VISIBLE))
+        }
+    }
     var appliedStyleKey by remember { mutableStateOf<String?>(null) }
     var lastCameraTarget by remember { mutableStateOf<LatLng?>(null) }
     var lastInsetPx by remember { mutableStateOf(-1) }
@@ -1691,8 +1711,28 @@ fun VelaMapView(
                                 .build(),
                         ),
                     )
+                    // SCREEN-SPACE PUCK (issue #251, "the puck itself moves", 2026-09-03). The
+                    // arrow is a GeoJSON symbol: its per-frame source update goes through
+                    // MapLibre's async workers while the camera move above is synchronous, so
+                    // the symbol lands on time or a frame late at random and the arrow jitters
+                    // by a frame of travel against a calm map (measured on a straight highway:
+                    // the white glyph moved 1-2 px on 95% of frames). In follow mode the puck is
+                    // therefore a Compose overlay at the projection of the SAME point through the
+                    // camera state just set, so the two cannot disagree by a frame. Same look:
+                    // rotated by the bearing relative to the camera, squashed by the tilt.
+                    val scr = cam.projection.toScreenLocation(MLLatLng(pt.lat, pt.lng))
+                    puckOverlayX.floatValue = scr.x
+                    puckOverlayY.floatValue = scr.y
+                    puckOverlayRot.floatValue = (((navPuck.displayBearing - camState[2]).toFloat() % 360f) + 360f) % 360f
+                    puckOverlaySquash.floatValue = kotlin.math.cos(Math.toRadians(navTiltEase[0])).toFloat().coerceIn(0.2f, 1f)
+                    if (!puckOverlayOn.value) puckOverlayOn.value = true
+                    if (!puckOverlayHidLayer[0]) {
+                        puckOverlayHidLayer[0] = true
+                        style.getLayer(ME_ARROW_LAYER)?.setProperties(PropertyFactory.visibility(Property.NONE))
+                    }
                 } else {
                     camState[0] = Double.NaN // reset → re-attach eases in from the live camera
+                    dropPuckOverlay()
                 }
                 // Keep the driven/ahead cut EXACTLY under the arrow — a GEOMETRY split updated
                 // here (throttled to sub-pixel at the CURRENT zoom): the ahead layer gets the
@@ -1783,6 +1823,7 @@ fun VelaMapView(
                     )
                 }
             } else {
+                dropPuckOverlay()
                 navPuck.raw?.let { setMeSource(style, it, navPuck.rawBearing ?: 0f) }
             }
         }
@@ -1820,7 +1861,8 @@ fun VelaMapView(
         }
     }
 
-    AndroidView(factory = { mapView }, modifier = modifier) { mv ->
+    androidx.compose.foundation.layout.Box(modifier) {
+    AndroidView(factory = { mapView }, modifier = Modifier.matchParentSize()) { mv ->
         // Re-assert non-focusability each pass — MapLibre re-enables it on surface
         // (re)creation, which would let it eat D-pad keys again (docs/dpad.md).
         if (mv.isFocusable) {
@@ -2567,6 +2609,7 @@ fun VelaMapView(
                 lastRouteMode = -1
                 lastBrowseGradKey = null
                 lastMeLayerKey = null
+                puckOverlayHidLayer[0] = false // fresh style re-created the symbol puck visible
                 lastEnsureKey[0] = -1 // fresh style dropped the overlay layers - re-ensure on next pass
                 lastGradM[0] = -1e9 // force the nav split to re-render on the fresh style
                 PoiIcons.satellite = satelliteOn
@@ -2906,6 +2949,26 @@ fun VelaMapView(
                 }
             }
         }
+    }
+    if (puckOverlayOn.value) {
+        val puckImg = remember { navPuckBitmap().asImageBitmap() }
+        val sizePx = puckImg.width
+        androidx.compose.foundation.Image(
+            bitmap = puckImg,
+            contentDescription = null,
+            modifier = Modifier
+                // Outer layer: place the centre at the projected point and squash by the tilt
+                // (in SCREEN space, after the rotation below - hence two layers).
+                .graphicsLayer {
+                    translationX = puckOverlayX.floatValue - sizePx / 2f
+                    translationY = puckOverlayY.floatValue - sizePx / 2f
+                    scaleY = puckOverlaySquash.floatValue
+                }
+                // Inner layer: the heading, relative to the camera (the map rotates under it).
+                .graphicsLayer { rotationZ = puckOverlayRot.floatValue }
+                .size(with(density) { sizePx.toDp() }),
+        )
+    }
     }
 }
 

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1497,6 +1497,10 @@ fun VelaMapView(
             // this branch and its moveCamera killed the route-fit flight at frame ~0 - the
             // "picking an alternate kills the fly-over" hitch. wasNavRef makes the teardown
             // one-shot per real drive.
+            // Nav ended (or never ran): the ticker that owns the overlay is gone, so drop it HERE -
+            // the in-ticker drops never run once the effect is cancelled (the arrow stayed on the
+            // browse map after ending a demo, user 2026-09-03).
+            dropPuckOverlay()
             if (!wasNavRef[0]) return@LaunchedEffect
             wasNavRef[0] = false
             navPuck.kalman.reset() // nav ended — don't carry a stale speed into the next trip

--- a/docs/puck-jitter.md
+++ b/docs/puck-jitter.md
@@ -1,0 +1,68 @@
+# Puck jitter: what it actually was
+
+Issue #251 was open from July to September 2026 and was re-diagnosed from scratch at least
+five times. Each pass found a real cause, fixed it, and the report came back. This is the
+record of what was wrong, in the order it was found, with the measurement that found it, so
+that nobody has to derive it a sixth time.
+
+The one-line version: **there were eight independent causes, and the last one, the one a
+driver's eye was actually on, was not physics at all.** The puck was a map symbol whose
+per-frame update could land one frame after the camera move, so the arrow vibrated by one
+frame of travel against a calm map.
+
+## The rule that came out of it
+
+A jitter report gets **measured before anything is touched**, in this order:
+
+1. `scripts/jitter/puck_track.py` on a screen recording: does the ARROW move on screen?
+2. `scripts/jitter/map_motion.py` and `rotation_fit.py`: does the MAP move unevenly, or turn
+   unevenly through a bend?
+3. `scripts/jitter/gl_frames.py` on a Perfetto trace: are map renders over budget, and are
+   the over-budget ones evenly spaced (a periodic culprit) or random (the device's floor)?
+4. Settings > Diagnostics: is Compatibility rendering on? It should not be on a healthy phone.
+
+A demo drive (Settings > Navigation > demo mode) has zero GPS noise. If it jitters, the
+cause is not GPS and no filter will fix it.
+
+## The eight causes
+
+| # | What | How it showed | Found by | Fix |
+|---|------|---------------|----------|-----|
+| 1 | The along-route POSITION was never filtered; the snapped fix went straight into the drawn progress | every metre of GPS noise was a metre the arrow travelled, once a second | replaying real trips | `AlongRouteFilter`, a 1-D Kalman on metres-along (#305) |
+| 2 | The progress rule stalled and surged: ease-toward-target plus a monotonic clamp fought each other at the fix cadence | stalled frames then lurches | replay + frame log | rate-domain correction, bounded catch-up (#305) |
+| 3 | The camera bearing followed digitization wiggle | the map swung under a steady arrow | screen-space band analysis | camera bearing eases with a steady/turn time constant |
+| 4 | The smoothing window's own width rippled with the Kalman speed | sideways drift on curves | analysis | eased window width |
+| 5 | Demo drives ran the puck clocks at 3x | stalls on 54% of frames in demo mode | frame log | gate the replay speedup on real replays only |
+| 6 | The UI thread stalled 60 ms once per fix: `SpokenScript.forDisplay` sorted the whole road-name dictionary twice per fix for English text that could never match, and `NavEngine.update` re-projected every maneuver over the route per fix | one 65 to 84 ms frame every 1.02 s, then a 3.5x catch-up step | screen recording timestamps + Perfetto (`Compose:recompose` 50 to 74 ms at 1 Hz) + trace markers bisecting the arguments of `ManeuverBanner` | fast path + digest cache; per-route geometry cache (#314) |
+| 7 | The route line's driven/ahead split re-uploaded a 3 km LineString every 150 ms | over-budget map renders spaced 133 to 167 ms, 46 in 8 s: a 6.7 Hz vibration of the whole map | `gl_frames.py`, then an A/B build with the throttle at 2 s (spacing went random, count 18 to 22) | the moving cut is a `line-gradient` PAINT update on a short 400 m piece; geometry slides every ~300 m (#316) |
+| 8 | **The puck was a GeoJSON symbol.** `setMeSource` goes through MapLibre's async worker tiling; `moveCamera` is synchronous. The symbol landed on time or one frame late at random | the white chevron moved 1 to 2 px on 95% of frames on a dead-straight highway with the map calm, in a saw-tooth | `puck_track.py` | in follow mode the puck is a Compose overlay at the projection of the same point through the camera state just set (#318) |
+
+And one that was not code: the test phone had been silently switched into **Compatibility
+rendering** (a TextureView map) by the crash sentinel, which counted any process death during
+map init, including force-stops during testing. The renderer sat at 89% of a core and every road
+juddered. The sentinel now counts only native crashes and says on the settings row when it
+engaged (#317).
+
+## Things that were tried and are worse
+
+- A per-frame **LineString** source for the moving route cut. A line re-tiles on every worker
+  thread on every update; only a point source is cheap per frame. Worker CPU went from 0.6 s to
+  1.4 s per thread per 8 s.
+- A whole-route **line-gradient** for the cut. 256 texels over the route smears the cut into a
+  routeLength/256 metre ramp.
+- Smoothing the **route geometry** for the arrow. Measured on the reporter's own roads: the
+  camera's turn rate through bends was already smooth (0.02 degrees per frame of jerk) and the
+  modelled arrow sat within a fraction of a pixel of the camera. The kinks were not what the eye
+  saw; cause 8 was.
+
+## What it cost and saved
+
+Total app CPU during a demo drive on a Pixel 4a, from Perfetto, same road: 173% of a core in
+the morning (compatibility rendering plus causes 6, 7, 8), 122% after. Main thread per fix:
+about 80 ms to about 1 ms.
+
+## Where the code is
+
+- `core/location/AlongRouteFilter.kt` (1, 2), `core/voice/SpokenScript.kt` and
+  `core/nav/NavEngine.kt` (6), `app/ui/map/VelaMapView.kt` (3, 4, 5, 7, 8 and the sentinel).
+- The longer notes, with the numbers, live in `CLAUDE.md` under the puck-jitter heading.

--- a/scripts/jitter/gl_frames.py
+++ b/scripts/jitter/gl_frames.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Map render-thread frame times from a Perfetto trace (see perfetto.cfg in this folder).
+#   adb shell 'cat perfetto.cfg | perfetto -c - --txt -o /data/misc/perfetto-traces/t.pb'
+#   adb pull /data/misc/perfetto-traces/t.pb && python3 scripts/jitter/gl_frames.py t.pb
+# A "render" is a run of the GL thread separated by sleeps > 0.3 ms. Prints the distribution and
+# the share over a 60 Hz budget. Also print the SPACING of the over-budget renders: a fixed
+# spacing is a periodic culprit. Needs the perfetto pip package.
+import sys, numpy as np
+from perfetto.trace_processor import TraceProcessor
+for f in sys.argv[1:]:
+    tp=TraceProcessor(trace=f); q=lambda s: list(tp.query(s))
+    rows=q("""select ts.ts, ts.dur, ts.state, t.name tname from thread_state ts join thread t using(utid) join process p using(upid) where p.name='app.vela' and (t.name like 'RenderThread %' or t.name='TextureViewRend') order by ts.ts""")
+    bs=None; fr=[]
+    for r in rows:
+        if r.state=='S' and r.dur>0.3e6:
+            if bs is not None: fr.append((bs,be)); bs=None
+        else:
+            if bs is None: bs=r.ts
+            be=r.ts+r.dur
+    d=np.array([(b-a)/1e6 for a,b in fr]); d=d[d>1.0]
+    cpu=q("""select sum(ts.dur)/1e6 ms from thread_state ts join thread t using(utid) join process p using(upid) where p.name='app.vela' and (t.name like 'RenderThread %' or t.name='TextureViewRend') and ts.state='Running'""")[0].ms
+    print("%s: GL renders %d | median %.1f ms p75 %.1f p90 %.1f p99 %.1f | >16.7ms %.0f%% | GL cpu %.0f%%" % (f, len(d), np.median(d), np.percentile(d,75), np.percentile(d,90), np.percentile(d,99), 100*(d>16.7).mean(), cpu/80))

--- a/scripts/jitter/map_motion.py
+++ b/scripts/jitter/map_motion.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Per-frame MAP translation from a screenrecord (gradient phase correlation of the map band).
+#   python3 scripts/jitter/map_motion.py v.mp4
+# Prints the step per frame and how many frames froze (duplicate) or doubled (catch-up). On a
+# Pixel 4a in SurfaceView mode the floor is ~3-4% each; a fixed cadence in the frozen frames means
+# something periodic on the render thread (2026-09-03: the 150 ms route-line re-upload).
+import sys, glob, os, subprocess, numpy as np
+from PIL import Image
+try:
+    import cv2
+except ImportError:
+    cv2=None
+vid=sys.argv[1]; d='nf_'+os.path.basename(vid).split('.')[0]
+if not os.path.isdir(d) or len(glob.glob(d+'/*.png'))<50:
+    subprocess.run(['rm','-rf',d]); os.makedirs(d, exist_ok=True); subprocess.run(['ffmpeg','-v','quiet','-i',vid,'-fps_mode','passthrough',d+'/f%08d.png'])
+fs=sorted(glob.glob(d+'/*.png'))[:420]
+def grad(f):
+    a=np.asarray(Image.open(f).convert('L').crop((0,900,1080,1900)),dtype=np.float32)
+    gy,gx=np.gradient(a); g=np.hypot(gx,gy); return g
+G=[grad(f) for f in fs]
+win=np.outer(np.hanning(G[0].shape[0]), np.hanning(G[0].shape[1])).astype(np.float32)
+def pc(a,b):
+    if cv2 is not None:
+        (dx,dy),resp=cv2.phaseCorrelate(a*win,b*win); return dx,dy,resp
+    A=np.fft.fft2(a*win); B=np.fft.fft2(b*win); R=A*np.conj(B); R/=np.abs(R)+1e-9; r=np.fft.ifft2(R).real
+    iy,ix=np.unravel_index(np.argmax(r), r.shape); dy=iy if iy<r.shape[0]/2 else iy-r.shape[0]; dx=ix if ix<r.shape[1]/2 else ix-r.shape[1]
+    return -dx,-dy,r.max()
+mv=np.array([pc(G[i],G[i+1]) for i in range(len(G)-1)])
+dx,dy=mv[:,0],mv[:,1]; mag=np.hypot(dx,dy); med=np.median(mag)
+print("%-16s frames %d | step median %.2f px (dy %.2f) sd %.2f | zero-motion (<25%% of median): %d (%.0f%%) | double-step (>160%%): %d (%.0f%%) | dx sd %.2f" % (os.path.basename(vid), len(G), med, np.median(dy), mag.std(), (mag<0.25*med).sum(), 100*(mag<0.25*med).sum()/len(mag), (mag>1.6*med).sum(), 100*(mag>1.6*med).sum()/len(mag), dx.std()))
+print("   first 60 steps:", " ".join("%.1f"%m for m in mag[:60]))

--- a/scripts/jitter/perfetto.cfg
+++ b/scripts/jitter/perfetto.cfg
@@ -1,0 +1,9 @@
+buffers { size_kb: 65536 fill_policy: RING_BUFFER }
+data_sources { config { name: "linux.ftrace" ftrace_config {
+  ftrace_events: "sched/sched_switch" ftrace_events: "sched/sched_wakeup" ftrace_events: "sched/sched_process_exit"
+  atrace_categories: "gfx" atrace_categories: "view" atrace_categories: "binder_driver" atrace_categories: "dalvik" atrace_categories: "sched"
+  atrace_apps: "app.vela" } } }
+data_sources { config { name: "linux.process_stats" process_stats_config { scan_all_processes_on_start: true } } }
+data_sources { config { name: "android.surfaceflinger.frametimeline" } }
+duration_ms: 8000
+# Perfetto config for nav profiling: sched + app atrace (Compose slices) + frame timeline.

--- a/scripts/jitter/puck_track.py
+++ b/scripts/jitter/puck_track.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Track the nav ARROW on screen, frame by frame, in an adb screenrecord.
+# This measures the thing a driver's eye is on. Nothing else in this folder does.
+#   adb shell screenrecord --time-limit 12 --bit-rate 16000000 /sdcard/v.mp4 && adb pull /sdcard/v.mp4
+#   mkdir nf && ffmpeg -i v.mp4 -fps_mode passthrough nf/f%08d.png
+#   python3 scripts/jitter/puck_track.py nf 400
+# Thresholds the WHITE chevron inside a 200 px box around the puck (portrait 1080x2340, puck low
+# on screen) and prints its centroid's per-frame motion. Healthy: |dy| mean well under 0.1 px and
+# ~0% of frames over half a pixel. Broken (2026-09-03, GeoJSON-symbol puck): 1.4 px, 91%.
+import sys, glob, numpy as np, cv2
+d=sys.argv[1]; fs=sorted(glob.glob(d+'/*.png'))[:int(sys.argv[2]) if len(sys.argv)>2 else 400]
+cs=[]
+for f in fs:
+    im=cv2.imread(f); roi=im[1560:1760, 440:640]
+    b,g,r=roi[:,:,0].astype(int),roi[:,:,1].astype(int),roi[:,:,2].astype(int)
+    white=(b>225)&(g>225)&(r>225)
+    ys,xs=np.nonzero(white)
+    if len(xs)<40: cs.append((np.nan,np.nan)); continue
+    cs.append((xs.mean()+440, ys.mean()+1560))
+c=np.array(cs); dx=np.diff(c[:,0]); dy=np.diff(c[:,1])
+print("%-14s white-glyph px/frame n=%d | x sd %.2f, y sd %.2f | |dx| mean %.2f p90 %.2f | |dy| mean %.2f p90 %.2f max %.2f | frames with |dy|>0.5: %d%%" % (d, len(c), np.nanstd(c[:,0]), np.nanstd(c[:,1]), np.nanmean(abs(dx)), np.nanpercentile(abs(dx),90), np.nanmean(abs(dy)), np.nanpercentile(abs(dy),90), np.nanmax(abs(dy)), int(100*np.nanmean(abs(dy)>0.5))))
+print("   y (first 50):", " ".join("%.1f"%y for y in c[:50,1]))

--- a/scripts/jitter/rotation_fit.py
+++ b/scripts/jitter/rotation_fit.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Per-frame map ROTATION (camera turn rate) from screenrecord frames, via an ECC Euclidean fit.
+#   python3 scripts/jitter/rotation_fit.py nf 360
+# Use through a bend: a smooth turn shows a slowly varying angle per frame; kinks or dropped
+# frames show as double-then-zero steps. Needs opencv-python-headless.
+import sys, glob, numpy as np, cv2
+d=sys.argv[1]; fs=sorted(glob.glob(d+'/*.png'))[:int(sys.argv[2]) if len(sys.argv)>2 else 360]
+def prep(f):
+    a=cv2.imread(f, cv2.IMREAD_GRAYSCALE)[900:1900, 0:1080]
+    a=cv2.resize(a,(540,500)); g=cv2.GaussianBlur(a,(0,0),1.2); return g.astype(np.float32)
+P=[prep(f) for f in fs]
+crit=(cv2.TERM_CRITERIA_EPS|cv2.TERM_CRITERIA_COUNT, 60, 1e-5)
+th=[]; dys=[]
+for i in range(len(P)-1):
+    W=np.eye(2,3,dtype=np.float32)
+    try:
+        cc,W=cv2.findTransformECC(P[i],P[i+1],W,cv2.MOTION_EUCLIDEAN,crit,None,5)
+        ang=np.degrees(np.arctan2(W[1,0],W[0,0])); th.append(ang); dys.append(W[1,2]*2)
+    except cv2.error: th.append(np.nan); dys.append(np.nan)
+th=np.array(th); dys=np.array(dys); ok=~np.isnan(th)
+print("%s: %d frames, rotation per frame: mean %+.3f deg sd %.3f | frame-to-frame CHANGE sd %.3f deg (jerk) | |dtheta|>0.2deg jumps: %d | dy median %.2f px, zero-motion %d, double %d" % (d, ok.sum(), np.nanmean(th), np.nanstd(th), np.nanstd(np.diff(th)), (np.abs(np.diff(th))>0.2).sum(), np.nanmedian(np.abs(dys)), (np.abs(dys)<0.25*np.nanmedian(np.abs(dys))).sum(), (np.abs(dys)>1.6*np.nanmedian(np.abs(dys))).sum()))
+print("  theta/frame (deg) first 150:", " ".join("%+.2f"%x for x in th[:150]))


### PR DESCRIPTION
Relates to #251. The report was "the puck itself moves", with the map calm.

Measured on the pixel that matters: the white chevron's centroid in an `adb screenrecord` of a dead-straight highway moved **1 to 2 px on 95% of frames**, in a saw-tooth (1683.3, 1682.1, 1683.2, 1684.3, 1686.8...). The puck was a GeoJSON symbol: its per-frame source update goes through MapLibre's async worker tiling while `moveCamera` is synchronous, so the symbol landed on time or one frame late at random. One frame of travel is about a pixel at nav zoom, and that was the vibration, on every road, independent of physics, geometry or frame pacing.

**Fix:** in follow mode the puck is a Compose overlay drawn at `projection.toScreenLocation(pt)` computed right after the camera move from the same camera state, so the two cannot disagree by a frame. Same `navPuckBitmap()`, rotated by `displayBearing - camera bearing`, foreshortened by `cos(tilt)` (two graphics layers: inner rotates, outer squashes and places). Per-frame writes go to `mutableFloatStateOf` holders read in the draw phase; nothing recomposes per frame. The map symbol is hidden while the overlay is on and restored when following stops, the puck disengages, or the style reloads. Browse mode and a panned map keep the symbol.

**After, same road:** chevron motion **0.07 px/frame, 2% of frames over half a pixel** (was 1.39 px, 91%). Looks identical at 2x zoom (ellipse, chevron, shadow).

Docs: CLAUDE.md (the rule: anything that must sit still on screen while the map moves cannot be a per-frame GeoJSON symbol), FEATURES.md. Static audit clean.