### PR TITLE
Redraw the road-ahead bar with icon badges, and keep the road pill off the speed sign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2256,6 +2256,11 @@ architecture note.
   `navSession.onLocation` path - puck/banner/voice keep working, `navStarved` keeps the
   "Searching for GPS" chip up for honesty, the first real fix re-anchors (route-plausible
   synthetics pass the outlier gate). Never feeds `tripStore.record` (no fake points in trips).
+  **Route bar (`RouteBarStrip`, 2026-09-04):** badges for CAMERA / RAIL_CROSSING / SPEED_HUMP, dots for
+  SIGNAL / STOP, an arrow marker with `remainingMeters` and a top cap with `model.spanM`; the Layout
+  centres every child on the track by its window fraction (`RouteBarSpan`). Labels are `requiredWidth`
+  wider than the strip so "768.8 mi" does not clip. The road-name pill in BAR mode caps its width at
+  screenWidth - 176 dp so it can never reach the speed-limit sign or the FAB column.
   **Road label placement (`RoadLabel`, pref `road_label`: bar|puck|off, default bar) and
   `PreferButtons` (pref `prefer_buttons`, default off; `showListButton = PreferButtons.on || dpadFirst`)
   live in `app/ui/NavChrome.kt` (2026-09-04). The bar's chevron handle is a focusable clickable Box

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1287,6 +1287,11 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   DISPLAYED speed is smoothed with a stop deadband (raw 1 Hz doppler flickered 59/60/61 at cruise), and
   speed derivation requires two GPS fixes past an accuracy-scaled floor (a BeaconDB hop minted phantom
   16 mph readouts at red lights).
+  **Road-ahead bar, second cut (2026-09-04):** redrawn to the TomTom RouteBar the #228 reporter
+  attached. A track from the arrow (bottom, with the remaining trip distance) to the top of the
+  look-ahead window (labelled with the distance it spans), congestion as red/amber segments, and
+  what is coming as round icon badges: cameras, level crossings, speed humps. Lights and stop signs
+  stay small dots because a town has dozens in a few km. The first cut's 3 dp ticks were unreadable.
   **Current road name, where you want it (2026-09-04):** Settings > Navigation > "Current road name":
   above the bottom bar (default, always centred, long names fit), under the arrow (issue #288's
   mockup), or off. **The nav bar has a chevron handle** that both hints at the swipe and is a real

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1307,10 +1307,11 @@ fun MapScreen(
             if (state.navigating && !landscapeChrome && !bar.isEmpty) {
                 app.vela.ui.nav.RouteBarStrip(
                     model = bar,
+                    remainingMeters = state.nav.remainingDistance,
                     modifier = Modifier
                         .align(Alignment.CenterStart)
-                        .padding(start = 10.dp)
-                        .fillMaxHeight(0.42f),
+                        .padding(start = 8.dp)
+                        .fillMaxHeight(0.46f),
                 )
             }
         }
@@ -1343,7 +1344,9 @@ fun MapScreen(
                         .then(if (landscapeChrome) Modifier.padding(start = (sidePanelWidthDp - 260.dp) / 2 + 16.dp) else Modifier)
                         .navigationBarsPadding()
                         .padding(bottom = with(LocalDensity.current) { navBarHeightPx.toDp() } + 16.dp + 10.dp)
-                        .widthIn(max = 260.dp)
+                        // Never reaches the speed-limit sign (left) or the FAB column (right):
+                        // centred, symmetric, ellipsised past this.
+                        .widthIn(max = (LocalConfiguration.current.screenWidthDp - 176).coerceAtLeast(120).dp)
                     else Modifier
                         // Long names would otherwise run off the screen when the puck sits near an edge.
                         .widthIn(max = 260.dp)

--- a/app/src/main/java/app/vela/ui/nav/RouteBarStrip.kt
+++ b/app/src/main/java/app/vela/ui/nav/RouteBarStrip.kt
@@ -2,92 +2,180 @@ package app.vela.ui.nav
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Navigation
+import androidx.compose.material.icons.filled.Train
+import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import app.vela.core.nav.RouteBar
+import app.vela.ui.formatDistance
 
 /**
- * The route bar (issue #228): a thin vertical strip showing the road AHEAD - you at the bottom,
- * the destination at the top, congestion painted along it and the road furniture ahead marked on
- * it.
- *
- * TomTom's original also carries live hazards; Vela's deliberately does not, because every keyless
- * live-incident source is a proven dead end. What it draws is exactly what the map already knows,
- * so the bar can never imply knowledge the app does not have.
- *
- * Sized and positioned by the caller. Everything here is a pure function of [model] - no state, no
- * animation - because it sits on the nav screen where a per-frame recomposition is expensive.
+ * The road ahead as a bar (issue #228, TomTom's RouteBar as the reference the reporter attached):
+ * a track from the arrow at the bottom to the top of the look-ahead window, congestion painted on
+ * it as red/amber segments, and what is coming up as ROUND ICON BADGES (speed and surveillance
+ * cameras, level crossings, speed humps) or small dots (lights, stop signs, which are too frequent
+ * in a town to badge). The arrow marker carries the remaining trip distance; the top cap says how
+ * much road the bar spans, so it reads as a scale rather than as decoration. The first cut of this
+ * (2026-09-02) was a 10 dp strip with 3 dp coloured ticks: technically the same information, and
+ * unreadable in practice (user 2026-09-04).
  */
 @Composable
-fun RouteBarStrip(model: RouteBar.Model, modifier: Modifier = Modifier) {
+fun RouteBarStrip(model: RouteBar.Model, remainingMeters: Double, modifier: Modifier = Modifier) {
     if (model.isEmpty) return
-    val track = MaterialTheme.colorScheme.surfaceVariant
-    Box(
-        modifier
-            .width(10.dp)
-            .clip(RoundedCornerShape(5.dp))
-            .background(track),
-    ) {
-        // Bottom-anchored fractions: 0 is you, 1 is the destination, which is how the strip reads
-        // when it stands beside a map with the puck low on the screen.
-        Layout(content = {
-            for (b in model.bands) {
+    val track = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f)
+    val chip = MaterialTheme.colorScheme.surface
+    val ink = MaterialTheme.colorScheme.onSurface
+    Column(modifier.width(STRIP_W.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            if (model.reachesDestination) "" else formatDistance(model.spanM),
+            style = MaterialTheme.typography.labelSmall,
+            color = ink.copy(alpha = 0.8f),
+            maxLines = 1,
+            softWrap = false,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.requiredWidth(LABEL_W.dp).padding(bottom = 2.dp),
+        )
+        Box(Modifier.fillMaxWidth().weight(1f)) {
+            Layout(content = {
+                // The track: a rounded channel the badges sit on.
                 Box(
                     Modifier
-                        .fillMaxWidth()
-                        .background(congestionColor(b.level))
-                        .layoutId(b.from, b.to),
+                        .width(TRACK_W.dp)
+                        .clip(RoundedCornerShape((TRACK_W / 2).dp))
+                        .background(track)
+                        .span(0.0, 1.0, kind = ROLE_TRACK),
                 )
-            }
-            for (p in model.pins) {
+                for (b in model.bands) {
+                    Box(
+                        Modifier
+                            .width(TRACK_W.dp)
+                            .clip(RoundedCornerShape((TRACK_W / 2).dp))
+                            .background(congestionColor(b.level))
+                            .span(b.from, b.to, kind = ROLE_BAND),
+                    )
+                }
+                for (p in model.pins) {
+                    when (p.kind) {
+                        RouteBar.Mark.SIGNAL, RouteBar.Mark.STOP -> Box(
+                            Modifier
+                                .size(DOT.dp)
+                                .clip(CircleShape)
+                                .background(pinColor(p.kind))
+                                .span(p.at, p.at, kind = ROLE_DOT),
+                        )
+                        else -> Box(
+                            Modifier
+                                .size(BADGE.dp)
+                                .shadow(2.dp, CircleShape)
+                                .clip(CircleShape)
+                                .background(pinColor(p.kind))
+                                .span(p.at, p.at, kind = ROLE_BADGE),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                when (p.kind) {
+                                    RouteBar.Mark.CAMERA -> Icons.Filled.Videocam
+                                    RouteBar.Mark.RAIL_CROSSING -> Icons.Filled.Train
+                                    else -> Icons.Filled.Warning
+                                },
+                                contentDescription = null,
+                                tint = Color.White,
+                                modifier = Modifier.size((BADGE - 10).dp),
+                            )
+                        }
+                    }
+                }
+                // The arrow, at the bottom of the track, where you are.
                 Box(
                     Modifier
-                        .fillMaxWidth()
-                        .height(3.dp)
-                        .background(pinColor(p.kind))
-                        .layoutId(p.at, p.at),
-                )
-            }
-        }) { measurables, constraints ->
-            val h = constraints.maxHeight
-            val placeables = measurables.map { m ->
-                val (from, to) = m.parentData as? Pair<*, *> ?: (0.0 to 0.0)
-                val f = (from as? Double) ?: 0.0
-                val t = (to as? Double) ?: 0.0
-                val bandH = ((t - f) * h).toInt()
-                m.measure(
-                    constraints.copy(
-                        minWidth = constraints.maxWidth,
-                        maxWidth = constraints.maxWidth,
-                        minHeight = 0,
-                        maxHeight = if (bandH > 0) bandH else constraints.maxHeight,
-                    ),
-                ) to f
-            }
-            layout(constraints.maxWidth, h) {
-                placeables.forEach { (p, f) ->
-                    // y grows downward, so a fraction near 1 (the destination) sits at the TOP.
-                    val y = (h - (f * h).toInt() - p.height).coerceIn(0, (h - p.height).coerceAtLeast(0))
-                    p.place(0, y)
+                        .size(BADGE.dp)
+                        .shadow(2.dp, CircleShape)
+                        .clip(CircleShape)
+                        .background(chip)
+                        .span(0.0, 0.0, kind = ROLE_PUCK),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(Icons.Filled.Navigation, contentDescription = null, tint = ink, modifier = Modifier.size(16.dp))
+                }
+            }) { measurables, constraints ->
+                val h = constraints.maxHeight
+                val w = constraints.maxWidth
+                // The track runs from the arrow's centre (bottom) to the top cap; badges centre on it.
+                val inset = (BADGE.dp.roundToPx() / 2)
+                val trackH = (h - 2 * inset).coerceAtLeast(1)
+                fun yAt(f: Double) = h - inset - (f * trackH).toInt()
+                val placed = measurables.map { m ->
+                    val d = m.parentData as RouteBarSpan
+                    val p = when (d.kind) {
+                        ROLE_TRACK -> m.measure(constraints.copy(minHeight = trackH, maxHeight = trackH, minWidth = 0))
+                        ROLE_BAND -> {
+                            val bh = ((d.to - d.from) * trackH).toInt().coerceIn(TRACK_W.dp.roundToPx(), trackH)
+                            m.measure(constraints.copy(minHeight = bh, maxHeight = bh, minWidth = 0))
+                        }
+                        else -> m.measure(constraints.copy(minWidth = 0, minHeight = 0))
+                    }
+                    Triple(p, d, d.kind)
+                }
+                layout(w, h) {
+                    for ((p, d, kind) in placed) {
+                        val x = (w - p.width) / 2
+                        val y = when (kind) {
+                            ROLE_TRACK -> inset
+                            ROLE_BAND -> yAt(d.to)
+                            else -> yAt(d.from) - p.height / 2
+                        }
+                        p.place(x, y.coerceIn(0, (h - p.height).coerceAtLeast(0)))
+                    }
                 }
             }
         }
+        Text(
+            formatDistance(remainingMeters),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = ink,
+            maxLines = 1,
+            softWrap = false,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.requiredWidth(LABEL_W.dp).padding(top = 2.dp),
+        )
     }
 }
 
-/** Same grading the route line and the ETA colour use, so the bar agrees with the map. */
+private const val STRIP_W = 34
+private const val LABEL_W = 64 // the distance labels may be wider than the strip ("768.8 mi")
+private const val TRACK_W = 8
+private const val BADGE = 26
+private const val DOT = 9
+private const val ROLE_TRACK = 0
+private const val ROLE_BAND = 1
+private const val ROLE_DOT = 2
+private const val ROLE_BADGE = 3
+private const val ROLE_PUCK = 4
+
 private fun congestionColor(level: Int): Color = when {
     level >= 3 -> Color(0xFF9C1C1C) // severe
     level == 2 -> Color(0xFFD93025) // heavy
@@ -102,11 +190,9 @@ private fun pinColor(kind: RouteBar.Mark): Color = when (kind) {
     RouteBar.Mark.SIGNAL -> Color(0xFF388E3C)
 }
 
-/** Carries a child's (from, to) fractions through measurement. */
-private fun Modifier.layoutId(from: Double, to: Double) =
-    this.then(RouteBarParentData(from to to))
+private fun Modifier.span(from: Double, to: Double, kind: Int) = this.then(RouteBarSpan(from, to, kind))
 
-private data class RouteBarParentData(val span: Pair<Double, Double>) :
+private data class RouteBarSpan(val from: Double, val to: Double, val kind: Int) :
     androidx.compose.ui.layout.ParentDataModifier, Modifier.Element {
-    override fun androidx.compose.ui.unit.Density.modifyParentData(parentData: Any?) = span
+    override fun androidx.compose.ui.unit.Density.modifyParentData(parentData: Any?) = this@RouteBarSpan
 }


### PR DESCRIPTION
Follow-up to #298 (issue #228) and #321.

**Route bar:** the first cut was a 10 dp strip with 3 dp coloured ticks, technically the same information as the TomTom RouteBar the #228 reporter attached and unreadable in practice. Redrawn: a track from the arrow marker at the bottom (with the remaining trip distance) to a top cap labelled with the distance the bar spans, congestion as red and amber segments, and cameras, level crossings and speed humps as round icon badges. Lights and stop signs stay small dots, since a town has dozens in a few kilometres.

**Road pill:** in its above-the-bar placement it now caps its width at screen width minus 176 dp, so a long name ellipsises instead of reaching the speed-limit sign or the button column.

Device-checked on the Pixel 4a during a demo drive (two camera badges, labels readable). Static audit clean. Docs: FEATURES.md, CLAUDE.md.