### PR TITLE
Give avoid-tolls and avoid-highways routes a traffic-aware ETA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2274,6 +2274,14 @@ architecture note.
   ticker reads it per frame through `trailHolder`; off means `routeGradient(..., driven = TRANSPARENT)`
   on the ahead and cut pieces and `ROUTE_LAYER` hidden, on means grey. A flip sets `splitReset` so the
   next frame re-applies everything. Paint only; never touch geometry for this.
+  **AVOID TOLLS / HIGHWAYS, the honest state (2026-09-05):** the FOSSGIS OSRM server has no
+  `exclude=` classes (`OSRM_SUPPORTS_EXCLUDE = false`), so ONLINE-ONLY users get the plain route plus
+  the "may still use tolls and highways" note (#293). With a downloaded region the on-device engine
+  routes the avoid; those routes used to leave `directions()` RAW (engine free-flow, no traffic, no
+  #242 calibration) - that is #325. Now they get Google's area traffic factor and the free-flow
+  calibration from the PLAIN pair (open OSRM vs Google when same-course), with NO congestion spans
+  (spans belong to Google's course). Google cannot be asked for an avoid route keylessly, so a
+  per-road-class calibration is not available; this is the best keyless estimate, not Google's.
   **OBF BAKE, MEASURED 2026-09-04 (read before touching scripts/build-obf-region.sh or the shim):**
   the memory ceiling is MapCreator's FIRST pass (`extractOsmToNodesDB`), so it does not depend on
   which sections you index, only on the PBF and on which analysis passes run. Same 345 MB

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -525,7 +525,23 @@ class GoogleMapsDataSource @Inject constructor(
                 val avoidRoutes = kotlinx.coroutines.withTimeoutOrNull(AVOID_ONDEVICE_TIMEOUT_MS) { avoidD.await() } ?: emptyList()
                 if (avoidRoutes.isNotEmpty()) {
                     avoidHonored = true
-                    return@coroutineScope avoidRoutes
+                    // These used to go out RAW: the on-device engine's free-flow time, no traffic, no
+                    // calibration, while every other route in the app carries Google's in-traffic
+                    // factor and (since #242) a free-flow-to-typical calibration. That is the "ETA
+                    // completely broken with avoid on" reports (#325, 2026-09-05). Google can't be
+                    // asked for an avoid route keylessly, so the calibration comes from the PLAIN
+                    // pair fetched alongside (open OSRM vs Google, when they follow the same course:
+                    // a property of the area's roads and driving, carried over to the avoid route),
+                    // and the traffic factor is Google's for the area. No congestion spans: those
+                    // belong to Google's course, not this one.
+                    val plainCal = open.firstOrNull()?.takeIf { top ->
+                        top.durationSeconds > 0 && gTop != null && gTop.durationSeconds > 0 &&
+                            gTop.polyline.size >= 5 && !RouteGeometry.divergent(top, gTop)
+                    }?.let { top ->
+                        val dScale = if (gTop!!.distanceMeters > 0) top.distanceMeters / gTop.distanceMeters else 1.0
+                        ((gTop.durationSeconds * dScale) / top.durationSeconds).coerceIn(0.5, 3.0)
+                    }
+                    return@coroutineScope avoidRoutes.map { applyTraffic(it, gTop, plainCal ?: 1.0, withSpans = false) }
                 }
             }
             // TRAFFIC-AWARE routing (option 3): if Google's live-traffic route took a DIFFERENT path
@@ -638,7 +654,7 @@ class GoogleMapsDataSource @Inject constructor(
     /** Overlay Google's live-traffic ETA + congestion onto an open-router [route] (best-effort):
      *  scale the route's free-flow duration by Google's in-traffic/typical ratio, and map its
      *  congestion spans onto the open geometry by fraction. No Google traffic → keep free-flow. */
-    private fun applyTraffic(route: Route, g: Route?, freeFlowCal: Double? = null): Route {
+    private fun applyTraffic(route: Route, g: Route?, freeFlowCal: Double? = null, withSpans: Boolean = true): Route {
         val typical = g?.durationSeconds?.takeIf { it > 0 } ?: return route
         val inTraffic = g.durationInTrafficSeconds ?: return route
         val factor = (inTraffic / typical).coerceIn(0.5, 4.0)
@@ -669,7 +685,8 @@ class GoogleMapsDataSource @Inject constructor(
         )
         return calibrated.copy(
             durationInTrafficSeconds = calibrated.durationSeconds * factor,
-            trafficSpans = g.trafficSpans.map { it.copy(startMeters = it.startMeters * scale, lengthMeters = it.lengthMeters * scale) },
+            trafficSpans = if (withSpans) g.trafficSpans.map { it.copy(startMeters = it.startMeters * scale, lengthMeters = it.lengthMeters * scale) }
+            else emptyList(),
         )
     }
 


### PR DESCRIPTION
Relates to #325 and the #286 comment.

With avoid tolls or highways on and an offline region installed, the on-device route left `directions()` raw: the engine's free-flow time, no traffic, none of the free-flow calibration every other route has carried since #242. That is the "ETA completely broke with avoid on" report.

Google cannot be asked for an avoid route keylessly (that is why #293's note exists), so the calibration now comes from the plain pair fetched alongside (open OSRM vs Google, when they follow the same course: a property of the area's roads and driving, carried over to the avoid route), and the traffic factor is Google's for the area. No congestion spans are mapped onto the avoid route, since they belong to Google's course, not this one.

Online-only users are unchanged: the public router has no `exclude=` classes, so they still get the plain route with the existing "may still use tolls and highways" note. Core tests green. Not device-verified: the Pixel 4a has no offline region installed, which is the only path this touches. CLAUDE.md records the honest state of avoid.