### PR TITLE
Draw country and state borders again; keep county and city limits off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1764,6 +1764,14 @@ architecture note.
   The **Map style Settings row was removed** (only one style ships; MapStyle/setStyle plumbing
   kept for a future re-add). Nav card trip time is a `FitText` (shrinks to fit, never wraps/
   ellipsises) so the 54dp buttons + Interface-size scale can't clip the arrival time.
+- **Country and state borders are DRAWN; county and city limits are not (discussion #353,
+  2026-09-09).** Liberty's `boundary_2` (admin 2), `boundary_3` (admin 3-6) and
+  `boundary_disputed` were hidden with the footpath/rail-hatching clutter in July because the
+  admin 5-6 county/city lines read as stray dashes all over a suburb. Google draws countries
+  (thin solid grey) and states/provinces (lighter, dashed, from ~z4) and not the rest, so
+  `applyMapTheme` now narrows `boundary_3`'s filter to admin 3-4 (minzoom 4, dashed) and themes
+  all three: the style's own dark grey vanished on the dark map. Never put the boundary ids back
+  in the hide list; if a region shows dashed junk, check its admin levels before touching the filter.
 - **Map COLOUR SETS (2026-07-11): Settings -> Appearance -> "Map colors" picks Modern or
   Classic.** `ui/MapColors` holder (pref `map_palette`; init in VelaApp); `applyMapTheme`
   dispatches to `applyLight`/`applyDark` (Modern, the pixel-sampled palette) or

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -646,6 +646,7 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 - 🟡 Self-hosted PMTiles - the no-key, no-quota Google-look path - remains for later
 - ⬜ Protomaps "Google-Maps-ify" style (road hierarchy ✅, hillshade ✅, POI icons ✅ done; this is the bundled-style variant)
 - ✅ Satellite layer - shipped 2026-07-13 via the Layers panel (Esri World Imagery hybrid; see the Layers entry below). Terrain relief ✅ too
+- ✅ **Country and state/province borders (2026-09-09, discussion #353)** - drawn the way Google draws them: countries as a thin solid grey line, states and provinces lighter and dashed from about zoom 4, both themed for light and dark. County and city limits stay off, as on Google; they were the stray-dash clutter that got every border hidden back in July.
 - ✅ Map rotation/tilt + heading-up mode during nav (tilted follow-camera, speed-adaptive zoom)
 
 ## Search & POIs (live Google data)

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -4763,16 +4763,57 @@ private fun applyMapTheme(style: Style, dark: Boolean) {
         PropertyFactory.circleStrokeColor(if (dark) "#162640" else "#f8f7f7"),
     )
     // Hide Liberty's dashed clutter that Google doesn't draw: footpaths/sidewalks,
-    // park outlines, the stepped admin/city/county BOUNDARY lines, and the railroad
-    // cross-tie hatching (the solid rail line stays). All read as weird stray dashes.
+    // park outlines, and the railroad cross-tie hatching (the solid rail line stays). All
+    // read as weird stray dashes.
     listOf(
         "road_path_pedestrian", "bridge_path_pedestrian", "bridge_path_pedestrian_casing", "tunnel_path_pedestrian",
         "park_outline",
-        "boundary_2", "boundary_3", "boundary_disputed",
         "road_major_rail_hatching", "road_transit_rail_hatching",
         "bridge_major_rail_hatching", "bridge_transit_rail_hatching",
         "tunnel_major_rail_hatching", "tunnel_transit_rail_hatching",
     ).forEach { style.getLayer(it)?.setProperties(PropertyFactory.visibility(Property.NONE)) }
+    // Country and state/province borders (discussion #353, 2026-09-09). They were hidden with
+    // the clutter above since July, but Google draws both: countries as a thin solid grey
+    // line, states and provinces dashed and lighter, from about zoom 4. What Google does NOT
+    // draw at these zooms is county and city limits, which on these tiles are admin levels
+    // 5 and 6 of the same layer and were the stray-dash mess the hide was really for, so the
+    // layer's filter is narrowed to levels 3 and 4 instead of hidden. Colours per theme: the
+    // style's own dark grey vanished on the dark map.
+    val borderInk = if (dark) "#8C95A3" else "#9AA0A6"
+    (style.getLayer("boundary_2") as? LineLayer)?.setProperties(
+        PropertyFactory.visibility(Property.VISIBLE),
+        PropertyFactory.lineColor(borderInk),
+        PropertyFactory.lineOpacity(
+            Expression.interpolate(Expression.linear(), Expression.zoom(), Expression.stop(0, 0.5f), Expression.stop(4, 1f)),
+        ),
+        PropertyFactory.lineWidth(
+            Expression.interpolate(Expression.linear(), Expression.zoom(), Expression.stop(3, 0.8f), Expression.stop(6, 1.2f), Expression.stop(12, 2f)),
+        ),
+    )
+    (style.getLayer("boundary_3") as? LineLayer)?.let { l ->
+        l.setFilter(
+            Expression.all(
+                Expression.gte(Expression.get("admin_level"), Expression.literal(3)),
+                Expression.lte(Expression.get("admin_level"), Expression.literal(4)),
+                Expression.neq(Expression.get("maritime"), Expression.literal(1)),
+                Expression.neq(Expression.get("disputed"), Expression.literal(1)),
+                Expression.not(Expression.has("claimed_by")),
+            ),
+        )
+        l.minZoom = 4f
+        l.setProperties(
+            PropertyFactory.visibility(Property.VISIBLE),
+            PropertyFactory.lineColor(if (dark) "#6F7887" else "#B4B8BC"),
+            PropertyFactory.lineDasharray(arrayOf(3f, 2f)),
+            PropertyFactory.lineWidth(
+                Expression.interpolate(Expression.linear(), Expression.zoom(), Expression.stop(4, 0.8f), Expression.stop(8, 1.2f), Expression.stop(12, 1.6f)),
+            ),
+        )
+    }
+    (style.getLayer("boundary_disputed") as? LineLayer)?.setProperties(
+        PropertyFactory.visibility(Property.VISIBLE),
+        PropertyFactory.lineColor(borderInk),
+    )
 }
 
 /** Known-fragile GPU stacks start in compatibility (TextureView) rendering from the FIRST


### PR DESCRIPTION
Discussion #353: no lines between countries, states or provinces.

They had been hidden since July together with the footpath and rail-hatching clutter, because the same tile layer also carries county and city limits (admin levels 5 and 6 in these tiles), which read as stray dashes all over a suburb.

Google draws countries as a thin solid grey line and states/provinces lighter and dashed from about zoom 4, and draws neither county nor city limits at those zooms. So `applyMapTheme` now narrows the `boundary_3` filter to admin levels 3 and 4 (minzoom 4, dashed) instead of hiding it, restores `boundary_2` and `boundary_disputed`, and themes all three for light and dark; the style's own dark grey was invisible on the dark map.

Device-checked on a Pixel 4a at district zoom in dark mode: the CA/OR and CA/NV lines meet at the tri-point as dashed light grey. The country-scale look follows the style's own widths and opacity ramp; worth an eyeball on a phone that can pinch.

Docs: CLAUDE.md, FEATURES.md.