### PR TITLE
Hide the road behind you during navigation, with a setting to bring it back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2256,6 +2256,10 @@ architecture note.
   `navSession.onLocation` path - puck/banner/voice keep working, `navStarved` keeps the
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
+  **Driven trail is a setting (`RouteTrail`, `route_trail`, default OFF = hidden, 2026-09-03):** the
+  ticker reads it per frame through `trailHolder`; off means `routeGradient(..., driven = TRANSPARENT)`
+  on the ahead and cut pieces and `ROUTE_LAYER` hidden, on means grey. A flip sets `splitReset` so the
+  next frame re-applies everything. Paint only; never touch geometry for this.
   **Read `docs/puck-jitter.md` first: the eight causes, the measurement scripts in `scripts/jitter/`, and
   the order to run them. Do not start from a theory.**
   **THE PUCK ITSELF JITTERED BECAUSE IT WAS A MAP SYMBOL (issue #251, fixed 2026-09-03). In

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1287,6 +1287,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   DISPLAYED speed is smoothed with a stop deadband (raw 1 Hz doppler flickered 59/60/61 at cruise), and
   speed derivation requires two GPS fixes past an accuracy-scaled floor (a BeaconDB hop minted phantom
   16 mph readouts at red lights).
+  **Road behind you (2026-09-03):** the driven part of the route no longer trails behind the arrow by
+  default; only the road ahead is drawn (Google's current look). Settings > Navigation > "Road behind
+  you" brings the grey trail back. Implemented as paint: the driven colour in the route gradients
+  becomes transparent and the full grey line is hidden, so nothing is re-uploaded.
   **The puck sits still (2026-09-03):** in follow mode the arrow is drawn as a screen overlay at
   the projection of its smoothed point through the camera state just set, instead of as a map
   symbol whose per-frame update could land a frame late. Measured on a straight highway, the

--- a/app/src/main/java/app/vela/VelaApp.kt
+++ b/app/src/main/java/app/vela/VelaApp.kt
@@ -94,6 +94,7 @@ class VelaApp : Application(), coil.ImageLoaderFactory {
         app.vela.ui.HideAdult.init(this)
         app.vela.ui.HideExternalLinks.init(this)
         app.vela.ui.Buildings3d.init(this)
+        app.vela.ui.RouteTrail.init(this)
         app.vela.ui.BuildingOverlay.init(this)
         app.vela.ui.BuildingDebug.init(this)
         app.vela.ui.MapPoiPrefs.init(this)

--- a/app/src/main/java/app/vela/ui/RouteTrail.kt
+++ b/app/src/main/java/app/vela/ui/RouteTrail.kt
@@ -1,0 +1,24 @@
+package app.vela.ui
+
+import android.content.Context
+import androidx.compose.runtime.mutableStateOf
+
+/** Whether the part of the route you have already driven stays drawn behind the arrow during
+ *  navigation (grey, Google's old look) or disappears (Google's current look, and the default
+ *  since 2026-09-03: the grey strip trailing down the screen under the arrow was the first thing
+ *  asked about once the puck stopped jittering). Read per frame by the nav ticker. */
+object RouteTrail {
+    val on = mutableStateOf(false)
+
+    fun init(context: Context) {
+        on.value = prefs(context).getBoolean(KEY, false)
+    }
+
+    fun set(context: Context, value: Boolean) {
+        on.value = value
+        prefs(context).edit().putBoolean(KEY, value).apply()
+    }
+
+    private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
+    private const val KEY = "route_trail"
+}

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -569,6 +569,12 @@ fun VelaMapView(
     val speedupHolder = rememberUpdatedState(replaySpeedup)
     val lastGradM = remember { doubleArrayOf(-1e9) } // progressM the route split was last set at
     val splitReset = remember { booleanArrayOf(false) } // style reload: re-anchor the window + coarse cut (layers came back hidden)
+    // "Road behind you": the driven part of the route stays grey (on) or disappears (off, the
+    // default). Read per frame by the ticker through a holder; a flip mid-drive re-anchors the
+    // split so the gradients and the full line's visibility are re-applied at once.
+    val trailOn = app.vela.ui.RouteTrail.on.value
+    val trailHolder = rememberUpdatedState(trailOn)
+    LaunchedEffect(trailOn) { splitReset[0] = true }
     val mPerPxHolder = remember { doubleArrayOf(10.0) } // metres/pixel at the camera (scale-bar feed) —
                                                         // sizes the split-update throttle to sub-pixel
     val lastScaleReport = remember { doubleArrayOf(-1.0) } // last mpp PUSHED to compose (gate, see reportScale)
@@ -1972,6 +1978,9 @@ fun VelaMapView(
                         style.getSourceAs<GeoJsonSource>(ROUTE_AHEAD_SRC)?.setGeoJson(lineFrom(aheadAnchor[0], tw))
                         aheadDirty = true
                     }
+                    // Driven colour: grey with the trail on, fully transparent with it off (the
+                    // full grey line beneath is hidden too, so only the road ahead is drawn).
+                    val driven = if (trailHolder.value) ROUTE_DRIVEN else android.graphics.Color.TRANSPARENT
                     if (aheadDirty) {
                         // Grey up to one texel past the piece start, so the ahead line's own soft
                         // edge lies under the piece's grey; colour from there.
@@ -1981,12 +1990,13 @@ fun VelaMapView(
                             ((cutStart[0] + NAV_CUT_HIDE_M - a0) / (a1 - a0)).toFloat().coerceIn(0f, 0.999f)
                         style.getLayer(ROUTE_AHEAD_LAYER)?.setProperties(
                             PropertyFactory.visibility(Property.VISIBLE),
-                            PropertyFactory.lineGradient(routeGradient(pa, gInt, remap(a0, a1))),
+                            PropertyFactory.lineGradient(routeGradient(pa, gInt, remap(a0, a1), driven)),
                         )
                         val traversed = android.graphics.Color.parseColor(
                             if (darkHolder.value) TRAVERSED_DARK else TRAVERSED_LIGHT,
                         )
                         style.getLayer(ROUTE_LAYER)?.setProperties(
+                            PropertyFactory.visibility(if (trailHolder.value) Property.VISIBLE else Property.NONE),
                             PropertyFactory.lineGradient(routeGradient(0f, traversed, emptyList())),
                         )
                     }
@@ -1996,7 +2006,7 @@ fun VelaMapView(
                     val pc = if (c1 - c0 <= 1.0) 0f else ((prog - c0) / (c1 - c0)).toFloat().coerceIn(0.0001f, 0.9999f)
                     style.getLayer(ROUTE_CUT_LAYER)?.setProperties(
                         PropertyFactory.visibility(Property.VISIBLE),
-                        PropertyFactory.lineGradient(routeGradient(pc, gInt, remap(c0, c1))),
+                        PropertyFactory.lineGradient(routeGradient(pc, gInt, remap(c0, c1), driven)),
                     )
                 }
             } else {
@@ -5476,12 +5486,13 @@ private fun routeGradient(
     p: Float,
     routeInt: Int,
     spans: List<Triple<Float, Float, Int>>,
+    driven: Int = ROUTE_DRIVEN, // TRANSPARENT when the "road behind you" trail is off
 ): Expression {
     val freeflow = if (spans.isEmpty()) routeInt else ROUTE_FREEFLOW
     // Colour AT fraction f (half-open: a stop at b colours [b, next)). Driven part is grey
     // STRICTLY BEFORE p (p == 0 preview paints no grey nub), so the cut lands exactly at p.
     fun colorAt(f: Float): Int {
-        if (p > 0f && f < p) return ROUTE_DRIVEN
+        if (p > 0f && f < p) return driven
         for ((s, e, lvl) in spans) if (f >= s && f < e) return trafficLevelColor(lvl)
         return freeflow
     }

--- a/app/src/main/java/app/vela/ui/settings/SettingsHub.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsHub.kt
@@ -317,6 +317,7 @@ private val SEARCH_INDEX: List<Pair<Int, SettingsSection>> = listOf(
     // Navigation
     R.string.settings_keep_screen_on to SettingsSection.NAVIGATION,
     R.string.settings_route_bar to SettingsSection.NAVIGATION,
+    R.string.settings_route_trail to SettingsSection.NAVIGATION,
     R.string.settings_traffic_lights to SettingsSection.NAVIGATION,
     R.string.settings_vibrate_on_turns to SettingsSection.NAVIGATION,
     R.string.settings_demo_drive to SettingsSection.NAVIGATION,

--- a/app/src/main/java/app/vela/ui/settings/sections/NavigationSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/NavigationSettings.kt
@@ -81,6 +81,13 @@ internal fun NavigationSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
             onCheckedChange = { routeBar = it; vm.setRouteBar(it) },
             hint = stringResource(R.string.settings_route_bar_hint),
         )
+        GroupDivider()
+        ToggleRow(
+            label = stringResource(R.string.settings_route_trail),
+            checked = app.vela.ui.RouteTrail.on.value,
+            onCheckedChange = { app.vela.ui.RouteTrail.set(context, it) },
+            hint = stringResource(R.string.settings_route_trail_hint),
+        )
 
         var trafficLights by remember { mutableStateOf(prefs.getBoolean("nav_traffic_lights", false)) }
         GroupDivider()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -766,6 +766,8 @@
     <string name="settings_nav_day_night">Day and night while navigating</string>
     <string name="settings_nav_day_night_hint">Keeps your chosen theme everywhere else, and switches by daylight only while you are driving.</string>
     <string name="mapscreen_shortcut_add">Add</string>
+    <string name="settings_route_trail">Road behind you</string>
+    <string name="settings_route_trail_hint">Keeps the part of the route you have already driven drawn in grey behind the arrow. Off hides it, so only the road ahead is drawn.</string>
     <string name="settings_route_bar">Road ahead bar</string>
     <string name="settings_route_bar_hint">A strip beside the map showing traffic and what is coming up on the rest of your route. Shows only what Vela actually knows: congestion, lights, stop signs, level crossings, speed bumps and surveillance cameras. Portrait only.</string>
     <string name="settings_font">Font</string>


### PR DESCRIPTION
The grey driven trail under the arrow is now off by default; only the road ahead is drawn (Google's current look). Settings > Navigation > "Road behind you" brings the old grey trail back.

Paint only: with the trail off, the driven colour in the route gradients is transparent and the full grey line is hidden. Nothing is re-uploaded per frame, so this does not touch the frame budget work in #316. Flipping the setting mid-drive re-anchors the route split so everything re-applies on the next frame.

Device-checked on the Pixel 4a: no trail below the arrow, the road ahead unchanged. Static audit clean. Docs: FEATURES.md, CLAUDE.md.