### PR TITLE
Fix six things the September review found in recent features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -858,7 +858,9 @@ Defaults that make the safe path the easy one:
   route into a sliver). NB the endpoints card was the subtle one - full width, its left half sat
   UNDER the chooser panel and the visible remainder read as an empty dark slab over the map.
   When adding ANY new route/nav chrome, give it the same landscape treatment or it will span the
-  screen.
+  screen. The nav follow ticker writes the WHOLE camera padding every frame, so `cameraLeftInsetPx`
+  goes into that `.padding(left, top, 0, 0)` too (review 2026-09-12): the inset effect's
+  setPadding alone was undone on the first frame and the puck sat on the column's seam.
   **LANDSCAPE (width > height) collapses the browse chrome to ONE line (2026-07-15, Google's
   landscape layout, device-verified on the 4a):** `landscapeChrome` in MapScreen puts the search
   bar at half width with the category chips scrolling beside it (`landscapeOneLine` Row), the
@@ -1189,7 +1191,9 @@ Defaults that make the safe path the easy one:
   failed raster tile. The deep layer CROSS-FADES in (rasterOpacity 0 at z18.6 -> 1 at z19.6):
   Esri's z20+ metro tiles are a different capture program than the z17-19 mosaic, so the
   handover is an era/lighting flip in the DATA - the fade blends the seam like Google does
-  (user noticed the pop, 2026-08-08). (4) **Road-name halos are
+  (user noticed the pop, 2026-08-08). The bottom credit follows whose pixels are on screen
+  (review 2026-09-12): `satDeep == -1` past the fade reads "Google" with no Esri capture year,
+  the blend zone credits both; zoom is derived from the scale bar's metres-per-pixel. (4) **Road-name halos are
   WIDER than the blanket** (2026-07-09): applyDark/applyLight give the three `highway-name-*`
   symbol layers `textHaloWidth 1.9` vs the 1.1 every other label gets - route lines and the
   dotted walking line run right under street names and made them unreadable; the fatter halo
@@ -1745,7 +1749,10 @@ architecture note.
   our users do not have. Handing us their own file is the one legitimate path, and Vela never
   fetches, ships or uploads it. Three details that matter: the file is VALIDATED BY LOADING IT
   before adoption (a silently-adopted corrupt font renders every screen in the fallback face, and a
-  silently-rejected one reads as a dead button), the picker filters `*/*` on purpose (font files
+  silently-rejected one reads as a dead button; NB Compose's `Font(File)` does NOT throw on bad
+  data on API 26+, the platform builder returns null and Compose only fails at first draw, so a
+  PDF picked by mistake was adopted, persisted and crash-looped every launch until the 2026-09-12
+  review: `AppFont.load` now asks `Typeface.Builder(f).build()` first, and the copy runs on IO), the picker filters `*/*` on purpose (font files
   arrive as font/ttf, application/x-font-ttf and octet-stream depending on the file manager - a
   filter that hides the user's own font is worse than a chooser showing too much), and init falls
   back to the system face if the stored copy no longer loads. **MAP LABELS ARE NOT AFFECTED** and
@@ -2969,8 +2976,14 @@ architecture note.
   in-traffic figure, and trafficRatio stays traffic-vs-typical so the colour/words don't turn red
   from OSRM optimism. directions() computes ONE calibration from the top OSRM route vs gTop and
   applies it to every OSRM-derived route in the response (alternates share the speed-model bias;
-  per-route calibration would re-rank them unfairly). Divergent-with-no-caller-cal keeps the old
-  ratio-only overlay. **Per-alternate re-rank (2026-07-01):** each Google route in `root[0][1]` carries its
+  per-route calibration would re-rank them unfairly). **The basis is whichever route FOLLOWS
+  Google's course (review 2026-09-12):** the top OSRM route when it does, else the via-snap.
+  Before, a divergent top (Google routing around a jam, when accuracy matters most) got no
+  calibration, the plain OSRM route kept its free-flow fiction and sorted as "Fastest" ahead of
+  Google's honest alternates; and the snap's ETA-margin gate compared Google's live ETA against
+  the RAW free-flow, so a jam-avoiding snap lost to the fiction every time. The gate now uses the
+  calibrated free-flow, and the `directions` diag logs `cal=`. Multi-stop trips still take the
+  ratio-only `applyTrafficRatio` path (open, #227 for stops). **Per-alternate re-rank (2026-07-01):** each Google route in `root[0][1]` carries its
   OWN `duration_in_traffic` (`parseRoute` reads `summary[10][0][0]` per route), so the returned list is now
   **sorted by live in-traffic ETA - fastest leads, Google-style.** (Earlier note that this was "impossible"
   was wrong: it's only true for the OSRM-only alts, which share `gTop`'s ratio; Google's alts carry real
@@ -3431,7 +3444,9 @@ architecture note.
   `:core` `nav/CameraAlerts.due` decides when to speak. Timing is SPEED-SCALED (12 s of lead,
   floored 150 m / capped 600 m) because a fixed distance is ample in town and ~2 s on a motorway;
   one announcement per camera per route; never for a camera behind you; silent below 2 m/s so
-  sitting beside one is not narrated. Unit-tested (`CameraAlertsTest`, `RouteProjectionTest`).
+  sitting beside one is not narrated. A new route key EMPTIES `routeCamMeters` before the fetch
+  (review 2026-09-12): a reroute resets traveledM to 0, so the old route's distances against it
+  announced a camera kilometres behind you until the corridor fetch landed. Unit-tested (`CameraAlertsTest`, `RouteProjectionTest`).
   **The spoken half is its own nested opt-in** (`SpeedCamWarn`, "Warn me out loud", shown only
   while the layer is on): being spoken to is a different ask from seeing a marker, and warning
   about cameras while driving is legally restricted in some countries. Respects the global
@@ -3572,7 +3587,10 @@ architecture note.
   draws only what the map already knows. Two clocks: marks are projected onto the polyline ONCE
   per route (`RouteBar.alongMeters`, 40 m corridor so a parallel street is not claimed as yours),
   the model is rebuilt per nav tick from that cache. Portrait only + never in PiP, deliberately -
-  issue #297 is already about landscape being crowded.
+  issue #297 is already about landscape being crowded (the PiP gate was missing until the
+  2026-09-12 review; the strip sat outside the `!pipUi` block). A merged cluster keeps the member
+  that says the MOST (`Mark.priority`: camera > crossing > hump > stop > light), because ALPR
+  cameras hang on signal masts and first-by-distance hid every one behind the light's dot.
   ⚠️ **INIT-ORDER TRAP (cost a launch crash, device-caught):** `refreshRouteBar()` was first called
   from the main `init` block, but `settingsPrefs` is declared ~3400 lines further down the class,
   and Kotlin runs property initializers + init blocks in DECLARATION order - so it read a null

--- a/app/src/main/java/app/vela/ui/AppFont.kt
+++ b/app/src/main/java/app/vela/ui/AppFont.kt
@@ -92,8 +92,17 @@ object AppFont {
         prefs(context).edit().remove(KEY_NAME).apply()
     }
 
-    /** null when the file is not a font the platform can parse. */
+    /**
+     * null when the file is not a font the platform can parse. Compose's `Font(File)` does NOT
+     * throw on bad data on API 26+: the platform builder returns null and Compose only finds out
+     * at first draw, with an IllegalStateException in every screen that draws text. A PDF picked
+     * by mistake was therefore adopted, persisted, re-adopted at the next launch, and the app
+     * could not start until its data was cleared. So the platform builder is asked FIRST, on the
+     * same file, and only a font it can actually build is wrapped for Compose.
+     */
     private fun load(f: File): FontFamily? = runCatching {
+        if (f.length() <= 0L) return null
+        android.graphics.Typeface.Builder(f).build() ?: return null
         FontFamily(androidx.compose.ui.text.font.Font(f))
     }.getOrNull()
 

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -1310,7 +1310,7 @@ fun MapScreen(
         // #297 is already about landscape being crowded, and adding a permanent strip there would
         // make that worse rather than better.
         state.routeBar?.let { bar ->
-            if (state.navigating && !landscapeChrome && !bar.isEmpty) {
+            if (state.navigating && !landscapeChrome && !pipUi && !bar.isEmpty) {
                 app.vela.ui.nav.RouteBarStrip(
                     model = bar,
                     remainingMeters = state.nav.remainingDistance,
@@ -2363,12 +2363,27 @@ fun MapScreen(
                         .padding(start = if (sidePanelUp) sidePanelWidthDp else 0.dp)
                         .padding(bottom = 16.dp + chromeLift),
                 ) {
+                    // Whose pixels are on screen. Past z19 where Esri has no native tiles the
+                    // deep layer is Google's imagery (satDeep == -1), cross-faded in over
+                    // z18.6..19.6 (ensureSatelliteDeep): credit Google there, both in the blend,
+                    // and drop Esri's capture year once Esri is no longer what you are looking at.
+                    val zoomNow = remember(metersPerPixelState.value, state.center) {
+                        val lat = state.center?.lat ?: 0.0
+                        val mpp = metersPerPixelState.value
+                        if (mpp <= 0.0) 0.0 else kotlin.math.ln(78271.517 * kotlin.math.cos(Math.toRadians(lat)) / mpp) / kotlin.math.ln(2.0)
+                    }
+                    val googleDeep = state.satDeep == -1 && zoomNow >= 18.6
+                    val googleOnly = state.satDeep == -1 && zoomNow >= 19.6
                     Text(
-                        stringResource(R.string.map_satellite_attribution),
+                        when {
+                            googleOnly -> stringResource(R.string.map_satellite_attribution_google)
+                            googleDeep -> stringResource(R.string.map_satellite_attribution) + " \u00b7 " + stringResource(R.string.map_satellite_attribution_google)
+                            else -> stringResource(R.string.map_satellite_attribution)
+                        },
                         style = MaterialTheme.typography.labelSmall,
                         color = if (darkTheme) Color(0xFFB8C2CC) else Color(0xFF4A4A4A),
                     )
-                    state.imageryYear?.let {
+                    state.imageryYear?.takeIf { !googleOnly }?.let {
                         Text(
                             it,
                             style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -5728,6 +5728,10 @@ class MapViewModel @Inject constructor(
         if (key == routeCamKey) return
         routeCamKey = key
         spokenCams = emptySet() // a genuinely new route: nothing has been announced on it yet
+        // And nothing is KNOWN on it yet: a reroute resets traveledM to 0 on the new route, so
+        // the old route's distances compared against it would announce a camera you left
+        // kilometres behind, every tick until the fetch lands (or forever if it fails).
+        routeCamMeters = emptyList()
         routeCamJob?.cancel()
         routeCamJob = viewModelScope.launch {
             val cams = runCatching {

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -1900,8 +1900,12 @@ fun VelaMapView(
                                 // AHEAD owns the view instead of splitting it with what's behind
                                 // (user 2026-07-14). Eased in on (re)attach - see the seed above.
                                 // Padding is sticky camera state - the nav teardown below resets
-                                // it for the browse map.
-                                .padding(0.0, cam.height * navPadEase[0], 0.0, 0.0)
+                                // it for the browse map. The LEFT inset is the landscape nav
+                                // column (issue #297): this per-frame write replaces the whole
+                                // padding, so without it here the setPadding call in the inset
+                                // effect was undone on the first frame and the puck sat on the
+                                // column's seam (review 2026-09-12).
+                                .padding(cameraLeftInsetPx.toDouble(), cam.height * navPadEase[0], 0.0, 0.0)
                                 .build(),
                         ),
                     )

--- a/app/src/main/java/app/vela/ui/settings/sections/AppearanceSettings.kt
+++ b/app/src/main/java/app/vela/ui/settings/sections/AppearanceSettings.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import kotlinx.coroutines.launch
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -98,13 +99,19 @@ internal fun AppearanceSettingsScreen(vm: MapViewModel, onBack: () -> Unit) {
         // cannot be redistributed - so the honest offer is "use what you already have a licence to".
         Spacer(Modifier.height(8.dp))
         val fontBad = stringResource(R.string.settings_font_bad)
+        val fontScope = androidx.compose.runtime.rememberCoroutineScope()
         val fontPicker = rememberLauncherForActivityResult(
             androidx.activity.result.contract.ActivityResultContracts.OpenDocument(),
         ) { uri ->
             if (uri != null) {
-                val name = queryDisplayName(context, uri) ?: context.getString(R.string.settings_font_custom)
-                if (!app.vela.ui.AppFont.setCustom(context, uri, name)) {
-                    android.widget.Toast.makeText(context, fontBad, android.widget.Toast.LENGTH_SHORT).show()
+                // Off the main thread: the copy is up to 12 MB and a cloud documents provider
+                // downloads the file synchronously inside openInputStream (an ANR on Drive).
+                fontScope.launch {
+                    val ok = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                        val name = queryDisplayName(context, uri) ?: context.getString(R.string.settings_font_custom)
+                        app.vela.ui.AppFont.setCustom(context, uri, name)
+                    }
+                    if (!ok) android.widget.Toast.makeText(context, fontBad, android.widget.Toast.LENGTH_SHORT).show()
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -747,6 +747,7 @@
     <string name="shortcut_work" translatable="false">Work</string>
     <string name="map_satellite_toggle">Satellite view</string>
     <string name="map_satellite_attribution" translatable="false">Esri, Maxar, Earthstar Geographics</string>
+    <string name="map_satellite_attribution_google" translatable="false">Google</string>
     <string name="map_layers">Layers</string>
     <string name="settings_layers_button">Show layers button</string>
     <string name="settings_layers_button_hint">The button on the map that flips satellite, traffic, transit and terrain.</string>

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -584,10 +584,30 @@ class GoogleMapsDataSource @Inject constructor(
             // intermediate via (short ETA, wrong last step) is the "10 min away" nav bug — AND be time-
             // competitive with OSRM's free-flow best.
             val snapReaches = trafficRoute != null
+            // One calibration for the whole response (issue #227): OSRM's free-flow model has no
+            // signal timing, so on an arterial it runs far under Google's TYPICAL for the same
+            // road. Taken from the route that FOLLOWS Google's course: the top OSRM route when it
+            // does, else the via-snap, which follows Google's course by construction. Before the
+            // 2026-09-12 review the divergent case (Google routing around a jam, exactly when it
+            // matters) got no calibration at all, so the plain OSRM route kept its fiction of an
+            // ETA and sorted ahead of Google's honest alternates as "Fastest". Alternates share
+            // the same optimistic speed model, so rebasing them all by one factor keeps the
+            // picker's ranking fair.
+            val freeFlowCal = gTop?.takeIf { it.durationSeconds > 0 && it.polyline.size >= 5 }?.let { g ->
+                val basis = open.firstOrNull()?.takeIf { !RouteGeometry.divergent(it, g) }
+                    ?: trafficRoute?.takeIf { !RouteGeometry.divergent(it, g) }
+                basis?.takeIf { it.durationSeconds > 0 }?.let { b ->
+                    val dScale = if (g.distanceMeters > 0) b.distanceMeters / g.distanceMeters else 1.0
+                    ((g.durationSeconds * dScale) / b.durationSeconds).coerceIn(0.5, 3.0)
+                }
+            }
             // With avoid on, the snap is the point (Google's avoiding course is slower than the
             // open router's unrestricted one by construction), so the ETA margin test is skipped.
+            // The margin compares Google's live ETA against OSRM's CALIBRATED free-flow: the raw
+            // free-flow is the very number the calibration exists to correct, and judged against
+            // it a jam-avoiding snap lost to the fiction every time.
             val snapWorthIt = trafficRoute != null && snapReaches && open.isNotEmpty() && googleEtaS != null &&
-                (avoidWanted || googleEtaS <= open.first().durationSeconds * SNAP_ETA_MARGIN)
+                (avoidWanted || googleEtaS <= open.first().durationSeconds * (freeFlowCal ?: 1.0) * SNAP_ETA_MARGIN)
             // Avoid on, Google answered, but the open router could not be led along its course:
             // Google's own (abbreviated) steps beat a plain route that ignores the avoid.
             // Only when the open route actually left Google's avoiding course; when it already
@@ -601,7 +621,8 @@ class GoogleMapsDataSource @Inject constructor(
                     "ratio=${gTop?.durationInTrafficSeconds?.let { t -> gTop?.durationSeconds?.takeIf { it > 0 }?.let { String.format(java.util.Locale.US, "%.2f", t / it) } }}); " +
                     "rerouted=${trafficRoute != null} snapKept=$snapWorthIt snapReaches=$snapReaches " +
                     "(gEta=${googleEtaS?.toInt()}s osrmFF=${open.firstOrNull()?.durationSeconds?.toInt()}s " +
-                    "sameCourse=${open.firstOrNull()?.let { t -> gTop?.takeIf { it.polyline.size >= 5 }?.let { !RouteGeometry.divergent(t, it) } }}); " +
+                    "sameCourse=${open.firstOrNull()?.let { t -> gTop?.takeIf { it.polyline.size >= 5 }?.let { !RouteGeometry.divergent(t, it) } }} " +
+                    "cal=${freeFlowCal?.let { String.format(java.util.Locale.US, "%.2f", it) }}); " +
                     "onDevice=${onDevice.size}$avoidTag",
                 "",
             )
@@ -612,16 +633,6 @@ class GoogleMapsDataSource @Inject constructor(
                 if (onDevice.isNotEmpty()) onDevice else google.map { it.copy(abbreviatedSteps = true) }
             } else {
                 if (avoidFallbackToGoogle) return@coroutineScope google.map { it.copy(abbreviatedSteps = true) }
-                // One calibration for the whole response, taken from the TOP OSRM route when it
-                // follows Google's course — alternates share the same optimistic speed model, so
-                // rebasing them by the same factor keeps the picker's ranking fair (issue #227).
-                val freeFlowCal = open.firstOrNull()?.takeIf { top ->
-                    top.durationSeconds > 0 && gTop != null && gTop.durationSeconds > 0 &&
-                        gTop.polyline.size >= 5 && !RouteGeometry.divergent(top, gTop)
-                }?.let { top ->
-                    val dScale = if (gTop!!.distanceMeters > 0) top.distanceMeters / gTop.distanceMeters else 1.0
-                    ((gTop.durationSeconds * dScale) / top.durationSeconds).coerceIn(0.5, 3.0)
-                }
                 // With avoid on, the open router's unrestricted routes are not offered as alternates.
                 val primary = if (snapWorthIt) (listOf(trafficRoute!!) + (if (avoidWanted) emptyList() else open)).map { applyTraffic(it, gTop, freeFlowCal) }
                     else open.map { applyTraffic(it, gTop, freeFlowCal) }

--- a/core/src/main/java/app/vela/core/nav/RouteBar.kt
+++ b/core/src/main/java/app/vela/core/nav/RouteBar.kt
@@ -21,7 +21,8 @@ object RouteBar {
 
     /** What a mark on the bar represents. The kinds are exactly the ones Vela already draws on the
      *  map, so the bar can never claim knowledge the map does not have. */
-    enum class Mark { SIGNAL, STOP, RAIL_CROSSING, SPEED_HUMP, CAMERA }
+    /** [priority]: which member of a merged cluster is drawn (higher wins); badges beat dots. */
+    enum class Mark(val priority: Int) { SIGNAL(0), STOP(1), SPEED_HUMP(2), RAIL_CROSSING(3), CAMERA(4) }
 
     /** A congestion band, as a fraction of the REMAINING trip: 0 = where you are, 1 = destination.
      *  [level] is Google's grade (1 moderate, 2 heavy, 3+ severe). */
@@ -111,9 +112,13 @@ object RouteBar {
             .filter { (_, m) -> m > done && m <= end }
             .sortedBy { it.second }
             .fold(mutableListOf<Pair<Mark, Double>>()) { acc, item ->
-                // Collapse a cluster to its first member: the point is "something is coming up
-                // here", and two glyphs a pixel apart carry no more information than one.
+                // Collapse a cluster to ONE member: the point is "something is coming up here",
+                // and two glyphs a pixel apart carry no more information than one. The kept
+                // member is the one that says the most: a camera or a crossing (a badge) over a
+                // light or a stop sign (a dot). ALPR cameras are mounted at signalled junctions,
+                // so keeping the first member by distance hid the camera behind the light's dot.
                 if (acc.isEmpty() || item.second - acc.last().second >= PIN_MERGE_M) acc += item
+                else if (item.first.priority > acc.last().first.priority) acc[acc.lastIndex] = item
                 acc
             }
             .map { (kind, m) -> Pin(kind, frac(m)) }

--- a/core/src/test/java/app/vela/core/nav/RouteBarTest.kt
+++ b/core/src/test/java/app/vela/core/nav/RouteBarTest.kt
@@ -74,6 +74,17 @@ class RouteBarTest {
         assertEquals("one glyph per junction", 2, m.pins.size)
     }
 
+    @Test fun `a camera at a signalled junction keeps its badge when the cluster merges`() {
+        val marks = listOf(
+            RouteBar.Mark.SIGNAL to 5_000.0,
+            RouteBar.Mark.CAMERA to 5_030.0, // mounted on the light's mast
+            RouteBar.Mark.STOP to 5_050.0,
+        )
+        val m = RouteBar.build(route(10_000.0), traveledM = 0.0, markMeters = marks, windowM = 20_000.0)
+        assertEquals(1, m.pins.size)
+        assertEquals(RouteBar.Mark.CAMERA, m.pins[0].kind)
+    }
+
     @Test fun `the bar stands down near the destination`() {
         val m = RouteBar.build(route(10_000.0, listOf(TrafficSpan(2, 9_950.0, 50.0))), traveledM = 9_800.0, windowM = 20_000.0)
         assertTrue("a 200 m sliver is noise, the banner covers that stretch", m.isEmpty)


### PR DESCRIPTION
Six confirmed findings from a read-through of the recent feature PRs, each small and self-contained:

- **Custom font (#271):** a file that is not a font could be adopted as the UI font, and the app then failed at first draw on every launch until its data was cleared. Compose's file font does not throw on bad data on API 26+, so the platform typeface builder is asked first. The copy also moved off the main thread (a cloud document downloads inside openInputStream).
- **Speed-camera warning (#300):** after a reroute the old route's camera distances stayed in use against the new route's progress until the corridor fetch landed, so a camera kilometres behind you could be announced. The list is cleared with the key.
- **Landscape nav (#310):** the follow camera rewrote the whole padding every frame with left = 0, so the left inset for the nav column never took effect and the puck sat on the column's seam.
- **Satellite credit (#247):** past z19 where Esri tops out the deep layer is Google imagery, but the credit still read Esri with an Esri capture year. It follows the provider now (both in the blend zone).
- **Route bar (#298):** a camera at a signalled junction merged into the light's dot and lost its badge; badges now win a merge. The strip also drew inside the PiP window despite the docs saying never.
- **ETA calibration (#242):** the free-flow calibration was skipped whenever Google's top route diverged from OSRM's, which is exactly the jam-avoiding case, so the plain OSRM route kept its too-fast ETA and sorted as Fastest ahead of Google's honest alternates. The calibration basis is now whichever route follows Google's course (top OSRM route, else the via-snap), the snap's time gate compares against the calibrated free-flow, and the diag logs the factor.

Core tests pass (new route-bar merge test). Device-checked on a Pixel 4a: picking a 200 KB random file named .ttf shows the not-a-font toast, the system font stays selected, and the app relaunches normally.