### PR TITLE
Say "take the 2nd exit" at roundabouts, and name straight-through

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1287,6 +1287,10 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   DISPLAYED speed is smoothed with a stop deadband (raw 1 Hz doppler flickered 59/60/61 at cruise), and
   speed derivation requires two GPS fixes past an accuracy-scaled floor (a BeaconDB hop minted phantom
   16 mph readouts at red lights).
+  **Roundabouts say "take the 2nd exit" (2026-09-05):** English used "take exit 2", which the spoken
+  "take exit N" rewrite (an espeak workaround for motorway exits) turned into "take the 2 exit".
+  Now ordinal like every other language, and a straight-through roundabout is named as such:
+  "go straight through onto 13th St, the 2nd exit".
   **Road-ahead bar, second cut (2026-09-04):** redrawn to the TomTom RouteBar the #228 reporter
   attached. A track from the arrow (bottom, with the remaining trip distance) to the top of the
   look-ahead window (labelled with the distance it spans), congestion as red/amber segments, and

--- a/core/src/main/java/app/vela/core/data/GraphHopperRouteEngine.kt
+++ b/core/src/main/java/app/vela/core/data/GraphHopperRouteEngine.kt
@@ -217,7 +217,7 @@ class GraphHopperRouteEngine(private val graphsRoot: File) : RouteEngine {
             val type = ghType(ins.sign, first = i == 0)
             val name = ins.name?.takeIf { it.isNotBlank() }
             val at = ins.points.let { if (it.size() > 0) LatLng(it.getLat(0), it.getLon(0)) else poly.firstOrNull() ?: LatLng(0.0, 0.0) }
-            // A roundabout instruction carries its exit number — thread it so the phrase reads "take exit N"
+            // A roundabout instruction carries its exit number — thread it so the phrase reads "take the Nth exit"
             // (without it, ROUNDABOUT fell to the "Enter the roundabout" branch and lost the exit).
             val rbExit = (ins as? com.graphhopper.util.RoundaboutInstruction)?.exitNumber?.takeIf { it > 0 }
             // Highways identify by REF, signs by DESTINATION — the same fields the OSRM path reads

--- a/core/src/main/java/app/vela/core/i18n/NavStrings.kt
+++ b/core/src/main/java/app/vela/core/i18n/NavStrings.kt
@@ -134,7 +134,14 @@ object EnNavStrings : NavStrings {
             }
             "off ramp" -> if (exitNo != null) "Take exit$exitTab$toward" else "Take the exit$toward"
             "fork" -> ("Keep $m").trim() + toward
-            "roundabout", "rotary", "exit roundabout", "exit rotary" -> if (rbExit != null) "At the roundabout, take exit $rbExit$onto" else "Enter the roundabout$onto"
+            // Ordinal, like every other language here and like Google ("take the 2nd exit"): "take
+            // exit 2" read as a numbered motorway exit (user 2026-09-05). Straight through is named
+            // as such, with the exit count kept as the confirmation.
+            "roundabout", "rotary", "exit roundabout", "exit rotary" -> when {
+                rbExit == null -> "Enter the roundabout$onto"
+                mod == "straight" -> "At the roundabout, go straight through$onto, the ${enOrdinal(rbExit)} exit"
+                else -> "At the roundabout, take the ${enOrdinal(rbExit)} exit$onto"
+            }
             "roundabout turn" -> ("At the roundabout, turn $m").trim() + onto
             "uturn" -> "Make a U-turn$onto"
             else -> if (m.isNotBlank()) ("Turn $m").trim() + onto else "Continue$onto"
@@ -214,6 +221,18 @@ object EnNavStrings : NavStrings {
         // "Use the right 2 lanes to take exit 172 toward Sacramento" — lowercase the maneuver's first
         // word so it reads as one sentence after the "In <distance>, " frame.
         return "Use $lanes to " + instruction.replaceFirstChar { it.lowercaseChar() }
+    }
+
+    /** "1st", "2nd", "3rd", "4th"... (11th-13th are "th"). TTS engines read these as the ordinal words. */
+    private fun enOrdinal(n: Int): String {
+        val suffix = when {
+            n % 100 in 11..13 -> "th"
+            n % 10 == 1 -> "st"
+            n % 10 == 2 -> "nd"
+            n % 10 == 3 -> "rd"
+            else -> "th"
+        }
+        return "$n$suffix"
     }
 
     /** Whole-word road abbreviation → spoken form, "I-80"→"Interstate 80", and 3-digit street ordinals

--- a/core/src/test/java/app/vela/core/GraphHopperRouterTest.kt
+++ b/core/src/test/java/app/vela/core/GraphHopperRouterTest.kt
@@ -40,8 +40,8 @@ class GraphHopperRouterTest {
         assertEquals("Head out on Elm St", GraphHopperRouteEngine.ghPhrase(ManeuverType.DEPART, "Elm St"))
         assertEquals("Make a U-turn onto Oak Ave", GraphHopperRouteEngine.ghPhrase(ManeuverType.UTURN, "Oak Ave"))
         assertEquals("Arrive at your destination", GraphHopperRouteEngine.ghPhrase(ManeuverType.ARRIVE, null))
-        // Roundabouts thread the exit number so they read "take exit N", not the generic "Enter the roundabout".
-        assertEquals("At the roundabout, take exit 2 onto Elm St", GraphHopperRouteEngine.ghPhrase(ManeuverType.ROUNDABOUT, "Elm St", 2))
+        // Roundabouts thread the exit number so they read "take the Nth exit", not the generic "Enter the roundabout".
+        assertEquals("At the roundabout, take the 2nd exit onto Elm St", GraphHopperRouteEngine.ghPhrase(ManeuverType.ROUNDABOUT, "Elm St", 2))
     }
 
     /** Highway steps read like the OSRM path now: sign destinations on ramps/forks/merges, and a

--- a/core/src/test/java/app/vela/core/OsrmRouterTest.kt
+++ b/core/src/test/java/app/vela/core/OsrmRouterTest.kt
@@ -62,7 +62,10 @@ class OsrmRouterTest {
         assertEquals("Turn right onto the local street", RouteGeometry.osrmPhrase("turn", "right", "the local street", null, null, null))
         assertEquals("Continue onto Olive Dr", RouteGeometry.osrmPhrase("new name", "straight", "Olive Dr", null, null, null))
         assertEquals("Arrive at your destination", RouteGeometry.osrmPhrase("arrive", null, null, null, null, null))
-        assertEquals("At the roundabout, take exit 2 onto Main St", RouteGeometry.osrmPhrase("roundabout", null, "Main St", null, null, 2))
+        assertEquals("At the roundabout, take the 2nd exit onto Main St", RouteGeometry.osrmPhrase("roundabout", null, "Main St", null, null, 2))
+        assertEquals("At the roundabout, go straight through onto Main St, the 2nd exit", RouteGeometry.osrmPhrase("roundabout", "straight", "Main St", null, null, 2))
+        assertEquals("At the roundabout, take the 3rd exit", RouteGeometry.osrmPhrase("roundabout", "left", null, null, null, 3))
+        assertEquals("At the roundabout, take the 11th exit", RouteGeometry.osrmPhrase("roundabout", "left", null, null, null, 11))
         assertEquals("Head out on Elm St", RouteGeometry.osrmPhrase("depart", "left", "Elm St", null, null, null))
     }
 

--- a/core/src/test/java/app/vela/core/i18n/NavStringsTest.kt
+++ b/core/src/test/java/app/vela/core/i18n/NavStringsTest.kt
@@ -19,7 +19,10 @@ class NavStringsTest {
         assertEquals("Turn right onto the local street", en.phrase("turn", "right", "the local street", null, null, null))
         assertEquals("Continue onto I 80", en.phrase("continue", "straight", "I 80", null, null, null))
         assertEquals("Take exit 15 toward Sacramento", en.phrase("off ramp", null, null, "Sacramento", "15", null))
-        assertEquals("At the roundabout, take exit 2 onto Elm St", en.phrase("roundabout", null, "Elm St", null, null, 2))
+        assertEquals("At the roundabout, take the 2nd exit onto Elm St", en.phrase("roundabout", null, "Elm St", null, null, 2))
+        // The spoken "take exit N" -> "take the N exit" rewrite (an espeak workaround for motorway
+        // exits) must not touch the roundabout ordinal: it read "take the 2 exit" (user 2026-09-05).
+        assertEquals("At the roundabout, take the 2nd exit onto Elm Street", en.expandForSpeech("At the roundabout, take the 2nd exit onto Elm St"))
         assertEquals("Make a U-turn onto Main St", en.phrase("uturn", null, "Main St", null, null, null))
         assertEquals("Head out on F St", en.phrase("depart", null, "F St", null, null, null))
         assertEquals("Arrive at your destination", en.phrase("arrive", null, null, null, null, null))


### PR DESCRIPTION
English roundabout instructions read "take exit 2" (the only language here without an ordinal), and the spoken rewrite that turns "take exit N" into "take the N exit" (an espeak workaround for motorway exits) made it "take the 2 exit" out loud.

Now "At the roundabout, take the 2nd exit onto X", and when the exit is straight ahead, "At the roundabout, go straight through onto X, the 2nd exit". Ordinals handle 11th to 13th. Tests updated, plus one asserting the speech rewrite leaves the ordinal alone. Core tests green.