### PR TITLE
Avoid tolls and highways through Google's keyless directions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2274,14 +2274,19 @@ architecture note.
   ticker reads it per frame through `trailHolder`; off means `routeGradient(..., driven = TRANSPARENT)`
   on the ahead and cut pieces and `ROUTE_LAYER` hidden, on means grey. A flip sets `splitReset` so the
   next frame re-applies everything. Paint only; never touch geometry for this.
-  **AVOID TOLLS / HIGHWAYS, the honest state (2026-09-05):** the FOSSGIS OSRM server has no
-  `exclude=` classes (`OSRM_SUPPORTS_EXCLUDE = false`), so ONLINE-ONLY users get the plain route plus
-  the "may still use tolls and highways" note (#293). With a downloaded region the on-device engine
-  routes the avoid; those routes used to leave `directions()` RAW (engine free-flow, no traffic, no
-  #242 calibration) - that is #325. Now they get Google's area traffic factor and the free-flow
-  calibration from the PLAIN pair (open OSRM vs Google when same-course), with NO congestion spans
-  (spans belong to Google's course). Google cannot be asked for an avoid route keylessly, so a
-  per-road-class calibration is not available; this is the best keyless estimate, not Google's.
+  **AVOID TOLLS / HIGHWAYS ARE KEYLESS ON GOOGLE (2026-09-06; the July "cannot" note was wrong).**
+  The flags are in the `!6m` feature block's `!2m` submessage of the `/maps/preview/directions` pb:
+  `!1b1` = avoid highways, `!2b1` = avoid tolls, group counts +1 each (`DirectionsPb.withAvoid`,
+  pattern-based so a recalibrated template survives). Found by capturing Google's own web client
+  (browser pane, "Avoid highways" ticked) - NOT in the `!20m` route-options group, where every scalar
+  field was probed to no effect. Verified live: Davis-Sacramento I-80 15.3 mi/21 min -> Old River Rd
+  27.1 mi/46 min; a Chicago tollway pair loses every toll mention. Pipeline: with avoid on, gTop IS
+  the avoiding route; the plain OSRM route diverges, the via-snap follows Google's course with named
+  turns, the ETA-margin gate is skipped (`avoidWanted`), the unrestricted OSRM routes are not offered
+  as alternates, and if the snap fails Google's abbreviated steps win over a plain route. The FOSSGIS
+  server still has no `exclude=` (`OSRM_SUPPORTS_EXCLUDE = false`); the on-device engine is the avoid
+  router ONLY when Google is unreachable, and the "may still use tolls" note shows only then.
+  Device-checked: Space Needle 35 min via I-5 -> 49 min via SR-522 with live traffic.
   **OBF BAKE, MEASURED 2026-09-04 (read before touching scripts/build-obf-region.sh or the shim):**
   the memory ceiling is MapCreator's FIRST pass (`extractOsmToNodesDB`), so it does not depend on
   which sections you index, only on the PBF and on which analysis passes run. Same 345 MB

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1287,6 +1287,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   DISPLAYED speed is smoothed with a stop deadband (raw 1 Hz doppler flickered 59/60/61 at cruise), and
   speed derivation requires two GPS fixes past an accuracy-scaled floor (a BeaconDB hop minted phantom
   16 mph readouts at red lights).
+  **Avoid tolls and highways work online (2026-09-06):** Google's keyless directions do honour the
+  avoid options after all (the flags were found by capturing Google's own web client), so with either
+  toggle on the route follows Google's avoiding course with the open router's named turns and Google's
+  live-traffic time. Alternates are avoid-aware too. A downloaded region is no longer required; the
+  on-device router only steps in when Google is unreachable, and only then does the "may still use
+  tolls and highways" note appear.
   **Roundabouts say "take the 2nd exit" (2026-09-05):** English used "take exit 2", which the spoken
   "take exit N" rewrite (an espeak workaround for motorway exits) turned into "take the 2 exit".
   Now ordinal like every other language, and a straight-through roundabout is named as such:

--- a/core/src/main/java/app/vela/core/data/google/DirectionsPb.kt
+++ b/core/src/main/java/app/vela/core/data/google/DirectionsPb.kt
@@ -31,18 +31,48 @@ object DirectionsPb {
         "!1i0!2i0!2m2!1i530!2i768!1m6!1m2!1i974!2i0!2m2!1i1024!2i768!1m6!1m2!1i0!2i0!2m2!1i1024" +
         "!2i20!1m6!1m2!1i0!2i748!2m2!1i1024!2i768!27b1!40i783!47m2!8b1!10e2"
 
-    fun build(origin: LatLng, destination: LatLng, mode: TravelMode, template: String = DEFAULT_TEMPLATE): String {
+    fun build(
+        origin: LatLng,
+        destination: LatLng,
+        mode: TravelMode,
+        template: String = DEFAULT_TEMPLATE,
+        avoidTolls: Boolean = false,
+        avoidHighways: Boolean = false,
+    ): String {
         val modeCode = when (mode) {
             TravelMode.DRIVE -> 0
             TravelMode.BICYCLE -> 1
             TravelMode.WALK -> 2
             TravelMode.TRANSIT -> 3
         }
-        return template
+        return withAvoid(template, avoidTolls && mode == TravelMode.DRIVE, avoidHighways && mode == TravelMode.DRIVE)
             .replace("{OLAT}", origin.lat.toString())
             .replace("{OLNG}", origin.lng.toString())
             .replace("{DLAT}", destination.lat.toString())
             .replace("{DLNG}", destination.lng.toString())
             .replace("{MODE}", modeCode.toString())
+    }
+
+    /** The avoid flags Google's own web client sends (captured from its `/maps/preview/directions`
+     *  request with "Avoid highways" ticked, 2026-09-06, and verified from a plain HTTP client:
+     *  Davis to Sacramento flips from I-80 15.3 mi / 21 min to Old River Rd 27.1 mi / 46 min;
+     *  Naperville to O'Hare with tolls avoided leaves the I-88/I-294 tollway for I-55/I-90). They
+     *  are NOT in the `!20m` route-options group (every scalar there was probed with no effect)
+     *  but in the `!6m` feature block's `!2m` submessage: `!1b1` = avoid highways, `!2b1` = avoid
+     *  tolls, the same field numbers the web `dir/` URL's `!2m1!1b1` carries. Counts on the
+     *  enclosing `!6m` and `!2m` groups grow by the number of flags added. Done by pattern so a
+     *  recalibrated template (CalibrationStore) keeps working as long as that block survives. */
+    internal fun withAvoid(template: String, avoidTolls: Boolean, avoidHighways: Boolean): String {
+        if (!avoidTolls && !avoidHighways) return template
+        val flags = buildString {
+            if (avoidHighways) append("!1b1")
+            if (avoidTolls) append("!2b1")
+        }
+        val added = flags.count { it == '!' }
+        val re = Regex("""!6m(\d+)(!1m5!18b1!30b1!31m1!1b1!34e1!2m)(\d+)""")
+        val m = re.find(template) ?: return template
+        val outer = m.groupValues[1].toInt() + added
+        val inner = m.groupValues[3].toInt() + added
+        return template.replaceRange(m.range, "!6m$outer${m.groupValues[2]}$inner$flags")
     }
 }

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -468,7 +468,7 @@ class GoogleMapsDataSource @Inject constructor(
         if (waypoints.isNotEmpty()) {
             return@io coroutineScope {
                 val viaD = async { RouteGeometry.routeVia(http, listOf(origin) + waypoints + destination, mode, avoidTolls, avoidHighways) }
-                val gD = async { googleDirectionsRetried(origin, destination, mode, tries) }
+                val gD = async { googleDirectionsRetried(origin, destination, mode, tries, avoidTolls, avoidHighways) }
                 val via = viaD.await().firstOrNull()
                 // OSRM unreachable → route the legs on-device (origin→w1→…→dest chained), like the
                 // single-destination path's offline fallback; only then fall to Google's DIRECT route
@@ -501,7 +501,7 @@ class GoogleMapsDataSource @Inject constructor(
             // (a 6-mi route came back with 2 of ~10 turns), so Google is only the FALLBACK + the
             // live-traffic source. Fetch both in parallel so the traffic round-trip is free.
             val openD = async { RouteGeometry.route(http, origin, destination, mode, avoidTolls, avoidHighways, tries, departBearingDeg) }
-            val googleD = async { googleDirectionsRetried(origin, destination, mode, tries) }
+            val googleD = async { googleDirectionsRetried(origin, destination, mode, tries, avoidTolls, avoidHighways) }
             val open = openD.await()
             val google = googleD.await()
             val gTop = google.firstOrNull()
@@ -511,7 +511,15 @@ class GoogleMapsDataSource @Inject constructor(
             // router - it goes FIRST. Old-format graphs / no coverage return empty and the
             // online chain below routes normally (avoid best-effort, never a dead end). No
             // live-traffic ETA on these: the offline result is free-flow, like any offline route.
-            if ((avoidTolls || avoidHighways) && mode == TravelMode.DRIVE && routeEngine.isReady(mode)) {
+            // Google's keyless directions DO honour avoid (DirectionsPb.withAvoid, 2026-09-06), so
+            // online the avoiding route IS gTop: the open router cannot exclude, so its plain route
+            // diverges and the snap below follows Google's course with named turns, and Google's
+            // own in-traffic time is the ETA. The on-device engine is the avoid router only when
+            // Google is unreachable. (Until today avoid was on-device-or-nothing, with the plain
+            // route and a note otherwise; #325's broken ETA came from that branch.)
+            val avoidWanted = (avoidTolls || avoidHighways) && mode == TravelMode.DRIVE
+            if (avoidWanted && gTop != null) avoidHonored = true
+            if (avoidWanted && gTop == null && routeEngine.isReady(mode)) {
                 // BOUNDED: the obf engine can spend many seconds on a long route, and this branch
                 // used to wait for it unconditionally - with an offline region installed an
                 // avoid-toggled plan just sat there (the Reddit report). The compute runs on an
@@ -525,30 +533,16 @@ class GoogleMapsDataSource @Inject constructor(
                 val avoidRoutes = kotlinx.coroutines.withTimeoutOrNull(AVOID_ONDEVICE_TIMEOUT_MS) { avoidD.await() } ?: emptyList()
                 if (avoidRoutes.isNotEmpty()) {
                     avoidHonored = true
-                    // These used to go out RAW: the on-device engine's free-flow time, no traffic, no
-                    // calibration, while every other route in the app carries Google's in-traffic
-                    // factor and (since #242) a free-flow-to-typical calibration. That is the "ETA
-                    // completely broken with avoid on" reports (#325, 2026-09-05). Google can't be
-                    // asked for an avoid route keylessly, so the calibration comes from the PLAIN
-                    // pair fetched alongside (open OSRM vs Google, when they follow the same course:
-                    // a property of the area's roads and driving, carried over to the avoid route),
-                    // and the traffic factor is Google's for the area. No congestion spans: those
-                    // belong to Google's course, not this one.
-                    val plainCal = open.firstOrNull()?.takeIf { top ->
-                        top.durationSeconds > 0 && gTop != null && gTop.durationSeconds > 0 &&
-                            gTop.polyline.size >= 5 && !RouteGeometry.divergent(top, gTop)
-                    }?.let { top ->
-                        val dScale = if (gTop!!.distanceMeters > 0) top.distanceMeters / gTop.distanceMeters else 1.0
-                        ((gTop.durationSeconds * dScale) / top.durationSeconds).coerceIn(0.5, 3.0)
-                    }
-                    return@coroutineScope avoidRoutes.map { applyTraffic(it, gTop, plainCal ?: 1.0, withSpans = false) }
+                    // Offline (no Google answer): the engine's own time is all there is. Online,
+                    // this branch never runs; Google's avoiding route carries the traffic ETA.
+                    return@coroutineScope avoidRoutes
                 }
             }
             // TRAFFIC-AWARE routing (option 3): if Google's live-traffic route took a DIFFERENT path
             // than OSRM's free-flow one — i.e. Google rerouted around a jam — re-run OSRM forced
             // through Google's path so we follow the traffic-smart route WITH full street-named steps.
             // (Only on real divergence, so the normal case stays the fast single OSRM call.)
-            val trafficRoute = if (!urgent && open.isNotEmpty() && gTop != null && gTop.polyline.size >= 5 &&
+            val trafficRoute = if ((!urgent || avoidWanted) && open.isNotEmpty() && gTop != null && gTop.polyline.size >= 5 &&
                 RouteGeometry.divergent(open.first(), gTop)) {
                 RouteGeometry.routeVia(http, listOf(origin) + RouteGeometry.sampleVias(gTop.polyline) + destination, mode, avoidTolls, avoidHighways)
                     .firstOrNull()
@@ -565,14 +559,24 @@ class GoogleMapsDataSource @Inject constructor(
             // a snap steps aside for OSRM's clean route. (A true per-alternate re-rank isn't possible: Google
             // hands back ONE live-traffic figure, so applyTraffic scales every route by the same ratio and
             // can't reorder the OSRM alternates — this ETA gate is the meaningful lever.)
+            val avoidTag = when {
+                !avoidWanted -> ""
+                gTop != null -> " avoid=google"
+                else -> " avoid=none"
+            }
             val googleEtaS = gTop?.durationInTrafficSeconds ?: gTop?.durationSeconds
             // The snapped via-route must actually REACH the destination — a truncated one ending at an
             // intermediate via (short ETA, wrong last step) is the "10 min away" nav bug — AND be time-
             // competitive with OSRM's free-flow best.
             val snapReaches = trafficRoute?.polyline?.lastOrNull()
                 ?.let { it.distanceTo(destination) <= SNAP_REACH_M } == true
+            // With avoid on, the snap is the point (Google's avoiding course is slower than the
+            // open router's unrestricted one by construction), so the ETA margin test is skipped.
             val snapWorthIt = trafficRoute != null && snapReaches && open.isNotEmpty() && googleEtaS != null &&
-                googleEtaS <= open.first().durationSeconds * SNAP_ETA_MARGIN
+                (avoidWanted || googleEtaS <= open.first().durationSeconds * SNAP_ETA_MARGIN)
+            // Avoid on, Google answered, but the open router could not be led along its course:
+            // Google's own (abbreviated) steps beat a plain route that ignores the avoid.
+            val avoidFallbackToGoogle = avoidWanted && gTop != null && !snapWorthIt
             diag.record(
                 "directions",
                 "$mode → OSRM ${open.size} routes / ${open.firstOrNull()?.maneuvers?.size ?: 0} steps; " +
@@ -581,7 +585,7 @@ class GoogleMapsDataSource @Inject constructor(
                     "rerouted=${trafficRoute != null} snapKept=$snapWorthIt snapReaches=$snapReaches " +
                     "(gEta=${googleEtaS?.toInt()}s osrmFF=${open.firstOrNull()?.durationSeconds?.toInt()}s " +
                     "sameCourse=${open.firstOrNull()?.let { t -> gTop?.takeIf { it.polyline.size >= 5 }?.let { !RouteGeometry.divergent(t, it) } }}); " +
-                    "onDevice=${onDevice.size}",
+                    "onDevice=${onDevice.size}$avoidTag",
                 "",
             )
             if (open.isEmpty()) {
@@ -590,6 +594,7 @@ class GoogleMapsDataSource @Inject constructor(
                 // upgraded to full steps by the nav recheck once the open router recovers.
                 if (onDevice.isNotEmpty()) onDevice else google.map { it.copy(abbreviatedSteps = true) }
             } else {
+                if (avoidFallbackToGoogle) return@coroutineScope google.map { it.copy(abbreviatedSteps = true) }
                 // One calibration for the whole response, taken from the TOP OSRM route when it
                 // follows Google's course — alternates share the same optimistic speed model, so
                 // rebasing them by the same factor keeps the picker's ranking fair (issue #227).
@@ -600,7 +605,8 @@ class GoogleMapsDataSource @Inject constructor(
                     val dScale = if (gTop!!.distanceMeters > 0) top.distanceMeters / gTop.distanceMeters else 1.0
                     ((gTop.durationSeconds * dScale) / top.durationSeconds).coerceIn(0.5, 3.0)
                 }
-                val primary = if (snapWorthIt) (listOf(trafficRoute!!) + open).map { applyTraffic(it, gTop, freeFlowCal) }
+                // With avoid on, the open router's unrestricted routes are not offered as alternates.
+                val primary = if (snapWorthIt) (listOf(trafficRoute!!) + (if (avoidWanted) emptyList() else open)).map { applyTraffic(it, gTop, freeFlowCal) }
                     else open.map { applyTraffic(it, gTop, freeFlowCal) }
                 // ALTERNATES to choose from = Google's OWN alternate routes (the real, traffic-aware ones you
                 // miss). Kept PROVISIONAL: their polyline + live ETA are shown now, but turn-by-turn is named
@@ -774,11 +780,11 @@ class GoogleMapsDataSource @Inject constructor(
      *  drastically between restarts (user real-drive report 2026-07-14). Two short backoff
      *  retries recover the routine blips; a genuinely unreachable Google still degrades to
      *  free-flow exactly as before, just honestly rarer. */
-    private suspend fun googleDirectionsRetried(origin: LatLng, destination: LatLng, mode: TravelMode, tries: Int = 3): List<Route> {
+    private suspend fun googleDirectionsRetried(origin: LatLng, destination: LatLng, mode: TravelMode, tries: Int = 3, avoidTolls: Boolean = false, avoidHighways: Boolean = false): List<Route> {
         var routes: List<Route> = emptyList()
         for (attempt in 0 until tries) {
             if (attempt > 0) kotlinx.coroutines.delay(300L * attempt)
-            routes = runCatching { googleDirections(origin, destination, mode) }.getOrNull().orEmpty()
+            routes = runCatching { googleDirections(origin, destination, mode, avoidTolls, avoidHighways) }.getOrNull().orEmpty()
             if (routes.isNotEmpty()) return routes
         }
         diag.record("directions", "google directions empty after $tries attempt(s) — trafficless fetch")
@@ -788,10 +794,10 @@ class GoogleMapsDataSource @Inject constructor(
     /** Google's keyless directions — now the FALLBACK router (OSRM unreachable) and the
      *  live-traffic source (ETA / duration-in-traffic / congestion spans). Its step list is
      *  abbreviated for long routes, which is exactly why OSRM is primary. */
-    private suspend fun googleDirections(origin: LatLng, destination: LatLng, mode: TravelMode): List<Route> {
+    private suspend fun googleDirections(origin: LatLng, destination: LatLng, mode: TravelMode, avoidTolls: Boolean = false, avoidHighways: Boolean = false): List<Route> {
         session.ensure()
         val cal = calibration.current()
-        val pb = DirectionsPb.build(origin, destination, mode, cal.directionsPb)
+        val pb = DirectionsPb.build(origin, destination, mode, cal.directionsPb, avoidTolls, avoidHighways)
         val url = "${cal.directionsEndpoint}&pb=${pb.enc()}"
         val routes = try {
             DirectionsParser.parse(GoogleResponse.parse(get(url)))


### PR DESCRIPTION
Fixes the real cause behind #325 and most likely #324, and retires the "avoid only works with a downloaded region" design.

The July finding that Google's keyless directions ignore avoid was wrong. The flags live in the request's `!6m` feature block (`!2m` submessage: `!1b1` highways, `!2b1` tolls), not the `!20m` route-options group where every scalar was probed to no effect. Found by capturing Google's own web client with "Avoid highways" ticked, then verified from a plain HTTP client: Davis to Sacramento leaves I-80 for Old River Rd (15.3 mi/21 min to 27.1 mi/46 min, matching Google's UI), and a Chicago tollway pair loses every toll mention.

**Pipeline:** with either toggle on, Google's avoiding route is the course the open router's turn-by-turn snap follows, Google's live-traffic time is the ETA, and alternates are avoid-aware. The ETA margin that normally gates the snap is skipped (an avoiding course is slower by construction) and the unrestricted OSRM routes are not offered beside it. If the snap cannot follow the course, Google's abbreviated steps win over a plain route that ignores the avoid. The on-device engine is the avoid router only when Google is unreachable, and only then does the "may still use tolls and highways" note appear.

`DirectionsPb.withAvoid` is pattern-based so a recalibrated template keeps working; unit tests cover both flags, driving-only, and an unrecognised template. Core tests green, static audit clean.

**Device-checked on the Pixel 4a:** Space Needle route 35 min via I-5 becomes 49 min via State Route 522 / Hwy 99 with live traffic, and returns to I-5 when the toggle is cleared.

Docs: CLAUDE.md (the corrected avoid state), FEATURES.md.