### PR TITLE
Reroute on the second fix after a wrong turn, stop the arrow coasting past it, smooth the trail-off fade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2232,7 +2232,16 @@ architecture note.
   fix coursing >HEADING_OFF_DEG (60) against the route's local bearing counts as an off-route hit even
   inside the corridor (`bearingDeg` rides onLocation -> update; null in replays/tests = unchanged), and
   a heading-diverged fix never counts toward onRouteStreak (else back-on-course would discard the
-  legit wrong-way reroute mid-fetch). The 3-hit debounce absorbs turn transients/lane changes),
+  legit wrong-way reroute mid-fetch). The 3-hit debounce absorbs turn transients/lane changes; a
+  heading-off fix that is ALSO a quarter-corridor (10 m) off the line counts DOUBLE while moving,
+  so a deliberate left-instead-of-straight reroutes on the 2nd fix after the turn (real drive
+  2026-09-07, `NavEngineWrongTurnTest`); a wide legit turn stays within a few metres of the corner
+  and keeps counting single. THE PUCK has its own wrong-turn rule in VelaMapView's fix block: the
+  engaged snap already rejects a fix whose course is 55°+ off the segment, but that rejection used
+  to be a plain "miss", so the arrow dead-reckoned straight on along the old line for 3 s and then
+  froze at the corner. A miss that succeeds when re-run WITHOUT the heading gate is a heading miss:
+  it sets `holdReckon` (the ticker treats the reckoning clock as expired, so the arrow stops) and
+  two of them disengage to the raw fix; a distance miss keeps the 3-miss spike tolerance),
   off-route measured on the
   windowed/anchored projection (never whole-polyline min), reroutes are single-flight + cooldown +
   latch-clear-on-failure (a failed fetch must NOT kill rerouting - the event is edge-triggered), and
@@ -2312,11 +2321,14 @@ architecture note.
   upward fling faster than NAV_BAR_FLING_PX_S, else spring back); commit = the same `openSteps` the
   list button calls, and `StepsSheet` animates in from its own height (`enter`). The button stays as
   the key path; the gesture is touch-only on purpose (docs/dpad.md).
-  **Trail OFF cannot use the cut piece (2026-09-06):** an overlay line cannot erase what is under it,
-  so a transparent "driven" stop on `ROUTE_CUT_LAYER` just revealed the blue ahead line beneath (the
-  growing stub). With the trail off, the cut piece is hidden and the AHEAD line's own gradient carries
-  the cut per frame (transparent before the arrow's window fraction); its ~12 m texel step hides under
-  the arrow. With the trail on, the cut piece paints grey over blue as before.
+  **Trail OFF is drawn by the cut piece over a CLEARED ahead line (2026-09-07).** An overlay line
+  cannot erase what is under it, so the first trail-off cut (2026-09-06) rode the AHEAD line's own
+  gradient - and that line's 256 texels span the 3 km window, 12 m each: on a real drive the blue
+  vanished in 12 m chunks with a dithered edge a texel ahead of the arrow. Now the ahead line's
+  gradient is transparent up to a texel BEFORE the cut piece's END (`pa` from `cutEnd`, recomputed
+  on each slide), so nothing sits under the piece, and the piece's per-frame gradient (1.6 m texels)
+  paints transparent before the arrow and colour after - the same per-frame path as the trail-on
+  grey cut, only the "driven" colour differs. Do not move the per-frame cut back onto the ahead line.
   **Spur rule v2 (2026-09-06, from the reporter's trip log):** the real appendix was a 121 m
   turn-right / U-turn / turn-right stub 56 m off a state route; the car never came within 47 m of
   its tip. The v1 rule missed it (a side street leaving at an angle projects a little further along

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1296,6 +1296,12 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   that the arrow then drove while the car went straight. A via route is now refused when any sampled
   point snapped more than 40 m from where it was asked for, or when the result is markedly longer
   than the course it was meant to follow; the plain route is used instead.
+  **Wrong turns read faster (2026-09-07):** a deliberate turn off the route now asks for a new
+  route on the second fix after the turn instead of the third, and the arrow stops gliding along
+  the old line the moment your course leaves it, dropping to your real position within two fixes
+  instead of coasting straight through the corner for three seconds. **Road behind you, off: smooth
+  (2026-09-07):** the line behind the arrow now clears in a continuous edge under the arrow instead
+  of 12 m chunks with a dithered fringe.
   **Road behind you, off: no stub (2026-09-06):** with the trail off, the line behind the arrow used
   to reappear as a growing blue stub that vanished in a chunk every 300 m. The cut is now carried by
   the ahead line's own gradient in that mode, so nothing is drawn behind the arrow at all.

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1681,7 +1681,10 @@ fun VelaMapView(
                 // canopy, and a 2 s cap made the puck glide-stall-lurch every cycle at exactly
                 // that cadence. 3 s still bounds a dropped-signal runaway to ~100 m at highway
                 // speed, and the decay below shaves the model right after it.
-                val sinceFix = (android.os.SystemClock.elapsedRealtime() - navPuck.targetAtMs) / 1000.0 * ts
+                // A heading miss (see the fix block) pins the reckoning clock past its cap: the
+                // car turned off this line, so gliding the arrow further along it is fiction.
+                val sinceFix = if (navPuck.holdReckon) DEAD_RECKON_S + 1.0
+                    else (android.os.SystemClock.elapsedRealtime() - navPuck.targetAtMs) / 1000.0 * ts
                 // Past the dead-reckon window with no accepted fix = a measurement outage: decay
                 // the modelled speed toward 0 (there's no evidence we're still moving) so the
                 // zoom/look-ahead don't ride a stale speed forever. A resumed fix re-measures.
@@ -2008,8 +2011,13 @@ fun VelaMapView(
                         // edge lies under the piece's grey; colour from there.
                         val a0 = aheadAnchor[0]
                         val a1 = navWin[0]
-                        val pa = if (a1 - a0 <= 1.0) 0f else
+                        // Trail ON: grey up to one texel past the piece start. Trail OFF: NOTHING
+                        // up to a texel before the piece's END, so the whole span under the cut
+                        // piece is clear and the piece alone decides what is drawn there.
+                        val pa = if (a1 - a0 <= 1.0) 0f else if (trailHolder.value)
                             ((cutStart[0] + NAV_CUT_HIDE_M - a0) / (a1 - a0)).toFloat().coerceIn(0f, 0.999f)
+                        else
+                            ((cutEnd[0] - a0) / (a1 - a0) - 1.5 / 256.0).toFloat().coerceIn(0f, 0.999f)
                         style.getLayer(ROUTE_AHEAD_LAYER)?.setProperties(
                             PropertyFactory.visibility(Property.VISIBLE),
                             PropertyFactory.lineGradient(routeGradient(pa, gInt, remap(a0, a1), driven)),
@@ -2022,30 +2030,20 @@ fun VelaMapView(
                             PropertyFactory.lineGradient(routeGradient(0f, traversed, emptyList())),
                         )
                     }
-                    // Per frame: only PAINT moves. Trail ON: the cut piece paints grey up to the
-                    // arrow over the ahead line. Trail OFF: the cut piece cannot erase what is
-                    // under it (a transparent stop just shows the blue beneath, which is what drew
-                    // a growing blue stub behind the arrow that vanished in a chunk every 300 m,
-                    // user 2026-09-06), so the AHEAD line's own gradient carries the cut instead:
-                    // transparent before the arrow's fraction of the window, colour after. Its
-                    // texel is the window/256 (~12 m at 3 km), a step that stays under the arrow.
-                    if (trailHolder.value) {
-                        val c0 = cutStart[0]
-                        val c1 = cutEnd[0]
-                        val pc = if (c1 - c0 <= 1.0) 0f else ((prog - c0) / (c1 - c0)).toFloat().coerceIn(0.0001f, 0.9999f)
-                        style.getLayer(ROUTE_CUT_LAYER)?.setProperties(
-                            PropertyFactory.visibility(Property.VISIBLE),
-                            PropertyFactory.lineGradient(routeGradient(pc, gInt, remap(c0, c1), driven)),
-                        )
-                    } else {
-                        if (aheadDirty) style.getLayer(ROUTE_CUT_LAYER)?.setProperties(PropertyFactory.visibility(Property.NONE))
-                        val a0 = aheadAnchor[0]
-                        val a1 = navWin[0]
-                        val pa = if (a1 - a0 <= 1.0) 0f else ((prog - a0) / (a1 - a0)).toFloat().coerceIn(0.0001f, 0.9999f)
-                        style.getLayer(ROUTE_AHEAD_LAYER)?.setProperties(
-                            PropertyFactory.lineGradient(routeGradient(pa, gInt, remap(a0, a1), android.graphics.Color.TRANSPARENT)),
-                        )
-                    }
+                    // Per frame: only PAINT moves, and only on the 400 m cut piece, whose 256
+                    // gradient texels are 1.6 m each. Trail ON it paints grey up to the arrow;
+                    // trail OFF it paints nothing up to the arrow, over an ahead line that is
+                    // itself clear under the whole piece (see `pa` above). The cut used to ride
+                    // the AHEAD line's gradient with the trail off, whose texel is the 3 km
+                    // window / 256 = 12 m: the line vanished in 12 m chunks with a dithered
+                    // edge a texel ahead of the arrow (real drive 2026-09-07).
+                    val c0 = cutStart[0]
+                    val c1 = cutEnd[0]
+                    val pc = if (c1 - c0 <= 1.0) 0f else ((prog - c0) / (c1 - c0)).toFloat().coerceIn(0.0001f, 0.9999f)
+                    style.getLayer(ROUTE_CUT_LAYER)?.setProperties(
+                        PropertyFactory.visibility(Property.VISIBLE),
+                        PropertyFactory.lineGradient(routeGradient(pc, gInt, remap(c0, c1), driven)),
+                    )
                 }
             } else {
                 dropPuckOverlay()
@@ -2705,6 +2703,8 @@ fun VelaMapView(
                 navPuck.progressM = m; navPuck.targetM = m; navPuck.engaged = true
                 navPuck.smoothWin = Double.NaN // re-seed the boxcar window from the first real speed
                 navPuck.fwdRejects = 0
+                navPuck.holdReckon = false
+                navPuck.headingMisses = 0
                 reanchor = true
                 accepted = true
             } else {
@@ -2757,7 +2757,9 @@ fun VelaMapView(
                 if (accepted) navPuck.fwdRejects = 0
             }
             navPuck.missCount = 0
+            navPuck.headingMisses = 0
             if (accepted) {
+                navPuck.holdReckon = false
                 navPuck.targetAtMs = now // anchor for dead reckoning
                 // (a REJECTED fix must NOT re-open the blind window: at a standstill that
                 // re-armed the creep every second; the old anchor stays until a fix is accepted)
@@ -2789,7 +2791,28 @@ fun VelaMapView(
             // — at 1 Hz that's still 3 s of frozen puck, and NavEngine's off-route detection
             // (45 m × 4 hits) drives the actual reroute in the meantime).
             navPuck.missCount += 1
-            if (navPuck.missCount >= 3) navPuck.engaged = false
+            // WHICH kind of miss? Re-run the snap without the heading gate: if the fix is within
+            // reach of the line but its course is 55°+ against it while moving, the driver has
+            // turned off the route. That is not a spike to dead-reckon through: the arrow
+            // used to glide straight on along the old line for 3 s and then freeze at the
+            // corner while the car was already down the side street (real drive 2026-09-07,
+            // "kept going on the correct route for too long"). Freeze the reckoning now and
+            // drop to the raw fix on the 2nd such miss; a distance miss keeps the 3-miss
+            // tolerance a canopy spike needs.
+            val missSpeed = maxOf(navPuck.speed, navPuck.speedAtAccept)
+            val headingMiss = myLocation != null && myBearing != null && navPuck.kalman.speed >= 2.0 &&
+                snapToRouteWindowed(
+                    myLocation, null, routePolyline, routeCum,
+                    navPuck.targetM - 25.0, navPuck.targetM + (missSpeed * 8.0).coerceIn(150.0, 600.0),
+                    maxM = 22.0 + missSpeed.coerceIn(0.0, 13.0),
+                ) != null
+            if (headingMiss) {
+                navPuck.headingMisses += 1
+                navPuck.holdReckon = true
+            } else {
+                navPuck.headingMisses = 0
+            }
+            if (navPuck.missCount >= 3 || navPuck.headingMisses >= 2) navPuck.engaged = false
             navPuck.raw = myLocation
             navPuck.rawBearing = myBearing
         } else if (!navMode || !navPuck.engaged) {
@@ -5312,6 +5335,9 @@ private class NavPuck {
     var drawn: LatLng? = null     // last point actually drawn — the camera follows THIS, not the raw fix
     var raw: LatLng? = null       // off-route fallback position
     var rawBearing: Float? = null
+    var headingMisses = 0         // consecutive misses where the fix was NEAR the route but heading
+                                  // AWAY from it (a wrong turn): disengage after 2, not 3
+    var holdReckon = false        // a heading miss froze dead reckoning: the car is not on this line
     var missCount = 0             // consecutive forward-look-ahead misses (GPS spike / off-route);
                                   // HOLD + dead-reckon through a few, then disengage to re-acquire
     var fwdRejects = 0            // consecutive over-maxStep forward steps — a persistent one is

--- a/core/src/main/java/app/vela/core/nav/NavEngine.kt
+++ b/core/src/main/java/app/vela/core/nav/NavEngine.kt
@@ -234,6 +234,13 @@ object NavEngine {
             // the reroute fires after ~2 fixes instead of a full debounce (user 2026-07-15,
             // "waits far too long after a wrong turn").
             moving && offDist > farOffM -> state.offRouteHits + 2
+            // Moving AGAINST the route and already a quarter-corridor off the line: a wrong turn,
+            // not a wide legit one (which stays within a few metres of the corner while the
+            // projection catches up). Counts double, so a deliberate left-instead-of-straight
+            // reroutes on the 2nd fix after the turn instead of the 3rd; the sustained
+            // back-on-course check in NavSession discards the rare false one (real drive
+            // 2026-09-07: "kept going on the correct route for too long").
+            moving && headingOff && offDist > offRouteM * 0.25 -> state.offRouteHits + 2
             else -> state.offRouteHits + 1
         }
         val offRoute = offHits >= OFF_ROUTE_HITS

--- a/core/src/test/java/app/vela/core/nav/NavEngineWrongTurnTest.kt
+++ b/core/src/test/java/app/vela/core/nav/NavEngineWrongTurnTest.kt
@@ -1,0 +1,70 @@
+package app.vela.core.nav
+
+import app.vela.core.model.LatLng
+import app.vela.core.model.Maneuver
+import app.vela.core.model.ManeuverType
+import app.vela.core.model.Route
+import app.vela.core.model.RouteLeg
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A deliberate wrong turn at speed must ask for a reroute on the SECOND fix after the turn, not
+ * the third (real drive 2026-09-07: the guidance kept the driver on the old line for too long).
+ * A wide but legitimate turn, which stays within a few metres of the corner while the fix's
+ * course swings, must not.
+ */
+class NavEngineWrongTurnTest {
+
+    private val lat = 38.5449
+    private val lng0 = -121.7405
+    private val mPerDegLng = 111_320.0 * Math.cos(Math.toRadians(lat))
+    private val mPerDegLat = 111_320.0
+
+    /** A 2 km route due east with a DEPART and an ARRIVE. */
+    private val route: Route by lazy {
+        val poly = (0..20).map { LatLng(lat, lng0 + (it * 100.0) / mPerDegLng) }
+        Route(
+            poly,
+            listOf(
+                RouteLeg(
+                    2000.0, 120.0, null,
+                    listOf(
+                        Maneuver(ManeuverType.DEPART, "Head east", poly.first(), 2000.0, 0.0),
+                        Maneuver(ManeuverType.ARRIVE, "Arrive", poly.last(), 0.0, 0.0),
+                    ),
+                ),
+            ),
+            2000.0, 120.0, null,
+        )
+    }
+
+    private fun east(m: Double) = LatLng(lat, lng0 + m / mPerDegLng)
+    private fun southOf(m: Double, s: Double) = LatLng(lat - s / mPerDegLat, lng0 + m / mPerDegLng)
+
+    private fun drive(state: NavState, at: LatLng, bearing: Double): Pair<NavState, List<NavEvent>> =
+        NavEngine.update(route, state, at, speedMps = 8.0, bearingDeg = bearing)
+
+    @Test fun `a left turn at speed reroutes on the second fix after the turn`() {
+        var st = NavState()
+        for (m in listOf(0.0, 8.0, 16.0, 24.0)) st = drive(st, east(m), 90.0).first
+        assertFalse(st.offRoute)
+        // Turned south at the 24 m mark: heading 180, 8 m/s, so 8 m then 16 m off the line.
+        val (s1, e1) = drive(st, southOf(24.0, 8.0), 180.0)
+        assertTrue("one heading-off fix is a turn transient, not yet a reroute", e1.none { it is NavEvent.RerouteNeeded })
+        val (s2, e2) = drive(s1, southOf(24.0, 16.0), 180.0)
+        assertTrue("second fix, 16 m off and heading away, must reroute", e2.any { it is NavEvent.RerouteNeeded })
+        assertTrue(s2.offRoute)
+    }
+
+    @Test fun `a wide turn that stays beside the corner does not reroute`() {
+        var st = NavState()
+        for (m in listOf(0.0, 8.0, 16.0, 24.0)) st = drive(st, east(m), 90.0).first
+        // Course swings 70° for two fixes but the car is 3 m and 6 m from the line: a wide
+        // legitimate turn, still counted single, so no reroute on the second fix.
+        val (s1, _) = drive(st, southOf(30.0, 3.0), 160.0)
+        val (_, e2) = drive(s1, southOf(36.0, 6.0), 160.0)
+        assertTrue(e2.none { it is NavEvent.RerouteNeeded })
+    }
+}


### PR DESCRIPTION
Two findings from a real drive today.

**Wrong turns were read too slowly.** Two separate causes:

- `NavEngine`: a moving fix coursing 60° or more against the route counted as one off-route hit, so a deliberate left-instead-of-straight needed three fixes before asking for a reroute. It now counts double once the fix is also a quarter-corridor (10 m) off the line, so the reroute fires on the second fix after the turn. A wide but legitimate turn stays within a few metres of the corner while the projection catches up and keeps counting single. `NavEngineWrongTurnTest` covers both cases.
- The puck: the engaged snap already rejects a fix whose course is 55° or more off the segment, but that rejection was treated as a plain miss, so the arrow dead-reckoned straight on along the old line for three seconds and then froze at the corner while the car was already down the side street. A miss that succeeds when re-run without the heading gate is now a heading miss: it freezes the reckoning clock at once and two of them drop the arrow to the raw fix. A distance miss keeps the three-miss tolerance a canopy spike needs.

**The trail-off fade came in 12 m chunks with a dithered edge.** The per-frame cut rode the ahead line's gradient, whose 256 texels span the 3 km window. The ahead line is now transparent up to a texel before the cut piece's end, so nothing sits under the piece, and the piece's own per-frame gradient (1.6 m texels) paints transparent before the arrow, the same path the trail-on grey cut already used.

Docs: CLAUDE.md (heading term, puck wrong-turn rule, trail-off drawing), FEATURES.md.