### PR TITLE
Diagnostics events for the reviews fetch and the location providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2427,6 +2427,13 @@ architecture note.
   dialog, the search page's Your lists rows and the map's list pins), so no sort key was added;
   `create` still prepends. The dialog shows up/down IconButtons per row (hidden with one list,
   disabled at the ends) rather than drag-to-reorder: D-pad reachable and no gesture library.
+  **Diagnostics events for reviews + location (2026-09-12):** `WebReviewsFetcher` records
+  `reviews` events (the hl it asked for and the app language, each page Google served with its
+  `document.documentElement.lang` and `navigator.language`, and the parsed count or the 45 s
+  timeout) and `LocationProvider` records `location` events (which providers exist/are on, then
+  the FIRST fix's provider, latency and accuracy; never coordinates). Both landed because #359
+  (English reviews on a zh-TW phone) and #362 (a flip phone that "never" gets a fix) could not
+  be reproduced here; ask those reporters for a Settings > Diagnostics export.
   **Puck size/colour setting (issue #344, 2026-09-12):** `ui/NavChrome.PuckStyle` (prefs
   `puck_size` normal/large/xl = 1x/1.25x/1.5x, `puck_style` blue/white). `navPuckBitmap(scale,
   whiteDisc)` draws both the Compose overlay (`remember(PuckStyle.key())`) and the `NAV_PUCK_IMG`

--- a/app/src/main/java/app/vela/web/WebReviewsFetcher.kt
+++ b/app/src/main/java/app/vela/web/WebReviewsFetcher.kt
@@ -42,6 +42,7 @@ import javax.inject.Singleton
 @Singleton
 class WebReviewsFetcher @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val diag: app.vela.core.diag.DiagLog,
 ) {
     private val pending = ConcurrentHashMap<String, CompletableDeferred<String>>()
     private val progress = ConcurrentHashMap<String, (Int) -> Unit>()
@@ -154,6 +155,12 @@ class WebReviewsFetcher @Inject constructor(
                                 return !(host == "google.com" || host.endsWith(".google.com"))
                             }
                             override fun onPageFinished(view: WebView?, url: String?) {
+                                // Diagnostics: which page Google actually served, and in what
+                                // language (issue #359: a reader whose reviews stay English while
+                                // the app asks for zh-TW; the export says which side to blame).
+                                view?.evaluateJavascript(
+                                    "location.host+location.pathname.slice(0,40)+' lang='+document.documentElement.lang+' nav='+navigator.language",
+                                ) { v -> diag.record("reviews", "page loaded", v?.trim('"')) }
                                 main.postDelayed({ if (!ready.isCompleted) ready.complete(Unit) }, SETTLE_MS)
                             }
                         }
@@ -161,7 +168,9 @@ class WebReviewsFetcher @Inject constructor(
                         // let the MAX_LOAD fallback inject the scraper into the old page and return the
                         // previous place's reviews for THIS featureId (empty > wrong).
                         wv.evaluateJavascript("try{document.documentElement.innerHTML=''}catch(e){}", null)
-                        wv.loadUrl("https://www.google.com/maps?cid=$cid&hl=${reviewsHl()}&gl=us")
+                        val hl = reviewsHl()
+                        diag.record("reviews", "load hl=$hl app=${app.vela.ui.AppLocale.language.value.ifBlank { "system" }}", "cid=$cid")
+                        wv.loadUrl("https://www.google.com/maps?cid=$cid&hl=$hl&gl=us")
                         // Proceed even if the SPA's onPageFinished is slow.
                         main.postDelayed({ if (!ready.isCompleted) ready.complete(Unit) }, MAX_LOAD_MS)
                         ready.await()
@@ -174,7 +183,13 @@ class WebReviewsFetcher @Inject constructor(
                 progress.remove(id)
                 partial.remove(id)
             }
-            if (raw.isNullOrEmpty()) emptyList() else runCatching { ReviewsWebParser.parse(raw) }.getOrDefault(emptyList())
+            val parsed = if (raw.isNullOrEmpty()) emptyList() else runCatching { ReviewsWebParser.parse(raw) }.getOrDefault(emptyList())
+            diag.record(
+                "reviews",
+                if (raw == null) "timed out after ${TOTAL_TIMEOUT_MS / 1000} s with nothing" else "${parsed.size} review(s) parsed",
+                parsed.firstOrNull()?.text?.take(60)?.let { "first text: $it" },
+            )
+            parsed
         }
     }
 

--- a/core/src/main/java/app/vela/core/location/LocationProvider.kt
+++ b/core/src/main/java/app/vela/core/location/LocationProvider.kt
@@ -39,6 +39,7 @@ data class ReplayFix(val lat: Double, val lng: Double, val t: Long, val bearing:
 @Singleton
 class LocationProvider @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val diag: app.vela.core.diag.DiagLog,
 ) {
     private val prefs: SharedPreferences =
         context.getSharedPreferences("vela_location", Context.MODE_PRIVATE)
@@ -85,8 +86,21 @@ class LocationProvider @Inject constructor(
             // onProviderDisabled as soon as a registered provider is off (degoogled devices
             // often have the NETWORK provider present but disabled), so the lambda died with
             // AbstractMethodError on every launch (user report, Android 10).
+            // Diagnostics (issue #362, a phone that "never" gets a fix): which providers exist
+            // and are on, then how long the FIRST fix took and from which provider. No
+            // coordinates are recorded.
+            val startedAt = android.os.SystemClock.elapsedRealtime()
+            var firstLogged = false
             val listener = object : LocationListener {
                 override fun onLocationChanged(loc: Location) {
+                    if (!firstLogged) {
+                        firstLogged = true
+                        diag.record(
+                            "location",
+                            "first fix from ${loc.provider} after ${(android.os.SystemClock.elapsedRealtime() - startedAt) / 1000} s",
+                            "accuracy=${if (loc.hasAccuracy()) loc.accuracy.toInt().toString() + " m" else "none"} speed=${loc.hasSpeed()}",
+                        )
+                    }
                     cache(loc)
                     trySend(loc)
                 }
@@ -99,6 +113,14 @@ class LocationProvider @Inject constructor(
                 override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) {}
             }
             val active = PROVIDERS.filter { mgr.allProviders.contains(it) }
+            diag.record(
+                "location",
+                "providers: " + PROVIDERS.joinToString(" ") { p ->
+                    if (!mgr.allProviders.contains(p)) "$p=absent"
+                    else "$p=" + (if (runCatching { mgr.isProviderEnabled(p) }.getOrDefault(false)) "on" else "off")
+                },
+                "all: ${mgr.allProviders.joinToString(",")}",
+            )
             active.forEach { p ->
                 runCatching {
                     mgr.requestLocationUpdates(p, minIntervalMs, minDistanceM, listener, Looper.getMainLooper())


### PR DESCRIPTION
Two reports could not be reproduced here and both need one fact from the phone: #359 (reviews stay English on a phone whose app language is zh-TW, on 0.4.1130) and #362 (a keypad phone that seems never to get a fix, or only after 15 to 30 s).

- `WebReviewsFetcher` records what it asked for (the `hl` and the app language), what Google served (host, path, `document.documentElement.lang`, `navigator.language` for each page load) and what came back (parsed count, or the 45 s timeout).
- `LocationProvider` records which providers exist and are enabled when updates start, then the first fix's provider, latency and accuracy.

No coordinates are recorded. Both appear in the Settings > Diagnostics export when Diagnostics is on. Core tests green.

Docs: CLAUDE.md.