### PR TITLE
Contacts in search open under the person's name, with photo and address label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1707,10 +1707,23 @@ architecture note.
   on, from SearchSettings). `app/data/ContactAddresses` loads ALL address-bearing contacts into
   memory ONCE (VM init + toggle-on, off-main) because localMatches runs synchronously per
   keystroke and a ContactsProvider binder query there would jank; the match is against that cache.
-  A CONTACT suggestion carries the ADDRESS as its `query`, so picking it rides the normal
-  searchRecent path (address searched exactly as if typed - the contact list itself never leaves
-  the phone; PRIVACY.md has the user-facing wording). Kind.CONTACT icon = person - that is why they are instant and the only thing that
-  shows offline. `LocalSuggestion` (kind RECENT_QUERY / RECENT_PLACE / SAVED_PLACE) renders above
+  A CONTACT suggestion carries the ADDRESS as its `query` plus the row's `badge` (the address
+  book's own type label via `StructuredPostal.getTypeLabel`, already platform-localized) and
+  `photoUri` (`PHOTO_THUMBNAIL_URI`, a content: URI that only resolves while the permission is
+  held; coil loads it over the person glyph so a missing photo just shows the glyph). **Picking
+  one goes through `openContactAddress(name, address)` (2026-09-06), NOT searchRecent:** geocode
+  the address (Google search when online, else `OfflineAddressStore.geocode`, the other as a
+  fallback), then `selectContactPlace` opens the hit renamed to the CONTACT with the address as
+  sublabel - the same branches as `selectSaved` (assign-as-Home/Work, stop + endpoint pickers,
+  a stop on a live drive) minus its search-by-name enrichment. That is what makes the sheet,
+  Save, Recents (`rememberRecentPlace`) and the directions To/From fields say whose place it is;
+  before, the pick searched the bare address and every trace of the person was lost. Nothing
+  geocodes → falls back to `searchRecent(address)` so the normal no-results/offline UI shows. The
+  row renders `ContactAvatar` + `SuggestionBadge` through `SuggestionRow`'s `leading`/`badge`
+  slots. `SearchCarScreen` shows up to two contact rows above the car results (`openContact`
+  geocodes then pushes RoutePreviewCarScreen under the name). The contact list itself never
+  leaves the phone; PRIVACY.md has the user-facing wording. Local rows are instant and the only
+  thing that shows offline. `LocalSuggestion` (kind RECENT_QUERY / RECENT_PLACE / SAVED_PLACE) renders above
   the network rows in `SearchEntryContent`. Dedup of network vs local is by `nameLocKey` (name +
   coarse location), NOT feature id - SavedPlace-backed locals carry no id, so an id-only compare
   double-shows them. Clear `localSuggestions` everywhere `suggestions` clears. **Press-hold / ⋮

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -2376,9 +2376,15 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   suggestion (or tap its ⋮) to save a place into one of your lists or drop a history row, the same
   list picker the place sheet uses. Looking up one location out of a chain no longer means
   re-typing the city.
-- ✅ **Search your contacts (issue #243, 2026-08-08).** Opt-in (Settings > Search, off by default;
-  the contacts permission is asked when you flip the toggle, never at install). Typing a contact's
-  name suggests their saved postal address at the top of the results with a person icon; picking it
-  searches the address like any typed query. Matching happens entirely on the phone against an
-  in-memory copy of the address-bearing contacts, so it is instant and nothing about your contact
-  list is uploaded.
+- ✅ **Search your contacts (issue #243, 2026-08-08; reworked 2026-09-06).** Opt-in (Settings >
+  Search, off by default; the contacts permission is asked when you flip the toggle, never at
+  install). Typing a contact's name suggests each of their saved addresses at the top of the
+  results as a person: their photo (or a person glyph on the same tinted disc Home and Work use)
+  and a "Contact · Home" or "Contact · Work" chip from your address book's own label. Picking one
+  looks up the address and opens it **under the contact's name** with the address beneath, so the
+  place sheet, Save, Directions and Recents all say whose place it is, and typing the name again
+  next week finds it in history. The same rows work in the directions "To" and "From" fields, as
+  a stop, and in the Android Auto search. Matching happens entirely on the phone against an
+  in-memory copy of the address-bearing contacts, so it is instant and works offline (the address
+  itself geocodes from a downloaded region when there is no signal); only the address string is
+  ever sent to a geocoder, never the name or the list.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -103,11 +103,15 @@ transmitted:
 There is no cloud sync. Uninstalling the app removes all of it.
 
 **Contacts (optional, off by default).** If you turn on Settings > Search > "Search your
-contacts", typing a contact's name suggests their saved postal address. The contact list is
-read and matched entirely on this phone (the permission is asked when you flip the toggle,
-never at install). Nothing about your contacts is uploaded; if you tap a suggestion, the
-ADDRESS text is searched exactly as if you had typed it yourself, which sends that one
-string to the geocoder like any other search.
+contacts", typing a contact's name suggests their saved postal addresses, shown with the
+contact's photo and the label your address book gives the address ("Home", "Work"). The
+contact list is read and matched entirely on this phone (the permission is asked when you flip
+the toggle, never at install), and the photo is displayed straight from the phone's contact
+store. Nothing about your contacts is uploaded; if you tap a suggestion, the ADDRESS text is
+looked up exactly as if you had typed it yourself, which sends that one string to the geocoder
+like any other search (or to the downloaded region's address index when you are offline). The
+result opens under the contact's name on this phone only; the name is never sent anywhere.
+Opened contact places appear in your Recents on this phone like any other place you open.
 
 ## No tracking
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,6 +23,13 @@ Last updated: 2026-07-13.
 - **Android Auto (2026-07-08).** Vela appears in the car launcher (AA "Unknown sources" for
   sideloads): live map, puck, route, and the current-maneuver card from the same NavSession the phone
   runs, plus car-side search and route start (see docs/ANDROID-AUTO.md).
+  **Open (agenda, pinned #179):** on most real head units it still does not show up, because
+  Android Auto only lists navigation apps installed from Google Play and Vela is sideloaded; the
+  "Unknown sources" switch and the installer spoof both get undone by the next in-app update.
+  Ideas from the thread to decide between: an AAAD-style install path, or a Play-listed shell app
+  that carries the Android Auto entitlement with the Google-scraping half delivered as a separate
+  add-on APK from GitHub (Nova/CoMaps pattern). Needs a decision on whether a Play listing is
+  acceptable at all before any code.
 - **Open building + house-number overlays (2026-07-04/05).** Microsoft footprints (ODbL) and OpenAddresses
   numbers as per-region PMTiles, streamed over the map by default where OSM is thin, downloadable for
   full offline. Traffic lights + stop signs draw at close zoom (keyless Overpass).

--- a/app/src/main/java/app/vela/car/screen/SearchCarScreen.kt
+++ b/app/src/main/java/app/vela/car/screen/SearchCarScreen.kt
@@ -12,12 +12,19 @@ import app.vela.core.model.Place
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.Dispatchers
+import app.vela.data.ContactAddresses
 
 /** Destination search on the car: debounced [app.vela.core.data.MapDataSource.search] biased to the
  *  last known location; tapping a result previews a route to it. */
 class SearchCarScreen(carContext: CarContext, private val deps: CarDeps) : Screen(carContext) {
 
     private var results: List<Place> = emptyList()
+    // Contact rows (issue #243, opt-in Settings > Search): matched on the phone against the
+    // in-memory address list, shown above the search results; picking one geocodes the
+    // address and previews a route under the person's name.
+    private var contacts: List<ContactAddresses.Entry> = emptyList()
     private var searching = false
     private var searchJob: Job? = null
 
@@ -33,10 +40,19 @@ class SearchCarScreen(carContext: CarContext, private val deps: CarDeps) : Scree
             builder.setLoading(true)
         } else {
             val list = ItemList.Builder()
-            if (results.isEmpty()) {
+            if (results.isEmpty() && contacts.isEmpty()) {
                 list.setNoItemsMessage(carContext.getString(app.vela.R.string.car_search_hint))
             } else {
-                results.take(6).forEach { p ->
+                contacts.forEach { e ->
+                    list.addItem(
+                        Row.Builder()
+                            .setTitle(e.name)
+                            .addText(listOfNotNull(carContext.getString(app.vela.R.string.suggestion_contact_badge), e.type, e.address).joinToString(" · "))
+                            .setOnClickListener { openContact(e) }
+                            .build(),
+                    )
+                }
+                results.take(6 - contacts.size).forEach { p ->
                     list.addItem(
                         Row.Builder()
                             .setTitle(p.name)
@@ -58,17 +74,38 @@ class SearchCarScreen(carContext: CarContext, private val deps: CarDeps) : Scree
     private fun runSearch(text: String) {
         searchJob?.cancel()
         if (text.isBlank()) {
-            results = emptyList(); searching = false; invalidate(); return
+            results = emptyList(); contacts = emptyList(); searching = false; invalidate(); return
         }
         searching = true
         invalidate()
         searchJob = lifecycleScope.launch {
             delay(300) // debounce
             val near = deps.locationProvider.lastKnown()
+            contacts = if (app.vela.ui.ContactsSearch.enabled.value && text.length >= 2) {
+                withContext(Dispatchers.IO) { ContactAddresses.ensureLoaded(carContext) }
+                ContactAddresses.matches(text, 2)
+            } else emptyList()
             val found = runCatching { deps.mapDataSource.search(text, near).places }.getOrDefault(emptyList())
             results = found
             searching = false
             invalidate()
+        }
+    }
+
+    /** Geocode the contact's address (the one string that leaves the phone) and preview a route. */
+    private fun openContact(e: ContactAddresses.Entry) {
+        searchJob?.cancel()
+        searching = true
+        invalidate()
+        searchJob = lifecycleScope.launch {
+            val near = deps.locationProvider.lastKnown()
+            val hit = runCatching { deps.mapDataSource.search(e.address, near).places.firstOrNull() }.getOrNull()
+            searching = false
+            if (hit != null) {
+                screenManager.push(RoutePreviewCarScreen(carContext, deps, e.name, hit.location))
+            } else {
+                invalidate()
+            }
         }
     }
 }

--- a/app/src/main/java/app/vela/data/ContactAddresses.kt
+++ b/app/src/main/java/app/vela/data/ContactAddresses.kt
@@ -17,7 +17,10 @@ import androidx.core.content.ContextCompat
  * searches the ADDRESS string like any typed query.
  */
 object ContactAddresses {
-    data class Entry(val name: String, val address: String)
+    /** One postal row of one contact. [type] is the address book's own label for the row ("Home",
+     *  "Work", or a custom one), already localized by the platform; [photoUri] is the contact's
+     *  thumbnail, a content: URI that only resolves while the permission is held. */
+    data class Entry(val name: String, val address: String, val type: String? = null, val photoUri: String? = null)
 
     @Volatile private var cache: List<Entry> = emptyList()
     @Volatile private var loaded = false
@@ -38,6 +41,9 @@ object ContactAddresses {
                 arrayOf(
                     ContactsContract.CommonDataKinds.StructuredPostal.DISPLAY_NAME,
                     ContactsContract.CommonDataKinds.StructuredPostal.FORMATTED_ADDRESS,
+                    ContactsContract.CommonDataKinds.StructuredPostal.TYPE,
+                    ContactsContract.CommonDataKinds.StructuredPostal.LABEL,
+                    ContactsContract.CommonDataKinds.StructuredPostal.PHOTO_THUMBNAIL_URI,
                 ),
                 null, null,
                 ContactsContract.CommonDataKinds.StructuredPostal.DISPLAY_NAME,
@@ -46,7 +52,15 @@ object ContactAddresses {
                 while (c.moveToNext() && out.size < 500) {
                     val name = c.getString(0)?.trim().orEmpty()
                     val addr = c.getString(1)?.replace('\n', ' ')?.replace(Regex("\\s+"), " ")?.trim().orEmpty()
-                    if (name.isNotEmpty() && addr.isNotEmpty()) out.add(Entry(name, addr))
+                    // The row's own label, in the platform's words (so "Home" is already "Casa" on
+                    // a Spanish phone); a custom label comes through as typed.
+                    val type = if (c.isNull(2)) null else runCatching {
+                        ContactsContract.CommonDataKinds.StructuredPostal.getTypeLabel(
+                            context.resources, c.getInt(2), c.getString(3),
+                        ).toString().trim().takeIf { it.isNotEmpty() }
+                    }.getOrNull()
+                    val photo = c.getString(4)?.takeIf { it.isNotBlank() }
+                    if (name.isNotEmpty() && addr.isNotEmpty()) out.add(Entry(name, addr, type, photo))
                 }
             }
         }

--- a/app/src/main/java/app/vela/ui/ContactsSearch.kt
+++ b/app/src/main/java/app/vela/ui/ContactsSearch.kt
@@ -6,8 +6,8 @@ import androidx.compose.runtime.mutableStateOf
 /**
  * "Search your contacts" toggle (issue #243, Settings → Search, OFF by default). When on, typing a
  * contact's name in the search box suggests their saved postal address (matched on-device against
- * [app.vela.data.ContactAddresses]; picking one searches the ADDRESS like any typed query — the
- * contact list itself never leaves the phone). READ_CONTACTS is asked at the point of use (flipping
+ * [app.vela.data.ContactAddresses]; picking one geocodes the ADDRESS like any typed query and opens
+ * it under the contact's name - the contact list itself never leaves the phone). READ_CONTACTS is asked at the point of use (flipping
  * this toggle on), never at install/onboarding. Same process-wide reactive holder shape as
  * [VoiceSearch]; init in VelaApp.
  */

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -3439,6 +3440,7 @@ private fun SearchEntryContent(
                 // closes any open menu instead of leaving it stranded on a different row.
                 var menuOpen by remember(s) { mutableStateOf(false) }
                 val place = s.place
+                val isContact = s.kind == app.vela.ui.map.LocalSuggestion.Kind.CONTACT
                 SuggestionRow(
                     icon = when (s.kind) {
                         app.vela.ui.map.LocalSuggestion.Kind.RECENT_QUERY -> Icons.Default.History
@@ -3449,6 +3451,11 @@ private fun SearchEntryContent(
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     label = s.label,
                     sublabel = s.sublabel,
+                    // A contact reads as a person, not a search: their photo (or a person on the
+                    // same tinted disc Home and Work use) and a "Contact · Home" chip, so the row
+                    // can never be mistaken for a place the geocoder found (user 2026-09-06).
+                    leading = if (isContact) ({ ContactAvatar(s.photoUri) }) else null,
+                    badge = if (isContact) listOfNotNull(stringResource(R.string.suggestion_contact_badge), s.badge).joinToString(" · ") else null,
                     onClick = { onPickLocal(s) },
                     onLongClick = { menuOpen = true },
                     trailing = {
@@ -3908,6 +3915,47 @@ private fun SectionLabel(text: String) {
 // combinedClickable powers the press-hold on suggestion rows (issue #180). The row still
 // clicks on tap / D-pad centre; long-press (touch) opens the same menu the trailing ⋮ opens,
 // so D-pad keeps a key path via the button.
+
+/** A contact's thumbnail on the tinted disc the Home/Work rows use; the person glyph shows
+ *  through when there is no photo (or it fails to load, the image simply never paints). */
+@Composable
+private fun ContactAvatar(photoUri: String?) {
+    Box(
+        Modifier
+            .size(36.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.16f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(Icons.Default.Person, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+        if (photoUri != null) {
+            coil.compose.AsyncImage(
+                model = photoUri,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}
+
+/** The small chip after a suggestion's label, in the accent tint so it reads as a category, not text. */
+@Composable
+private fun SuggestionBadge(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.primary,
+        maxLines = 1,
+        modifier = Modifier
+            .background(
+                MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                RoundedCornerShape(6.dp),
+            )
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+    )
+}
+
 @OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 private fun SuggestionRow(
@@ -3919,6 +3967,10 @@ private fun SuggestionRow(
     onRemove: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
     trailing: (@Composable () -> Unit)? = null,
+    /** Replaces [icon] when set (a contact's photo disc). */
+    leading: (@Composable () -> Unit)? = null,
+    /** A small chip after the label ("Contact · Home"). */
+    badge: String? = null,
 ) {
     val hasTrailing = onRemove != null || trailing != null
     Row(
@@ -3927,7 +3979,11 @@ private fun SuggestionRow(
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Icon(icon, contentDescription = null, modifier = Modifier.padding(end = 12.dp), tint = tint)
+        if (leading != null) {
+            Box(Modifier.padding(end = 12.dp)) { leading() }
+        } else {
+            Icon(icon, contentDescription = null, modifier = Modifier.padding(end = 12.dp), tint = tint)
+        }
         if (sublabel == null) {
             Text(
                 label,
@@ -3939,13 +3995,20 @@ private fun SuggestionRow(
             )
         } else {
             Column(Modifier.weight(1f)) {
-                Text(
-                    label,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        label,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false),
+                    )
+                    if (badge != null) {
+                        Spacer(Modifier.width(8.dp))
+                        SuggestionBadge(badge)
+                    }
+                }
                 Text(
                     sublabel,
                     style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -91,9 +91,14 @@ data class LocalSuggestion(
     val place: Place? = null,
     val query: String? = null,
     val removable: Boolean = false,
+    /** CONTACT rows: the address book's label for this address ("Home", "Work"), platform-localized. */
+    val badge: String? = null,
+    /** CONTACT rows: the contact's thumbnail content: URI, if they have a photo. */
+    val photoUri: String? = null,
 ) {
-    // CONTACT rows (issue #243) carry the contact's postal address as [query]: picking one runs it
-    // through the normal search-submit path, exactly as if the address had been typed.
+    // CONTACT rows (issue #243) carry the contact's postal address as [query]. Picking one
+    // geocodes that address and opens the result under the CONTACT'S name (see
+    // MapViewModel.openContactAddress); the address string is the only thing that leaves the phone.
     enum class Kind { RECENT_QUERY, RECENT_PLACE, SAVED_PLACE, CONTACT }
 }
 
@@ -1162,7 +1167,12 @@ class MapViewModel @Inject constructor(
         // that string reaches the geocoder; the contact list itself never leaves the phone.
         if (app.vela.ui.ContactsSearch.enabled.value) {
             app.vela.data.ContactAddresses.matches(t).forEach {
-                out.add(LocalSuggestion(LocalSuggestion.Kind.CONTACT, it.name, it.address, query = it.address))
+                out.add(
+                    LocalSuggestion(
+                        LocalSuggestion.Kind.CONTACT, it.name, it.address, query = it.address,
+                        badge = it.type, photoUri = it.photoUri,
+                    ),
+                )
             }
         }
 
@@ -1184,9 +1194,67 @@ class MapViewModel @Inject constructor(
     /** Open (place-backed) or re-run (recent query) a local suggestion tapped in the search page. */
     fun pickLocalSuggestion(s: LocalSuggestion) {
         when {
+            s.kind == LocalSuggestion.Kind.CONTACT && s.query != null -> openContactAddress(s.label, s.query)
             s.place != null -> selectPlace(s.place)
             s.query != null -> searchRecent(s.query)
         }
+    }
+
+    /**
+     * A contact row was picked: geocode the address, then open it under the PERSON'S name with
+     * the address beneath, the way Home and Work open (a labelled place, not a bare address).
+     * Until 2026-09-06 the pick just searched the address string, so the sheet, Save and Recents
+     * all read "1451 W Covell Blvd" with no trace of whose house it was, and typing the name
+     * again a week later found nothing in history. Honours the directions endpoint and stop
+     * pickers like any other pick, so a contact works in the "To" field. Only the address string
+     * goes to the geocoder (the offline address store first when the phone is offline); the
+     * name never leaves the phone. Falls back to the plain search when nothing geocodes, so the
+     * usual no-results / offline handling shows.
+     */
+    fun openContactAddress(name: String, address: String) {
+        val near = plausibleBias(_state.value.myLocation) ?: plausibleBias(mapCenter)
+        searchJob?.cancel()
+        suggestJob?.cancel()
+        _state.update { it.copy(searching = true, suggestions = emptyList(), localSuggestions = emptyList()) }
+        searchJob = viewModelScope.launch {
+            // Prefer the ADDRESS feature over a business that happens to sit at it: searching a
+            // house number where a shop is returns the shop first, and its rating, hours and
+            // price would otherwise dress up the contact's home (device-checked 2026-09-06).
+            fun pickAddressHit(hits: List<Place>): Place? =
+                hits.take(3).firstOrNull { it.rating == null && it.category == null } ?: hits.firstOrNull()
+            val online = runCatching { if (isOnline()) pickAddressHit(dataSource.search(address, near).places) else null }.getOrNull()
+            val hit = online ?: withContext(Dispatchers.IO) {
+                runCatching { addressStore.geocode(address, near, 1).firstOrNull() }.getOrNull()
+            } ?: runCatching { if (!isOnline()) pickAddressHit(dataSource.search(address, near).places) else null }.getOrNull()
+            _state.update { it.copy(searching = false) }
+            if (hit == null) { searchRecent(address); return@launch }
+            // A bare place on purpose: whatever else the geocoder knew about that spot is not
+            // the contact's, so the sheet shows the person, the address and the actions.
+            selectContactPlace(Place(id = hit.id, name = name, location = hit.location, address = hit.address ?: address))
+        }
+    }
+
+    /** Open a geocoded contact address as a labelled place. Same branches as [selectSaved]
+     *  (assign-as-Home/Work, stop and endpoint pickers, a stop on a live drive), minus the
+     *  search-by-name enrichment: searching "John Snow" near a house finds nothing useful. */
+    private fun selectContactPlace(base: Place) {
+        val sp = SavedPlace.of(base)
+        if (consumeAssign(sp)) return
+        if (_state.value.pickingStop) { addStop(base); return }
+        if (_state.value.pickingDest) { setDirectionsDestination(base); return }
+        if (_state.value.pickingOrigin) { setDirectionsOrigin(base); return }
+        if (_state.value.navigating) { addStopDuringNav(base); return }
+        routeJob?.cancel()
+        _state.update {
+            it.copy(
+                selected = base, center = base.location, placesHere = emptyList(), reviews = emptyList(),
+                reviewsLoading = false, reviewsFound = 0, photosLoading = false, loadingDetails = false,
+                stopDepartures = null, stopDeparturesLoading = false, stopDeparturesFor = null,
+                directionsOpen = false, routes = emptyList(), activeRoute = null,
+                transit = emptyList(), transitLoading = false, showSteps = false,
+            )
+        }
+        rememberRecentPlace(sp)
     }
 
     /** Drop a local suggestion from history via its X (recent search or recently-viewed place);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,7 +40,8 @@
     <string name="settings_voice_search_toggle">Voice search mic</string>
     <string name="settings_voice_search_hint">Shows a mic in the search bar to speak your search.</string>
     <string name="settings_contacts_search">Search your contacts</string>
-    <string name="settings_contacts_search_hint">Typing a contact\'s name suggests their saved address. Your contacts stay on this phone; picking a suggestion searches the address like any typed query.</string>
+    <string name="settings_contacts_search_hint">Typing a contact\'s name suggests their saved addresses, with their photo and the address label from your address book. Your contacts stay on this phone; picking one looks up that address like any typed query and opens it under the contact\'s name.</string>
+    <string name="suggestion_contact_badge">Contact</string>
     <string name="search_voice_cd">Voice search</string>
     <string name="search_voice_prompt">Speak to search</string>
     <string name="settings_voice">Voice</string>


### PR DESCRIPTION
Follow-up to #243. Contact suggestions used to search the bare address on pick, so the place sheet, Save and Recents all read as a street address with no trace of whose place it was, and typing the name again later found nothing in history.

- **The row reads as a person.** The contact's photo, or a person glyph on the same tinted disc Home and Work use, plus a "Contact · Home" / "Contact · Work" chip from the address book's own label (already localized by the platform). A contact with two addresses shows two rows you can tell apart.
- **Picking opens the place under the contact's name.** The address is geocoded (Google when online, the downloaded region's address index when not, each as the other's fallback), the address feature is preferred over a business sitting at the same number, and the result opens as a bare place: name, address, actions. No rating, hours or price from whatever the geocoder knew about that spot. It takes the same branches as a saved place, so it works in the directions To/From fields, as a stop, as a stop on a live drive, as a Home/Work assignment, and it lands in Recents under the name.
- **Android Auto search** lists up to two contact rows above the results and previews a route under the name.
- `SuggestionRow` gained `leading` and `badge` slots.

Privacy unchanged: opt-in, off by default, permission asked at the toggle; only the address string ever leaves the phone. PRIVACY.md updated for the photo and the Recents entry.

Device-checked on a Pixel 4a: suggestion row, place sheet, directions destination field.

Also adds the open Android Auto sideload problem (pinned #179) to the ROADMAP as an agenda item with the two approaches people proposed in the thread.