### PR TITLE
Review pass over the feature PRs since the last stable release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,8 +100,11 @@ Defaults that make the safe path the easy one:
   fields and make the whole recording unparseable, and a drive cannot be recorded twice. The
   write goes to a temp file and is renamed over the original, so it can never be half-written), and "Select trips"
   turns the list into a multi-select whose Share hands the whole set to ACTION_SEND_MULTIPLE
-  (`MapViewModel.exportTripsIntent`; one unreadable CSV is skipped, not fatal, and a single pick
-  falls through to the existing single-trip intent). Optional pref `trip_name_on_save` (Settings
+  (`MapViewModel.exportTripsIntent`; one unreadable CSV is skipped, not fatal). **Every trip in
+  that set goes out TRIMMED** through `scrubTripForSharing` at the default radius (review
+  2026-09-06: it used to ship the raw traces, and with one box ticked it even skipped the trim
+  dialog); a trip that trims to nothing is left out, never sent raw. The raw file is reachable
+  only from the single-trip dialog's "Share full trace". Optional pref `trip_name_on_save` (Settings
   toggle, shown only while trip recording is on, default OFF) makes `finishTrip` - which now
   RETURNS the kept `TripMeta` instead of Unit - arm `MapUiState.tripToName`, and MapScreen prompts
   for a name on the map right after the drive. TRAP: an early `return@forEachIndexed` inside the
@@ -137,7 +140,13 @@ Defaults that make the safe path the easy one:
   format is append-only, so a tag added later would otherwise be published by a scrubber written
   before it existed: **if you add a line kind to `TripLog`, decide in `TripScrub` whether it is
   safe to share.** The scrub is non-destructive (the on-device trip is never modified) and the
-  raw file is still reachable behind "Share full trace".
+  raw file is still reachable behind "Share full trace". Two rules added by the 2026-09-06 review
+  (15 tests): an `S`/`J`/`B` event survives only if a fix within `EVENT_NEAR_MS` (3 s) of it
+  survived, because a Home/Work zone passed MID-trip deletes fixes inside the kept time window
+  and the spoken "turn onto <its street>" has to go with them; and a route block whose polyline
+  trims to nothing drops its `RD` and `M` lines too, or `TripLog.parse` folds them into the
+  previous block. The share dialog computes the report in a `LaunchedEffect` on IO, not in
+  `remember` on the main thread.
 - **Demo / simulate-driving mode** (Settings → Navigation, off by default, pref `demo_drive` in
   `vela_settings`). Drives a planned route as a SYNTHETIC GPS trace so nav can be shown/tested
   **anywhere** with no real fix - this is how the Davis `docs/screenshots/05-navigation.png` was shot
@@ -664,8 +673,9 @@ Defaults that make the safe path the easy one:
   `autoStartOnRoute`; MapScreen consumes it ONCE when a route lands). **It fires through
   MapScreen's `onStartNav`, never straight at the VM** - a one-tap Start must not become a way
   around the precise-location and notification gates the picker's Start honours; and the flag is
-  consume-once + cleared by `clearRoute`/`startNav` so a later refetch (mode change, added stop)
-  cannot silently launch a drive. Not offered for the parked car (you are already at the start of
+  consume-once + cleared by `clearRoute`/`startNav` AND by a route fetch that returns nothing
+  (review 2026-09-06: an empty reply used to leave the flag armed for the next, unrelated
+  Directions request) so a later refetch (mode change, added stop) cannot silently launch a drive. Not offered for the parked car (you are already at the start of
   that walk). The nav bottom bar swapped End's labelled Button for a 54dp X icon on the LEFT with
   the trip figures CENTRED and Steps on the right: two controls of the same size doing the same
   job should be the same shape, and this is the arrangement where they cannot be mistaken for
@@ -1084,7 +1094,14 @@ Defaults that make the safe path the easy one:
   own export. Migration path for people arriving from Organic Maps / CoMaps / OsmAnd. ⚠️ **GPX is
   lat-then-lon but KML and GeoJSON are LNG FIRST** - reading either the wrong way round silently
   imports a whole collection into the Gulf of Guinea, so both orders are pinned by
-  `PlaceImportTest`. Deliberately imports ONLY name + coordinate (+ address where Takeout gives
+  `PlaceImportTest`. Review 2026-09-06: a KML placemark whose `<coordinates>` holds more than one
+  tuple (a LineString track, a Polygon area) is SKIPPED rather than pinned at its first vertex;
+  Takeout's capitalised keys (`Title`, `Location`, `Business Name`) are read as well as the
+  lower-case ones; `importMerge` runs `distinctBy { id }` over the incoming set because two
+  placemarks at one rounded coordinate share an id (every later id-keyed action would hit both);
+  `ImportFormats.describe` tests KML before the XML prolog (both are XML, so every KML used to be
+  called GPX); and both import launchers in `SavedPlacesSettings` read + parse on `Dispatchers.IO`.
+  Deliberately imports ONLY name + coordinate (+ address where Takeout gives
   one): every format agrees on those, and a confidently wrong address is worse than no import.
   Ids are content-derived from the rounded coordinate, so re-importing the same file adds nothing
   (device-verified: "Imported 3 place(s)" then "Everything in that file is already saved").
@@ -1768,7 +1785,9 @@ architecture note.
   pinned `hl=en&gl=us`, and the page language decides WHICH reviews Google serves - a Chinese reader
   looking at a Chinese restaurant got the English ones. Reviews are CONTENT and must never be
   translated for the reader, so the fetch uses `reviewsHl()` (the app locale, with the zh-TW/zh-CN
-  script split, gated to `SUPPORTED_HL`). ⚠️ **Unpinning `hl` ALONE breaks the scraper** - it keyed
+  script split, gated to `SUPPORTED_HL`). ⚠️ PR #307 shipped the scraper side of this but the
+  `loadUrl` stayed pinned to `hl=en` and `reviewsHl()` did not exist; the 2026-09-06 review pass
+  wired it (`WebReviewsFetcher.reviewsHl`, `AppLocale.effective()`). ⚠️ **Unpinning `hl` ALONE breaks the scraper** - it keyed
   on English text in four places, all verified live on a zh-TW page: the star SELECTOR
   (`aria-label*="star"` vs the real `5 顆星`), `num()`'s `/([0-9.]+)\s*star/i` (returned 0 for every
   review), the reviews TAB (`/^reviews\b/i` vs 評論) and the more-reviews BUTTON. Ratings now read

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -247,7 +247,8 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   so a tag added to the format later cannot be published by a scrubber written before it existed.
   The dialog shows what was removed and the first surviving coordinate before anything leaves the
   device; **Share full trace** is still there, and the on-device copy is never modified.
-  `core/replay/TripScrub`, 13 tests.
+  Sharing several trips at once trims every one of them the same way. `core/replay/TripScrub`,
+  15 tests.
 - ✅ **Google-style nav puck (2026-07-11).** The navigation arrow is a white chevron inside a
   filled bright-navy circle with a soft drop shadow (no white ring, per user feedback); it rotates
   about the exact GPS point. Replaces the bare blue chevron. **Enlarged twice from feedback

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -3512,6 +3512,9 @@ class MapViewModel @Inject constructor(
                         status = if (routes.isEmpty()) appContext.getString(R.string.mapvm_no_mode_route_found, mode.name.lowercase()) else null,
                     )
                 }
+                // A fetch that found nothing must not leave the Start-pill auto-start armed for
+                // the next, unrelated Directions request.
+                if (routes.isEmpty()) autoStartOnRoute = false
                 val flockEpoch = ++routesEpoch // stamp THIS route set; a newer route() bumps it and stales the flock job
                 if (routes.isNotEmpty()) refreshFlockOnRoute(routes, flockEpoch)
                 // The default active route can be a PROVISIONAL Google alternate (it sorts to the
@@ -4260,19 +4263,22 @@ class MapViewModel @Inject constructor(
      * should not cost the user the other nine. Returns null only when NOTHING could be read.
      */
     fun exportTripsIntent(metas: List<app.vela.replay.TripMeta>): android.content.Intent? {
-        if (metas.size == 1) return exportTripIntent(metas.first())
         return runCatching {
             val dir = java.io.File(appContext.cacheDir, "export").apply { mkdirs() }
             val uris = java.util.ArrayList<android.net.Uri>()
             var points = 0
             for (meta in metas) {
-                val csv = tripStore.rawCsv(meta.id) ?: continue
-                val file = java.io.File(dir, "vela-trip-${meta.id}.csv")
-                file.writeText(csv)
+                // Every trip goes out TRIMMED at the default radius around Home and Work, the
+                // same treatment the single-trip Share dialog enforces. This path used to ship the
+                // raw traces, and with one box ticked it even skipped the dialog. A trip too
+                // short to keep anything after trimming is left out, not sent raw.
+                val report = scrubTripForSharing(meta) ?: continue
+                val file = java.io.File(dir, "vela-trip-shared-${meta.id}.csv")
+                file.writeText(report.csv)
                 uris += androidx.core.content.FileProvider.getUriForFile(
                     appContext, "${appContext.packageName}.fileprovider", file,
                 )
-                points += meta.fixCount
+                points += report.fixesAfter
             }
             if (uris.isEmpty()) return null
             val send = android.content.Intent(android.content.Intent.ACTION_SEND_MULTIPLE).apply {

--- a/app/src/main/java/app/vela/ui/settings/sections/DiagnosticsSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/DiagnosticsSettings.kt
@@ -394,7 +394,14 @@ private fun TripShareDialog(
     onClose: () -> Unit,
 ) {
     var radius by remember { mutableStateOf(app.vela.core.replay.TripScrub.DEFAULT_RADIUS_M) }
-    val report = remember(meta.id, radius) { vm.scrubTripForSharing(meta, radius) }
+    // The scrub reads and rewrites the whole CSV, so it runs off the main thread and re-runs
+    // when the radius changes, instead of inside composition.
+    var report by remember(meta.id) { mutableStateOf<app.vela.core.replay.TripScrub.Report?>(null) }
+    var scrubbed by remember(meta.id) { mutableStateOf(false) }
+    LaunchedEffect(meta.id, radius) {
+        report = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) { vm.scrubTripForSharing(meta, radius) }
+        scrubbed = true
+    }
     app.vela.ui.VelaDialog(
         onDismissRequest = onClose,
         title = stringResource(R.string.settings_trip_share_title),
@@ -435,7 +442,10 @@ private fun TripShareDialog(
                 }
             }
             Spacer(Modifier.height(8.dp))
-            if (report == null) {
+            val shown = report
+            if (!scrubbed) {
+                // The summary arrives a moment after the dialog opens.
+            } else if (shown == null) {
                 Text(
                     stringResource(R.string.settings_trip_scrub_short),
                     style = MaterialTheme.typography.bodyMedium,
@@ -445,14 +455,14 @@ private fun TripShareDialog(
                 Text(
                     stringResource(
                         R.string.settings_trip_share_summary,
-                        report.fixesRemoved, report.fixesAfter,
-                        report.trimmedStartM.toInt(), report.trimmedEndM.toInt(),
+                        shown.fixesRemoved, shown.fixesAfter,
+                        shown.trimmedStartM.toInt(), shown.trimmedEndM.toInt(),
                     ),
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Spacer(Modifier.height(6.dp))
                 Hint(stringResource(R.string.settings_trip_share_also))
-                report.firstRemaining?.let { p ->
+                shown.firstRemaining?.let { p ->
                     Spacer(Modifier.height(6.dp))
                     Hint(
                         stringResource(

--- a/app/src/main/java/app/vela/ui/settings/sections/SavedPlacesSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/SavedPlacesSettings.kt
@@ -11,6 +11,10 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalContext
@@ -27,13 +31,18 @@ import app.vela.ui.dpadRowSibling // D-pad-only operation (docs/dpad.md)
 @Composable
 internal fun SavedPlacesSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     SettingsScaffold(stringResource(R.string.settings_saved_places), onBack) { topRow ->
         Spacer(Modifier.height(4.dp))
         PageIntro(stringResource(R.string.settings_saved_places_hint))
         val importLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
             ActivityResultContracts.OpenDocument(),
         ) { uri ->
-            if (uri != null) toastImport(context, vm.importSavedFromUri(uri), places = true)
+            // Off the main thread: a large GPX or KML is read and regex-parsed in full.
+            if (uri != null) scope.launch {
+                val res = withContext(Dispatchers.IO) { vm.importSavedFromUri(uri) }
+                toastImport(context, res, places = true)
+            }
         }
         SettingsGroup {
         Row(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp)) {
@@ -62,7 +71,10 @@ internal fun SavedPlacesSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
         val listImportLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
             ActivityResultContracts.OpenDocument(),
         ) { uri ->
-            if (uri != null) toastImport(context, vm.importListsFromUri(uri), places = false)
+            if (uri != null) scope.launch {
+                val res = withContext(Dispatchers.IO) { vm.importListsFromUri(uri) }
+                toastImport(context, res, places = false)
+            }
         }
         SettingsGroup(title = stringResource(R.string.mapscreen_section_lists)) {
         app.vela.ui.settings.Hint(stringResource(R.string.settings_lists_export_hint))

--- a/app/src/main/java/app/vela/web/WebReviewsFetcher.kt
+++ b/app/src/main/java/app/vela/web/WebReviewsFetcher.kt
@@ -161,7 +161,7 @@ class WebReviewsFetcher @Inject constructor(
                         // let the MAX_LOAD fallback inject the scraper into the old page and return the
                         // previous place's reviews for THIS featureId (empty > wrong).
                         wv.evaluateJavascript("try{document.documentElement.innerHTML=''}catch(e){}", null)
-                        wv.loadUrl("https://www.google.com/maps?cid=$cid&hl=en&gl=us")
+                        wv.loadUrl("https://www.google.com/maps?cid=$cid&hl=${reviewsHl()}&gl=us")
                         // Proceed even if the SPA's onPageFinished is slow.
                         main.postDelayed({ if (!ready.isCompleted) ready.complete(Unit) }, MAX_LOAD_MS)
                         ready.await()
@@ -434,6 +434,22 @@ class WebReviewsFetcher @Inject constructor(
          *  Outside this set the page stays English: a language the scraper cannot navigate would
          *  return FEWER reviews than English does. */
         val SUPPORTED_HL = setOf("en", "fr", "de", "es", "it", "pt", "nl", "ru", "pl", "sv", "uk", "zh", "ja", "he")
+
+        /** The page language for the hidden reviews WebView: the app's language when the scraper's
+         *  word lists cover it (issue #278: the page language decides WHICH reviews Google serves,
+         *  so a Chinese reader on an English page got English reviews), English otherwise. Chinese
+         *  keeps its script (zh-TW for Traditional regions). This is the half of #307 that was
+         *  described but never wired (review 2026-09-06). */
+        fun reviewsHl(): String {
+            val loc = app.vela.ui.AppLocale.effective()
+            val lang = loc.language.lowercase()
+            if (lang !in SUPPORTED_HL) return "en"
+            if (lang == "zh") {
+                val hant = loc.script.equals("Hant", ignoreCase = true) || loc.country.uppercase() in setOf("TW", "HK", "MO")
+                return if (hant) "zh-TW" else "zh-CN"
+            }
+            return lang
+        }
         const val MAX_LOAD_MS = 7_000L
         // Offscreen viewport for the headless WebView — tall so the virtualized review list renders a
         // healthy batch per scroll position.

--- a/core/src/main/java/app/vela/core/data/ImportResult.kt
+++ b/core/src/main/java/app/vela/core/data/ImportResult.kt
@@ -44,8 +44,9 @@ object ImportFormats {
                     head.contains("google.com/maps")
                 ) -> "Google Takeout"
             head.contains("\"FeatureCollection\"") || head.contains("\"features\"") -> "GeoJSON"
-            head.trimStart().startsWith("<?xml") || head.contains("<gpx") -> "GPX"
+            // KML before GPX: both start with an XML prolog.
             head.contains("<kml") || head.contains("<Placemark") -> "KML"
+            head.trimStart().startsWith("<?xml") || head.contains("<gpx") -> "GPX"
             head.contains("\"bookmarks\"") || head.contains("\"organicmaps\"") -> "Organic Maps"
             else -> null
         }

--- a/core/src/main/java/app/vela/core/data/PlaceImport.kt
+++ b/core/src/main/java/app/vela/core/data/PlaceImport.kt
@@ -66,6 +66,9 @@ object PlaceImport {
             // into the sea off west Africa, so it is worth being explicit about.
             val parts = coords.split(Regex("[,\\s]+")).mapNotNull { it.toDoubleOrNull() }
             if (parts.size < 2) return@mapNotNull null
+            // A LineString or Polygon placemark (a track, an area) carries many tuples. Its first
+            // vertex is not a place, so the placemark is skipped rather than pinned at one end.
+            if (parts.size > 3) return@mapNotNull null
             val lng = parts[0]
             val lat = parts[1]
             place(nameIn(body) ?: fallbackName(lat, lng), lat, lng)
@@ -120,15 +123,19 @@ object PlaceImport {
      *  `properties.name` (or `title`). */
     private fun geoJsonName(props: JsonObject?): String? {
         val p = props ?: return null
-        val loc = p["location"] as? JsonObject
-        return (loc?.get("name")?.text() ?: p["name"]?.text() ?: p["title"]?.text())
-            ?.trim()?.takeIf { it.isNotBlank() }
+        val loc = (p["location"] ?: p["Location"]) as? JsonObject
+        // Older Takeout exports capitalise their keys ("Title", "Location", "Business Name").
+        return (
+            loc?.get("name")?.text() ?: loc?.get("Business Name")?.text()
+                ?: p["name"]?.text() ?: p["title"]?.text() ?: p["Title"]?.text()
+            )?.trim()?.takeIf { it.isNotBlank() }
     }
 
     private fun geoJsonAddress(props: JsonObject?): String? {
         val p = props ?: return null
-        val loc = p["location"] as? JsonObject
-        return (loc?.get("address")?.text() ?: p["address"]?.text())?.trim()?.takeIf { it.isNotBlank() }
+        val loc = (p["location"] ?: p["Location"]) as? JsonObject
+        return (loc?.get("address")?.text() ?: loc?.get("Address")?.text() ?: p["address"]?.text())
+            ?.trim()?.takeIf { it.isNotBlank() }
     }
 
     private fun JsonElement.num(): Double? = runCatching { jsonPrimitive.doubleOrNull }.getOrNull()

--- a/core/src/main/java/app/vela/core/data/SavedPlaceStore.kt
+++ b/core/src/main/java/app/vela/core/data/SavedPlaceStore.kt
@@ -57,7 +57,9 @@ class SavedPlaceStore @Inject constructor(
             ?: return ImportResult.WrongFormat(ImportFormats.describe(json))
         val current = saved()
         val existing = current.mapTo(HashSet()) { it.id }
-        val added = incoming.filterNot { it.id in existing }
+        // Two placemarks at one rounded coordinate share an id. Keep the first of them, or every
+        // id-keyed action afterwards (unsave, list membership) hits both at once.
+        val added = incoming.distinctBy { it.id }.filterNot { it.id in existing }
         if (added.isEmpty()) return ImportResult.NothingNew
         prefs.edit().putString(KEY, this.json.encodeToString(current + added)).apply()
         return ImportResult.Added(added.size)

--- a/core/src/main/java/app/vela/core/replay/TripScrub.kt
+++ b/core/src/main/java/app/vela/core/replay/TripScrub.kt
@@ -44,6 +44,9 @@ object TripScrub {
     /** Metres trimmed around each private place by default. */
     const val DEFAULT_RADIUS_M = 400.0
 
+    /** An event survives only if a fix this close in time survived (fixes arrive at about 1 Hz). */
+    const val EVENT_NEAR_MS = 3_000L
+
     /** What a scrub did, so it can be shown before anything leaves the device. */
     data class Report(
         val csv: String,
@@ -93,6 +96,25 @@ object TripScrub {
         val tZero = kept.first().second.t
         val keptFrom = kept.first().second.t
         val keptTo = kept.last().second.t
+        // An event (spoken line, jank or battery sample) survives only if a fix within
+        // EVENT_NEAR_MS of it survived: the trimmed windows are not just the two ends. A Home or
+        // Work zone passed mid-trip deletes its fixes, and the spoken "turn onto <its street>"
+        // must go with them.
+        val keptTimes = LongArray(kept.size) { kept[it].second.t }
+        fun nearKeptFix(t: Long): Boolean {
+            var lo = 0
+            var hi = keptTimes.size - 1
+            while (lo < hi) {
+                val mid = (lo + hi) ushr 1
+                if (keptTimes[mid] < t) lo = mid + 1 else hi = mid
+            }
+            val a = keptTimes[lo]
+            val b = if (lo > 0) keptTimes[lo - 1] else a
+            return kotlin.math.abs(a - t) <= EVENT_NEAR_MS || kotlin.math.abs(b - t) <= EVENT_NEAR_MS
+        }
+        // When a route block's polyline is dropped whole, its totals and maneuvers must go too,
+        // or the parser folds them into the PREVIOUS block.
+        var blockDropped = false
 
         var maneuversDropped = 0
         var spokenDropped = 0
@@ -124,29 +146,30 @@ object TripScrub {
                     val poly = runCatching { PolylineCodec.decode(line.substring(3)) }.getOrDefault(emptyList())
                     val run = longestPublicRun(poly, ::private)
                     if (run.size != poly.size) routeTrimmed = true
-                    if (run.size >= 2) out.append("RP,").append(PolylineCodec.encode(run)).append('\n')
+                    blockDropped = run.size < 2
+                    if (!blockDropped) out.append("RP,").append(PolylineCodec.encode(run)).append('\n')
                 }
                 // Distance and duration totals identify nothing on their own and are needed to
-                // make sense of the trace.
-                "RD" -> out.append(line).append('\n')
+                // make sense of the trace, but they belong to their route block.
+                "RD" -> if (!blockDropped) out.append(line).append('\n') else otherDropped++
                 "M" -> {
                     val f = line.split(',', limit = 6)
                     val lat = f.getOrNull(2)?.toDoubleOrNull()
                     val lng = f.getOrNull(3)?.toDoubleOrNull()
-                    if (lat == null || lng == null || private(LatLng(lat, lng))) maneuversDropped++
+                    if (blockDropped || lat == null || lng == null || private(LatLng(lat, lng))) maneuversDropped++
                     else out.append(line).append('\n')
                 }
                 "S" -> {
                     // Spoken lines outside the surviving window are the ones that name the
                     // destination and the streets at either end.
                     val t = line.split(',').getOrNull(1)?.toLongOrNull()
-                    if (t == null || t < keptFrom || t > keptTo) spokenDropped++
+                    if (t == null || t < keptFrom || t > keptTo || !nearKeptFix(t)) spokenDropped++
                     else out.append(rebaseEvent(line, tZero)).append('\n')
                 }
                 // Frame pacing and battery carry no position.
                 "J", "B" -> {
                     val t = line.split(',').getOrNull(1)?.toLongOrNull()
-                    if (t == null || t < keptFrom || t > keptTo) otherDropped++
+                    if (t == null || t < keptFrom || t > keptTo || !nearKeptFix(t)) otherDropped++
                     else out.append(rebaseEvent(line, tZero)).append('\n')
                 }
                 else -> otherDropped++

--- a/core/src/test/java/app/vela/core/replay/TripScrubTest.kt
+++ b/core/src/test/java/app/vela/core/replay/TripScrubTest.kt
@@ -155,6 +155,42 @@ class TripScrubTest {
         assertTrue(TripLog.parsePoints(withWork.csv.split('\n')).none { dist(it.latLng, mid) <= 400.0 })
     }
 
+    @Test fun `a spoken line inside a mid-trip private zone goes with its fixes`() {
+        // A zone in the MIDDLE of the drive (a Work address passed on the way) deletes fixes
+        // there; the spoken line at that moment is inside the kept window by time but names the
+        // street at that zone, so it must go too.
+        val n = 200
+        val mid = LatLng(originLat, originLng + step * (n / 2))
+        val csv = trip(n) + "S,${1756700000000L + (n / 2) * 1000},Passing the office on Zone Street\n"
+        val r = TripScrub.scrub(csv, radiusM = 400.0, extraZones = listOf(mid))!!
+        assertTrue(!r.csv.contains("Zone Street"))
+        assertTrue("a spoken line beside a surviving fix stays", r.csv.contains("Midpoint Road") || r.spokenDropped >= 3)
+    }
+
+    @Test fun `a route block trimmed to nothing takes its totals and maneuvers with it`() {
+        // A short second segment entirely inside the destination zone: its RP is dropped, so its
+        // RD and M lines must not survive to be folded into the previous block by the parser.
+        val n = 200
+        val tail = (0 until 3).map { LatLng(originLat, originLng + step * (n - 3 + it)) }
+        val csv = trip(n) + TripLog.encodeRoute(
+            Route(
+                tail,
+                listOf(
+                    RouteLeg(
+                        50.0, 10.0, null,
+                        listOf(Maneuver(ManeuverType.ARRIVE, "Arrive at the door on Door Lane", tail.last(), 0.0, 0.0)),
+                    ),
+                ),
+                50.0, 10.0, null,
+            ),
+            "reroute",
+        )
+        val r = scrub(csv)!!
+        assertTrue(!r.csv.contains("Door Lane"))
+        val lines = r.csv.split('\n')
+        assertEquals(lines.count { it.startsWith("RP,") }, lines.count { it.startsWith("RD,") })
+    }
+
     private fun dist(a: LatLng, b: LatLng): Double {
         val r = 6_371_000.0
         val p1 = Math.toRadians(a.lat)


### PR DESCRIPTION
Third of the review batches over the PRs merged since the last stable release (after #336 nav runtime and #337 routing). Bugs found by reading each feature PR against what it said it did.

- **Reviews in the app's language never landed.** #307 fixed the scraper for a non-English page but left the WebView URL pinned to `hl=en`, and `reviewsHl()` did not exist. Wired now: app locale, gated to the languages the scraper's word lists cover, zh-CN/zh-TW split.
- **Multi-select trip share sent the raw traces**, and with one trip ticked it skipped the trim dialog entirely. Every trip in the set goes through the scrub at the default radius; a trip that trims to nothing is left out rather than sent raw.
- **TripScrub kept events that belonged to a deleted mid-trip zone.** An event survived if its time fell inside the kept window, but a Home or Work zone passed mid-drive deletes fixes inside that window and the spoken line naming its street stayed. Events now need a surviving fix within 3 s. A route block whose polyline trims to nothing also drops its totals and maneuvers, which the parser used to fold into the previous block. 15 tests.
- The share dialog computed the scrub inside `remember` on the main thread. It is a `LaunchedEffect` on IO now.
- **Place import:** KML tracks and areas were pinned at their first vertex (skipped now); two placemarks at one rounded coordinate shared an id and both were imported (`distinctBy`); Takeout's capitalised keys were ignored; every KML file was described as GPX; both import launchers read and parsed on the main thread.
- A route fetch that returned nothing left the Start pill's auto-start armed for the next unrelated Directions request.

Left alone on purpose: the transit icon-name guard that excludes protocol-relative gstatic paths. Without it a bus leg invents a line called "bus2"; the review suggestion to accept those paths was wrong.

Docs: CLAUDE.md (trip export, scrub rules, reviews language, import, auto-start), FEATURES.md.