### PR TITLE
Swipe the ETA bar up to open the step list during navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2256,6 +2256,11 @@ architecture note.
   `navSession.onLocation` path - puck/banner/voice keep working, `navStarved` keeps the
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
+  **Nav bottom bar = drag handle for the step sheet (2026-09-04):** `NavControls` carries a vertical
+  drag (lift follows the finger up to NAV_BAR_LIFT_MAX_DP; commit past NAV_BAR_LIFT_COMMIT_DP or an
+  upward fling faster than NAV_BAR_FLING_PX_S, else spring back); commit = the same `openSteps` the
+  list button calls, and `StepsSheet` animates in from its own height (`enter`). The button stays as
+  the key path; the gesture is touch-only on purpose (docs/dpad.md).
   **Driven trail is a setting (`RouteTrail`, `route_trail`, default OFF = hidden, 2026-09-03):** the
   ticker reads it per frame through `trailHolder`; off means `routeGradient(..., driven = TRANSPARENT)`
   on the ahead and cut pieces and `ROUTE_LAYER` hidden, on means grey. A flip sets `splitReset` so the

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1287,6 +1287,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   DISPLAYED speed is smoothed with a stop deadband (raw 1 Hz doppler flickered 59/60/61 at cruise), and
   speed derivation requires two GPS fixes past an accuracy-scaled floor (a BeaconDB hop minted phantom
   16 mph readouts at red lights).
+  **Swipe up for the steps (2026-09-04):** the ETA bar at the bottom of the nav screen is the handle
+  for the step list, Google-style. Drag it up (it lifts with the finger) or fling it and the step
+  sheet slides in from where the bar was; swipe the sheet down and the bar is back. The list button
+  is still there and is the tap and D-pad path, so keypad phones lose nothing.
   **Road behind you (2026-09-03):** the driven part of the route no longer trails behind the arrow by
   default; only the road ahead is drawn (Google's current look). Settings > Navigation > "Road behind
   you" brings the grey trail back. Implemented as paint: the driven colour in the route gradients

--- a/app/src/main/java/app/vela/ui/nav/NavOverlays.kt
+++ b/app/src/main/java/app/vela/ui/nav/NavOverlays.kt
@@ -4,6 +4,11 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import kotlin.math.roundToInt
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -362,6 +367,11 @@ fun ManeuverBanner(
 // Show the lane diagram only within this distance of the maneuver (~0.5 mi) — beyond it the arrows are
 // just noise telling you to pick a lane for an exit miles ahead.
 private const val LANE_SHOW_M = 800.0
+// The nav bottom bar as a drag handle (see NavControls): how far it must be lifted to commit to
+// the step sheet, how far it may lift at all, and the upward fling speed that commits regardless.
+private const val NAV_BAR_LIFT_COMMIT_DP = 56
+private const val NAV_BAR_LIFT_MAX_DP = 120
+private const val NAV_BAR_FLING_PX_S = 900f
 
 // A "then <next>" compound preview only makes sense when the next maneuver closely follows this one
 // (~0.3 mi) — an exit-then-merge, not a turn 5 miles later. Matches Google's compound-maneuver treatment.
@@ -694,6 +704,14 @@ fun NavControls(
     modifier: Modifier = Modifier,
 ) {
     val dark = isAppInDarkTheme()
+    // Google's gesture: the ETA bar is the handle for the step list. Drag it UP and the card lifts
+    // with the finger; past NAV_BAR_LIFT_COMMIT_DP (or an upward fling) it commits and the step
+    // sheet slides in from where the bar was; below that it springs back. The list button stays
+    // as the tap and D-pad path (docs/dpad.md), so keypad phones lose nothing.
+    val lift = remember { Animatable(0f) }
+    val liftScope = rememberCoroutineScope()
+    val density = LocalDensity.current
+    val latestSteps by rememberUpdatedState(onSteps)
     // Colour the ETA by live traffic (Google-style): green free-flowing → amber →
     // red. Default ink when there's no live data (offline / traffic-less route).
     val etaColor = when {
@@ -703,7 +721,35 @@ fun NavControls(
         else -> SheetPalette.TrafficGreen
     }
     Card(
-        modifier.fillMaxWidth(),
+        modifier
+            .fillMaxWidth()
+            .offset { IntOffset(0, lift.value.roundToInt().coerceAtMost(0)) }
+            .pointerInput(Unit) {
+                val commitPx = with(density) { NAV_BAR_LIFT_COMMIT_DP.dp.toPx() }
+                val maxLiftPx = with(density) { NAV_BAR_LIFT_MAX_DP.dp.toPx() }
+                val tracker = androidx.compose.ui.input.pointer.util.VelocityTracker()
+                detectVerticalDragGestures(
+                    onDragStart = { tracker.resetTracking() },
+                    onVerticalDrag = { change, dy ->
+                        change.consume()
+                        tracker.addPosition(change.uptimeMillis, change.position)
+                        liftScope.launch { lift.snapTo((lift.value + dy).coerceIn(-maxLiftPx, 0f)) }
+                    },
+                    onDragEnd = {
+                        val vy = tracker.calculateVelocity().y
+                        val commit = -lift.value > commitPx || vy < -NAV_BAR_FLING_PX_S
+                        liftScope.launch {
+                            if (commit) {
+                                latestSteps()
+                                lift.snapTo(0f)
+                            } else {
+                                lift.animateTo(0f)
+                            }
+                        }
+                    },
+                    onDragCancel = { liftScope.launch { lift.animateTo(0f) } },
+                )
+            },
         // Match the banner's treatment: generous radius + shadow, a floating pill not a bar.
         shape = RoundedCornerShape(28.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),

--- a/app/src/main/java/app/vela/ui/nav/StepsSheet.kt
+++ b/app/src/main/java/app/vela/ui/nav/StepsSheet.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -127,6 +129,10 @@ fun StepsSheet(
     val scope = rememberCoroutineScope()
     val drag = remember { Animatable(0f) }
     var sheetHeightPx by remember { mutableIntStateOf(0) }
+    // Slides in from the bottom edge (the bar it replaces was just lifted by the finger, or the
+    // list button was tapped): the enter offset starts at the sheet's own height and eases to 0.
+    val enter = remember { Animatable(1f) }
+    LaunchedEffect(Unit) { enter.animateTo(0f, animationSpec = tween(260)) }
     val density = LocalDensity.current
     val settleDrag: (Float) -> Unit = { velocityPxS ->
         val flick = with(density) { FLING_COMMIT_DPS.dp.toPx() }
@@ -171,7 +177,7 @@ fun StepsSheet(
         modifier
             .fillMaxWidth()
             .onSizeChanged { sheetHeightPx = it.height }
-            .offset { IntOffset(0, drag.value.roundToInt().coerceAtLeast(0)) }
+            .offset { IntOffset(0, (drag.value + sheetHeightPx * enter.value).roundToInt().coerceAtLeast(0)) }
             .pointerInput(Unit) {
                 sheetDragGestures(
                     dragBy = { dy -> scope.launch { drag.snapTo((drag.value + dy).coerceAtLeast(0f)) } },


### PR DESCRIPTION
The bottom ETA bar is now the handle for the step sheet, the way Google does it. Drag it up and it lifts with the finger; past 56 dp or on an upward fling it commits and the step sheet slides in from where the bar was, otherwise it springs back. Swiping the sheet down still returns to the bar.

The list button stays and remains the tap and D-pad path (docs/dpad.md), so keypad phones lose nothing; the gesture is touch-only on purpose. Static D-pad audit clean.

Device-checked on the Pixel 4a during a demo drive: swipe up opens, swipe down closes, list button unchanged. Docs: FEATURES.md, CLAUDE.md.