### PR TITLE
Fix: @Singleton ended up on RerouteGate, leaving NavSession unscoped

### DIFF
--- a/core/src/main/java/app/vela/core/nav/NavSession.kt
+++ b/core/src/main/java/app/vela/core/nav/NavSession.kt
@@ -33,10 +33,10 @@ import javax.inject.Singleton
  * faster route the user can accept. That's the "is there a better way right now"
  * behaviour traffic apps live on.
  */
-@Singleton
 /** Outcome of [NavSession.rerouteGate] - whether a reroute request may proceed. */
 enum class RerouteGate { START, SKIP_IN_FLIGHT, SKIP_COOLDOWN, ABANDON_STUCK_AND_START }
 
+@Singleton
 class NavSession @Inject constructor(
     private val dataSource: MapDataSource,
     private val voice: VoiceGuide,


### PR DESCRIPTION
### What

`974d0d86` inserted the `RerouteGate` enum between the `@Singleton` annotation and `class NavSession`:

```kotlin
@Singleton
/** Outcome of [NavSession.rerouteGate] ... */
enum class RerouteGate { START, SKIP_IN_FLIGHT, SKIP_COOLDOWN, ABANDON_STUCK_AND_START }

class NavSession @Inject constructor(
```

so the annotation now applies to the **enum**. `NavSession` is constructor-injected and nothing else provides it, so since that commit Hilt has been creating a **new `NavSession` per injection point**.

### Why it matters

That is exactly the failure `NavSession`'s own KDoc warns about:

> Held as a singleton so the foreground service (which feeds it location with the screen off) and the UI ViewModel (which observes state) share exactly one nav loop - no double voice prompts, no divergent state.

With the scope gone, `NavigationService` and `MapViewModel` drive separate sessions: two reroute loops, two sets of voice prompts, and UI state that does not match what the service is guiding on.

### Fix

Move the annotation back onto the class. The enum needs no scope. One line.

### How I found it

Porting the reroute-gate work into a downstream fork ([alltechdev/vela-dpad](https://github.com/alltechdev/vela-dpad), the D-pad/keypad-phone fork). I was adapting `974d0d86` by hand, noticed the annotation had moved, and the KDoc paragraph above made it clear that was not intentional.

Not device-verified - it is a DI annotation placement, so the check that matters is that `NavSession` carries `@Singleton` again.