### PR TITLE
Custom order for Your lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2422,6 +2422,11 @@ architecture note.
   harness is a scratch Python port of AlongRouteFilter + the rate rule over the trip's fixes.
   **Read `docs/puck-jitter.md` first: the eight causes, the measurement scripts in `scripts/jitter/`, and
   the order to run them. Do not start from a theory.**
+  **List order (issue #343, 2026-09-12):** `PlaceListStore.move(id, delta)` swaps within the stored
+  JSON array, and that array order IS the display order everywhere (`state.lists` feeds the
+  dialog, the search page's Your lists rows and the map's list pins), so no sort key was added;
+  `create` still prepends. The dialog shows up/down IconButtons per row (hidden with one list,
+  disabled at the ends) rather than drag-to-reorder: D-pad reachable and no gesture library.
   **Puck size/colour setting (issue #344, 2026-09-12):** `ui/NavChrome.PuckStyle` (prefs
   `puck_size` normal/large/xl = 1x/1.25x/1.5x, `puck_style` blue/white). `navPuckBitmap(scale,
   whiteDisc)` draws both the Compose overlay (`remember(PuckStyle.key())`) and the `NAV_PUCK_IMG`

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -249,6 +249,7 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   device; **Share full trace** is still there, and the on-device copy is never modified.
   Sharing several trips at once trims every one of them the same way. `core/replay/TripScrub`,
   15 tests.
+- ✅ **Custom list order (2026-09-12, issue #343).** Your lists can be put in any order: up and down arrows on each row in the Your lists dialog (keypad reachable), and the order sticks everywhere lists appear, on the search page and as pins on the map.
 - ✅ **Arrow size and colours (2026-09-12, issue #344).** Settings > Navigation: the navigation arrow comes in Normal, Large (1.25x) and Extra large (1.5x), and in a white-disc-with-blue-arrow variant for people who found the blue disc blending into the blue route line. One setting drives both the follow-mode arrow and the map symbol.
 - ✅ **Google-style nav puck (2026-07-11).** The navigation arrow is a white chevron inside a
   filled bright-navy circle with a soft drop shadow (no white ring, per user feedback); it rotates

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -2400,6 +2401,7 @@ fun MapScreen(
                     onCreateList = { name -> vm.createList(name) },
                     onUpdateList = vm::updateList,
                     onDeleteList = vm::deleteList,
+                    onMoveList = vm::moveList,
                     onDismiss = { listsSheetOpen = false },
                 )
             }
@@ -4396,6 +4398,7 @@ private fun ListsSheet(
     onCreateList: (String) -> String,
     onUpdateList: (app.vela.core.model.PlaceList) -> Unit,
     onDeleteList: (String) -> Unit,
+    onMoveList: (String, Int) -> Unit = { _, _ -> },
     onDismiss: () -> Unit,
 ) {
     var editing by remember { mutableStateOf<app.vela.core.model.PlaceList?>(null) }
@@ -4431,7 +4434,7 @@ private fun ListsSheet(
                     )
                 }
                 LazyColumn(Modifier.heightIn(max = 420.dp)) {
-                    items(lists, key = { it.id }) { list ->
+                    itemsIndexed(lists, key = { _, l -> l.id }) { index, list ->
                         Row(
                             Modifier
                                 .fillMaxWidth()
@@ -4450,7 +4453,17 @@ private fun ListsSheet(
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                             }
-                            IconButton(onClick = { editing = list }) {
+                            // Custom order (issue #343): nudge up/down, D-pad reachable, no drag
+                            // needed. The store's array order is the display order everywhere.
+                            if (lists.size > 1) {
+                                IconButton(onClick = { onMoveList(list.id, -1) }, enabled = index > 0, modifier = Modifier.size(36.dp).dpadHighlight(CircleShape)) {
+                                    Icon(androidx.compose.material.icons.Icons.Default.KeyboardArrowUp, contentDescription = stringResource(R.string.list_move_up), tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(20.dp))
+                                }
+                                IconButton(onClick = { onMoveList(list.id, 1) }, enabled = index < lists.size - 1, modifier = Modifier.size(36.dp).dpadHighlight(CircleShape)) {
+                                    Icon(androidx.compose.material.icons.Icons.Default.KeyboardArrowDown, contentDescription = stringResource(R.string.list_move_down), tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(20.dp))
+                                }
+                            }
+                            IconButton(onClick = { editing = list }, modifier = Modifier.size(36.dp).dpadHighlight(CircleShape)) {
                                 Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.list_edit), tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(18.dp))
                             }
                         }

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -3205,6 +3205,11 @@ class MapViewModel @Inject constructor(
         _state.update { it.copy(lists = listStore.update(list)) }
     }
 
+    /** Custom list order (issue #343): nudge a list up or down; the store's order is the display order. */
+    fun moveList(listId: String, delta: Int) {
+        _state.update { it.copy(lists = listStore.move(listId, delta)) }
+    }
+
     fun deleteList(listId: String) {
         _state.update {
             it.copy(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -652,4 +652,6 @@
     <string name="settings_puck_style">Pfeilfarben</string>
     <string name="settings_puck_style_blue">Blaue Scheibe, weißer Pfeil</string>
     <string name="settings_puck_style_white">Weiße Scheibe, blauer Pfeil</string>
+    <string name="list_move_up">Liste nach oben</string>
+    <string name="list_move_down">Liste nach unten</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -652,4 +652,6 @@
     <string name="settings_puck_style">Colores de la flecha</string>
     <string name="settings_puck_style_blue">Disco azul, flecha blanca</string>
     <string name="settings_puck_style_white">Disco blanco, flecha azul</string>
+    <string name="list_move_up">Subir la lista</string>
+    <string name="list_move_down">Bajar la lista</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -652,4 +652,6 @@
     <string name="settings_puck_style">Couleurs de la flèche</string>
     <string name="settings_puck_style_blue">Disque bleu, flèche blanche</string>
     <string name="settings_puck_style_white">Disque blanc, flèche bleue</string>
+    <string name="list_move_up">Monter la liste</string>
+    <string name="list_move_down">Descendre la liste</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -652,4 +652,6 @@
     <string name="settings_puck_style">Colori della freccia</string>
     <string name="settings_puck_style_blue">Disco blu, freccia bianca</string>
     <string name="settings_puck_style_white">Disco bianco, freccia blu</string>
+    <string name="list_move_up">Sposta la lista in alto</string>
+    <string name="list_move_down">Sposta la lista in basso</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -653,4 +653,6 @@
     <string name="settings_puck_style">צבעי החץ</string>
     <string name="settings_puck_style_blue">עיגול כחול, חץ לבן</string>
     <string name="settings_puck_style_white">עיגול לבן, חץ כחול</string>
+    <string name="list_move_up">העברת הרשימה למעלה</string>
+    <string name="list_move_down">העברת הרשימה למטה</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -672,4 +672,6 @@
     <string name="settings_puck_style">矢印の色</string>
     <string name="settings_puck_style_blue">青い円に白い矢印</string>
     <string name="settings_puck_style_white">白い円に青い矢印</string>
+    <string name="list_move_up">リストを上へ</string>
+    <string name="list_move_down">リストを下へ</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -652,4 +652,6 @@
     <string name="settings_puck_style">Pijlkleuren</string>
     <string name="settings_puck_style_blue">Blauwe schijf, witte pijl</string>
     <string name="settings_puck_style_white">Witte schijf, blauwe pijl</string>
+    <string name="list_move_up">Lijst omhoog</string>
+    <string name="list_move_down">Lijst omlaag</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -660,4 +660,6 @@
     <string name="settings_puck_style">Kolory strzałki</string>
     <string name="settings_puck_style_blue">Niebieskie kółko, biała strzałka</string>
     <string name="settings_puck_style_white">Białe kółko, niebieska strzałka</string>
+    <string name="list_move_up">Przenieś listę wyżej</string>
+    <string name="list_move_down">Przenieś listę niżej</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -652,4 +652,6 @@
     <string name="settings_puck_style">Cores da seta</string>
     <string name="settings_puck_style_blue">Disco azul, seta branca</string>
     <string name="settings_puck_style_white">Disco branco, seta azul</string>
+    <string name="list_move_up">Mover lista para cima</string>
+    <string name="list_move_down">Mover lista para baixo</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -660,4 +660,6 @@
     <string name="settings_puck_style">Цвета стрелки</string>
     <string name="settings_puck_style_blue">Синий круг, белая стрелка</string>
     <string name="settings_puck_style_white">Белый круг, синяя стрелка</string>
+    <string name="list_move_up">Поднять список</string>
+    <string name="list_move_down">Опустить список</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -652,4 +652,6 @@
     <string name="settings_puck_style">Pilens färger</string>
     <string name="settings_puck_style_blue">Blå skiva, vit pil</string>
     <string name="settings_puck_style_white">Vit skiva, blå pil</string>
+    <string name="list_move_up">Flytta listan upp</string>
+    <string name="list_move_down">Flytta listan ner</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -660,4 +660,6 @@
     <string name="settings_puck_style">Кольори стрілки</string>
     <string name="settings_puck_style_blue">Синє коло, біла стрілка</string>
     <string name="settings_puck_style_white">Біле коло, синя стрілка</string>
+    <string name="list_move_up">Підняти список</string>
+    <string name="list_move_down">Опустити список</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -672,4 +672,6 @@
     <string name="settings_puck_style">箭頭配色</string>
     <string name="settings_puck_style_blue">藍色圓盤，白色箭頭</string>
     <string name="settings_puck_style_white">白色圓盤，藍色箭頭</string>
+    <string name="list_move_up">上移清單</string>
+    <string name="list_move_down">下移清單</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -672,4 +672,6 @@
     <string name="settings_puck_style">箭头配色</string>
     <string name="settings_puck_style_blue">蓝色圆盘，白色箭头</string>
     <string name="settings_puck_style_white">白色圆盘，蓝色箭头</string>
+    <string name="list_move_up">上移列表</string>
+    <string name="list_move_down">下移列表</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -647,6 +647,8 @@
     <string name="mapscreen_section_lists">Your lists</string>
     <string name="mapscreen_new_list">New</string>
     <string name="list_edit">Edit list</string>
+    <string name="list_move_up">Move list up</string>
+    <string name="list_move_down">Move list down</string>
     <string name="list_new_title">New list</string>
     <string name="list_edit_title">Edit list</string>
     <string name="list_name_label">List name</string>

--- a/core/src/main/java/app/vela/core/data/PlaceListStore.kt
+++ b/core/src/main/java/app/vela/core/data/PlaceListStore.kt
@@ -38,6 +38,20 @@ class PlaceListStore @Inject constructor(
 
     fun delete(listId: String): List<PlaceList> = write(lists().filterNot { it.id == listId })
 
+    /** Moves [listId] by [delta] positions (negative = up). The stored array order IS the
+     *  display order everywhere (Your lists dialog, the search page, the map pins), so a
+     *  custom order is just a persisted swap (issue #343). No-op at the ends. */
+    fun move(listId: String, delta: Int): List<PlaceList> {
+        val cur = lists().toMutableList()
+        val i = cur.indexOfFirst { it.id == listId }
+        if (i < 0) return cur
+        val j = (i + delta).coerceIn(0, cur.size - 1)
+        if (j == i) return cur
+        val item = cur.removeAt(i)
+        cur.add(j, item)
+        return write(cur)
+    }
+
     /** Adds [place] to [listId] (idempotent via [ListPlace.matches] — the same chain store
      *  re-resolved under a fresh volatile id must not become a duplicate entry). */
     fun addPlace(listId: String, place: ListPlace): List<PlaceList> = write(


### PR DESCRIPTION
Closes the ordering half of #343 (the bookmark-button half shipped in #361).

Each row in the Your lists dialog gets up and down arrows: hidden when there is only one list, disabled at the ends, reachable on a keypad. The store's array order is the display order everywhere (the dialog, the search page's Your lists rows, the list pins on the map), so `PlaceListStore.move` just swaps within the stored array and no sort key was added. Strings in all fifteen languages.

Device-checked on a Pixel 4a: a second list moved below the first and the order stuck.

Docs: CLAUDE.md, FEATURES.md.