### PR TITLE
Put the current road name above the bar by default, and give the nav bar a handle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2256,6 +2256,10 @@ architecture note.
   `navSession.onLocation` path - puck/banner/voice keep working, `navStarved` keeps the
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
+  **Road label placement (`RoadLabel`, pref `road_label`: bar|puck|off, default bar) and
+  `PreferButtons` (pref `prefer_buttons`, default off; `showListButton = PreferButtons.on || dpadFirst`)
+  live in `app/ui/NavChrome.kt` (2026-09-04). The bar's chevron handle is a focusable clickable Box
+  with `dpadHighlight`, so it is a key target on its own; the list button is the belt-and-braces one.
   **Nav bottom bar = drag handle for the step sheet (2026-09-04):** `NavControls` carries a vertical
   drag (lift follows the finger up to NAV_BAR_LIFT_MAX_DP; commit past NAV_BAR_LIFT_COMMIT_DP or an
   upward fling faster than NAV_BAR_FLING_PX_S, else spring back); commit = the same `openSteps` the

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1287,6 +1287,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   DISPLAYED speed is smoothed with a stop deadband (raw 1 Hz doppler flickered 59/60/61 at cruise), and
   speed derivation requires two GPS fixes past an accuracy-scaled floor (a BeaconDB hop minted phantom
   16 mph readouts at red lights).
+  **Current road name, where you want it (2026-09-04):** Settings > Navigation > "Current road name":
+  above the bottom bar (default, always centred, long names fit), under the arrow (issue #288's
+  mockup), or off. **The nav bar has a chevron handle** that both hints at the swipe and is a real
+  button (tap, focus ring, OK). Settings > Navigation > "Prefer buttons over swipes" keeps the
+  separate step-list button beside it; keypad-first phones get that button automatically.
   **Swipe up for the steps (2026-09-04):** the ETA bar at the bottom of the nav screen is the handle
   for the step list, Google-style. Drag it up (it lifts with the finger) or fling it and the step
   sheet slides in from where the bar was; swipe the sheet down and the bar is back. The list button

--- a/app/src/main/java/app/vela/VelaApp.kt
+++ b/app/src/main/java/app/vela/VelaApp.kt
@@ -95,6 +95,8 @@ class VelaApp : Application(), coil.ImageLoaderFactory {
         app.vela.ui.HideExternalLinks.init(this)
         app.vela.ui.Buildings3d.init(this)
         app.vela.ui.RouteTrail.init(this)
+        app.vela.ui.RoadLabel.init(this)
+        app.vela.ui.PreferButtons.init(this)
         app.vela.ui.BuildingOverlay.init(this)
         app.vela.ui.BuildingDebug.init(this)
         app.vela.ui.MapPoiPrefs.init(this)

--- a/app/src/main/java/app/vela/ui/NavChrome.kt
+++ b/app/src/main/java/app/vela/ui/NavChrome.kt
@@ -1,0 +1,45 @@
+package app.vela.ui
+
+import android.content.Context
+import androidx.compose.runtime.mutableStateOf
+
+/** Where the name of the road you are driving is shown during navigation (issue #288 asked for
+ *  it under the arrow; that pill cannot be centred for long names because it is pinned to the
+ *  arrow, so the default is Google's fixed spot above the bottom bar). Values: "off", "bar", "puck". */
+object RoadLabel {
+    const val OFF = "off"
+    const val BAR = "bar"
+    const val PUCK = "puck"
+    val mode = mutableStateOf(BAR)
+
+    fun init(context: Context) {
+        mode.value = prefs(context).getString(KEY, BAR) ?: BAR
+    }
+
+    fun set(context: Context, value: String) {
+        mode.value = value
+        prefs(context).edit().putString(KEY, value).apply()
+    }
+
+    private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
+    private const val KEY = "road_label"
+}
+
+/** "Prefer buttons over swipes": keeps a discrete button wherever a gesture has one (today: the
+ *  step-list button on the nav bar beside the swipe-up handle). Off by default; keypad-first
+ *  devices behave as if it were on. */
+object PreferButtons {
+    val on = mutableStateOf(false)
+
+    fun init(context: Context) {
+        on.value = prefs(context).getBoolean(KEY, false)
+    }
+
+    fun set(context: Context, value: Boolean) {
+        on.value = value
+        prefs(context).edit().putBoolean(KEY, value).apply()
+    }
+
+    private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
+    private const val KEY = "prefer_buttons"
+}

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1319,7 +1319,8 @@ fun MapScreen(
         // shield already uses; prefer its ref ("US-23 S") and fall back to the street name.
         // Hidden while previewing a step (previewing must not change where you "are"), in PiP,
         // and until the ticker has reported a puck position.
-        if (state.navigating && !pipUi && state.previewStepIndex == null) {
+        val roadLabelMode = app.vela.ui.RoadLabel.mode.value
+        if (state.navigating && !pipUi && state.previewStepIndex == null && roadLabelMode != app.vela.ui.RoadLabel.OFF) {
             val liveIdx = state.nav.stepIndex
             val onRoad = state.activeRoute?.maneuvers?.getOrNull(liveIdx - 1)
                 ?.let { it.ref?.takeIf { r -> r.isNotBlank() } ?: it.road?.takeIf { r -> r.isNotBlank() } }
@@ -1329,13 +1330,22 @@ fun MapScreen(
                 val shownRoad =
                     if (state.roadNameLatin.isEmpty()) onRoad
                     else app.vela.core.voice.SpokenScript.forDisplay(onRoad, uiLang, state.roadNameLatin)
+                // Two placements: Google's fixed spot centred above the bottom bar (default: it
+                // can always be centred, whatever the name's length) or pinned under the arrow
+                // (issue #288's mockup; long names clamp to the screen edge there).
+                val abovePill = roadLabelMode == app.vela.ui.RoadLabel.BAR
                 Surface(
                     shape = CircleShape,
                     color = MaterialTheme.colorScheme.surface,
                     shadowElevation = 3.dp,
-                    modifier = Modifier
-                        // Long names ("Snohomish Cascade Drive Southeast") would otherwise run off
-                        // the screen when the puck sits near an edge.
+                    modifier = if (abovePill) Modifier
+                        .align(if (landscapeChrome) Alignment.BottomStart else Alignment.BottomCenter)
+                        .then(if (landscapeChrome) Modifier.padding(start = (sidePanelWidthDp - 260.dp) / 2 + 16.dp) else Modifier)
+                        .navigationBarsPadding()
+                        .padding(bottom = with(LocalDensity.current) { navBarHeightPx.toDp() } + 16.dp + 10.dp)
+                        .widthIn(max = 260.dp)
+                    else Modifier
+                        // Long names would otherwise run off the screen when the puck sits near an edge.
                         .widthIn(max = 260.dp)
                         // Centred under the puck, then CLAMPED into the viewport: measured so the
                         // pill can be any width and still sit centred, offset below the puck glyph
@@ -1905,6 +1915,7 @@ fun MapScreen(
                     onStop = vm::stopNav,
                     onSteps = vm::openSteps,
                     trafficRatio = state.activeRoute?.trafficRatio,
+                    showListButton = app.vela.ui.PreferButtons.on.value || dpadFirst,
                     // Measured AFTER the padding → the bar surface itself; navBarClearance adds the
                     // padding + gap back. Everything stacked above the bar keys off this.
                     modifier = Modifier.onGloballyPositioned { navBarHeightPx = it.size.height },

--- a/app/src/main/java/app/vela/ui/nav/NavOverlays.kt
+++ b/app/src/main/java/app/vela/ui/nav/NavOverlays.kt
@@ -4,6 +4,8 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import kotlin.math.roundToInt
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
@@ -701,6 +703,7 @@ fun NavControls(
     onStop: () -> Unit,
     onSteps: () -> Unit,
     trafficRatio: Double? = null,
+    showListButton: Boolean = true, // false = the chevron handle alone (a focusable button itself)
     modifier: Modifier = Modifier,
 ) {
     val dark = isAppInDarkTheme()
@@ -763,8 +766,26 @@ fun NavControls(
         // one a labelled button - two different shapes doing the same job at the same size. As
         // icons they read as a matched pair with the numbers between them, which is also the one
         // arrangement where the two 54dp targets cannot be hit by mistake for each other.
+        // The handle: a chevron that says "this lifts", and a real button (tap, focus ring, OK)
+        // so the gesture is never the only way in. Sits in the card's top padding.
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .padding(top = 4.dp)
+                .height(20.dp)
+                .dpadHighlight(RoundedCornerShape(10.dp))
+                .clickable(onClick = onSteps),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.Default.KeyboardArrowUp,
+                contentDescription = stringResource(R.string.nav_steps_handle_cd),
+                tint = SheetPalette.dim(dark),
+                modifier = Modifier.size(22.dp),
+            )
+        }
         Row(
-            Modifier.fillMaxWidth().padding(horizontal = 18.dp, vertical = 14.dp),
+            Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, top = 2.dp, bottom = 14.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -804,8 +825,12 @@ fun NavControls(
             }
             Spacer(Modifier.width(8.dp))
             // Bigger driving targets (user 2026-07-11, car-screen use): 54dp buttons, 26dp glyphs.
-            FilledTonalIconButton(onClick = onSteps, modifier = Modifier.size(54.dp)) {
-                Icon(Icons.AutoMirrored.Filled.List, contentDescription = stringResource(R.string.nav_steps), modifier = Modifier.size(26.dp))
+            if (showListButton) {
+                FilledTonalIconButton(onClick = onSteps, modifier = Modifier.size(54.dp)) {
+                    Icon(Icons.AutoMirrored.Filled.List, contentDescription = stringResource(R.string.nav_steps), modifier = Modifier.size(26.dp))
+                }
+            } else {
+                Spacer(Modifier.size(54.dp)) // keeps the figures centred against the End button
             }
         }
     }

--- a/app/src/main/java/app/vela/ui/settings/SettingsHub.kt
+++ b/app/src/main/java/app/vela/ui/settings/SettingsHub.kt
@@ -318,6 +318,8 @@ private val SEARCH_INDEX: List<Pair<Int, SettingsSection>> = listOf(
     R.string.settings_keep_screen_on to SettingsSection.NAVIGATION,
     R.string.settings_route_bar to SettingsSection.NAVIGATION,
     R.string.settings_route_trail to SettingsSection.NAVIGATION,
+    R.string.settings_road_label to SettingsSection.NAVIGATION,
+    R.string.settings_prefer_buttons to SettingsSection.NAVIGATION,
     R.string.settings_traffic_lights to SettingsSection.NAVIGATION,
     R.string.settings_vibrate_on_turns to SettingsSection.NAVIGATION,
     R.string.settings_demo_drive to SettingsSection.NAVIGATION,

--- a/app/src/main/java/app/vela/ui/settings/sections/NavigationSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/NavigationSettings.kt
@@ -42,6 +42,7 @@ import app.vela.core.model.TravelMode
 import app.vela.ui.map.MapViewModel
 import app.vela.ui.settings.GroupDivider
 import app.vela.ui.settings.Hint
+import app.vela.ui.settings.SelectableRow
 import app.vela.ui.settings.SettingsGroup
 import app.vela.ui.settings.SettingsScaffold
 import app.vela.ui.settings.ToggleRow
@@ -88,6 +89,33 @@ internal fun NavigationSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
             onCheckedChange = { app.vela.ui.RouteTrail.set(context, it) },
             hint = stringResource(R.string.settings_route_trail_hint),
         )
+        GroupDivider()
+        ToggleRow(
+            label = stringResource(R.string.settings_prefer_buttons),
+            checked = app.vela.ui.PreferButtons.on.value,
+            onCheckedChange = { app.vela.ui.PreferButtons.set(context, it) },
+            hint = stringResource(R.string.settings_prefer_buttons_hint),
+        )
+        }
+        Spacer(Modifier.height(12.dp))
+        SettingsGroup {
+        Text(
+            stringResource(R.string.settings_road_label),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(start = 20.dp, top = 12.dp, bottom = 4.dp),
+        )
+        listOf(
+            app.vela.ui.RoadLabel.BAR to stringResource(R.string.settings_road_label_bar),
+            app.vela.ui.RoadLabel.PUCK to stringResource(R.string.settings_road_label_puck),
+            app.vela.ui.RoadLabel.OFF to stringResource(R.string.settings_road_label_off),
+        ).forEach { (id, label) ->
+            SelectableRow(
+                label = label,
+                selected = app.vela.ui.RoadLabel.mode.value == id,
+                onClick = { app.vela.ui.RoadLabel.set(context, id) },
+            )
+        }
+        Hint(stringResource(R.string.settings_road_label_hint))
 
         var trafficLights by remember { mutableStateOf(prefs.getBoolean("nav_traffic_lights", false)) }
         GroupDivider()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -766,6 +766,14 @@
     <string name="settings_nav_day_night">Day and night while navigating</string>
     <string name="settings_nav_day_night_hint">Keeps your chosen theme everywhere else, and switches by daylight only while you are driving.</string>
     <string name="mapscreen_shortcut_add">Add</string>
+    <string name="settings_road_label">Current road name</string>
+    <string name="settings_road_label_off">Off</string>
+    <string name="settings_road_label_bar">Above the bottom bar</string>
+    <string name="settings_road_label_puck">Under the arrow</string>
+    <string name="settings_road_label_hint">Where the name of the road you are on is shown while driving. Above the bar keeps it centred and readable for long names; under the arrow follows the arrow around.</string>
+    <string name="settings_prefer_buttons">Prefer buttons over swipes</string>
+    <string name="settings_prefer_buttons_hint">Keeps a button for things that also have a swipe, such as the step list on the navigation bar. Always on for phones without a touch screen.</string>
+    <string name="nav_steps_handle_cd">Show steps</string>
     <string name="settings_route_trail">Road behind you</string>
     <string name="settings_route_trail_hint">Keeps the part of the route you have already driven drawn in grey behind the arrow. Off hides it, so only the road ahead is drawn.</string>
     <string name="settings_route_bar">Road ahead bar</string>


### PR DESCRIPTION
Follow-up to #313 and #320.

**Road name:** the pill from #288 sat under the arrow, where a long name cannot be centred (it is pinned to the arrow and clamped to the screen edge). It now defaults to Google's spot, centred above the bottom bar; Settings > Navigation > "Current road name" offers above the bar / under the arrow / off.

**Handle:** the nav bar gets a chevron at its top edge. It hints that the bar lifts (the #320 swipe had no affordance) and it is a real button with a focus ring, so the swipe is never the only way to the step list. The separate list button moves behind Settings > Navigation > "Prefer buttons over swipes"; keypad-first phones get it automatically, so nothing changes for them.

Device-checked on the Pixel 4a: pill centred above the bar, chevron opens the steps on tap, swipe still works. Static D-pad audit clean. Docs: FEATURES.md, CLAUDE.md. Also drops a real road name that had crept into a code comment.