### PR TITLE
Detect a via-route spur by its shape, not just by snap distance or length

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2275,6 +2275,12 @@ architecture note.
   growing stub). With the trail off, the cut piece is hidden and the AHEAD line's own gradient carries
   the cut per frame (transparent before the arrow's window fraction); its ~12 m texel step hides under
   the arrow. With the trail on, the cut piece paints grey over blue as before.
+  **Via-route spur guard, the SHAPE test (2026-09-06, same day, after the reporter said the appendix
+  hung off a motorway with no turn for miles):** a via that lands on an OFF-RAMP snaps a few metres
+  and adds only a ramp pair, so the snap-distance and length guards below miss it. `hasSpur(route,
+  course)` projects the via route onto Google's line (windowed) and flags any >=250 m stretch that
+  advances <35% of the distance travelled; the first/last 300 m are exempt. Applied to every via
+  route in `directions()`; unit-tested with an out-and-back appendix and a ramp-shaped loop.
   **Via-route spur guard (2026-09-06):** `routeOsrm` refuses a via route when any interior via snapped
   >40 m (`VIA_SNAP_MAX_M`, from OSRM's `waypoints[].distance`) and `snapReaches` also requires the via
   route to be no longer than Google's course x1.05 + 400 m. Either symptom is a sampled point that

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1287,6 +1287,9 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   DISPLAYED speed is smoothed with a stop deadband (raw 1 Hz doppler flickered 59/60/61 at cruise), and
   speed derivation requires two GPS fixes past an accuracy-scaled floor (a BeaconDB hop minted phantom
   16 mph readouts at red lights).
+  **No more route "appendix", second pass (2026-09-06):** the shape itself is now detected: a via
+  route that keeps travelling while making no progress along Google's line (an off-ramp and back,
+  where the snap distance is tiny and the extra length is just a ramp pair) is refused too.
   **No more route "appendix" (2026-09-06):** when the open router is led along Google's course
   through sampled points, a point that snapped onto a side road used to produce a spur out and back
   that the arrow then drove while the car went straight. A via route is now refused when any sampled

--- a/core/src/main/java/app/vela/core/data/RouteGeometry.kt
+++ b/core/src/main/java/app/vela/core/data/RouteGeometry.kt
@@ -694,6 +694,84 @@ object RouteGeometry {
      *  dense that a via landing on a turn gets swallowed into a via arrive/depart and the turn is lost
      *  (measured ~1-in-10 named-turn loss at 60 vias; negligible at ~12). Only ever used on the
      *  divergent minority of routes, so the tradeoff rides on few requests. */
+    /**
+     * True when [route] contains a SPUR relative to [course]: a stretch where it keeps travelling
+     * but makes no progress along the course, then comes back. That is what a via that snapped
+     * onto an off-ramp or frontage road produces (real drive 2026-09-06: an appendix hanging off a
+     * motorway with no turn due for miles; the arrow drove out and back while the car went
+     * straight). Neither the snap distance (metres) nor the extra length (a ramp pair) is large in
+     * that case, so those checks miss it; this one looks at the shape.
+     *
+     * Each route vertex is projected onto the course (windowed, both advance together); over any
+     * stretch of at least [SPUR_MIN_M] metres of route where the projection advanced less than
+     * [SPUR_ADVANCE_FRACTION] of the distance travelled, the route has a spur. The first and last
+     * [SPUR_END_SLACK_M] are exempt: the origin and destination approaches legitimately differ.
+     */
+    internal fun hasSpur(route: List<LatLng>, course: List<LatLng>): Boolean {
+        if (route.size < 3 || course.size < 2) return false
+        val cum = app.vela.core.nav.RouteBar.cumulative(course)
+        val total = cum.last()
+        if (total < SPUR_MIN_M * 3) return false
+        val rcum = app.vela.core.nav.RouteBar.cumulative(route)
+        val rtotal = rcum.last()
+        // Windowed projection: a route vertex is matched to the nearest course segment near where
+        // the previous one matched, falling back to a global search when nothing is close.
+        var seg = 0
+        var stretchStartR = 0.0
+        var stretchStartC = 0.0
+        var maxC = 0.0
+        for (i in route.indices) {
+            val p = route[i]
+            var best = Double.MAX_VALUE
+            var bestAlong = 0.0
+            val lo = (seg - 3).coerceAtLeast(0)
+            val hi = (seg + 60).coerceAtMost(course.size - 2)
+            fun scan(a: Int, b: Int) {
+                for (k in a..b) {
+                    val (along, d) = projectOnSegment(course[k], course[k + 1], cum[k], p)
+                    if (d < best) { best = d; bestAlong = along; seg = k }
+                }
+            }
+            scan(lo, hi)
+            if (best > SPUR_LOCAL_M) scan(0, course.size - 2)
+            val r = rcum[i]
+            if (r < SPUR_END_SLACK_M || r > rtotal - SPUR_END_SLACK_M) {
+                stretchStartR = r; stretchStartC = bestAlong; maxC = bestAlong
+                continue
+            }
+            if (bestAlong > maxC + SPUR_ADVANCE_STEP_M) {
+                // Real progress along the course: the stretch under suspicion ends here.
+                maxC = bestAlong
+                stretchStartR = r
+                stretchStartC = bestAlong
+            } else {
+                val travelled = r - stretchStartR
+                if (travelled >= SPUR_MIN_M && (maxC - stretchStartC) < travelled * SPUR_ADVANCE_FRACTION) return true
+            }
+        }
+        return false
+    }
+
+    private fun projectOnSegment(a: LatLng, b: LatLng, cumA: Double, p: LatLng): Pair<Double, Double> {
+        val latScale = Math.cos(Math.toRadians(a.lat))
+        val bx = (b.lng - a.lng) * latScale
+        val by = b.lat - a.lat
+        val px = (p.lng - a.lng) * latScale
+        val py = p.lat - a.lat
+        val len2 = bx * bx + by * by
+        val t = if (len2 <= 0.0) 0.0 else ((px * bx + py * by) / len2).coerceIn(0.0, 1.0)
+        val dx = px - bx * t
+        val dy = py - by * t
+        val segLen = Math.sqrt(len2) * 111_320.0
+        return (cumA + segLen * t) to Math.hypot(dx, dy) * 111_320.0
+    }
+
+    private const val SPUR_MIN_M = 250.0            // a stretch this long with no progress is a spur
+    private const val SPUR_ADVANCE_FRACTION = 0.35  // progress along the course below this share of distance travelled
+    private const val SPUR_ADVANCE_STEP_M = 15.0    // how much further along the course counts as advancing
+    private const val SPUR_END_SLACK_M = 300.0      // origin/destination approaches may differ from the course
+    private const val SPUR_LOCAL_M = 200.0          // beyond this from the windowed match, search the whole course
+
     internal fun sampleVias(poly: List<LatLng>, count: Int = 12): List<LatLng> {
         if (poly.size < 3) return emptyList() // need at least one interior point
         val interior = poly.size - 2

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -546,6 +546,9 @@ class GoogleMapsDataSource @Inject constructor(
                 RouteGeometry.divergent(open.first(), gTop)) {
                 RouteGeometry.routeVia(http, listOf(origin) + RouteGeometry.sampleVias(gTop.polyline) + destination, mode, avoidTolls, avoidHighways)
                     .firstOrNull()
+                    // A via that landed on a ramp or frontage road makes the route run out and
+                    // back (the "appendix"); refuse the whole via route rather than drive it.
+                    ?.takeIf { !RouteGeometry.hasSpur(it.polyline, gTop.polyline) }
             } else null
             // OFFLINE fallback: OSRM (and Google) need the network. When OSRM came back empty — no
             // connectivity, or the FOSSGIS server is down — route fully ON-DEVICE from a downloaded

--- a/core/src/test/java/app/vela/core/RouteSpurTest.kt
+++ b/core/src/test/java/app/vela/core/RouteSpurTest.kt
@@ -1,0 +1,51 @@
+package app.vela.core
+
+import app.vela.core.data.RouteGeometry
+import app.vela.core.model.LatLng
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The via-route "appendix": a spur out to a snapped-away point and back, while the course it was
+ *  meant to follow goes straight on. */
+class RouteSpurTest {
+    // A straight east-west course, 6 km, a vertex every 100 m (1 deg lng ~ 87 km at this latitude).
+    private val lat = 38.55
+    private fun east(m: Double) = LatLng(lat, -121.75 + m / (111_320.0 * Math.cos(Math.toRadians(lat))))
+    private val course = (0..60).map { east(it * 100.0) }
+
+    @Test fun `the same line has no spur`() {
+        assertFalse(RouteGeometry.hasSpur(course, course))
+    }
+
+    @Test fun `a parallel road that keeps advancing is not a spur`() {
+        val parallel = course.map { LatLng(it.lat + 0.0012, it.lng) } // ~130 m north, same progress
+        assertFalse(RouteGeometry.hasSpur(parallel, course))
+    }
+
+    @Test fun `an out-and-back appendix off the middle is a spur`() {
+        // Follow the course to 3 km, go 400 m north and come back, then carry on.
+        val out = (1..4).map { LatLng(lat + it * 0.0009, east(3000.0).lng) }
+        val route = course.take(31) + out + out.reversed() + course.drop(31)
+        assertTrue(RouteGeometry.hasSpur(route, course))
+    }
+
+    @Test fun `a ramp-shaped loop that rejoins further along is a spur too`() {
+        // Leave at 3 km, run 300 m beside the course 40 m off it, loop back 250 m, rejoin: distance
+        // grows, progress along the course does not.
+        val off = 40.0 / 111_320.0
+        val loop = listOf(
+            LatLng(lat + off, east(3100.0).lng), LatLng(lat + off, east(3300.0).lng),
+            LatLng(lat + 2 * off, east(3300.0).lng), LatLng(lat + 2 * off, east(3050.0).lng),
+            LatLng(lat + off, east(3000.0).lng),
+        )
+        val route = course.take(31) + loop + course.drop(31)
+        assertTrue(RouteGeometry.hasSpur(route, course))
+    }
+
+    @Test fun `a different approach at the ends is tolerated`() {
+        val detourStart = listOf(LatLng(lat + 0.002, course[0].lng), LatLng(lat + 0.002, course[2].lng))
+        val route = listOf(course[0]) + detourStart + course.drop(3)
+        assertFalse(RouteGeometry.hasSpur(route, course))
+    }
+}


### PR DESCRIPTION
Follow-up to #332 after the reporter described the appendix more precisely: it hung off a motorway with no turn due for miles.

A sampled point that lands on an off-ramp snaps only a few metres from Google's line, and the detour is a ramp pair, so both guards in #332 (snap distance over 40 m; route longer than the course by 5% + 400 m) pass it. This adds the shape test: the via route is projected onto Google's line (windowed, both advance together) and any stretch of 250 m or more that advances less than 35% of the distance travelled is a spur. The first and last 300 m are exempt because the origin and destination approaches legitimately differ. A parallel road that keeps advancing is not flagged (that is what the existing divergence test is for).

Applied to every via route in `directions()`. Unit tests: identical line, parallel road, out-and-back appendix, ramp-shaped loop, differing approach at the ends. Core tests green, static audit clean.