### PR TITLE
Arrow size and colour settings for the navigation puck

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2422,6 +2422,12 @@ architecture note.
   harness is a scratch Python port of AlongRouteFilter + the rate rule over the trip's fixes.
   **Read `docs/puck-jitter.md` first: the eight causes, the measurement scripts in `scripts/jitter/`, and
   the order to run them. Do not start from a theory.**
+  **Puck size/colour setting (issue #344, 2026-09-12):** `ui/NavChrome.PuckStyle` (prefs
+  `puck_size` normal/large/xl = 1x/1.25x/1.5x, `puck_style` blue/white). `navPuckBitmap(scale,
+  whiteDisc)` draws both the Compose overlay (`remember(PuckStyle.key())`) and the `NAV_PUCK_IMG`
+  symbol; the symbol image is registered once per style load, so `PuckStyle.key()` rides the
+  `styleKey` and a change reloads the style. The white disc gets a hairline `#B9BDC2` ring so it
+  keeps an edge over the light map.
   **THE PUCK ITSELF JITTERED BECAUSE IT WAS A MAP SYMBOL (issue #251, fixed 2026-09-03). In
   follow mode the puck is now a COMPOSE OVERLAY, not the `ME_ARROW_LAYER` symbol.** Measured the
   pixel that matters: the white chevron's centroid in an `adb screenrecord` (`scripts/jitter/puck_track.py`: threshold

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -249,6 +249,7 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   device; **Share full trace** is still there, and the on-device copy is never modified.
   Sharing several trips at once trims every one of them the same way. `core/replay/TripScrub`,
   15 tests.
+- ✅ **Arrow size and colours (2026-09-12, issue #344).** Settings > Navigation: the navigation arrow comes in Normal, Large (1.25x) and Extra large (1.5x), and in a white-disc-with-blue-arrow variant for people who found the blue disc blending into the blue route line. One setting drives both the follow-mode arrow and the map symbol.
 - ✅ **Google-style nav puck (2026-07-11).** The navigation arrow is a white chevron inside a
   filled bright-navy circle with a soft drop shadow (no white ring, per user feedback); it rotates
   about the exact GPS point. Replaces the bare blue chevron. **Enlarged twice from feedback

--- a/app/src/main/java/app/vela/VelaApp.kt
+++ b/app/src/main/java/app/vela/VelaApp.kt
@@ -97,6 +97,7 @@ class VelaApp : Application(), coil.ImageLoaderFactory {
         app.vela.ui.Buildings3d.init(this)
         app.vela.ui.RouteTrail.init(this)
         app.vela.ui.RoadLabel.init(this)
+        app.vela.ui.PuckStyle.init(this)
         app.vela.ui.PreferButtons.init(this)
         app.vela.ui.BuildingOverlay.init(this)
         app.vela.ui.BuildingDebug.init(this)

--- a/app/src/main/java/app/vela/ui/NavChrome.kt
+++ b/app/src/main/java/app/vela/ui/NavChrome.kt
@@ -25,6 +25,48 @@ object RoadLabel {
     private const val KEY = "road_label"
 }
 
+/** The navigation arrow's size and colours (issue #344): three sizes for eyes that want a bigger
+ *  target, and a white-disc variant so the puck does not blend into the blue route line. Both the
+ *  follow-mode Compose overlay and the map symbol draw from the same bitmap, so one holder feeds
+ *  both; the map style key carries [key] so a change re-registers the symbol image. */
+object PuckStyle {
+    const val SIZE_NORMAL = "normal"
+    const val SIZE_LARGE = "large"
+    const val SIZE_XL = "xl"
+    const val STYLE_BLUE = "blue"
+    const val STYLE_WHITE = "white"
+    val size = mutableStateOf(SIZE_NORMAL)
+    val style = mutableStateOf(STYLE_BLUE)
+
+    fun scale(): Float = when (size.value) {
+        SIZE_LARGE -> 1.25f
+        SIZE_XL -> 1.5f
+        else -> 1f
+    }
+    fun whiteDisc(): Boolean = style.value == STYLE_WHITE
+    fun key(): String = "${size.value}/${style.value}"
+
+    fun init(context: Context) {
+        val p = prefs(context)
+        size.value = p.getString(KEY_SIZE, SIZE_NORMAL) ?: SIZE_NORMAL
+        style.value = p.getString(KEY_STYLE, STYLE_BLUE) ?: STYLE_BLUE
+    }
+
+    fun setSize(context: Context, value: String) {
+        size.value = value
+        prefs(context).edit().putString(KEY_SIZE, value).apply()
+    }
+
+    fun setStyle(context: Context, value: String) {
+        style.value = value
+        prefs(context).edit().putString(KEY_STYLE, value).apply()
+    }
+
+    private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
+    private const val KEY_SIZE = "puck_size"
+    private const val KEY_STYLE = "puck_style"
+}
+
 /** "Prefer buttons over swipes": keeps a discrete button wherever a gesture has one (today: the
  *  step-list button on the nav bar beside the swipe-up handle). Off by default; keypad-first
  *  devices behave as if it were on. */

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -2851,7 +2851,9 @@ fun VelaMapView(
             navPuck.rawBearing = myBearing
         }
         // Palette in the key so a Settings colour-set switch reloads the style, same as a theme flip.
-        val styleKey = "$styleUri|dark=$darkTheme|pal=${app.vela.ui.MapColors.current()}|sat=$satelliteOn"
+        // The puck style rides the key too: the symbol image is registered once per style load
+        // (issue #344), so a size/colour change reloads to re-register it.
+        val styleKey = "$styleUri|dark=$darkTheme|pal=${app.vela.ui.MapColors.current()}|sat=$satelliteOn|puck=${app.vela.ui.PuckStyle.key()}"
         if (appliedStyleKey != styleKey) {
             appliedStyleKey = styleKey
             val builder = if (styleUri.startsWith("asset://")) {
@@ -3247,7 +3249,8 @@ fun VelaMapView(
         }
     }
     if (puckOverlayOn.value) {
-        val puckImg = remember { navPuckBitmap().asImageBitmap() }
+        val puckKey = app.vela.ui.PuckStyle.key()
+        val puckImg = remember(puckKey) { navPuckBitmap().asImageBitmap() }
         val sizePx = puckImg.width
         androidx.compose.foundation.Image(
             bitmap = puckImg,
@@ -6164,8 +6167,13 @@ private fun arrowBitmap(): Bitmap {
 /** Navigation puck: a WHITE chevron inside a filled BRIGHT-NAVY circle with a soft drop shadow
  *  and NO white ring (user 2026-07-11: bigger, drop the ring, brighter navy blue). Points up
  *  (north) so `iconRotate(bearing)` aims it down the heading. */
-private fun navPuckBitmap(): Bitmap {
-    val size = 202 // +15% per issue #251 (2026-08-10); the earlier chain was 96 -> 112 -> 136 -> 176
+private fun navPuckBitmap(
+    scale: Float = app.vela.ui.PuckStyle.scale(),
+    whiteDisc: Boolean = app.vela.ui.PuckStyle.whiteDisc(),
+): Bitmap {
+    // 202 = +15% per issue #251 (2026-08-10); the earlier chain was 96 -> 112 -> 136 -> 176.
+    // [scale] is the Settings "Arrow size" (issue #344): Large 1.25x, Extra large 1.5x.
+    val size = (202 * scale).toInt()
     val bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
     val canvas = Canvas(bmp)
     // Drawn in the original 176-space and scaled whole, so the disc/arrow/shadow proportions the
@@ -6183,11 +6191,24 @@ private fun navPuckBitmap(): Bitmap {
         },
     )
     // The bright-navy disc - no white ring this time (user call). #1a46e5 = a vivid, deep blue.
+    // The "white disc" style (issue #344) inverts it: white disc, blue chevron, plus a hairline
+    // grey ring so the disc still has an edge over a light map.
+    val blue = android.graphics.Color.parseColor("#1a46e5")
     canvas.drawCircle(
         cx, cy, r,
-        Paint(Paint.ANTI_ALIAS_FLAG).apply { color = android.graphics.Color.parseColor("#1a46e5") },
+        Paint(Paint.ANTI_ALIAS_FLAG).apply { color = if (whiteDisc) android.graphics.Color.WHITE else blue },
     )
-    // White chevron/arrow, centred, pointing up - scaled up with the bigger disc.
+    if (whiteDisc) {
+        canvas.drawCircle(
+            cx, cy, r - 1f,
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = android.graphics.Color.parseColor("#B9BDC2")
+                style = Paint.Style.STROKE
+                strokeWidth = 2f
+            },
+        )
+    }
+    // Chevron/arrow, centred, pointing up - scaled up with the bigger disc.
     val arrow = Path().apply {
         moveTo(cx, cy - 32f)          // tip
         lineTo(cx + 27f, cy + 26f)    // bottom-right
@@ -6198,7 +6219,7 @@ private fun navPuckBitmap(): Bitmap {
     canvas.drawPath(
         arrow,
         Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = android.graphics.Color.WHITE
+            color = if (whiteDisc) blue else android.graphics.Color.WHITE
             style = Paint.Style.FILL
         },
     )

--- a/app/src/main/java/app/vela/ui/settings/sections/NavigationSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/NavigationSettings.kt
@@ -117,6 +117,42 @@ internal fun NavigationSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
         }
         Hint(stringResource(R.string.settings_road_label_hint))
 
+        // Arrow size + colours (issue #344): bigger targets for ageing eyes, and a white disc so
+        // the puck does not blend into the blue route line.
+        GroupDivider()
+        Text(
+            stringResource(R.string.settings_puck_size),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(start = 20.dp, top = 12.dp, bottom = 4.dp),
+        )
+        listOf(
+            app.vela.ui.PuckStyle.SIZE_NORMAL to stringResource(R.string.settings_puck_size_normal),
+            app.vela.ui.PuckStyle.SIZE_LARGE to stringResource(R.string.settings_puck_size_large),
+            app.vela.ui.PuckStyle.SIZE_XL to stringResource(R.string.settings_puck_size_xl),
+        ).forEach { (id, label) ->
+            SelectableRow(
+                label = label,
+                selected = app.vela.ui.PuckStyle.size.value == id,
+                onClick = { app.vela.ui.PuckStyle.setSize(context, id) },
+            )
+        }
+        GroupDivider()
+        Text(
+            stringResource(R.string.settings_puck_style),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(start = 20.dp, top = 12.dp, bottom = 4.dp),
+        )
+        listOf(
+            app.vela.ui.PuckStyle.STYLE_BLUE to stringResource(R.string.settings_puck_style_blue),
+            app.vela.ui.PuckStyle.STYLE_WHITE to stringResource(R.string.settings_puck_style_white),
+        ).forEach { (id, label) ->
+            SelectableRow(
+                label = label,
+                selected = app.vela.ui.PuckStyle.style.value == id,
+                onClick = { app.vela.ui.PuckStyle.setStyle(context, id) },
+            )
+        }
+
         var trafficLights by remember { mutableStateOf(prefs.getBoolean("nav_traffic_lights", false)) }
         GroupDivider()
         ToggleRow(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -645,4 +645,11 @@
     <string name="place_copy_name">Namen kopieren</string>
     <string name="update_notes_show">Was ist neu</string>
     <string name="update_notes_hide">Neuerungen ausblenden</string>
+    <string name="settings_puck_size">Pfeilgröße</string>
+    <string name="settings_puck_size_normal">Normal</string>
+    <string name="settings_puck_size_large">Groß</string>
+    <string name="settings_puck_size_xl">Extra groß</string>
+    <string name="settings_puck_style">Pfeilfarben</string>
+    <string name="settings_puck_style_blue">Blaue Scheibe, weißer Pfeil</string>
+    <string name="settings_puck_style_white">Weiße Scheibe, blauer Pfeil</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -645,4 +645,11 @@
     <string name="place_copy_name">Copiar nombre</string>
     <string name="update_notes_show">Novedades</string>
     <string name="update_notes_hide">Ocultar novedades</string>
+    <string name="settings_puck_size">Tamaño de la flecha</string>
+    <string name="settings_puck_size_normal">Normal</string>
+    <string name="settings_puck_size_large">Grande</string>
+    <string name="settings_puck_size_xl">Extra grande</string>
+    <string name="settings_puck_style">Colores de la flecha</string>
+    <string name="settings_puck_style_blue">Disco azul, flecha blanca</string>
+    <string name="settings_puck_style_white">Disco blanco, flecha azul</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -645,4 +645,11 @@
     <string name="place_copy_name">Copier le nom</string>
     <string name="update_notes_show">Nouveautés</string>
     <string name="update_notes_hide">Masquer les nouveautés</string>
+    <string name="settings_puck_size">Taille de la flèche</string>
+    <string name="settings_puck_size_normal">Normale</string>
+    <string name="settings_puck_size_large">Grande</string>
+    <string name="settings_puck_size_xl">Très grande</string>
+    <string name="settings_puck_style">Couleurs de la flèche</string>
+    <string name="settings_puck_style_blue">Disque bleu, flèche blanche</string>
+    <string name="settings_puck_style_white">Disque blanc, flèche bleue</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -645,4 +645,11 @@
     <string name="place_copy_name">Copia nome</string>
     <string name="update_notes_show">Novità</string>
     <string name="update_notes_hide">Nascondi novità</string>
+    <string name="settings_puck_size">Dimensione della freccia</string>
+    <string name="settings_puck_size_normal">Normale</string>
+    <string name="settings_puck_size_large">Grande</string>
+    <string name="settings_puck_size_xl">Molto grande</string>
+    <string name="settings_puck_style">Colori della freccia</string>
+    <string name="settings_puck_style_blue">Disco blu, freccia bianca</string>
+    <string name="settings_puck_style_white">Disco bianco, freccia blu</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -646,4 +646,11 @@
     <string name="place_copy_name">העתקת השם</string>
     <string name="update_notes_show">מה חדש</string>
     <string name="update_notes_hide">הסתרת מה חדש</string>
+    <string name="settings_puck_size">גודל החץ</string>
+    <string name="settings_puck_size_normal">רגיל</string>
+    <string name="settings_puck_size_large">גדול</string>
+    <string name="settings_puck_size_xl">גדול במיוחד</string>
+    <string name="settings_puck_style">צבעי החץ</string>
+    <string name="settings_puck_style_blue">עיגול כחול, חץ לבן</string>
+    <string name="settings_puck_style_white">עיגול לבן, חץ כחול</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -665,4 +665,11 @@
     <string name="place_copy_name">名前をコピー</string>
     <string name="update_notes_show">新機能</string>
     <string name="update_notes_hide">新機能を隠す</string>
+    <string name="settings_puck_size">矢印のサイズ</string>
+    <string name="settings_puck_size_normal">標準</string>
+    <string name="settings_puck_size_large">大</string>
+    <string name="settings_puck_size_xl">特大</string>
+    <string name="settings_puck_style">矢印の色</string>
+    <string name="settings_puck_style_blue">青い円に白い矢印</string>
+    <string name="settings_puck_style_white">白い円に青い矢印</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -645,4 +645,11 @@
     <string name="place_copy_name">Naam kopiëren</string>
     <string name="update_notes_show">Wat is nieuw</string>
     <string name="update_notes_hide">Nieuw verbergen</string>
+    <string name="settings_puck_size">Pijlgrootte</string>
+    <string name="settings_puck_size_normal">Normaal</string>
+    <string name="settings_puck_size_large">Groot</string>
+    <string name="settings_puck_size_xl">Extra groot</string>
+    <string name="settings_puck_style">Pijlkleuren</string>
+    <string name="settings_puck_style_blue">Blauwe schijf, witte pijl</string>
+    <string name="settings_puck_style_white">Witte schijf, blauwe pijl</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -653,4 +653,11 @@
     <string name="place_copy_name">Kopiuj nazwę</string>
     <string name="update_notes_show">Co nowego</string>
     <string name="update_notes_hide">Ukryj nowości</string>
+    <string name="settings_puck_size">Rozmiar strzałki</string>
+    <string name="settings_puck_size_normal">Normalny</string>
+    <string name="settings_puck_size_large">Duży</string>
+    <string name="settings_puck_size_xl">Bardzo duży</string>
+    <string name="settings_puck_style">Kolory strzałki</string>
+    <string name="settings_puck_style_blue">Niebieskie kółko, biała strzałka</string>
+    <string name="settings_puck_style_white">Białe kółko, niebieska strzałka</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -645,4 +645,11 @@
     <string name="place_copy_name">Copiar nome</string>
     <string name="update_notes_show">Novidades</string>
     <string name="update_notes_hide">Ocultar novidades</string>
+    <string name="settings_puck_size">Tamanho da seta</string>
+    <string name="settings_puck_size_normal">Normal</string>
+    <string name="settings_puck_size_large">Grande</string>
+    <string name="settings_puck_size_xl">Extra grande</string>
+    <string name="settings_puck_style">Cores da seta</string>
+    <string name="settings_puck_style_blue">Disco azul, seta branca</string>
+    <string name="settings_puck_style_white">Disco branco, seta azul</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -653,4 +653,11 @@
     <string name="place_copy_name">Копировать название</string>
     <string name="update_notes_show">Что нового</string>
     <string name="update_notes_hide">Скрыть список изменений</string>
+    <string name="settings_puck_size">Размер стрелки</string>
+    <string name="settings_puck_size_normal">Обычный</string>
+    <string name="settings_puck_size_large">Большой</string>
+    <string name="settings_puck_size_xl">Очень большой</string>
+    <string name="settings_puck_style">Цвета стрелки</string>
+    <string name="settings_puck_style_blue">Синий круг, белая стрелка</string>
+    <string name="settings_puck_style_white">Белый круг, синяя стрелка</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -645,4 +645,11 @@
     <string name="place_copy_name">Kopiera namn</string>
     <string name="update_notes_show">Nyheter</string>
     <string name="update_notes_hide">Dölj nyheter</string>
+    <string name="settings_puck_size">Pilens storlek</string>
+    <string name="settings_puck_size_normal">Normal</string>
+    <string name="settings_puck_size_large">Stor</string>
+    <string name="settings_puck_size_xl">Extra stor</string>
+    <string name="settings_puck_style">Pilens färger</string>
+    <string name="settings_puck_style_blue">Blå skiva, vit pil</string>
+    <string name="settings_puck_style_white">Vit skiva, blå pil</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -653,4 +653,11 @@
     <string name="place_copy_name">Копіювати назву</string>
     <string name="update_notes_show">Що нового</string>
     <string name="update_notes_hide">Сховати зміни</string>
+    <string name="settings_puck_size">Розмір стрілки</string>
+    <string name="settings_puck_size_normal">Звичайний</string>
+    <string name="settings_puck_size_large">Великий</string>
+    <string name="settings_puck_size_xl">Дуже великий</string>
+    <string name="settings_puck_style">Кольори стрілки</string>
+    <string name="settings_puck_style_blue">Синє коло, біла стрілка</string>
+    <string name="settings_puck_style_white">Біле коло, синя стрілка</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -665,4 +665,11 @@
     <string name="place_copy_name">複製名稱</string>
     <string name="update_notes_show">更新內容</string>
     <string name="update_notes_hide">隱藏更新內容</string>
+    <string name="settings_puck_size">箭頭大小</string>
+    <string name="settings_puck_size_normal">標準</string>
+    <string name="settings_puck_size_large">大</string>
+    <string name="settings_puck_size_xl">特大</string>
+    <string name="settings_puck_style">箭頭配色</string>
+    <string name="settings_puck_style_blue">藍色圓盤，白色箭頭</string>
+    <string name="settings_puck_style_white">白色圓盤，藍色箭頭</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -665,4 +665,11 @@
     <string name="place_copy_name">复制名称</string>
     <string name="update_notes_show">更新内容</string>
     <string name="update_notes_hide">隐藏更新内容</string>
+    <string name="settings_puck_size">箭头大小</string>
+    <string name="settings_puck_size_normal">标准</string>
+    <string name="settings_puck_size_large">大</string>
+    <string name="settings_puck_size_xl">特大</string>
+    <string name="settings_puck_style">箭头配色</string>
+    <string name="settings_puck_style_blue">蓝色圆盘，白色箭头</string>
+    <string name="settings_puck_style_white">白色圆盘，蓝色箭头</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -772,6 +772,13 @@
     <string name="settings_road_label_off">Off</string>
     <string name="settings_road_label_bar">Above the bottom bar</string>
     <string name="settings_road_label_puck">Under the arrow</string>
+    <string name="settings_puck_size">Arrow size</string>
+    <string name="settings_puck_size_normal">Normal</string>
+    <string name="settings_puck_size_large">Large</string>
+    <string name="settings_puck_size_xl">Extra large</string>
+    <string name="settings_puck_style">Arrow colours</string>
+    <string name="settings_puck_style_blue">Blue disc, white arrow</string>
+    <string name="settings_puck_style_white">White disc, blue arrow</string>
     <string name="settings_road_label_hint">Where the name of the road you are on is shown while driving. Above the bar keeps it centred and readable for long names; under the arrow follows the arrow around.</string>
     <string name="settings_prefer_buttons">Prefer buttons over swipes</string>
     <string name="settings_prefer_buttons_hint">Keeps a button for things that also have a swipe, such as the step list on the navigation bar. Always on for phones without a touch screen.</string>


### PR DESCRIPTION
Fixes #344.

Settings > Navigation gains two choices:

- **Arrow size**: Normal, Large (1.25x), Extra large (1.5x).
- **Arrow colours**: the blue disc with a white arrow, or a white disc with a blue arrow (plus a hairline grey ring so it keeps an edge over a light map), for people who found the blue puck blending into the blue route line.

One holder (`PuckStyle`) feeds both the follow-mode Compose overlay and the map symbol, which draw from the same bitmap; the map style key carries the setting so the symbol image is re-registered on a change. Strings in all fifteen languages.

Device-checked on a Pixel 4a on a demo drive at Extra large + white.

Docs: CLAUDE.md, FEATURES.md.