### PR TITLE
Refuse via routes with a snapped-away point, and draw nothing behind the arrow with the trail off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2270,6 +2270,15 @@ architecture note.
   upward fling faster than NAV_BAR_FLING_PX_S, else spring back); commit = the same `openSteps` the
   list button calls, and `StepsSheet` animates in from its own height (`enter`). The button stays as
   the key path; the gesture is touch-only on purpose (docs/dpad.md).
+  **Trail OFF cannot use the cut piece (2026-09-06):** an overlay line cannot erase what is under it,
+  so a transparent "driven" stop on `ROUTE_CUT_LAYER` just revealed the blue ahead line beneath (the
+  growing stub). With the trail off, the cut piece is hidden and the AHEAD line's own gradient carries
+  the cut per frame (transparent before the arrow's window fraction); its ~12 m texel step hides under
+  the arrow. With the trail on, the cut piece paints grey over blue as before.
+  **Via-route spur guard (2026-09-06):** `routeOsrm` refuses a via route when any interior via snapped
+  >40 m (`VIA_SNAP_MAX_M`, from OSRM's `waypoints[].distance`) and `snapReaches` also requires the via
+  route to be no longer than Google's course x1.05 + 400 m. Either symptom is a sampled point that
+  landed on a frontage road or ramp; the plain route is used instead.
   **Driven trail is a setting (`RouteTrail`, `route_trail`, default OFF = hidden, 2026-09-03):** the
   ticker reads it per frame through `trailHolder`; off means `routeGradient(..., driven = TRANSPARENT)`
   on the ahead and cut pieces and `ROUTE_LAYER` hidden, on means grey. A flip sets `splitReset` so the

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1287,6 +1287,14 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   DISPLAYED speed is smoothed with a stop deadband (raw 1 Hz doppler flickered 59/60/61 at cruise), and
   speed derivation requires two GPS fixes past an accuracy-scaled floor (a BeaconDB hop minted phantom
   16 mph readouts at red lights).
+  **No more route "appendix" (2026-09-06):** when the open router is led along Google's course
+  through sampled points, a point that snapped onto a side road used to produce a spur out and back
+  that the arrow then drove while the car went straight. A via route is now refused when any sampled
+  point snapped more than 40 m from where it was asked for, or when the result is markedly longer
+  than the course it was meant to follow; the plain route is used instead.
+  **Road behind you, off: no stub (2026-09-06):** with the trail off, the line behind the arrow used
+  to reappear as a growing blue stub that vanished in a chunk every 300 m. The cut is now carried by
+  the ahead line's own gradient in that mode, so nothing is drawn behind the arrow at all.
   **Avoid tolls and highways work online (2026-09-06):** Google's keyless directions do honour the
   avoid options after all (the flags were found by capturing Google's own web client), so with either
   toggle on the route follows Google's avoiding course with the open router's named turns and Google's

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -2000,14 +2000,30 @@ fun VelaMapView(
                             PropertyFactory.lineGradient(routeGradient(0f, traversed, emptyList())),
                         )
                     }
-                    // Per frame: only the cut piece's PAINT moves.
-                    val c0 = cutStart[0]
-                    val c1 = cutEnd[0]
-                    val pc = if (c1 - c0 <= 1.0) 0f else ((prog - c0) / (c1 - c0)).toFloat().coerceIn(0.0001f, 0.9999f)
-                    style.getLayer(ROUTE_CUT_LAYER)?.setProperties(
-                        PropertyFactory.visibility(Property.VISIBLE),
-                        PropertyFactory.lineGradient(routeGradient(pc, gInt, remap(c0, c1), driven)),
-                    )
+                    // Per frame: only PAINT moves. Trail ON: the cut piece paints grey up to the
+                    // arrow over the ahead line. Trail OFF: the cut piece cannot erase what is
+                    // under it (a transparent stop just shows the blue beneath, which is what drew
+                    // a growing blue stub behind the arrow that vanished in a chunk every 300 m,
+                    // user 2026-09-06), so the AHEAD line's own gradient carries the cut instead:
+                    // transparent before the arrow's fraction of the window, colour after. Its
+                    // texel is the window/256 (~12 m at 3 km), a step that stays under the arrow.
+                    if (trailHolder.value) {
+                        val c0 = cutStart[0]
+                        val c1 = cutEnd[0]
+                        val pc = if (c1 - c0 <= 1.0) 0f else ((prog - c0) / (c1 - c0)).toFloat().coerceIn(0.0001f, 0.9999f)
+                        style.getLayer(ROUTE_CUT_LAYER)?.setProperties(
+                            PropertyFactory.visibility(Property.VISIBLE),
+                            PropertyFactory.lineGradient(routeGradient(pc, gInt, remap(c0, c1), driven)),
+                        )
+                    } else {
+                        style.getLayer(ROUTE_CUT_LAYER)?.setProperties(PropertyFactory.visibility(Property.NONE))
+                        val a0 = aheadAnchor[0]
+                        val a1 = navWin[0]
+                        val pa = if (a1 - a0 <= 1.0) 0f else ((prog - a0) / (a1 - a0)).toFloat().coerceIn(0.0001f, 0.9999f)
+                        style.getLayer(ROUTE_AHEAD_LAYER)?.setProperties(
+                            PropertyFactory.lineGradient(routeGradient(pa, gInt, remap(a0, a1), android.graphics.Color.TRANSPARENT)),
+                        )
+                    }
                 }
             } else {
                 dropPuckOverlay()

--- a/core/src/main/java/app/vela/core/data/RouteGeometry.kt
+++ b/core/src/main/java/app/vela/core/data/RouteGeometry.kt
@@ -202,6 +202,11 @@ object RouteGeometry {
 
     private const val BEARING_TOLERANCE_DEG = 65
 
+    /** How far (m) an interior via may snap from where it was asked before the via route is
+     *  refused as unreliable (see routeOsrm). Google's polyline points sit on the carriageway;
+     *  a snap beyond this landed on some other road. */
+    private const val VIA_SNAP_MAX_M = 40.0
+
     private fun routeOsrm(
         http: OkHttpClient,
         points: List<LatLng>,
@@ -228,8 +233,21 @@ object RouteGeometry {
             try {
                 http.newCall(req).execute().use { resp ->
                     if (resp.isSuccessful) {
-                        val routes = json.parseToJsonElement(resp.body?.string().orEmpty())
-                            .jsonObject["routes"]?.jsonArray
+                        val body = json.parseToJsonElement(resp.body?.string().orEmpty()).jsonObject
+                        // A via that OSRM had to snap far from where it was asked for is the
+                        // "appendix": the route runs out to a side road and back, and the puck then
+                        // drives that spur while the car goes straight (real drive, 2026-09-06). The
+                        // vias are points sampled off Google's own line, so a big snap distance means
+                        // the sample landed near a frontage road or ramp, not on the course. Refuse
+                        // the whole via route; the caller falls back to the plain route.
+                        if (points.size > 2) {
+                            val wps = body["waypoints"]?.jsonArray
+                            val badVia = wps != null && wps.size == points.size && (1 until wps.size - 1).any { i ->
+                                (wps[i].jsonObject["distance"]?.jsonPrimitive?.doubleOrNull ?: 0.0) > VIA_SNAP_MAX_M
+                            }
+                            if (badVia) return emptyList()
+                        }
+                        val routes = body["routes"]?.jsonArray
                         if (routes != null) return routes.mapNotNull { parseOsrmRoute(it.jsonObject) }
                     }
                     // A 4xx is deterministic (e.g. FOSSGIS answers InvalidValue for exclude=

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -569,7 +569,10 @@ class GoogleMapsDataSource @Inject constructor(
             // intermediate via (short ETA, wrong last step) is the "10 min away" nav bug — AND be time-
             // competitive with OSRM's free-flow best.
             val snapReaches = trafficRoute?.polyline?.lastOrNull()
-                ?.let { it.distanceTo(destination) <= SNAP_REACH_M } == true
+                ?.let { it.distanceTo(destination) <= SNAP_REACH_M } == true &&
+                // A via route markedly LONGER than the course it was meant to follow has a detour
+                // in it (a via that snapped to a side road: the spur the puck then drives).
+                gTop != null && trafficRoute!!.distanceMeters <= gTop.distanceMeters * SNAP_LENGTH_SLACK + SNAP_LENGTH_SLACK_M
             // With avoid on, the snap is the point (Google's avoiding course is slower than the
             // open router's unrestricted one by construction), so the ETA margin test is skipped.
             val snapWorthIt = trafficRoute != null && snapReaches && open.isNotEmpty() && googleEtaS != null &&
@@ -946,6 +949,8 @@ class GoogleMapsDataSource @Inject constructor(
         // (its detour is time-competitive with OSRM's ideal → the jam justifies the reroute). Tunable from
         // real side-by-side data — the `directions` diag logs gEta/osrmFF so the threshold can be pinned.
         const val SNAP_ETA_MARGIN = 1.2
+        private const val SNAP_LENGTH_SLACK = 1.05
+        private const val SNAP_LENGTH_SLACK_M = 400.0
         const val SNAP_REACH_M = 500.0 // the snapped route's last point must be within this of the destination
         const val MAX_ROUTES = 4       // primary + up to 3 alternates in the picker
         // Radii (m) to probe out toward the street when the geocode is set-back from it. Two rings


### PR DESCRIPTION
Two things from a real drive report.

**The route "appendix":** when the open router is led along Google's course through sampled points (the traffic snap), a point that snapped onto a side road produced a spur out and back, and the arrow drove that spur while the car went straight on. A via route is now refused when any interior point snapped more than 40 m from where it was asked for (OSRM's `waypoints[].distance`), or when the result is longer than Google's course by more than 5% + 400 m; the plain route is used instead.

**Blue stub behind the arrow with "Road behind you" off:** the cut piece is an overlay and cannot erase what is under it, so a transparent driven stop just showed the blue ahead line beneath, growing until the piece slid every 300 m and it vanished in a chunk. In that mode the cut piece is now hidden and the ahead line's own gradient carries the cut per frame (paint only, nothing re-uploaded). Measured on the Pixel 4a over 72 s of demo: zero route-blue pixels behind the arrow at every sample.

Core tests green, static audit clean. Docs: FEATURES.md, CLAUDE.md.