### PR TITLE
Let the puck catch up faster after a cut corner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2318,6 +2318,13 @@ architecture note.
   Output sizes: Saarland 8 MB routing-only vs 52 MB with address+POI vs OsmAnd's own 66 MB
   roads-only / 125 MB full; Washington 111 MB vs OsmAnd 595 MB roads-only. Also: the workflow
   file was invalid YAML (duplicate `default:` key) from Aug 16 to Sep 3, so no bake ran at all.
+  **Corner-cut lag (2026-09-06, from the reporter's trip log, replayed offline):** a cut corner
+  jumps the along-route measurement ~30 m in one fix; the puck's catch-up cap (`maxCatchUp`,
+  was 0.5v+1) then took ~7 s at 7 m/s to drain it, so the arrow ran straight after the car had
+  turned. Raising the Kalman Q did nothing (the estimate already followed); the cap was the limiter.
+  Now 1.5v+2: 34 m -> 7 m in 2.5 s, per-fix speed step unchanged (p50 0.27 m/s). A shorter
+  PUCK_CORRECT_TIME_S (0.35) would cost smoothness (0.47/1.64 m/s) - left at 0.6. The replay
+  harness is a scratch Python port of AlongRouteFilter + the rate rule over the trip's fixes.
   **Read `docs/puck-jitter.md` first: the eight causes, the measurement scripts in `scripts/jitter/`, and
   the order to run them. Do not start from a theory.**
   **THE PUCK ITSELF JITTERED BECAUSE IT WAS A MAP SYMBOL (issue #251, fixed 2026-09-03). In

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1702,7 +1702,14 @@ fun VelaMapView(
                 // stall (the floor is 0 only when the model says stopped), it cannot lurch (the
                 // nudge is capped as a fraction of speed), and it is still monotonic.
                 val err = navPuck.along.alongM - navPuck.progressM
-                val maxCatchUp = navPuck.speed * 0.5 + 1.0   // m/s of extra closing speed
+                // 1.5x + 2, up from 0.5x + 1 (2026-09-06, from a shared real drive): cutting a
+                // corner makes the along-route measurement jump ~30 m in one fix (the route's
+                // corner is longer than the path the car took), and at city speed the old cap
+                // needed 7 s to drain it - the arrow "kept going straight" after the car had
+                // turned. Replayed against that trip: the jump drains to 7 m in 2.5 s now, and the
+                // per-fix speed step on ordinary driving is unchanged (p50 0.27 m/s both ways).
+                // The Kalman gain was NOT the limiter (raising Q changed nothing); this cap was.
+                val maxCatchUp = navPuck.speed * 1.5 + 2.0   // m/s of extra closing speed
                 val maxHoldBack = navPuck.speed * 0.25 + 0.5 // ...and of braking, so it never reverses
                 val corr = (err / PUCK_CORRECT_TIME_S).coerceIn(-maxHoldBack, maxCatchUp)
                 navPuck.progressM += ((navPuck.speed + corr) * dtT.coerceAtMost(0.5)).coerceAtLeast(0.0)

--- a/docs/puck-jitter.md
+++ b/docs/puck-jitter.md
@@ -43,6 +43,15 @@ map init, including force-stops during testing. The renderer sat at 89% of a cor
 juddered. The sentinel now counts only native crashes and says on the settings row when it
 engaged (#317).
 
+## After the fix: the puck was too sticky
+
+Once the vibration was gone, the next report was the opposite: the arrow followed the drawn
+road more faithfully than the car, running straight for a moment after a corner the driver had
+cut. From the shared trip: the along-route measurement jumps about 30 m in one fix at such a
+corner, and the catch-up cap of 0.5x speed + 1 m/s needed about 7 s to drain that at city speed.
+The Kalman gain was not the limiter; the cap was. It is now 1.5x speed + 2 m/s, which drains the
+jump in about 2.5 s with no measurable change to ordinary-driving smoothness.
+
 ## Things that were tried and are worse
 
 - A per-frame **LineString** source for the moving route cut. A line re-tiles on every worker


### PR DESCRIPTION
From a shared real drive (the same trip that pinned down the route appendix in #334): the arrow followed the drawn road more faithfully than the car, running straight for a moment after a corner the driver had cut.

Replayed offline (a scratch port of `AlongRouteFilter` plus the rate rule over the trip's fixes): cutting the corner jumps the along-route measurement about 30 m in one fix, because the route's corner is longer than the path the car took. At 7 m/s the catch-up cap of 0.5x speed + 1 m/s needed about 7 s to drain that. Raising the Kalman process noise changed nothing (the estimate already followed the fix); the cap was the limiter.

Now 1.5x speed + 2 m/s: the jump drains to 7 m in 2.5 s, and the per-fix speed step on ordinary driving is unchanged (median 0.27 m/s both ways, p90 1.00 → 1.04). Shortening `PUCK_CORRECT_TIME_S` to 0.35 would have halved smoothness (0.47 / 1.64 m/s), so it stays at 0.6.

Demo drive on the Pixel 4a after: the arrow still moves 0.01 px per frame, so nothing from #318 regressed. Docs: CLAUDE.md, docs/puck-jitter.md.