### PR TITLE
Issue sweep: place links, lists from search, light search bar, 24-hour clocks, live overview, release notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1764,6 +1764,24 @@ architecture note.
   The **Map style Settings row was removed** (only one style ships; MapStyle/setStyle plumbing
   kept for a future re-add). Nav card trip time is a `FitText` (shrinks to fit, never wraps/
   ellipsises) so the 54dp buttons + Interface-size scale can't clip the arrival time.
+- **Issue sweep 2026-09-10, the traps behind each:** (#343) `ListsSheet` must be composed
+  OUTSIDE the `fabChromeOk` block: that block is gone while the search overlay is up, and the
+  search bar's Your-lists button is exactly there, so the flag flipped and nothing rendered.
+  (#351) `SearchBar`'s Card is white + 6dp shadow + hairline border in LIGHT only (dark keeps
+  the flat surfaceContainerLow: a shadow smears on a dark map). (#357) The 12/24-hour clock is a
+  device SETTING, not the locale: `ui/Clock24` reads `DateFormat.is24HourFormat` at startup and
+  in `MainActivity.onResume`, mirrors it into `:core` `data/ClockFormat` for Transitous' board
+  times, and `formatArrivalClock` / `formatDateTime` honour it; never use
+  `ofLocalizedTime(SHORT)` alone for a clock the user sees. (#352) The nav Overview is a LIVE
+  refit loop in VelaMapView (`overviewLive`, arrow-to-destination every 4 s, keyed on the
+  polyline so a reroute refits), ended by pan/pinch/Re-center; the tick is the user's request,
+  the polyline key is not. (#330) `UpdateCard` shows `UpdateInfo.notes` through
+  `plainReleaseNotes` (markdown stripped, CI's versionName/versionCode lines dropped, 24 lines).
+  (#359) `PlaceSheet` share menu: Copy link = `placeUrl()` = the cid deep link, same as Open on
+  web. Reviews-language on #359 was NOT reproducible: the device sends `hl=zh-TW`, Google serves
+  Chinese, and the scraper completes on a zh-TW page in a 1200x3000 viewport in 19 s (browser
+  proxy); the reporter is most likely on a build older than #339. The P4a's own scrape timed out
+  in BOTH languages that day (result null at TOTAL_TIMEOUT_MS) - environmental, watch it.
 - **Country and state borders are DRAWN; county and city limits are not (discussion #353,
   2026-09-09).** Liberty's `boundary_2` (admin 2), `boundary_3` (admin 3-6) and
   `boundary_disputed` were hidden with the footpath/rail-hatching clutter in July because the

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -646,6 +646,7 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
 - 🟡 Self-hosted PMTiles - the no-key, no-quota Google-look path - remains for later
 - ⬜ Protomaps "Google-Maps-ify" style (road hierarchy ✅, hillshade ✅, POI icons ✅ done; this is the bundled-style variant)
 - ✅ Satellite layer - shipped 2026-07-13 via the Layers panel (Esri World Imagery hybrid; see the Layers entry below). Terrain relief ✅ too
+- ✅ **Issue sweep 2026-09-10.** *Copy link shares the place, not a pin* (issue #359): the place sheet's Copy link now copies the same Google Maps place link that Open on web uses, so the recipient lands on the store. *Your lists opens from the search page* (issue #343): the bookmark button in the search bar did nothing while the search overlay was up. *Light-mode search bar has contrast* (issue #351): white, with a shadow and a hairline border, like Google's; dark mode unchanged. *24-hour clock* (issue #357): the arrival time, transit boards and saved-trip timestamps follow the phone's 12/24-hour setting, not just the locale. *Live overview* (issue #352): the in-nav Overview keeps refitting to the road still ahead as you drive, tightening towards the destination, until you pan, pinch or Re-center. *What's new before you update* (issue #330): the update card folds out the release notes. Plus the Reviews/About tab labels and Copy name were untranslated in every language.
 - ✅ **Country and state/province borders (2026-09-09, discussion #353)** - drawn the way Google draws them: countries as a thin solid grey line, states and provinces lighter and dashed from about zoom 4, both themed for light and dark. County and city limits stay off, as on Google; they were the stray-dash clutter that got every border hidden back in July.
 - ✅ Map rotation/tilt + heading-up mode during nav (tilted follow-camera, speed-adaptive zoom)
 
@@ -1106,7 +1107,7 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   factory / swallow-`close()`); graphs are built off-device by `tools/graphbuilder`. On-device end-to-end
   verified (Pixel 5a): downloaded a region from the GitHub release → offline → 21.8 mi route via the crosstown arterial
   with named steps + a correct 28-min ETA.
-  - **Get a region two ways:** pick it under **Settings → Offline → Routing regions** (regions covering your current
+  - **Get a region two ways:** pick it under **Settings → Offline maps → Entire states & countries** (regions covering your current
     location sort to the top and are flagged "covers your location"; a **name filter** appears once the
     catalog is large, so a region you're *travelling* to - "Japan", "Texas" - is one type away instead of a
     long scroll), **or** just download offline map tiles for an area - "Download the area you're viewing" now

--- a/app/src/main/java/app/vela/MainActivity.kt
+++ b/app/src/main/java/app/vela/MainActivity.kt
@@ -31,6 +31,12 @@ class MainActivity : ComponentActivity() {
         super.attachBaseContext(AppLocale.wrap(app.vela.ui.AdaptiveDensity.wrap(newBase)))
     }
 
+    override fun onResume() {
+        super.onResume()
+        // The 12/24-hour clock setting can change while Vela sits in the background (issue #357).
+        app.vela.ui.Clock24.refresh(this)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/app/vela/VelaApp.kt
+++ b/app/src/main/java/app/vela/VelaApp.kt
@@ -65,6 +65,7 @@ class VelaApp : Application(), coil.ImageLoaderFactory {
         // CategoryFilter.enabled). Gates the ambient POI fan-out in GoogleMapsDataSource.
         app.vela.core.data.LowRamMode.enabled = app.vela.ui.MemoryPressure.lowRam
         Units.init(this)
+        app.vela.ui.Clock24.refresh(this) // the 12/24-hour clock setting (issue #357); MainActivity refreshes it on resume
         AppTheme.init(this)
         DynamicColor.init(this)
         AppLocale.init(this) // resolve the app language (system default) → drives the nav-text locale

--- a/app/src/main/java/app/vela/ui/Format.kt
+++ b/app/src/main/java/app/vela/ui/Format.kt
@@ -63,9 +63,33 @@ fun formatSpeedLimit(kmh: Double): Pair<Int, String> =
     if (Units.imperial.value) (kmh * 0.621371).roundToInt() to "mph"
     else kmh.roundToInt() to "km/h"
 
-/** Wall-clock arrival time for a trip [remainingSeconds] from now, e.g. "7:42 PM"
- *  (locale-aware 12/24-hour), the way Google shows ETA during navigation. */
+/** The device's 12/24-hour clock SETTING (Settings > System > Date & time), which is separate
+ *  from the locale: a US-English phone set to 24-hour shows "19:42" everywhere else and used to
+ *  show "7:42 PM" here (issue #357). Read at startup and on every resume; mirrored into :core's
+ *  [app.vela.core.data.ClockFormat] for the transit boards. */
+object Clock24 {
+    val on = mutableStateOf(false)
+
+    fun refresh(context: Context) {
+        val v = android.text.format.DateFormat.is24HourFormat(context)
+        on.value = v
+        app.vela.core.data.ClockFormat.use24h = v
+    }
+}
+
+/** Wall-clock arrival time for a trip [remainingSeconds] from now, e.g. "7:42 PM" or "19:42",
+ *  following the device's 12/24-hour setting, the way Google shows ETA during navigation. */
 fun formatArrivalClock(remainingSeconds: Double): String {
     val arrival = java.time.LocalTime.now().plusSeconds(remainingSeconds.toLong())
-    return arrival.format(java.time.format.DateTimeFormatter.ofLocalizedTime(java.time.format.FormatStyle.SHORT))
+    val fmt = if (Clock24.on.value) java.time.format.DateTimeFormatter.ofPattern("HH:mm")
+        else java.time.format.DateTimeFormatter.ofLocalizedTime(java.time.format.FormatStyle.SHORT)
+    return arrival.format(fmt)
+}
+
+/** "Sep 7, 7:42 PM" / "7 Sep, 19:42": a saved trip's or log's timestamp in the device's own date
+ *  and time formats. */
+fun formatDateTime(context: Context, epochMs: Long): String {
+    val d = java.util.Date(epochMs)
+    return android.text.format.DateFormat.getMediumDateFormat(context).format(d) + ", " +
+        android.text.format.DateFormat.getTimeFormat(context).format(d)
 }

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -2343,16 +2343,6 @@ fun MapScreen(
                     onDismiss = { showParkingHistory = false },
                 )
             }
-            if (listsSheetOpen) {
-                ListsSheet(
-                    lists = state.lists,
-                    onOpenList = { listsSheetOpen = false; vm.openList(it) },
-                    onCreateList = { name -> vm.createList(name) },
-                    onUpdateList = vm::updateList,
-                    onDeleteList = vm::deleteList,
-                    onDismiss = { listsSheetOpen = false },
-                )
-            }
             // (The live-traffic overlay toggle moved to Settings → Map — it's a
             // niche browse-only layer, and nav now shows per-segment route traffic,
             // so it no longer earns a spot on the map.)
@@ -2400,6 +2390,19 @@ fun MapScreen(
                 )
             }
         }
+            // Outside the FAB-chrome block on purpose: the Your-lists button in the search bar is
+            // reachable while the search overlay is open, and that block is not composed then,
+            // so the button set a flag nothing rendered (issue #343).
+            if (listsSheetOpen) {
+                ListsSheet(
+                    lists = state.lists,
+                    onOpenList = { listsSheetOpen = false; vm.openList(it) },
+                    onCreateList = { name -> vm.createList(name) },
+                    onUpdateList = vm::updateList,
+                    onDeleteList = vm::deleteList,
+                    onDismiss = { listsSheetOpen = false },
+                )
+            }
 
             // Portrait, place card at (or near) its minimized bar: the locate FAB rides ABOVE the
             // card's measured top edge (user 2026-07-20: current location stays reachable with a
@@ -2633,6 +2636,7 @@ fun MapScreen(
                     state.updateInfo?.let { u ->
                         UpdateCard(
                             versionName = u.versionName,
+                            notes = u.notes,
                             downloadPct = state.updateDownloadPct,
                             onUpdate = { vm.downloadUpdate() },
                             onDismiss = { vm.dismissUpdate() },
@@ -4218,6 +4222,7 @@ private fun RegionDownloadCard(name: String, places: Boolean, pct: Int, area: Bo
 @Composable
 private fun UpdateCard(
     versionName: String,
+    notes: String = "",
     downloadPct: Int?,
     onUpdate: () -> Unit,
     onDismiss: () -> Unit,
@@ -4233,6 +4238,25 @@ private fun UpdateCard(
     ) {
         Column(Modifier.fillMaxWidth().padding(start = 16.dp, end = 8.dp, top = 8.dp, bottom = 4.dp)) {
             Text(stringResource(R.string.update_available_title, versionName), fontWeight = FontWeight.SemiBold)
+            // What changed, from the release's own notes, folded by default (issue #330): the
+            // nightly notes are the commit list since the last release, which is exactly the
+            // "what am I installing" answer, minus markdown glyphs.
+            val plainNotes = remember(notes) { plainReleaseNotes(notes) }
+            if (plainNotes.isNotEmpty() && downloadPct == null) {
+                var showNotes by remember { mutableStateOf(false) }
+                TextButton(onClick = { showNotes = !showNotes }, contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp)) {
+                    Text(stringResource(if (showNotes) R.string.update_notes_hide else R.string.update_notes_show), style = MaterialTheme.typography.labelLarge)
+                }
+                if (showNotes) {
+                    Text(
+                        plainNotes,
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 24,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(end = 8.dp, bottom = 4.dp),
+                    )
+                }
+            }
             if (downloadPct != null) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(stringResource(R.string.update_downloading, downloadPct), style = MaterialTheme.typography.bodySmall, modifier = Modifier.weight(1f))
@@ -4266,6 +4290,17 @@ private fun UpdateCard(
         }
     }
 }
+
+/** Release notes as plain lines: headings, bullets and links stripped, the CI's own
+ *  versionName/versionCode bookkeeping lines dropped. Keeps the first 24 lines. */
+internal fun plainReleaseNotes(notes: String): String =
+    notes.lines()
+        .map { it.trim().trimStart('#').trim() }
+        .map { it.replace(Regex("""^[-*]\s+"""), "\u2022 ") }
+        .map { it.replace(Regex("""\[([^\]]+)\]\([^)]*\)"""), "$1").replace(Regex("""\*\*|__|`"""), "") }
+        .filter { it.isNotBlank() && !it.startsWith("versionName", ignoreCase = true) && !it.startsWith("versionCode", ignoreCase = true) && !it.startsWith("<") }
+        .take(24)
+        .joinToString("\n")
 
 /** A notice pushed through the signed calibration channel - level-tinted, with an
  *  optional "Learn more" link and a per-id Dismiss. */
@@ -4500,8 +4535,7 @@ private fun ParkingHistorySheet(
                                     fontWeight = if (isCurrent) FontWeight.Bold else FontWeight.Normal,
                                 )
                                 Text(
-                                    java.text.SimpleDateFormat("MMM d, h:mm a", java.util.Locale.getDefault())
-                                        .format(java.util.Date(entry.savedAtMillis)),
+                                    app.vela.ui.formatDateTime(androidx.compose.ui.platform.LocalContext.current, entry.savedAtMillis),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -594,8 +594,11 @@ fun VelaMapView(
     }
     // Re-center during nav also returns a pinch-zoomed/tilted camera to auto (issue #238: the
     // override kept following, so navCameraDetached stayed false and no Re-center path existed).
+    val overviewLive = remember { booleanArrayOf(false) }   // live overview refit loop running (issue #352)
+    val overviewTickSeen = remember { intArrayOf(0) }
     LaunchedEffect(navRecenterTick) {
         if (navRecenterTick > 0) {
+            overviewLive[0] = false
             navUserZoom[0] = Double.NaN
             navUserTilt[0] = Double.NaN
             zoomOverride.value(false)
@@ -1518,32 +1521,57 @@ fun VelaMapView(
         }
     }
 
-    // The in-nav ROUTE OVERVIEW (Google's fly-over): fit the whole route while the drive keeps
+    // The in-nav ROUTE OVERVIEW (Google's fly-over): fit the road AHEAD while the drive keeps
     // navigating - the VM marked the camera detached, so the follow ticker has already stepped
     // aside and the existing Re-center button glides back into the puck-low follow. Camera only;
     // guidance, voice and the puck (which keeps moving along the overview) are untouched.
-    LaunchedEffect(navOverviewTick) {
+    // LIVE (issue #352): Google's overview keeps refitting to the road still ahead as you drive,
+    // so the frame tightens towards the destination and the last turns are readable. Ours was a
+    // one-shot fit of the whole route, origin to destination. After the first fit the effect
+    // keeps refitting arrow-to-destination every few seconds until a pan, a pinch or Re-center
+    // ends it (`overviewLive`, cleared by those handlers). Keyed on the polyline too, so a
+    // reroute refits the NEW route; a polyline change while the overview is not live is ignored
+    // (the tick is the user's request, the polyline key is not).
+    LaunchedEffect(navOverviewTick, routePolyline) {
+        val fresh = overviewTickSeen[0] != navOverviewTick
+        overviewTickSeen[0] = navOverviewTick
         if (navOverviewTick == 0 || !navMode || routePolyline.size < 2) return@LaunchedEffect
+        if (!fresh && !overviewLive[0]) return@LaunchedEffect
         val map = mapRef ?: return@LaunchedEffect
+        fun fitRemaining(animMs: Int) {
+            val cum = routeCum
+            if (cum.size != routePolyline.size || cum.isEmpty()) return
+            val fromM = navPuck.progressM.coerceIn(0.0, cum.last())
+            val b = MLLatLngBounds.Builder()
+            val (p0, _) = pointAtMeters(routePolyline, cum, fromM)
+            b.include(MLLatLng(p0.lat, p0.lng))
+            for (i in indexAtMeters(cum, fromM) until routePolyline.size) b.include(MLLatLng(routePolyline[i].lat, routePolyline[i].lng))
+            b.include(MLLatLng(routePolyline.last().lat, routePolyline.last().lng))
+            runCatching {
+                // Fit NORTH-UP and FLAT (the bearing/tilt overload): the plain bounds fit kept the
+                // follow's rotated 55-degree camera, and a tilted, rotated fit shows LESS than the
+                // whole route however correct the math (user 2026-07-15: "doesn't quite show the
+                // full route") - Google's overview levels out too.
+                flightDepth[0]++
+                map.animateCamera(
+                    CameraUpdateFactory.newLatLngBounds(
+                        b.build(), 0.0, 0.0,
+                        70, (map.height * 0.30).toInt(), 70, (map.height * 0.22).toInt(),
+                    ),
+                    animMs,
+                    flightCb(),
+                )
+            }
+        }
         // The puck-low top padding would skew a bounds fit; the follow re-applies it per frame
         // when Re-center re-attaches.
-        map.moveCamera(CameraUpdateFactory.paddingTo(0.0, 0.0, 0.0, 0.0))
-        val b = MLLatLngBounds.Builder()
-        routePolyline.forEach { b.include(MLLatLng(it.lat, it.lng)) }
-        runCatching {
-            // Fit NORTH-UP and FLAT (the bearing/tilt overload): the plain bounds fit kept the
-            // follow's rotated 55-degree camera, and a tilted, rotated fit shows LESS than the
-            // whole route however correct the math (user 2026-07-15: "doesn't quite show the
-            // full route") - Google's overview levels out too.
-            flightDepth[0]++
-            map.animateCamera(
-                CameraUpdateFactory.newLatLngBounds(
-                    b.build(), 0.0, 0.0,
-                    70, (map.height * 0.30).toInt(), 70, (map.height * 0.22).toInt(),
-                ),
-                700,
-                flightCb(),
-            )
+        if (fresh) map.moveCamera(CameraUpdateFactory.paddingTo(0.0, 0.0, 0.0, 0.0))
+        overviewLive[0] = true
+        fitRemaining(700)
+        while (overviewLive[0] && navModeHolder.value) {
+            kotlinx.coroutines.delay(4_000)
+            if (!overviewLive[0] || !navModeHolder.value) break
+            fitRemaining(600)
         }
     }
 
@@ -2299,6 +2327,7 @@ fun VelaMapView(
                         // misread the scaling guard fixes for pinch) - it detached the camera the
                         // moment a two-finger tilt started.
                         if (navModeHolder.value && !scaling[0] && !shoving[0]) {
+                            overviewLive[0] = false
                             navPanned.value()
                             navUserZoom[0] = Double.NaN
                             zoomOverride.value(false)
@@ -2309,6 +2338,7 @@ fun VelaMapView(
                 map.addOnScaleListener(object : MapLibreMap.OnScaleListener {
                     override fun onScaleBegin(detector: StandardScaleGestureDetector) {
                         scaling[0] = true
+                        overviewLive[0] = false
                         browseZoomGoal[0] = Double.NaN // fingers beat a pending locate-tap zoom
                     }
                     // Capture the zoom CONTINUOUSLY (not only on end) so the override is set even

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -3804,18 +3804,25 @@ private fun ShareIconButton(place: Place, tint: Color) {
 
     // Open this exact place on the Google Maps website (in the browser), not share a link. Prefer the
     // place's own cid deep-link (opens the real place page); fall back to a name+coords query.
-    fun openWeb() {
+    // The place's own link: the cid deep link when the place has a feature id (opens THE STORE in
+    // Google Maps or Vela), else a name + coordinate search.
+    fun placeUrl(): String {
         val cid = place.featureId?.substringAfter(":", "")?.removePrefix("0x")?.takeIf { it.isNotBlank() }
             ?.let { runCatching { java.math.BigInteger(it, 16).toString() }.getOrNull() }
-        val url = if (cid != null) "https://www.google.com/maps?cid=$cid"
+        return if (cid != null) "https://www.google.com/maps?cid=$cid"
             else "https://www.google.com/maps/search/?api=1&query=${Uri.encode(place.name)}%20$lat%2C$lng"
-        runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url))) }
+    }
+
+    fun openWeb() {
+        runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(placeUrl()))) }
         open = false
     }
 
-    // Copy the place's Google Maps link straight to the clipboard (a quiet toast confirms).
+    // Copy the place's Google Maps link straight to the clipboard (a quiet toast confirms). The
+    // same link Open-on-web uses: this used to copy a bare coordinate query, so the recipient got
+    // a pin instead of the place (issue #359).
     fun copyLink() {
-        val url = "https://www.google.com/maps/search/?api=1&query=$lat%2C$lng"
+        val url = placeUrl()
         runCatching {
             val cm = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
             cm.setPrimaryClip(android.content.ClipData.newPlainText(place.name, url))

--- a/app/src/main/java/app/vela/ui/search/SearchBar.kt
+++ b/app/src/main/java/app/vela/ui/search/SearchBar.kt
@@ -108,10 +108,17 @@ fun SearchBar(
     // D-pad: the "arm the field" clickable goes on the TEXT REGION only (below), NOT the
     // whole Card — a card-level clickable made the entire bar ONE focus stop and swallowed
     // the Settings gear inside it (the gear became unreachable by D-pad; measured on-device).
+    // Light theme: a WHITE bar with a real shadow and a hairline border, the way Google's sits
+    // on its near-white map. surfaceContainerLow on the light land colour was almost the same
+    // tone as the map, so the bar dissolved into it (issue #351). Dark keeps the flat tone: a
+    // shadow reads as a smear on a dark map.
+    val dark = app.vela.ui.theme.isAppInDarkTheme()
     Card(
         modifier.fillMaxWidth(),
         shape = RoundedCornerShape(28.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        colors = CardDefaults.cardColors(containerColor = if (dark) MaterialTheme.colorScheme.surfaceContainerLow else MaterialTheme.colorScheme.surfaceContainerLowest),
+        elevation = CardDefaults.cardElevation(defaultElevation = if (dark) 0.dp else 6.dp),
+        border = if (dark) null else androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f)),
     ) {
         Row(
             Modifier.fillMaxWidth().height(52.dp).padding(horizontal = 6.dp),

--- a/app/src/main/java/app/vela/ui/settings/sections/DiagnosticsSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/DiagnosticsSettings.kt
@@ -227,8 +227,7 @@ internal fun DiagnosticsSettingsScreen(vm: MapViewModel, onBack: () -> Unit, onC
                     Column(Modifier.weight(1f)) {
                         Text(t.label, style = MaterialTheme.typography.bodyMedium, fontWeight = androidx.compose.ui.text.font.FontWeight.Medium, maxLines = 1)
                         val recordedAt = if (t.startedAt > 0L)
-                            java.text.SimpleDateFormat("MMM d, h:mm a", java.util.Locale.getDefault())
-                                .format(java.util.Date(t.startedAt))
+                            app.vela.ui.formatDateTime(androidx.compose.ui.platform.LocalContext.current, t.startedAt)
                         else null
                         Hint(listOfNotNull(recordedAt, stringResource(R.string.settings_trip_points, t.fixCount)).joinToString(" · "))
                     }

--- a/app/src/main/java/app/vela/ui/settings/sections/NavigationSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/NavigationSettings.kt
@@ -233,8 +233,7 @@ internal fun NavigationSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
                     )
                     Spacer(Modifier.width(10.dp))
                     Text(
-                        java.text.SimpleDateFormat("MMM d, h:mm a", java.util.Locale.getDefault())
-                            .format(java.util.Date(entry.savedAtMillis)),
+                        app.vela.ui.formatDateTime(androidx.compose.ui.platform.LocalContext.current, entry.savedAtMillis),
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = if (isCurrent) androidx.compose.ui.text.font.FontWeight.Bold else androidx.compose.ui.text.font.FontWeight.Normal,
                         modifier = Modifier.weight(1f),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -640,4 +640,9 @@
     <string name="voice_error_vad">Ein Teil des Sprachmodells fehlt. Lade es unter Einstellungen \u2192 Suche erneut herunter.</string>
     <string name="voice_error_audio">Dieses Telefon hat sein Mikrofon nicht für Vela geöffnet. Schließe andere Apps, die Audio aufnehmen, und versuche es erneut.</string>
     <string name="voice_error_recording">Die Aufnahme wurde unerwartet beendet. Versuche es erneut.</string>
+    <string name="place_tab_reviews">Rezensionen</string>
+    <string name="place_tab_about">Info</string>
+    <string name="place_copy_name">Namen kopieren</string>
+    <string name="update_notes_show">Was ist neu</string>
+    <string name="update_notes_hide">Neuerungen ausblenden</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -640,4 +640,9 @@
     <string name="voice_error_vad">Falta parte del modelo de voz. Vuelve a descargarlo en Ajustes \u2192 Búsqueda.</string>
     <string name="voice_error_audio">Este teléfono no abrió su micrófono para Vela. Cierra cualquier otra app que grabe audio e inténtalo de nuevo.</string>
     <string name="voice_error_recording">La grabación se detuvo inesperadamente. Inténtalo de nuevo.</string>
+    <string name="place_tab_reviews">Reseñas</string>
+    <string name="place_tab_about">Información</string>
+    <string name="place_copy_name">Copiar nombre</string>
+    <string name="update_notes_show">Novedades</string>
+    <string name="update_notes_hide">Ocultar novedades</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -640,4 +640,9 @@
     <string name="voice_error_vad">Une partie du modèle vocal est manquante. Téléchargez-le à nouveau dans Paramètres \u2192 Recherche.</string>
     <string name="voice_error_audio">Ce téléphone n\'a pas ouvert son micro pour Vela. Fermez toute autre application qui enregistre du son et réessayez.</string>
     <string name="voice_error_recording">L\'enregistrement s\'est arrêté de manière inattendue. Réessayez.</string>
+    <string name="place_tab_reviews">Avis</string>
+    <string name="place_tab_about">À propos</string>
+    <string name="place_copy_name">Copier le nom</string>
+    <string name="update_notes_show">Nouveautés</string>
+    <string name="update_notes_hide">Masquer les nouveautés</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -640,4 +640,9 @@
     <string name="voice_error_vad">Manca una parte del modello vocale. Scaricalo di nuovo in Impostazioni \u2192 Ricerca.</string>
     <string name="voice_error_audio">Questo telefono non ha aperto il microfono per Vela. Chiudi altre app che registrano audio e riprova.</string>
     <string name="voice_error_recording">La registrazione si è interrotta inaspettatamente. Riprova.</string>
+    <string name="place_tab_reviews">Recensioni</string>
+    <string name="place_tab_about">Informazioni</string>
+    <string name="place_copy_name">Copia nome</string>
+    <string name="update_notes_show">Novità</string>
+    <string name="update_notes_hide">Nascondi novità</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -641,4 +641,9 @@
     <string name="voice_error_vad">חלק ממודל הקול חסר. הורד אותו שוב בהגדרות \u2192 חיפוש.</string>
     <string name="voice_error_audio">הטלפון לא פתח את המיקרופון עבור Vela. סגור אפליקציות אחרות שמקליטות ונסה שוב.</string>
     <string name="voice_error_recording">ההקלטה נעצרה באופן לא צפוי. נסה שוב.</string>
+    <string name="place_tab_reviews">ביקורות</string>
+    <string name="place_tab_about">מידע</string>
+    <string name="place_copy_name">העתקת השם</string>
+    <string name="update_notes_show">מה חדש</string>
+    <string name="update_notes_hide">הסתרת מה חדש</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -660,4 +660,9 @@
     <string name="voice_error_vad">音声モデルの一部が不足しています。設定 \u2192 検索 から再ダウンロードしてください。</string>
     <string name="voice_error_audio">この端末でマイクを開けませんでした。録音中の他のアプリを閉じて再試行してください。</string>
     <string name="voice_error_recording">録音が予期せず停止しました。もう一度お試しください。</string>
+    <string name="place_tab_reviews">クチコミ</string>
+    <string name="place_tab_about">概要</string>
+    <string name="place_copy_name">名前をコピー</string>
+    <string name="update_notes_show">新機能</string>
+    <string name="update_notes_hide">新機能を隠す</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -640,4 +640,9 @@
     <string name="voice_error_vad">Een deel van het spraakmodel ontbreekt. Download het opnieuw via Instellingen \u2192 Zoeken.</string>
     <string name="voice_error_audio">Deze telefoon opende de microfoon niet voor Vela. Sluit andere apps die audio opnemen en probeer opnieuw.</string>
     <string name="voice_error_recording">De opname stopte onverwacht. Probeer opnieuw.</string>
+    <string name="place_tab_reviews">Reviews</string>
+    <string name="place_tab_about">Info</string>
+    <string name="place_copy_name">Naam kopiëren</string>
+    <string name="update_notes_show">Wat is nieuw</string>
+    <string name="update_notes_hide">Nieuw verbergen</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -648,4 +648,9 @@
     <string name="voice_error_vad">Brakuje części modelu głosowego. Pobierz go ponownie w Ustawienia \u2192 Wyszukiwanie.</string>
     <string name="voice_error_audio">Ten telefon nie udostępnił mikrofonu Veli. Zamknij inne aplikacje nagrywające dźwięk i spróbuj ponownie.</string>
     <string name="voice_error_recording">Nagrywanie nieoczekiwanie się zatrzymało. Spróbuj ponownie.</string>
+    <string name="place_tab_reviews">Opinie</string>
+    <string name="place_tab_about">Informacje</string>
+    <string name="place_copy_name">Kopiuj nazwę</string>
+    <string name="update_notes_show">Co nowego</string>
+    <string name="update_notes_hide">Ukryj nowości</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -640,4 +640,9 @@
     <string name="voice_error_vad">Falta parte do modelo de voz. Transfere-o novamente em Definições \u2192 Pesquisa.</string>
     <string name="voice_error_audio">Este telemóvel não abriu o microfone para o Vela. Fecha outras apps que gravem áudio e tenta de novo.</string>
     <string name="voice_error_recording">A gravação parou inesperadamente. Tenta de novo.</string>
+    <string name="place_tab_reviews">Avaliações</string>
+    <string name="place_tab_about">Sobre</string>
+    <string name="place_copy_name">Copiar nome</string>
+    <string name="update_notes_show">Novidades</string>
+    <string name="update_notes_hide">Ocultar novidades</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -648,4 +648,9 @@
     <string name="voice_error_vad">Часть голосовой модели отсутствует. Скачайте её заново в Настройках \u2192 Поиск.</string>
     <string name="voice_error_audio">Этот телефон не открыл микрофон для Vela. Закройте другие приложения, записывающие звук, и попробуйте снова.</string>
     <string name="voice_error_recording">Запись неожиданно прервалась. Попробуйте снова.</string>
+    <string name="place_tab_reviews">Отзывы</string>
+    <string name="place_tab_about">Описание</string>
+    <string name="place_copy_name">Копировать название</string>
+    <string name="update_notes_show">Что нового</string>
+    <string name="update_notes_hide">Скрыть список изменений</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -640,4 +640,9 @@
     <string name="voice_error_vad">En del av röstmodellen saknas. Ladda ner den igen under Inställningar \u2192 Sök.</string>
     <string name="voice_error_audio">Telefonen öppnade inte mikrofonen för Vela. Stäng andra appar som spelar in ljud och försök igen.</string>
     <string name="voice_error_recording">Inspelningen stoppades oväntat. Försök igen.</string>
+    <string name="place_tab_reviews">Recensioner</string>
+    <string name="place_tab_about">Om</string>
+    <string name="place_copy_name">Kopiera namn</string>
+    <string name="update_notes_show">Nyheter</string>
+    <string name="update_notes_hide">Dölj nyheter</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -648,4 +648,9 @@
     <string name="voice_error_vad">Частина голосової моделі відсутня. Завантажте її знову в Налаштуваннях \u2192 Пошук.</string>
     <string name="voice_error_audio">Цей телефон не відкрив мікрофон для Vela. Закрийте інші додатки, що записують звук, і спробуйте ще раз.</string>
     <string name="voice_error_recording">Запис несподівано зупинився. Спробуйте ще раз.</string>
+    <string name="place_tab_reviews">Відгуки</string>
+    <string name="place_tab_about">Опис</string>
+    <string name="place_copy_name">Копіювати назву</string>
+    <string name="update_notes_show">Що нового</string>
+    <string name="update_notes_hide">Сховати зміни</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -660,4 +660,9 @@
     <string name="voice_error_vad">語音模型缺少部分檔案。請在設定 \u2192 搜尋 中重新下載。</string>
     <string name="voice_error_audio">這部手機未為 Vela 開啟麥克風。請關閉其他正在錄音的應用程式後重試。</string>
     <string name="voice_error_recording">錄音意外中斷。請重試。</string>
+    <string name="place_tab_reviews">評論</string>
+    <string name="place_tab_about">簡介</string>
+    <string name="place_copy_name">複製名稱</string>
+    <string name="update_notes_show">更新內容</string>
+    <string name="update_notes_hide">隱藏更新內容</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -660,4 +660,9 @@
     <string name="voice_error_vad">语音模型缺少部分文件。请在设置 \u2192 搜索 中重新下载。</string>
     <string name="voice_error_audio">这部手机未为 Vela 打开麦克风。请关闭其他正在录音的应用后重试。</string>
     <string name="voice_error_recording">录音意外中断。请重试。</string>
+    <string name="place_tab_reviews">评论</string>
+    <string name="place_tab_about">简介</string>
+    <string name="place_copy_name">复制名称</string>
+    <string name="update_notes_show">更新内容</string>
+    <string name="update_notes_hide">隐藏更新内容</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -373,6 +373,8 @@
     <string name="place_open_web">Open on the web</string>
     <string name="place_copy_link">Copy link</string>
     <string name="place_copy_name">Copy name</string>
+    <string name="update_notes_show">What\'s new</string>
+    <string name="update_notes_hide">Hide what\'s new</string>
     <string name="place_name_copied">Name copied</string>
     <string name="place_link_copied">Link copied</string>
     <string name="place_share_gmaps_link">Google Maps link</string>

--- a/core/src/main/java/app/vela/core/data/ClockFormat.kt
+++ b/core/src/main/java/app/vela/core/data/ClockFormat.kt
@@ -1,0 +1,7 @@
+package app.vela.core.data
+
+/** The device's 12/24-hour clock setting, pushed in by the app (a plain holder, like
+ *  [LowDataMode]): :core has no Context, and the transit boards format times. */
+object ClockFormat {
+    @Volatile var use24h: Boolean = false
+}

--- a/core/src/main/java/app/vela/core/data/transit/Transitous.kt
+++ b/core/src/main/java/app/vela/core/data/transit/Transitous.kt
@@ -317,10 +317,11 @@ object Transitous {
     /** ISO-8601 UTC ("2026-07-13T20:26:00Z") to epoch seconds. */
     internal fun parseIso(iso: String): Long? = runCatching { java.time.Instant.parse(iso).epochSecond }.getOrNull()
 
-    /** 12-hour clock text in the STOP's timezone (falls back to the device zone), matching the
-     *  Google-board format the row UI and its TIME-based logic already render. */
+    /** Clock text in the STOP's timezone (falls back to the device zone): 12-hour like the
+     *  Google boards, or 24-hour when the device's clock setting says so ([ClockFormat],
+     *  issue #357). */
     internal fun clockText(epochSec: Long, tz: String?): String {
-        val fmt = SimpleDateFormat("h:mm a", Locale.US)
+        val fmt = SimpleDateFormat(if (app.vela.core.data.ClockFormat.use24h) "HH:mm" else "h:mm a", Locale.US)
         fmt.timeZone = tz?.let { runCatching { TimeZone.getTimeZone(it) }.getOrNull() } ?: TimeZone.getDefault()
         return fmt.format(Date(epochSec * 1000))
     }


### PR DESCRIPTION
Six of the issues filed since Sept 6, plus the translations they exposed.

- **#359 Copy link shares the place, not a pin.** It copied a bare coordinate query; it now copies the same cid place link that Open on web uses, name+coordinate search as the fallback. The reviews-language half of #359 did not reproduce: the device sends `hl=zh-TW`, Google serves Chinese, and the scraper completes on a zh-TW page in a real viewport in 19 s. The reporter is most likely on a build older than #339.
- **#343 Your lists opens from the search page.** The lists sheet was composed inside the FAB-chrome block, which is not composed while the search overlay is up, so the button set a flag nothing rendered.
- **#351 Light-mode search bar has contrast.** White, 6dp shadow, hairline border, like Google's; dark mode unchanged.
- **#357 24-hour clock.** Arrival time, transit boards and saved-trip timestamps follow the device's 12/24-hour setting (not the locale), read at startup and on resume, mirrored into `:core` for Transitous.
- **#352 Live overview.** The nav Overview keeps refitting arrow-to-destination every 4 s until a pan, a pinch or Re-center; a reroute refits the new route.
- **#330 What's new before updating.** The update card folds out the release notes with markdown stripped and CI's bookkeeping lines dropped.
- Reviews/About tab labels and Copy name were untranslated in all 14 locales (seen on a Chinese-language phone); added, with the two new strings.
- FEATURES.md pointed at a settings entry that no longer exists (#348).

Device-checked on a Pixel 4a: lists sheet from the search page, light search bar. Core tests green.

Docs: CLAUDE.md, FEATURES.md.