### PR TITLE
Fix: Hebrew readers still get English reviews (Android reports "iw", not "he")

### DIFF
--- a/app/src/main/java/app/vela/web/WebReviewsFetcher.kt
+++ b/app/src/main/java/app/vela/web/WebReviewsFetcher.kt
@@ -433,7 +433,11 @@ class WebReviewsFetcher @Inject constructor(
         /** Languages whose review-page wording the scraper's word lists cover (see `reviewsHl`).
          *  Outside this set the page stays English: a language the scraper cannot navigate would
          *  return FEWER reviews than English does. */
-        val SUPPORTED_HL = setOf("en", "fr", "de", "es", "it", "pt", "nl", "ru", "pl", "sv", "uk", "zh", "ja", "he")
+        // NB "iw" as well as "he": java.util.Locale.getLanguage() returns the OBSOLETE ISO code
+        // for Hebrew on Android (the app's own resource dir is values-iw), so a "he"-only set
+        // sends every Hebrew reader back to the English page - the one locale whose review words
+        // were added by hand. Indonesian ("in") and Yiddish ("ji") carry the same trap.
+        val SUPPORTED_HL = setOf("en", "fr", "de", "es", "it", "pt", "nl", "ru", "pl", "sv", "uk", "zh", "ja", "he", "iw")
 
         /** The page language for the hidden reviews WebView: the app's language when the scraper's
          *  word lists cover it (issue #278: the page language decides WHICH reviews Google serves,
@@ -444,6 +448,9 @@ class WebReviewsFetcher @Inject constructor(
             val loc = app.vela.ui.AppLocale.effective()
             val lang = loc.language.lowercase()
             if (lang !in SUPPORTED_HL) return "en"
+            // Google's own parameter for Hebrew is the legacy code, which is also what the
+            // locale reports - pass it through rather than "correcting" it.
+            if (lang == "he") return "iw"
             if (lang == "zh") {
                 val hant = loc.script.equals("Hant", ignoreCase = true) || loc.country.uppercase() in setOf("TW", "HK", "MO")
                 return if (hant) "zh-TW" else "zh-CN"


### PR DESCRIPTION
### What

`90cec75c` made the hidden review page follow the app's language, gated on `SUPPORTED_HL`, which lists `"he"`.

On Android, `java.util.Locale.getLanguage()` returns the **obsolete** ISO 639 code for Hebrew - `"iw"`, not `"he"`. (Same for Indonesian: `"in"`, not `"id"`; and Yiddish: `"ji"`.) So for a Hebrew user:

```kotlin
val lang = loc.language.lowercase()   // "iw"
if (lang !in SUPPORTED_HL) return "en"  // taken, every time
```

`reviewsHl()` returns `"en"` and the page loads in English.

The codebase already reflects this rule elsewhere - the app's own resource directory is `values-iw`.

### Why it matters

Hebrew is the one locale in `SUPPORTED_HL` whose review words were added to `ReviewWords` by hand (`ביקור`, `עוד`, `כל`). Those words are currently unreachable: a Hebrew reader still gets the English reviews of a local place, which is exactly what that commit set out to stop.

### Fix

Accept both codes, and send Google the legacy one - `hl=iw` is what its parameter has always used for Hebrew, and it is what the locale reports anyway. Two lines plus a comment recording the trap so `in`/`ji` do not repeat it.

### How I found it

A code review over a port of `90cec75c` into a downstream fork ([alltechdev/vela-dpad](https://github.com/alltechdev/vela-dpad)), whose primary market is Hebrew-speaking - so the one locale that silently did nothing was the one that got noticed.

Not device-verified. The check that matters is `Locale("he").language == "iw"` on Android, which is JDK behaviour, not a rendering question.