### PR TITLE
Bake obf regions routing-only and lean, so a US state fits a free runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2274,6 +2274,16 @@ architecture note.
   ticker reads it per frame through `trailHolder`; off means `routeGradient(..., driven = TRANSPARENT)`
   on the ahead and cut pieces and `ROUTE_LAYER` hidden, on means grey. A flip sets `splitReset` so the
   next frame re-applies everything. Paint only; never touch geometry for this.
+  **OBF BAKE, MEASURED 2026-09-04 (read before touching scripts/build-obf-region.sh or the shim):**
+  the memory ceiling is MapCreator's FIRST pass (`extractOsmToNodesDB`), so it does not depend on
+  which sections you index, only on the PBF and on which analysis passes run. Same 345 MB
+  Washington extract at a 12 GB heap: full routing+address+POI = OOM (7 min); routing-only with
+  default passes = OOM (peak 11 GB); routing-only LEAN (multipolygon, route-relation, proximity and
+  country-region indexing off) = SUCCESS, 48 min, 111 MB obf. Bavaria (810 MB) OOMs at 12g even
+  lean (first pass, 81%); pieces that size need osmium chunks or a 32 GB machine (22g worked).
+  Output sizes: Saarland 8 MB routing-only vs 52 MB with address+POI vs OsmAnd's own 66 MB
+  roads-only / 125 MB full; Washington 111 MB vs OsmAnd 595 MB roads-only. Also: the workflow
+  file was invalid YAML (duplicate `default:` key) from Aug 16 to Sep 3, so no bake ran at all.
   **Read `docs/puck-jitter.md` first: the eight causes, the measurement scripts in `scripts/jitter/`, and
   the order to run them. Do not start from a theory.**
   **THE PUCK ITSELF JITTERED BECAUSE IT WAS A MAP SYMBOL (issue #251, fixed 2026-09-03). In

--- a/scripts/VelaObfShim.java
+++ b/scripts/VelaObfShim.java
@@ -5,23 +5,36 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Bakes a Vela obf: routing + address + POI sections only. The map-rendering and transport
- * sections are excluded on purpose (MapLibre draws Vela's map; transit comes from GTFS), which is
- * most of the size difference against a stock OsmAnd file. Compiled and run by
- * scripts/build-obf-region.sh against the OsmAndMapCreator jars; kept as a shim because
- * MainUtilities' CLI has no --no-map/--no-poi switches, only the settings object does.
+ * Bakes a Vela obf. Default: the ROUTING section only, with the indexing passes routing does not
+ * need switched off (multipolygons, route relations, proximity, country regions). Measured
+ * 2026-09-04 on the same 345 MB Washington extract: the full routing+address+POI bake dies in
+ * MapCreator's first pass at a 12 GB heap (as does routing-only with the default passes on), the
+ * lean routing-only bake completes at 12 GB in 48 minutes and produces a 111 MB obf, against
+ * 595 MB for OsmAnd's own roads-only file of the same state. That is what lets a free 16 GB
+ * runner bake a US state at all. The engine (ObfRouteEngine) reads only the routing section.
  *
- * Usage: java VelaObfShim <region.osm.pbf>
+ * VELA_OBF_SECTIONS=routing,address,poi restores the phase-2 sections (offline search on obf),
+ * at the old memory cost; VELA_OBF_LEAN=false restores MapCreator's default passes.
+ * MainUtilities' CLI has no --no-map/--no-poi switches, only the settings object does.
  * Writes <Region>.obf next to the input, exactly like `generate-obf` would.
  */
 public class VelaObfShim {
     public static void main(String[] args) throws Exception {
         IndexCreatorSettings settings = new IndexCreatorSettings();
+        String sections = System.getenv("VELA_OBF_SECTIONS") == null ? "routing" : System.getenv("VELA_OBF_SECTIONS");
+        boolean lean = !"false".equals(System.getenv("VELA_OBF_LEAN"));
         settings.indexMap = false;
         settings.indexTransport = false;
-        settings.indexRouting = true;
-        settings.indexAddress = true;
-        settings.indexPOI = true;
+        settings.indexRouting = sections.contains("routing");
+        settings.indexAddress = sections.contains("address");
+        settings.indexPOI = sections.contains("poi");
+        if (lean) {
+            settings.indexMultipolygon = false;
+            settings.indexRouteRelations = false;
+            settings.indexByProximity = false;
+            settings.indexCountryRegions = false;
+        }
+        System.out.println("vela obf: sections=" + sections + " lean=" + lean);
         List<String> a = new ArrayList<>();
         a.add(args[0]);
         MainUtilities.generateObf(a, settings);

--- a/scripts/build-obf-region.sh
+++ b/scripts/build-obf-region.sh
@@ -55,10 +55,12 @@ javac -cp "$WORK/mapcreator/OsmAndMapCreator.jar:$WORK/mapcreator/lib/*" -d "$WO
 # why 14g never had a chance, and why no GC flag was ever going to save it. ParallelGC vs SerialGC
 # did not change the outcome, only the time to reach it (50 min vs 3 h to the same OOM), so it is
 # still the right collector here: a doomed region should fail fast.
-JAVA_HEAP="${JAVA_HEAP:-14g}"
+# 12g, not 14g: a 16 GB runner OOM-kills the JVM itself above that, and the lean routing-only
+# bake (see VelaObfShim.java) was MEASURED to complete a 345 MB US state at 12g.
+JAVA_HEAP="${JAVA_HEAP:-12g}"
 echo "→ index heap: $JAVA_HEAP"
 set +e
-( cd "$WORK" && java -Xmx"$JAVA_HEAP" -XX:+UseSerialGC -cp "$WORK/mapcreator/OsmAndMapCreator.jar:$WORK/mapcreator/lib/*:$WORK" VelaObfShim region.osm.pbf )
+( cd "$WORK" && java -Xmx"$JAVA_HEAP" -XX:+UseParallelGC -cp "$WORK/mapcreator/OsmAndMapCreator.jar:$WORK/mapcreator/lib/*:$WORK" VelaObfShim region.osm.pbf )
 RC=$?
 set -e
 if [ $RC -ne 0 ]; then
@@ -78,7 +80,7 @@ echo "→ $ID: ${SIZE} MB obf (download == installed), bbox $BBOX"
 
 gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1 || \
   gh release create "$TAG" --repo "$REPO" --prerelease --title "Offline obf regions" \
-    --notes "Vela-baked obf files (routing + address + POI, no rendering section) for offline routing and search. Data assets, not a code release."
+    --notes "Vela-baked obf files (routing section only, lean bake) for offline routing. Data assets, not a code release."
 
 gh release upload "$TAG" "$WORK/$ID.obf" --clobber --repo "$REPO"
 


### PR DESCRIPTION
Measured on the same 345 MB Washington extract at a 12 GB heap (the most a 16 GB runner can give a JVM):

| bake | result |
|---|---|
| routing + address + POI (what the script did) | OOM in MapCreator's first pass, 7 min |
| routing only, default passes | OOM in the first pass, peak 11 GB |
| routing only, lean (multipolygon, route-relation, proximity, country-region passes off) | **success, 48 min, 111 MB obf** |

OsmAnd's own roads-only file for the same state is 595 MB. Saarland: 8 MB routing-only vs 52 MB with address+POI. The ceiling is the first pass, so section choice only changes the output size; the lean passes are what change the memory. Bavaria (810 MB) still does not fit at 12g even lean; extracts that size need osmium chunks or a bigger machine.

The engine reads only the routing section, so nothing users can reach changes. `VELA_OBF_SECTIONS=routing,address,poi` restores the phase-2 sections at the old cost. Default heap 14g to 12g, SerialGC to ParallelGC (a region that does not fit now fails in minutes, not hours). CLAUDE.md records the numbers.

After merge: dispatch **Build obf regions** with `staging: true` for the small groups first.