### PR TITLE
Say in the route picker when a route was computed offline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2442,6 +2442,10 @@ architecture note.
   dialog, the search page's Your lists rows and the map's list pins), so no sort key was added;
   `create` still prepends. The dialog shows up/down IconButtons per row (hidden with one list,
   disabled at the ends) rather than drag-to-reorder: D-pad reachable and no gesture library.
+  **`Route.offline` (2026-09-12, issue #350):** every route that came from `routeEngine.route`
+  (the two single-leg sites and `chainOnDevice`) is tagged in GoogleMapsDataSource, and the picker
+  row prints `place_route_offline` in the traffic slot. Downloaded regions are the FALLBACK, not a
+  replacement: online, OSRM + Google traffic still answer even with the whole state installed.
   **Puck snap tolerance is MODE-AWARE (2026-09-12, `puckSnapTolerance`):** driving keeps 22 m +
   speed (lane offset + fix lag); walking/cycling use 8 m + 1.2x the fix accuracy, capped at 16 m,
   so a shortcut over a crosswalk frees the arrow within a fix or two instead of dragging it along

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -249,6 +249,7 @@ Status legend: ✅ done · 🟡 partial / in progress · ⬜ planned
   device; **Share full trace** is still there, and the on-device copy is never modified.
   Sharing several trips at once trims every one of them the same way. `core/replay/TripScrub`,
   15 tests.
+- ✅ **The route picker says when a route was computed offline (2026-09-12, issue #350).** A route from a downloaded region shows "offline route, no live traffic" where an online route shows its traffic word, so you always know which kind you are looking at. Downloaded regions remain the fallback: with signal, routes still come with Google's live traffic.
 - ✅ **On foot or by bike the arrow lets go of the route sooner (2026-09-12).** The arrow used to stay glued to the planned line until you were 22 m off it, the car setting. Walking and cycling now use 8 m plus a share of the GPS accuracy, so cutting a corner across a crosswalk shows you where you are within a fix or two.
 - ✅ **Custom list order (2026-09-12, issue #343).** Your lists can be put in any order: up and down arrows on each row in the Your lists dialog (keypad reachable), and the order sticks everywhere lists appear, on the search page and as pins on the map.
 - ✅ **Arrow size and colours (2026-09-12, issue #344).** Settings > Navigation: the navigation arrow comes in Normal, Large (1.25x) and Extra large (1.5x), and in a white-disc-with-blue-arrow variant for people who found the blue disc blending into the blue route line. One setting drives both the follow-mode arrow and the map symbol.

--- a/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
+++ b/app/src/main/java/app/vela/ui/place/PlaceSheet.kt
@@ -1939,7 +1939,9 @@ private fun RouteOption(r: Route, selected: Boolean, fastestEtaSeconds: Double, 
             // The traffic word GRADES with the same thresholds that colour the ETA (trafficEtaColor),
             // so "heavy traffic" in words backs up the red time - colour alone isn't readable for
             // everyone. A live route whose typical time is unknown keeps the plain "live traffic".
-            val trafficWord = if (!r.hasLiveTraffic) null else when {
+            // An on-device route says so in the traffic slot (issue #350): the user asked to know
+            // which kind of route they are looking at, and "no traffic word" alone did not say.
+            val trafficWord = if (r.offline) stringResource(R.string.place_route_offline) else if (!r.hasLiveTraffic) null else when {
                 r.trafficRatio == null -> stringResource(R.string.place_live_traffic)
                 r.trafficRatio!! > 1.4 -> stringResource(R.string.place_traffic_heavy)
                 r.trafficRatio!! > 1.15 -> stringResource(R.string.place_traffic_moderate)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -654,4 +654,5 @@
     <string name="settings_puck_style_white">Weiße Scheibe, blauer Pfeil</string>
     <string name="list_move_up">Liste nach oben</string>
     <string name="list_move_down">Liste nach unten</string>
+    <string name="place_route_offline">Offline-Route, kein Live-Verkehr</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -654,4 +654,5 @@
     <string name="settings_puck_style_white">Disco blanco, flecha azul</string>
     <string name="list_move_up">Subir la lista</string>
     <string name="list_move_down">Bajar la lista</string>
+    <string name="place_route_offline">ruta sin conexión, sin tráfico en vivo</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -654,4 +654,5 @@
     <string name="settings_puck_style_white">Disque blanc, flèche bleue</string>
     <string name="list_move_up">Monter la liste</string>
     <string name="list_move_down">Descendre la liste</string>
+    <string name="place_route_offline">itinéraire hors ligne, sans trafic en direct</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -654,4 +654,5 @@
     <string name="settings_puck_style_white">Disco bianco, freccia blu</string>
     <string name="list_move_up">Sposta la lista in alto</string>
     <string name="list_move_down">Sposta la lista in basso</string>
+    <string name="place_route_offline">percorso offline, senza traffico in tempo reale</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -655,4 +655,5 @@
     <string name="settings_puck_style_white">עיגול לבן, חץ כחול</string>
     <string name="list_move_up">העברת הרשימה למעלה</string>
     <string name="list_move_down">העברת הרשימה למטה</string>
+    <string name="place_route_offline">מסלול לא מקוון, ללא תנועה בזמן אמת</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -674,4 +674,5 @@
     <string name="settings_puck_style_white">白い円に青い矢印</string>
     <string name="list_move_up">リストを上へ</string>
     <string name="list_move_down">リストを下へ</string>
+    <string name="place_route_offline">オフライン経路、リアルタイム交通情報なし</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -654,4 +654,5 @@
     <string name="settings_puck_style_white">Witte schijf, blauwe pijl</string>
     <string name="list_move_up">Lijst omhoog</string>
     <string name="list_move_down">Lijst omlaag</string>
+    <string name="place_route_offline">offline route, geen live verkeer</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -662,4 +662,5 @@
     <string name="settings_puck_style_white">Białe kółko, niebieska strzałka</string>
     <string name="list_move_up">Przenieś listę wyżej</string>
     <string name="list_move_down">Przenieś listę niżej</string>
+    <string name="place_route_offline">trasa offline, bez ruchu na żywo</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -654,4 +654,5 @@
     <string name="settings_puck_style_white">Disco branco, seta azul</string>
     <string name="list_move_up">Mover lista para cima</string>
     <string name="list_move_down">Mover lista para baixo</string>
+    <string name="place_route_offline">rota offline, sem trânsito em tempo real</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -662,4 +662,5 @@
     <string name="settings_puck_style_white">Белый круг, синяя стрелка</string>
     <string name="list_move_up">Поднять список</string>
     <string name="list_move_down">Опустить список</string>
+    <string name="place_route_offline">офлайн-маршрут, без пробок</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -654,4 +654,5 @@
     <string name="settings_puck_style_white">Vit skiva, blå pil</string>
     <string name="list_move_up">Flytta listan upp</string>
     <string name="list_move_down">Flytta listan ner</string>
+    <string name="place_route_offline">offline-rutt, ingen livetrafik</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -662,4 +662,5 @@
     <string name="settings_puck_style_white">Біле коло, синя стрілка</string>
     <string name="list_move_up">Підняти список</string>
     <string name="list_move_down">Опустити список</string>
+    <string name="place_route_offline">офлайн-маршрут, без заторів</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -674,4 +674,5 @@
     <string name="settings_puck_style_white">白色圓盤，藍色箭頭</string>
     <string name="list_move_up">上移清單</string>
     <string name="list_move_down">下移清單</string>
+    <string name="place_route_offline">離線路線，無即時路況</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -674,4 +674,5 @@
     <string name="settings_puck_style_white">白色圆盘，蓝色箭头</string>
     <string name="list_move_up">上移列表</string>
     <string name="list_move_down">下移列表</string>
+    <string name="place_route_offline">离线路线，无实时路况</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -327,6 +327,7 @@
     <string name="place_delta_min">+%1$d min</string> <!-- format -->
     <string name="place_via">via %1$s</string> <!-- format -->
     <string name="place_live_traffic">live traffic</string>
+    <string name="place_route_offline">offline route, no live traffic</string>
     <string name="place_traffic_light">light traffic</string>
     <string name="place_traffic_moderate">moderate traffic</string>
     <string name="place_traffic_heavy">heavy traffic</string>

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -527,7 +527,7 @@ class GoogleMapsDataSource @Inject constructor(
                 // defeat the timeout entirely. Past the deadline the online chain answers (tagged
                 // not-honored below) and the orphaned compute finishes and is discarded.
                 val avoidD = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).async {
-                    runCatching { routeEngine.route(origin, destination, mode, avoidTolls, avoidHighways) }.getOrDefault(emptyList())
+                    runCatching { routeEngine.route(origin, destination, mode, avoidTolls, avoidHighways).map { it.copy(offline = true) } }.getOrDefault(emptyList())
                 }
                 val avoidRoutes = kotlinx.coroutines.withTimeoutOrNull(AVOID_ONDEVICE_TIMEOUT_MS) { avoidD.await() } ?: emptyList()
                 if (avoidRoutes.isNotEmpty()) {
@@ -566,7 +566,7 @@ class GoogleMapsDataSource @Inject constructor(
             // connectivity, or the FOSSGIS server is down — route fully ON-DEVICE from a downloaded
             // GraphHopper graph, if one covers this area. No traffic offline, but complete named turns.
             val onDevice = if (open.isEmpty() && trafficRoute == null && routeEngine.isReady(mode))
-                routeEngine.route(origin, destination, mode, avoidTolls, avoidHighways) else emptyList()
+                routeEngine.route(origin, destination, mode, avoidTolls, avoidHighways).map { it.copy(offline = true) } else emptyList()
             // Lead with Google's jam-avoiding path (option 3) only when it EARNS it: its live in-traffic
             // ETA is within a small margin of OSRM's FREE-FLOW best, so even Google's detour is time-
             // competitive → the jam is real. The old code led with the snap on ANY >700 m divergence, so a
@@ -734,7 +734,7 @@ class GoogleMapsDataSource @Inject constructor(
      *  (cross-region or off-graph), so the caller can fall through. */
     private fun chainOnDevice(points: List<LatLng>, mode: TravelMode, avoidTolls: Boolean = false, avoidHighways: Boolean = false): Route? {
         val legs = points.zipWithNext().map { (a, b) ->
-            runCatching { routeEngine.route(a, b, mode, avoidTolls, avoidHighways).firstOrNull() }.getOrNull() ?: return null
+            runCatching { routeEngine.route(a, b, mode, avoidTolls, avoidHighways).firstOrNull()?.copy(offline = true) }.getOrNull() ?: return null
         }
         val polyline = legs.flatMapIndexed { i, leg -> if (i == 0) leg.polyline else leg.polyline.drop(1) }
         // Boundary DEPART/ARRIVE steps are dropped, but their step distance is FOLDED into the
@@ -763,6 +763,7 @@ class GoogleMapsDataSource @Inject constructor(
             durationSeconds = dur,
             durationInTrafficSeconds = null, // offline — no live traffic
             summary = legs.firstOrNull()?.summary,
+            offline = true,
         )
     }
 

--- a/core/src/main/java/app/vela/core/model/Route.kt
+++ b/core/src/main/java/app/vela/core/model/Route.kt
@@ -152,6 +152,10 @@ data class Route(
     // toggled-on avoid is never silently ignored (the Reddit "still routed me through the
     // motorway" report).
     val avoidNotHonored: Boolean = false,
+    // Computed ON THE PHONE from a downloaded region (no network, or an avoid toggle Google could
+    // not honour). The picker says so instead of a traffic word: an offline route has no live
+    // traffic and the user should know which kind they are looking at (issue #350).
+    val offline: Boolean = false,
 ) {
     val hasLiveTraffic: Boolean get() = durationInTrafficSeconds != null
     val maneuvers: List<Maneuver> get() = legs.flatMap { it.maneuvers }


### PR DESCRIPTION
Issue #350: nothing told the user which kind of route they were looking at.

Every route from the on-device engine (the two single-leg sites and the multi-stop chain in `GoogleMapsDataSource`) now carries `Route.offline`, and the picker row prints "offline route, no live traffic" in the slot where an online route shows its traffic word. Downloaded regions stay the fallback: with signal, OSRM and Google's traffic still answer even with the whole state installed. Strings in all fifteen languages. Core tests green.

Docs: CLAUDE.md, FEATURES.md.