### PR TITLE
Nav runtime review fixes: no second puck after re-center, no per-frame recomposition from the road label

### DIFF
--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -495,7 +495,11 @@ fun MapScreen(
     var navBannerBottomPx by remember { mutableStateOf(0) }
     // Where the nav puck sits on screen, for the current-road label under it (issue #288).
     // Null until the nav ticker reports one; reset when a drive ends.
-    var puckScreen by remember { mutableStateOf<Offset?>(null) }
+    // The arrow's screen position, written by the ticker's rare real moves and READ IN THE
+    // LAYOUT LAMBDA of the road pill only, so a report re-lays-out one Surface rather than
+    // recomposing this screen (review 2026-09-06). Cleared when a drive ends.
+    val puckScreen = remember { mutableStateOf<Offset?>(null) }
+    LaunchedEffect(state.navigating) { if (!state.navigating) puckScreen.value = null }
     // The endpoints card's bottom edge, so the notification column can sit under it in
     // directions mode instead of printing over it (user 2026-07-13).
     var topCardBottomPx by remember { mutableStateOf(0) }
@@ -1087,7 +1091,7 @@ fun MapScreen(
             navOverviewTick = navOverviewTick,
             navRecenterTick = navRecenterTick,
             onNavZoomOverride = { navZoomOverride = it },
-            onPuckScreen = { x, y -> puckScreen = Offset(x, y) },
+            onPuckScreen = { x, y -> puckScreen.value = Offset(x, y) },
             onPoiTap = vm::onPoiTap,
             onMarkerTap = { i -> displayedPlaces(state).getOrNull(i)?.let(vm::selectPlace) },
             parkingSpot = state.parkingSpot,
@@ -1325,8 +1329,9 @@ fun MapScreen(
             val liveIdx = state.nav.stepIndex
             val onRoad = state.activeRoute?.maneuvers?.getOrNull(liveIdx - 1)
                 ?.let { it.ref?.takeIf { r -> r.isNotBlank() } ?: it.road?.takeIf { r -> r.isNotBlank() } }
-            val at = puckScreen
-            if (onRoad != null && at != null) {
+            // Composition reads only "do we have a position"; the value itself is read in layout.
+            val havePuck = puckScreen.value != null
+            if (onRoad != null && (havePuck || roadLabelMode == app.vela.ui.RoadLabel.BAR)) {
                 val uiLang = app.vela.ui.AppLocale.effective().language
                 val shownRoad =
                     if (state.roadNameLatin.isEmpty()) onRoad
@@ -1356,6 +1361,7 @@ fun MapScreen(
                         .layout { measurable, constraints ->
                             val placeable = measurable.measure(constraints)
                             layout(placeable.width, placeable.height) {
+                                val at = puckScreen.value ?: Offset(constraints.maxWidth / 2f, 0f)
                                 val margin = 8.dp.roundToPx()
                                 val maxX = (constraints.maxWidth - placeable.width - margin)
                                     .coerceAtLeast(margin)

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -303,6 +303,10 @@ private var previewApplied = false // distinguishes "never applied" from "applie
 private var lastRouteMode = -1     // 0=dashed 1=browse 2=nav; transition one-shots key off this
 private var lastBrowseGradKey: Int? = null
 private var lastMeLayerKey: Int? = null
+/** True while the follow-mode Compose overlay draws the puck: applyData must then keep the symbol
+ *  puck hidden whatever its own key says, or a pinch/re-center that spans no fix brought BOTH pucks
+ *  back for the rest of the drive (review 2026-09-06). Set by the ticker, cleared by dropPuckOverlay. */
+@Volatile private var puckOverlayOwnsArrow = false
 private val lastEnsureKey = intArrayOf(-1)
 
 // AUDIT FIX 6 (2026-07-15): discrete animateCamera FLIGHTS (locate, route fit, overview,
@@ -574,7 +578,7 @@ fun VelaMapView(
     // split so the gradients and the full line's visibility are re-applied at once.
     val trailOn = app.vela.ui.RouteTrail.on.value
     val trailHolder = rememberUpdatedState(trailOn)
-    LaunchedEffect(trailOn) { splitReset[0] = true }
+    LaunchedEffect(trailOn) { splitReset[0] = true; lastGradM[0] = -1e9 } // -1e9 so the block runs even while stopped
     val mPerPxHolder = remember { doubleArrayOf(10.0) } // metres/pixel at the camera (scale-bar feed) —
                                                         // sizes the split-update throttle to sub-pixel
     val lastScaleReport = remember { doubleArrayOf(-1.0) } // last mpp PUSHED to compose (gate, see reportScale)
@@ -664,6 +668,7 @@ fun VelaMapView(
         }
     }
     var styleRef by remember { mutableStateOf<Style?>(null) }
+    val navPuck = remember { NavPuck() }
     // The follow-mode puck OVERLAY (see the ticker): screen position + transform, written per
     // frame by the ticker and read in the DRAW phase (graphicsLayer lambdas), so a frame costs
     // one layer redraw and no recomposition.
@@ -675,10 +680,18 @@ fun VelaMapView(
     val puckOverlayHidLayer = remember { booleanArrayOf(false) } // ME_ARROW_LAYER hidden for the overlay
     fun dropPuckOverlay() {
         if (puckOverlayOn.value) puckOverlayOn.value = false
+        lastPuckScreen[0] = Float.NaN
+        lastPuckScreen[1] = Float.NaN
         if (puckOverlayHidLayer[0]) {
             puckOverlayHidLayer[0] = false
+            puckOverlayOwnsArrow = false
             lastMeLayerKey = null // applyData re-derives the symbol puck's visibility on its next pass
-            styleRef?.getLayer(ME_ARROW_LAYER)?.setProperties(PropertyFactory.visibility(Property.VISIBLE))
+            styleRef?.let { st ->
+                // The source was not fed while the overlay drew (see the ticker), so put the symbol
+                // where the arrow last was before showing it.
+                navPuck.drawn?.let { setMeSource(st, it, navPuck.displayBearing) }
+                st.getLayer(ME_ARROW_LAYER)?.setProperties(PropertyFactory.visibility(Property.VISIBLE))
+            }
         }
     }
     var appliedStyleKey by remember { mutableStateOf<String?>(null) }
@@ -709,7 +722,6 @@ fun VelaMapView(
     LaunchedEffect(navFollowing) {
         if (navFollowing) { lastNavTarget = null; lastNavBearing = null }
     }
-    val navPuck = remember { NavPuck() }
     val routeCum = remember(routePolyline) { cumLengths(routePolyline) }
 
     // CROSS-STREET-ONLY nav labels (user 2026-07-16: "only show roads we are on or that we
@@ -1768,22 +1780,10 @@ fun VelaMapView(
                     )
                 }
                 navPuck.drawn = pt // the camera follows this smoothed point, not the raw fix
-                setMeSource(style, pt, navPuck.displayBearing)
-                // Where the puck landed on screen, for the current-road label beneath it
-                // (issue #288). Projection is a cheap matrix op, but the REPORT is gated on real
-                // movement - the follow camera parks the puck at one spot, so pushing this into
-                // compose every frame would recompose the label 60x a second for nothing.
-                runCatching { mapRef?.projection?.toScreenLocation(MLLatLng(pt.lat, pt.lng)) }
-                    .getOrNull()?.let { sp ->
-                        if (lastPuckScreen[0].isNaN() ||
-                            kotlin.math.abs(sp.x - lastPuckScreen[0]) > 2f ||
-                            kotlin.math.abs(sp.y - lastPuckScreen[1]) > 2f
-                        ) {
-                            lastPuckScreen[0] = sp.x
-                            lastPuckScreen[1] = sp.y
-                            puckScreenCb.value(sp.x, sp.y)
-                        }
-                    }
+                // While the Compose overlay draws the puck the symbol layer is hidden, so the
+                // per-frame source upload is pure waste (review 2026-09-06); dropPuckOverlay
+                // re-feeds it once before the symbol comes back.
+                if (!puckOverlayHidLayer[0]) setMeSource(style, pt, navPuck.displayBearing)
                 // Drive the follow-camera HERE, per frame (60 fps) with a continuous ease, instead
                 // of the recomposition-driven block below (which re-pointed only ~1-3×/s in
                 // throttled 550 ms eases — the "stiff" feel). Ease the camera toward the smooth
@@ -1891,7 +1891,22 @@ fun VelaMapView(
                     if (!puckOverlayOn.value) puckOverlayOn.value = true
                     if (!puckOverlayHidLayer[0]) {
                         puckOverlayHidLayer[0] = true
+                        puckOverlayOwnsArrow = true
                         style.getLayer(ME_ARROW_LAYER)?.setProperties(PropertyFactory.visibility(Property.NONE))
+                    }
+                    // Where the arrow sits on screen, for the road label pinned under it (issue
+                    // #288). Reported only while FOLLOWING (the camera parks the arrow, so this
+                    // fires on the rare real move) and from the same projection the overlay uses,
+                    // so the label can never trail the arrow by a frame. Reporting from a detached
+                    // camera recomposed the whole screen at 60 Hz while the arrow crossed it
+                    // (review 2026-09-06).
+                    if (lastPuckScreen[0].isNaN() ||
+                        kotlin.math.abs(scr.x - lastPuckScreen[0]) > 2f ||
+                        kotlin.math.abs(scr.y - lastPuckScreen[1]) > 2f
+                    ) {
+                        lastPuckScreen[0] = scr.x
+                        lastPuckScreen[1] = scr.y
+                        puckScreenCb.value(scr.x, scr.y)
                     }
                 } else {
                     camState[0] = Double.NaN // reset → re-attach eases in from the live camera
@@ -2023,7 +2038,7 @@ fun VelaMapView(
                             PropertyFactory.lineGradient(routeGradient(pc, gInt, remap(c0, c1), driven)),
                         )
                     } else {
-                        style.getLayer(ROUTE_CUT_LAYER)?.setProperties(PropertyFactory.visibility(Property.NONE))
+                        if (aheadDirty) style.getLayer(ROUTE_CUT_LAYER)?.setProperties(PropertyFactory.visibility(Property.NONE))
                         val a0 = aheadAnchor[0]
                         val a1 = navWin[0]
                         val pa = if (a1 - a0 <= 1.0) 0f else ((prog - a0) / (a1 - a0)).toFloat().coerceIn(0.0001f, 0.9999f)
@@ -2836,7 +2851,7 @@ fun VelaMapView(
                 lastRouteMode = -1
                 lastBrowseGradKey = null
                 lastMeLayerKey = null
-                puckOverlayHidLayer[0] = false // fresh style re-created the symbol puck visible
+                puckOverlayHidLayer[0] = false // fresh style re-created the symbol puck; the ticker re-hides it (puckOverlayOwnsArrow keeps applyData from showing it meanwhile)
                 lastEnsureKey[0] = -1 // fresh style dropped the overlay layers - re-ensure on next pass
                 lastGradM[0] = -1e9 // force the nav split to re-render on the fresh style
                 splitReset[0] = true
@@ -5987,7 +6002,7 @@ private fun applyData(
         )
         style.getLayer(ME_ARROW_LAYER)?.setProperties(
             PropertyFactory.iconImage(if (navMode) NAV_PUCK_IMG else ME_ARROW_IMG),
-            PropertyFactory.visibility(if (me != null && bearing != null && !meStale) Property.VISIBLE else Property.NONE),
+            PropertyFactory.visibility(if (me != null && bearing != null && !meStale && !puckOverlayOwnsArrow) Property.VISIBLE else Property.NONE),
         )
     }
 

--- a/app/src/main/java/app/vela/ui/nav/RouteBarStrip.kt
+++ b/app/src/main/java/app/vela/ui/nav/RouteBarStrip.kt
@@ -132,7 +132,9 @@ fun RouteBarStrip(model: RouteBar.Model, remainingMeters: Double, modifier: Modi
                     val p = when (d.kind) {
                         ROLE_TRACK -> m.measure(constraints.copy(minHeight = trackH, maxHeight = trackH, minWidth = 0))
                         ROLE_BAND -> {
-                            val bh = ((d.to - d.from) * trackH).toInt().coerceIn(TRACK_W.dp.roundToPx(), trackH)
+                            // coerceIn throws when min > max: on a strip shorter than the track width
+                            // (a tiny multi-window pane) clamp to the track height instead.
+                            val bh = ((d.to - d.from) * trackH).toInt().coerceAtMost(trackH).coerceAtLeast(minOf(TRACK_W.dp.roundToPx(), trackH))
                             m.measure(constraints.copy(minHeight = bh, maxHeight = bh, minWidth = 0))
                         }
                         else -> m.measure(constraints.copy(minWidth = 0, minHeight = 0))

--- a/app/src/main/java/app/vela/ui/nav/StepsSheet.kt
+++ b/app/src/main/java/app/vela/ui/nav/StepsSheet.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -177,6 +178,9 @@ fun StepsSheet(
         modifier
             .fillMaxWidth()
             .onSizeChanged { sheetHeightPx = it.height }
+            // Invisible until measured: the enter offset is a fraction of the sheet's own height,
+            // which is 0 on the first frame, so that frame would flash the sheet fully open.
+            .graphicsLayer { alpha = if (sheetHeightPx == 0) 0f else 1f }
             .offset { IntOffset(0, (drag.value + sheetHeightPx * enter.value).roundToInt().coerceAtLeast(0)) }
             .pointerInput(Unit) {
                 sheetDragGestures(


### PR DESCRIPTION
From a review pass over everything merged since v0.4.955.

- **Double puck after pan/pinch + re-center.** Dropping the overlay re-derived the symbol layer's visibility, and a re-follow that spanned no GPS fix never re-hid it, so both pucks drew for the rest of the drive (the #251 halo jitter, back). The overlay now owns the symbol layer's visibility while it draws; `applyData` respects that; the symbol's source is fed once before it comes back instead of every frame while hidden.
- **60 Hz recomposition after a pan.** The arrow's screen position for the road label was reported from a detached camera too, recomposing `MapScreen` every frame while the arrow crossed it. Now reported only while following, from the overlay's own projection, and read in the label's layout lambda rather than in composition. Cleared when a drive ends.
- "Road behind you" flip applies while stopped (the split block runs on the flip, not on the next metre).
- The hidden cut layer is hidden once, not per frame.
- Step sheet no longer flashes fully open on its first frame (invisible until measured).
- Road-ahead bar: `coerceIn` could throw on a strip shorter than the track width.

Device-checked on the Pixel 4a: pan during a demo drive, Re-center, one puck (8920 arrow pixels before and after, one bounding box). Static audit clean.