### PR TITLE
Routing review fixes: avoid keeps named turns, set-back stops route again, spans stay on their own course

### DIFF
--- a/core/src/main/java/app/vela/core/data/RouteGeometry.kt
+++ b/core/src/main/java/app/vela/core/data/RouteGeometry.kt
@@ -175,8 +175,14 @@ object RouteGeometry {
         mode: TravelMode,
         avoidTolls: Boolean = false,
         avoidHighways: Boolean = false,
+        departBearingDeg: Double? = null,
+        // True only for the traffic SNAP (vias sampled off Google's line, which must sit on the
+        // road): a via that snapped far away is refused. A user's STOP is routinely set back
+        // from the road (a mall lot, a driveway), so the multi-stop router must not use this.
+        strictVias: Boolean = false,
     ): List<Route> =
-        if (waypoints.size < 2) emptyList() else routeOsrm(http, waypoints, mode, alternatives = false, avoidTolls, avoidHighways)
+        if (waypoints.size < 2) emptyList()
+        else routeOsrm(http, waypoints, mode, alternatives = false, avoidTolls, avoidHighways, departBearingDeg = departBearingDeg, strictVias = strictVias)
 
     /**
      * OSRM `bearings=`, constraining only the FIRST waypoint to the direction the car is actually
@@ -216,6 +222,7 @@ object RouteGeometry {
         avoidHighways: Boolean = false,
         tries: Int = OSRM_TRIES,
         departBearingDeg: Double? = null,
+        strictVias: Boolean = false,
     ): List<Route> {
         val backend = backend(mode) ?: return emptyList()
         val coords = points.joinToString(";") { "${it.lng},${it.lat}" }
@@ -240,7 +247,7 @@ object RouteGeometry {
                         // vias are points sampled off Google's own line, so a big snap distance means
                         // the sample landed near a frontage road or ramp, not on the course. Refuse
                         // the whole via route; the caller falls back to the plain route.
-                        if (points.size > 2) {
+                        if (strictVias && points.size > 2) {
                             val wps = body["waypoints"]?.jsonArray
                             val badVia = wps != null && wps.size == points.size && (1 until wps.size - 1).any { i ->
                                 (wps[i].jsonObject["distance"]?.jsonPrimitive?.doubleOrNull ?: 0.0) > VIA_SNAP_MAX_M
@@ -710,11 +717,17 @@ object RouteGeometry {
      * it missed the real one. The first and last [SPUR_END_SLACK_M] are exempt: the origin and
      * destination approaches legitimately differ from the course.
      */
-    internal fun hasSpur(route: List<LatLng>, course: List<LatLng>): Boolean {
-        if (route.size < 3 || course.size < 2) return false
+    internal fun hasSpur(route: List<LatLng>, course: List<LatLng>): Boolean = spurAt(route, course) != null
+
+    /** Metres along [route] where a spur was detected (see [hasSpur]), or null. */
+    internal fun spurAt(route: List<LatLng>, course: List<LatLng>): Double? {
+        if (route.size < 3 || course.size < 2) return null
         val cum = app.vela.core.nav.RouteBar.cumulative(course)
         val total = cum.last()
-        if (total < SPUR_MIN_M * 3) return false
+        if (total < SPUR_MIN_M * 3) return null
+        // One latitude scale for the whole course (a route spans a few degrees at most): the
+        // per-projection cos() was most of the cost on a long route (review 2026-09-06).
+        val latScale = Math.cos(Math.toRadians(course[course.size / 2].lat))
         val rcum = app.vela.core.nav.RouteBar.cumulative(route)
         val rtotal = rcum.last()
         var seg = 0
@@ -727,7 +740,7 @@ object RouteGeometry {
             var bestAlong = 0.0
             fun scan(a: Int, b: Int) {
                 for (k in a..b) {
-                    val (along, d) = projectOnSegment(course[k], course[k + 1], cum[k], p)
+                    val (along, d) = projectOnSegment(course[k], course[k + 1], cum[k], p, latScale)
                     if (d < best) { best = d; bestAlong = along; seg = k }
                 }
             }
@@ -741,16 +754,15 @@ object RouteGeometry {
             if (bestAlong > maxC) maxC = bestAlong
             val travelled = r - stretchStartR
             val progress = maxC - stretchStartC
-            if (travelled >= SPUR_MIN_M && progress < travelled * SPUR_PROGRESS_FRACTION) return true
+            if (travelled >= SPUR_MIN_M && progress < travelled * SPUR_PROGRESS_FRACTION) return r
             if (progress >= travelled * SPUR_NORMAL_FRACTION) {
                 stretchStartR = r; stretchStartC = bestAlong; maxC = bestAlong
             }
         }
-        return false
+        return null
     }
 
-    private fun projectOnSegment(a: LatLng, b: LatLng, cumA: Double, p: LatLng): Pair<Double, Double> {
-        val latScale = Math.cos(Math.toRadians(a.lat))
+    private fun projectOnSegment(a: LatLng, b: LatLng, cumA: Double, p: LatLng, latScale: Double): Pair<Double, Double> {
         val bx = (b.lng - a.lng) * latScale
         val by = b.lat - a.lat
         val px = (p.lng - a.lng) * latScale

--- a/core/src/main/java/app/vela/core/data/google/DirectionsPb.kt
+++ b/core/src/main/java/app/vela/core/data/google/DirectionsPb.kt
@@ -62,6 +62,11 @@ object DirectionsPb {
      *  tolls, the same field numbers the web `dir/` URL's `!2m1!1b1` carries. Counts on the
      *  enclosing `!6m` and `!2m` groups grow by the number of flags added. Done by pattern so a
      *  recalibrated template (CalibrationStore) keeps working as long as that block survives. */
+    /** Whether [withAvoid] can place the flags in [template] at all. */
+    fun avoidSupported(template: String): Boolean = AVOID_BLOCK.containsMatchIn(template)
+
+    private val AVOID_BLOCK = Regex("""!6m(\d+)(!1m5!18b1!30b1!31m1!1b1!34e1!2m)(\d+)""")
+
     internal fun withAvoid(template: String, avoidTolls: Boolean, avoidHighways: Boolean): String {
         if (!avoidTolls && !avoidHighways) return template
         val flags = buildString {
@@ -69,8 +74,7 @@ object DirectionsPb {
             if (avoidTolls) append("!2b1")
         }
         val added = flags.count { it == '!' }
-        val re = Regex("""!6m(\d+)(!1m5!18b1!30b1!31m1!1b1!34e1!2m)(\d+)""")
-        val m = re.find(template) ?: return template
+        val m = AVOID_BLOCK.find(template) ?: return template
         val outer = m.groupValues[1].toInt() + added
         val inner = m.groupValues[3].toInt() + added
         return template.replaceRange(m.range, "!6m$outer${m.groupValues[2]}$inner$flags")

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -467,7 +467,7 @@ class GoogleMapsDataSource @Inject constructor(
         // whole origin→dest so the time is traffic-aware. A waypointed trip is a single path — no alternates.
         if (waypoints.isNotEmpty()) {
             return@io coroutineScope {
-                val viaD = async { RouteGeometry.routeVia(http, listOf(origin) + waypoints + destination, mode, avoidTolls, avoidHighways) }
+                val viaD = async { RouteGeometry.routeVia(http, listOf(origin) + waypoints + destination, mode, avoidTolls, avoidHighways, departBearingDeg) }
                 val gD = async { googleDirectionsRetried(origin, destination, mode, tries, avoidTolls, avoidHighways) }
                 val via = viaD.await().firstOrNull()
                 // OSRM unreachable → route the legs on-device (origin→w1→…→dest chained), like the
@@ -481,7 +481,9 @@ class GoogleMapsDataSource @Inject constructor(
                     else -> gD.await().take(1).map { it.copy(abbreviatedSteps = true) }
                 }
                 // Online routers cannot honour the avoid toggles; only the on-device chain can.
-                if ((avoidTolls || avoidHighways) && mode == TravelMode.DRIVE && onDevice == null) {
+                // Google's direct route honours avoid (DirectionsPb.withAvoid); the open router's
+                // via route and its on-device fallback do not - only those get the note.
+                if ((avoidTolls || avoidHighways) && mode == TravelMode.DRIVE && via != null) {
                     result = result.map { it.copy(avoidNotHonored = true) }
                 }
                 diag.record(
@@ -518,7 +520,9 @@ class GoogleMapsDataSource @Inject constructor(
             // Google is unreachable. (Until today avoid was on-device-or-nothing, with the plain
             // route and a note otherwise; #325's broken ETA came from that branch.)
             val avoidWanted = (avoidTolls || avoidHighways) && mode == TravelMode.DRIVE
-            if (avoidWanted && gTop != null) avoidHonored = true
+            // Honoured only when the request could actually carry the flags: a recalibrated pb
+            // template without the feature block makes withAvoid a no-op (review 2026-09-06).
+            if (avoidWanted && gTop != null && DirectionsPb.avoidSupported(calibration.current().directionsPb)) avoidHonored = true
             if (avoidWanted && gTop == null && routeEngine.isReady(mode)) {
                 // BOUNDED: the obf engine can spend many seconds on a long route, and this branch
                 // used to wait for it unconditionally - with an offline region installed an
@@ -542,19 +546,32 @@ class GoogleMapsDataSource @Inject constructor(
             // than OSRM's free-flow one — i.e. Google rerouted around a jam — re-run OSRM forced
             // through Google's path so we follow the traffic-smart route WITH full street-named steps.
             // (Only on real divergence, so the normal case stays the fast single OSRM call.)
-            val trafficRoute = if ((!urgent || avoidWanted) && open.isNotEmpty() && gTop != null && gTop.polyline.size >= 5 &&
-                RouteGeometry.divergent(open.first(), gTop)) {
-                RouteGeometry.routeVia(http, listOf(origin) + RouteGeometry.sampleVias(gTop.polyline) + destination, mode, avoidTolls, avoidHighways)
-                    .firstOrNull()
-                    // A via that landed on a ramp or frontage road makes the route run out and
-                    // back (the "appendix"); refuse the whole via route rather than drive it.
-                    ?.takeIf { !RouteGeometry.hasSpur(it.polyline, gTop.polyline) }
+            val topDivergent = open.isNotEmpty() && gTop != null && gTop.polyline.size >= 5 &&
+                RouteGeometry.divergent(open.first(), gTop)
+            val viaRoute = if ((!urgent || avoidWanted) && topDivergent) {
+                RouteGeometry.routeVia(
+                    http, listOf(origin) + RouteGeometry.sampleVias(gTop!!.polyline) + destination, mode,
+                    avoidTolls, avoidHighways, departBearingDeg, strictVias = true,
+                ).firstOrNull()
             } else null
+            // Cheap checks first, the shape test last (it walks the whole route): the via route
+            // must reach the destination and not be markedly LONGER than the course it followed
+            // (a via that snapped to a side road adds a detour).
+            val viaReaches = viaRoute != null && gTop != null &&
+                viaRoute.polyline.lastOrNull()?.let { it.distanceTo(destination) <= SNAP_REACH_M } == true &&
+                viaRoute.distanceMeters <= gTop.distanceMeters * SNAP_LENGTH_SLACK + SNAP_LENGTH_SLACK_M
+            // The "appendix": a stretch that travels without progressing along Google's line,
+            // then comes back. Refused only when a TURN or U-TURN sits on it - a loop ramp that
+            // OSM draws in full and Google's line chords is the same shape without one (review
+            // 2026-09-06), and a loop ramp is a MERGE/RAMP, never a U-turn.
+            val trafficRoute = viaRoute?.takeIf { r ->
+                viaReaches && !spurWithTurn(r, gTop!!.polyline)
+            }
             // OFFLINE fallback: OSRM (and Google) need the network. When OSRM came back empty — no
             // connectivity, or the FOSSGIS server is down — route fully ON-DEVICE from a downloaded
             // GraphHopper graph, if one covers this area. No traffic offline, but complete named turns.
             val onDevice = if (open.isEmpty() && trafficRoute == null && routeEngine.isReady(mode))
-                routeEngine.route(origin, destination, mode) else emptyList()
+                routeEngine.route(origin, destination, mode, avoidTolls, avoidHighways) else emptyList()
             // Lead with Google's jam-avoiding path (option 3) only when it EARNS it: its live in-traffic
             // ETA is within a small margin of OSRM's FREE-FLOW best, so even Google's detour is time-
             // competitive → the jam is real. The old code led with the snap on ANY >700 m divergence, so a
@@ -571,18 +588,17 @@ class GoogleMapsDataSource @Inject constructor(
             // The snapped via-route must actually REACH the destination — a truncated one ending at an
             // intermediate via (short ETA, wrong last step) is the "10 min away" nav bug — AND be time-
             // competitive with OSRM's free-flow best.
-            val snapReaches = trafficRoute?.polyline?.lastOrNull()
-                ?.let { it.distanceTo(destination) <= SNAP_REACH_M } == true &&
-                // A via route markedly LONGER than the course it was meant to follow has a detour
-                // in it (a via that snapped to a side road: the spur the puck then drives).
-                gTop != null && trafficRoute!!.distanceMeters <= gTop.distanceMeters * SNAP_LENGTH_SLACK + SNAP_LENGTH_SLACK_M
+            val snapReaches = trafficRoute != null
             // With avoid on, the snap is the point (Google's avoiding course is slower than the
             // open router's unrestricted one by construction), so the ETA margin test is skipped.
             val snapWorthIt = trafficRoute != null && snapReaches && open.isNotEmpty() && googleEtaS != null &&
                 (avoidWanted || googleEtaS <= open.first().durationSeconds * SNAP_ETA_MARGIN)
             // Avoid on, Google answered, but the open router could not be led along its course:
             // Google's own (abbreviated) steps beat a plain route that ignores the avoid.
-            val avoidFallbackToGoogle = avoidWanted && gTop != null && !snapWorthIt
+            // Only when the open route actually left Google's avoiding course; when it already
+            // follows it (no toll or motorway on the way anyway), the open route with its full
+            // named turns IS the avoiding route (review 2026-09-06: this used to throw it away).
+            val avoidFallbackToGoogle = avoidWanted && gTop != null && !snapWorthIt && topDivergent
             diag.record(
                 "directions",
                 "$mode → OSRM ${open.size} routes / ${open.firstOrNull()?.maneuvers?.size ?: 0} steps; " +
@@ -645,6 +661,19 @@ class GoogleMapsDataSource @Inject constructor(
         } else planned
     }
 
+    /** True when [RouteGeometry.spurAt] finds a spur on [route] AND one of the route's own
+     *  maneuvers within [SPUR_TURN_NEAR_M] of it is a turn or U-turn. */
+    private fun spurWithTurn(route: Route, course: List<LatLng>): Boolean {
+        val at = RouteGeometry.spurAt(route.polyline, course) ?: return false
+        val cum = app.vela.core.nav.RouteProjection.cumulative(route.polyline)
+        val idx = cum.indexOfFirst { it >= at }.let { if (it < 0) route.polyline.lastIndex else it }
+        val here = route.polyline[idx]
+        return route.maneuvers.any { m ->
+            (m.type == app.vela.core.model.ManeuverType.UTURN || m.type.name.startsWith("TURN")) &&
+                m.location.distanceTo(here) <= SPUR_TURN_NEAR_M
+        }
+    }
+
     /** Drop routes that follow ~the same path as an earlier one (keeps the picker to genuinely distinct
      *  choices). Order is preserved, so the primary stays first. */
     private fun dedupeRoutes(routes: List<Route>): List<Route> {
@@ -681,11 +710,9 @@ class GoogleMapsDataSource @Inject constructor(
         // don't turn red just because OSRM was optimistic). A divergent route (a genuinely
         // different path) can inherit the caller's calibration (the bias is the road network's,
         // not one route's); with none it keeps the old ratio-only overlay.
-        val cal = freeFlowCal ?: run {
-            val sameCourse = route.durationSeconds > 0 && route.polyline.size >= 2 &&
-                g.polyline.size >= 5 && !RouteGeometry.divergent(route, g)
-            if (sameCourse) ((typical * scale) / route.durationSeconds).coerceIn(0.5, 3.0) else 1.0
-        }
+        val sameCourse = route.durationSeconds > 0 && route.polyline.size >= 2 &&
+            g.polyline.size >= 5 && !RouteGeometry.divergent(route, g)
+        val cal = freeFlowCal ?: if (sameCourse) ((typical * scale) / route.durationSeconds).coerceIn(0.5, 3.0) else 1.0
         val calibrated = if (cal == 1.0) route else route.copy(
             durationSeconds = route.durationSeconds * cal,
             legs = route.legs.map { leg ->
@@ -697,7 +724,10 @@ class GoogleMapsDataSource @Inject constructor(
         )
         return calibrated.copy(
             durationInTrafficSeconds = calibrated.durationSeconds * factor,
-            trafficSpans = if (withSpans) g.trafficSpans.map { it.copy(startMeters = it.startMeters * scale, lengthMeters = it.lengthMeters * scale) }
+            // Google's congestion spans belong to Google's course: mapped by fraction onto a route
+            // that takes different roads they painted red segments on roads Google never reported
+            // on (review 2026-09-06).
+            trafficSpans = if (withSpans && sameCourse) g.trafficSpans.map { it.copy(startMeters = it.startMeters * scale, lengthMeters = it.lengthMeters * scale) }
             else emptyList(),
         )
     }
@@ -952,7 +982,8 @@ class GoogleMapsDataSource @Inject constructor(
         // (its detour is time-competitive with OSRM's ideal → the jam justifies the reroute). Tunable from
         // real side-by-side data — the `directions` diag logs gEta/osrmFF so the threshold can be pinned.
         const val SNAP_ETA_MARGIN = 1.2
-        private const val SNAP_LENGTH_SLACK = 1.05
+        private const val SPUR_TURN_NEAR_M = 150.0
+    private const val SNAP_LENGTH_SLACK = 1.05
         private const val SNAP_LENGTH_SLACK_M = 400.0
         const val SNAP_REACH_M = 500.0 // the snapped route's last point must be within this of the destination
         const val MAX_ROUTES = 4       // primary + up to 3 alternates in the picker

--- a/core/src/main/java/app/vela/core/location/AlongRouteFilter.kt
+++ b/core/src/main/java/app/vela/core/location/AlongRouteFilter.kt
@@ -85,7 +85,7 @@ class AlongRouteFilter {
          * clamped so one absurd reading can neither freeze nor blow up the estimate.
          */
         fun measurementVariance(accuracyM: Float?): Double {
-            val acc = (accuracyM ?: DEFAULT_ACC_M).toDouble().coerceIn(1.0, 60.0)
+            val acc = (accuracyM?.takeIf { !it.isNaN() } ?: DEFAULT_ACC_M).toDouble().coerceIn(1.0, 60.0)
             val sigma = (acc * 0.66).coerceAtLeast(2.5)
             return sigma * sigma
         }

--- a/core/src/main/java/app/vela/core/nav/NavSession.kt
+++ b/core/src/main/java/app/vela/core/nav/NavSession.kt
@@ -82,9 +82,9 @@ class NavSession @Inject constructor(
     private var rerouteJob: Job? = null
     private var rerouteStartedMs = 0L
     /** Deadline the in-flight reroute is running under (see [rerouteAttempt]). */
-    private var rerouteDeadlineMs = REROUTE_FETCH_TIMEOUT_MS
+    @Volatile private var rerouteDeadlineMs = REROUTE_FETCH_TIMEOUT_MS
     /** Consecutive reroute attempts that came back with nothing; reset on any adopted route. */
-    private var rerouteFailStreak = 0
+    @Volatile private var rerouteFailStreak = 0
     // @Volatile: written on the Default dispatcher (reroute coroutine) / caller thread and read
     // on the location thread — a stale read would defeat the cooldown or the generation guard.
     @Volatile private var lastRerouteAdoptMs = 0L

--- a/core/src/test/java/app/vela/core/DirectionsPbAvoidTest.kt
+++ b/core/src/test/java/app/vela/core/DirectionsPbAvoidTest.kt
@@ -1,0 +1,45 @@
+package app.vela.core
+
+import app.vela.core.data.google.DirectionsPb
+import app.vela.core.model.LatLng
+import app.vela.core.model.TravelMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The avoid flags live in the `!6m` feature block's `!2m` submessage (captured from Google's own
+ *  web client and verified live 2026-09-06); the group counts must grow with them. */
+class DirectionsPbAvoidTest {
+    private val block = "!6m56!1m5!18b1!30b1!31m1!1b1!34e1!2m4!5m1!6e2"
+
+    @Test fun `no flags leaves the template alone`() {
+        assertEquals(DirectionsPb.DEFAULT_TEMPLATE, DirectionsPb.withAvoid(DirectionsPb.DEFAULT_TEMPLATE, false, false))
+    }
+
+    @Test fun `avoid highways adds 1b1 and bumps both counts`() {
+        val out = DirectionsPb.withAvoid(DirectionsPb.DEFAULT_TEMPLATE, avoidTolls = false, avoidHighways = true)
+        assertTrue(out.contains("!6m57!1m5!18b1!30b1!31m1!1b1!34e1!2m5!1b1!5m1!6e2"))
+        assertTrue(!out.contains(block))
+    }
+
+    @Test fun `avoid tolls adds 2b1, both adds both`() {
+        assertTrue(DirectionsPb.withAvoid(DirectionsPb.DEFAULT_TEMPLATE, true, false).contains("!6m57!1m5!18b1!30b1!31m1!1b1!34e1!2m5!2b1!5m1!6e2"))
+        assertTrue(DirectionsPb.withAvoid(DirectionsPb.DEFAULT_TEMPLATE, true, true).contains("!6m58!1m5!18b1!30b1!31m1!1b1!34e1!2m6!1b1!2b1!5m1!6e2"))
+    }
+
+    @Test fun `flags only apply to driving`() {
+        val walk = DirectionsPb.build(LatLng(38.5449, -121.7405), LatLng(38.5816, -121.4944), TravelMode.WALK, avoidTolls = true, avoidHighways = true)
+        assertTrue(walk.contains(block))
+        val drive = DirectionsPb.build(LatLng(38.5449, -121.7405), LatLng(38.5816, -121.4944), TravelMode.DRIVE, avoidTolls = true, avoidHighways = true)
+        assertTrue(drive.contains("!2m6!1b1!2b1"))
+    }
+
+    @Test fun `a template without the block is returned untouched rather than corrupted`() {
+        assertEquals("!1m1!2b1", DirectionsPb.withAvoid("!1m1!2b1", true, true))
+    }
+
+    @Test fun `avoidSupported tells a template with the block from one without`() {
+        assertTrue(DirectionsPb.avoidSupported(DirectionsPb.DEFAULT_TEMPLATE))
+        assertTrue(!DirectionsPb.avoidSupported("!1m1!2b1"))
+    }
+}


### PR DESCRIPTION
From a review pass over the directions pipeline since v0.4.955. All from reading the code; the two behaviour changes that matter most are device-checked below.

- **Avoid on, open route already on Google's course** (no toll/motorway on the way, the common case for anyone who leaves the toggle on): the open route with full named turns was thrown away for Google's abbreviated steps, and the recheck could never heal it. The fallback now applies only when the open route actually left Google's course and the snap could not follow it.
- **Multi-stop trips with a stop set back from the road** (mall lot, driveway) came back empty since #332, because the via snap guard applied to every multi-point request; stops were then dropped. The guard is opt-in for the traffic snap only.
- **Spur rule scope:** refused only when a turn or U-turn sits on the spur, so a loop ramp that OSM draws in full and Google's line chords is left alone. Runs after the cheap checks; one latitude scale per course instead of a cosine per projection.
- **Congestion spans** are mapped onto a route only when it follows Google's course (they painted red segments onto alternates on other roads).
- Avoid on + Google unreachable + open router down: the on-device fallback now routes with the avoid flags instead of unrestricted-and-labelled-honoured. Avoid is reported honoured only when the request template can carry the flags (`DirectionsPb.avoidSupported`).
- Multi-stop reroutes get the departure bearing they were missing. Two reroute counters shared across threads are `@Volatile`. A NaN accuracy no longer poisons the along-route filter.
- The `DirectionsPbAvoidTest` file from #331 had never been committed; it is now, plus a case for `avoidSupported`.

Core tests green.