### PR TITLE
Let the arrow leave the route sooner on foot and by bike

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2442,6 +2442,12 @@ architecture note.
   dialog, the search page's Your lists rows and the map's list pins), so no sort key was added;
   `create` still prepends. The dialog shows up/down IconButtons per row (hidden with one list,
   disabled at the ends) rather than drag-to-reorder: D-pad reachable and no gesture library.
+  **Puck snap tolerance is MODE-AWARE (2026-09-12, `puckSnapTolerance`):** driving keeps 22 m +
+  speed (lane offset + fix lag); walking/cycling use 8 m + 1.2x the fix accuracy, capped at 16 m,
+  so a shortcut over a crosswalk frees the arrow within a fix or two instead of dragging it along
+  the route (it used to be 22 m for everyone). The heading gate is not consulted below 2.5 m/s
+  off-road (GPS bearing is noise at walking pace), so a pedestrian's release is distance-driven.
+  The engine's reroute corridor was already mode-aware (`offRouteCorridor`).
   **Diagnostics events for reviews + location (2026-09-12):** `WebReviewsFetcher` records
   `reviews` events (the hl it asked for and the app language, each page Google served with its
   `document.documentElement.lang` and `navigator.language`, and the parsed count or the 45 s

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -249,6 +249,7 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   device; **Share full trace** is still there, and the on-device copy is never modified.
   Sharing several trips at once trims every one of them the same way. `core/replay/TripScrub`,
   15 tests.
+- ✅ **On foot or by bike the arrow lets go of the route sooner (2026-09-12).** The arrow used to stay glued to the planned line until you were 22 m off it, the car setting. Walking and cycling now use 8 m plus a share of the GPS accuracy, so cutting a corner across a crosswalk shows you where you are within a fix or two.
 - ✅ **Custom list order (2026-09-12, issue #343).** Your lists can be put in any order: up and down arrows on each row in the Your lists dialog (keypad reachable), and the order sticks everywhere lists appear, on the search page and as pins on the map.
 - ✅ **Arrow size and colours (2026-09-12, issue #344).** Settings > Navigation: the navigation arrow comes in Normal, Large (1.25x) and Extra large (1.5x), and in a white-disc-with-blue-arrow variant for people who found the blue disc blending into the blue route line. One setting drives both the follow-mode arrow and the map symbol.
 - ✅ **Google-style nav puck (2026-07-11).** The navigation arrow is a white chevron inside a

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -2683,11 +2683,18 @@ fun VelaMapView(
                 // window exactly when the resume fix needs it big, costing a disengage cycle.
                 val aheadSpeed = maxOf(navPuck.speed, navPuck.speedAtAccept)
                 val ahead = (aheadSpeed * 8.0).coerceIn(150.0, 600.0)
+                // Mode-aware tolerance (user 2026-09-12: "gets me unstuck slower than Google on
+                // foot"). A car sits a lane off the centreline at speed, so it keeps 22 m plus
+                // speed; a walker or cyclist is where the fix says, within its accuracy, so 8 m
+                // plus a share of the reported accuracy, capped at 16 m: cutting a corner over a
+                // crosswalk frees the arrow within a fix or two instead of dragging it along the
+                // route. The heading gate needs a real course: GPS bearing is noise at walking
+                // pace, so below 2.5 m/s off-road it is not consulted.
                 snapToRouteWindowed(
                     myLocation,
-                    if (navPuck.kalman.speed < 1.0) null else myBearing,
+                    if (navPuck.kalman.speed < (if (navDriveMode) 1.0 else 2.5)) null else myBearing,
                     routePolyline, routeCum, navPuck.targetM - 25.0, navPuck.targetM + ahead,
-                    maxM = 22.0 + aheadSpeed.coerceIn(0.0, 13.0),
+                    maxM = puckSnapTolerance(navDriveMode, aheadSpeed, myAccuracyM),
                 )
             } else {
                 // Not yet engaged (nav start, or the ticker just re-keyed on a reroute): one
@@ -2830,11 +2837,11 @@ fun VelaMapView(
             // drop to the raw fix on the 2nd such miss; a distance miss keeps the 3-miss
             // tolerance a canopy spike needs.
             val missSpeed = maxOf(navPuck.speed, navPuck.speedAtAccept)
-            val headingMiss = myLocation != null && myBearing != null && navPuck.kalman.speed >= 2.0 &&
+            val headingMiss = myLocation != null && myBearing != null && navPuck.kalman.speed >= (if (navDriveMode) 2.0 else 2.5) &&
                 snapToRouteWindowed(
                     myLocation, null, routePolyline, routeCum,
                     navPuck.targetM - 25.0, navPuck.targetM + (missSpeed * 8.0).coerceIn(150.0, 600.0),
-                    maxM = 22.0 + missSpeed.coerceIn(0.0, 13.0),
+                    maxM = puckSnapTolerance(navDriveMode, missSpeed, myAccuracyM),
                 ) != null
             if (headingMiss) {
                 navPuck.headingMisses += 1
@@ -5369,6 +5376,14 @@ private fun snapToRouteWindowed(
     if (gpsBearing != null && angleDelta(gpsBearing, routeBearing) > 55f) return null
     return Triple(pt, routeBearing, bestM)
 }
+
+/** How far off the route line a fix may sit and still be drawn ON it. Driving: 22 m plus up
+ *  to 13 m with speed (a lane offset plus fix lag on a wide road). On foot or by bike: 8 m plus
+ *  1.2x the fix's own accuracy, capped at 16 m, so a deliberate shortcut frees the arrow within
+ *  a fix or two (user 2026-09-12). */
+private fun puckSnapTolerance(drive: Boolean, speedMps: Double, accuracyM: Float?): Double =
+    if (drive) 22.0 + speedMps.coerceIn(0.0, 13.0)
+    else (8.0 + 1.2 * (accuracyM?.toDouble() ?: 8.0)).coerceIn(8.0, 16.0)
 
 /** Smallest absolute difference between two compass bearings (deg), 0..180. */
 private fun angleDelta(a: Float, b: Float): Float = kotlin.math.abs((a - b + 540f) % 360f - 180f)


### PR DESCRIPTION
The puck's snap tolerance was 22 m plus speed for every travel mode, which is the car setting (a lane offset plus fix lag on a wide road). On foot, a shortcut across a crosswalk stayed glued to the planned line for that whole distance.

Walking and cycling now use 8 m plus 1.2x the fix's own accuracy, capped at 16 m (`puckSnapTolerance`), and the heading gate is not consulted below 2.5 m/s off-road, since GPS bearing is noise at walking pace. The arrow frees within a fix or two of a deliberate shortcut. Driving is unchanged; the engine's reroute corridor was already mode-aware.

Not device-testable on a demo drive (the demo follows the route by definition); needs a real walk.

Docs: CLAUDE.md, FEATURES.md.