### PR TITLE
Derive the units default from the device locale, not the in-app language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2442,6 +2442,11 @@ architecture note.
   dialog, the search page's Your lists rows and the map's list pins), so no sort key was added;
   `create` still prepends. The dialog shows up/down IconButtons per row (hidden with one list,
   disabled at the ends) rather than drag-to-reorder: D-pad reachable and no gesture library.
+  **Units default reads the DEVICE locale (2026-09-12):** `Units.init` used `Locale.getDefault()`,
+  but `AppLocale.wrap` (attachBaseContext) has already replaced the JVM default with the in-app
+  language, and the plain "English" choice carries no country, so a US phone flipped to km the
+  moment the language picker was touched. It now reads `Resources.getSystem()`'s locale. Any
+  other "default from locale" decision must do the same (see `AppLocale.deviceDefaultSupported`).
   **`Route.offline` (2026-09-12, issue #350):** every route that came from `routeEngine.route`
   (the two single-leg sites and `chainOnDevice`) is tagged in GoogleMapsDataSource, and the picker
   row prints `place_route_offline` in the traffic slot. Downloaded regions are the FALLBACK, not a

--- a/app/src/main/java/app/vela/ui/Format.kt
+++ b/app/src/main/java/app/vela/ui/Format.kt
@@ -14,7 +14,13 @@ object Units {
     val imperial = mutableStateOf(false)
 
     fun init(context: Context) {
-        val default = Locale.getDefault().country in setOf("US", "GB", "LR", "MM")
+        // The DEVICE's locale, not the JVM default: AppLocale.wrap runs before this (in
+        // attachBaseContext) and sets the JVM default to the in-app language, which for the
+        // plain "English" choice has no country, so a US phone silently flipped to kilometres
+        // the moment its owner touched the language picker (seen on the P4a, 2026-09-12).
+        val country = android.content.res.Resources.getSystem().configuration.locales.get(0)?.country
+            ?: Locale.getDefault().country
+        val default = country in setOf("US", "GB", "LR", "MM")
         imperial.value = prefs(context).getBoolean(KEY, default)
     }
 


### PR DESCRIPTION
Found while comparing screens: the Pixel 4a showed kilometres after a round trip through the language picker. AppLocale.wrap runs in attachBaseContext, before Units.init, and sets the JVM default locale to the in-app language; the plain "English" choice has no country, so the imperial default vanished. Units.init now reads the device's system locale (Resources.getSystem()) for its default. An explicit units choice in Settings was and is unaffected. Docs: CLAUDE.md.