### PR TITLE
Make the spur rule catch the appendix from the reporter's trip log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2275,6 +2275,12 @@ architecture note.
   growing stub). With the trail off, the cut piece is hidden and the AHEAD line's own gradient carries
   the cut per frame (transparent before the arrow's window fraction); its ~12 m texel step hides under
   the arrow. With the trail on, the cut piece paints grey over blue as before.
+  **Spur rule v2 (2026-09-06, from the reporter's trip log):** the real appendix was a 121 m
+  turn-right / U-turn / turn-right stub 56 m off a state route; the car never came within 47 m of
+  its tip. The v1 rule missed it (a side street leaving at an angle projects a little further along
+  the course every vertex, and the 15 m "advance" step reset the stretch each time). Now a stretch
+  resets only on NORMAL progress (>=80% of distance travelled) and flags at >=80 m travelled with
+  <45% progress. Validated in Python against the actual route geometry before porting.
   **Via-route spur guard, the SHAPE test (2026-09-06, same day, after the reporter said the appendix
   hung off a motorway with no turn for miles):** a via that lands on an OFF-RAMP snaps a few metres
   and adds only a ramp pair, so the snap-distance and length guards below miss it. `hasSpur(route,

--- a/core/src/main/java/app/vela/core/data/RouteGeometry.kt
+++ b/core/src/main/java/app/vela/core/data/RouteGeometry.kt
@@ -696,16 +696,19 @@ object RouteGeometry {
      *  divergent minority of routes, so the tradeoff rides on few requests. */
     /**
      * True when [route] contains a SPUR relative to [course]: a stretch where it keeps travelling
-     * but makes no progress along the course, then comes back. That is what a via that snapped
-     * onto an off-ramp or frontage road produces (real drive 2026-09-06: an appendix hanging off a
-     * motorway with no turn due for miles; the arrow drove out and back while the car went
-     * straight). Neither the snap distance (metres) nor the extra length (a ramp pair) is large in
-     * that case, so those checks miss it; this one looks at the shape.
+     * but makes little progress along the course, then comes back. That is what a via that snapped
+     * onto a side street or off-ramp produces (real drive 2026-09-06, from the trip log: a 121 m
+     * out-and-back off a state route, 56 m to the side, turn right / U-turn / turn right, while the
+     * car went straight and never came within 47 m of its tip). Neither the snap distance nor the
+     * extra length is large in that case, so those checks miss it; this one looks at the shape.
      *
-     * Each route vertex is projected onto the course (windowed, both advance together); over any
-     * stretch of at least [SPUR_MIN_M] metres of route where the projection advanced less than
-     * [SPUR_ADVANCE_FRACTION] of the distance travelled, the route has a spur. The first and last
-     * [SPUR_END_SLACK_M] are exempt: the origin and destination approaches legitimately differ.
+     * Each route vertex is projected onto the course (windowed, both advance together). A stretch
+     * begins wherever progress was last normal; over a stretch of at least [SPUR_MIN_M] metres of
+     * route in which the best progress along the course is under [SPUR_PROGRESS_FRACTION] of the
+     * distance travelled, the route has a spur. The first version of this reset the stretch on any
+     * 15 m of forward projection, which a side street leaving at an angle supplies every vertex -
+     * it missed the real one. The first and last [SPUR_END_SLACK_M] are exempt: the origin and
+     * destination approaches legitimately differ from the course.
      */
     internal fun hasSpur(route: List<LatLng>, course: List<LatLng>): Boolean {
         if (route.size < 3 || course.size < 2) return false
@@ -714,8 +717,6 @@ object RouteGeometry {
         if (total < SPUR_MIN_M * 3) return false
         val rcum = app.vela.core.nav.RouteBar.cumulative(route)
         val rtotal = rcum.last()
-        // Windowed projection: a route vertex is matched to the nearest course segment near where
-        // the previous one matched, falling back to a global search when nothing is close.
         var seg = 0
         var stretchStartR = 0.0
         var stretchStartC = 0.0
@@ -724,29 +725,25 @@ object RouteGeometry {
             val p = route[i]
             var best = Double.MAX_VALUE
             var bestAlong = 0.0
-            val lo = (seg - 3).coerceAtLeast(0)
-            val hi = (seg + 60).coerceAtMost(course.size - 2)
             fun scan(a: Int, b: Int) {
                 for (k in a..b) {
                     val (along, d) = projectOnSegment(course[k], course[k + 1], cum[k], p)
                     if (d < best) { best = d; bestAlong = along; seg = k }
                 }
             }
-            scan(lo, hi)
+            scan((seg - 3).coerceAtLeast(0), (seg + 60).coerceAtMost(course.size - 2))
             if (best > SPUR_LOCAL_M) scan(0, course.size - 2)
             val r = rcum[i]
             if (r < SPUR_END_SLACK_M || r > rtotal - SPUR_END_SLACK_M) {
                 stretchStartR = r; stretchStartC = bestAlong; maxC = bestAlong
                 continue
             }
-            if (bestAlong > maxC + SPUR_ADVANCE_STEP_M) {
-                // Real progress along the course: the stretch under suspicion ends here.
-                maxC = bestAlong
-                stretchStartR = r
-                stretchStartC = bestAlong
-            } else {
-                val travelled = r - stretchStartR
-                if (travelled >= SPUR_MIN_M && (maxC - stretchStartC) < travelled * SPUR_ADVANCE_FRACTION) return true
+            if (bestAlong > maxC) maxC = bestAlong
+            val travelled = r - stretchStartR
+            val progress = maxC - stretchStartC
+            if (travelled >= SPUR_MIN_M && progress < travelled * SPUR_PROGRESS_FRACTION) return true
+            if (progress >= travelled * SPUR_NORMAL_FRACTION) {
+                stretchStartR = r; stretchStartC = bestAlong; maxC = bestAlong
             }
         }
         return false
@@ -766,9 +763,9 @@ object RouteGeometry {
         return (cumA + segLen * t) to Math.hypot(dx, dy) * 111_320.0
     }
 
-    private const val SPUR_MIN_M = 250.0            // a stretch this long with no progress is a spur
-    private const val SPUR_ADVANCE_FRACTION = 0.35  // progress along the course below this share of distance travelled
-    private const val SPUR_ADVANCE_STEP_M = 15.0    // how much further along the course counts as advancing
+    private const val SPUR_MIN_M = 80.0             // a stretch this long with too little progress is a spur
+    private const val SPUR_PROGRESS_FRACTION = 0.45 // progress along the course below this share of distance travelled (a 45-degree stub lands at ~37%)
+    private const val SPUR_NORMAL_FRACTION = 0.8    // progress at or above this share = normal driving, stretch resets
     private const val SPUR_END_SLACK_M = 300.0      // origin/destination approaches may differ from the course
     private const val SPUR_LOCAL_M = 200.0          // beyond this from the windowed match, search the whole course
 

--- a/core/src/test/java/app/vela/core/RouteSpurTest.kt
+++ b/core/src/test/java/app/vela/core/RouteSpurTest.kt
@@ -43,9 +43,20 @@ class RouteSpurTest {
         assertTrue(RouteGeometry.hasSpur(route, course))
     }
 
+    @Test fun `the real one - a 120 m turn-right, u-turn, turn-right stub off the course`() {
+        // From a shared trip: the route left a state route onto a side street at an angle for
+        // ~60 m, U-turned and came back, while Google's course (and the car) went straight.
+        val j = course[47] // 4.7 km in
+        val ls = Math.cos(Math.toRadians(lat))
+        fun off(alongM: Double, sideM: Double) = LatLng(j.lat + sideM / 111_320.0, j.lng + alongM / (111_320.0 * ls))
+        val out = listOf(off(15.0, 20.0), off(30.0, 40.0), off(42.0, 56.0))
+        val route = course.take(48) + out + out.reversed() + course.drop(48)
+        assertTrue(RouteGeometry.hasSpur(route, course))
+    }
+
     @Test fun `a different approach at the ends is tolerated`() {
-        val detourStart = listOf(LatLng(lat + 0.002, course[0].lng), LatLng(lat + 0.002, course[2].lng))
-        val route = listOf(course[0]) + detourStart + course.drop(3)
+        val detourStart = listOf(LatLng(lat + 0.001, course[0].lng), LatLng(lat + 0.001, course[1].lng))
+        val route = listOf(course[0]) + detourStart + course.drop(2)
         assertFalse(RouteGeometry.hasSpur(route, course))
     }
 }


### PR DESCRIPTION
Follow-up to #333, with the actual geometry in hand (the reporter shared the trip).

The appendix was a **121 m turn-right / U-turn / turn-right stub, 56 m off a state route, 4.7 km into the route**, and the car never came within 47 m of its tip. It was in the original route from the start (no reroute involved), at the spacing where the traffic snap's sampled points fall, which settles the cause as a via that snapped onto the side street.

The first shape rule missed it: a side street leaving at an angle projects a little further along the course at every vertex, and the 15 m "advance" step reset the suspicious stretch each time. The stretch now resets only on normal progress (80% or more of the distance travelled) and flags at 80 m travelled with under 45% of progress. Validated against the real route geometry in a scratch replay before porting: the real spur flags (83 m travelled, 21 m progress), the route without it does not, a parallel road and a resampled switchback road do not.

Tests: the existing shapes plus a stub shaped like the real one. Core tests green.