### PR TITLE
Fix the rest of what the September review found

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -666,7 +666,7 @@ Defaults that make the safe path the easy one:
   With no geometry (Google fallback, offline GraphHopper/obf, or an entry too straight for its sign
   to mean anything) it draws its NEUTRAL form - ring plus entry stub, NO exit arrow - because an
   arrow pointing somewhere we did not measure is the whole bug. `maneuverIcon(type)` can only produce
-  the neutral form; call `maneuverIconFor(maneuver)` wherever the Maneuver is in hand. NB the
+  the neutral form; call `maneuverIconFor(maneuver)` wherever the Maneuver is in hand. **Android Auto reads the same geometry (review 2026-09-12):** `ManeuverMapper` picks CW/CCW from `roundabout.clockwise` (counter-clockwise only as the no-geometry default) and the exit number from `Maneuver.roundaboutExit`, set by all three routers (OSRM `maneuver.exit`, GraphHopper `exitNumber`, obf `exitOut`); it used to hard-code CCW and exit 1. GraphHopper and obf still give NO glyph geometry: both expose a turn angle whose sign convention is undocumented in the vendored jars, and a guessed arrow is the original bug. NB the
   notification glyph (`service/NavGlyphs`) still draws its own fixed straight-out roundabout.
   **Place sheet has START beside Directions; the nav bar is END | figures | STEPS (issues
   #272/#273, 2026-08-17).** Directions opens the picker whose own Start sits BELOW the route list,
@@ -858,7 +858,7 @@ Defaults that make the safe path the easy one:
   route into a sliver). NB the endpoints card was the subtle one - full width, its left half sat
   UNDER the chooser panel and the visible remainder read as an empty dark slab over the map.
   When adding ANY new route/nav chrome, give it the same landscape treatment or it will span the
-  screen. The nav follow ticker writes the WHOLE camera padding every frame, so `cameraLeftInsetPx`
+  screen. Use `.align(if (landscapeChrome) ...Start else ...Center).landscapeColumn(landscapeChrome, sidePanelWidthDp)`: the helper caps the width AND pads the display cutout on the start edge (in landscape the notch sits on the left, outside the status-bar insets; the turn card's margin ran under it, review 2026-09-12). The nav follow ticker writes the WHOLE camera padding every frame, so `cameraLeftInsetPx`
   goes into that `.padding(left, top, 0, 0)` too (review 2026-09-12): the inset effect's
   setPadding alone was undone on the first frame and the puck sat on the column's seam.
   **LANDSCAPE (width > height) collapses the browse chrome to ONE line (2026-07-15, Google's
@@ -1057,7 +1057,7 @@ Defaults that make the safe path the easy one:
   single one-minute ticker in VelaRoot and whenever a fix moves) so `isAppInDarkTheme()` stays a
   plain state read. The position is stored ROUNDED TO ~1 KM (sunset moves ~4 s per km of longitude,
   so precision buys nothing and a theme setting has no business keeping a precise record of where
-  its owner was). Separately, **`AppTheme.navDayNight`** switches by daylight ONLY while navigating
+  its owner was). The stored point is TIMESTAMPED and trusted for 24 h and only while location permission is still granted (review 2026-09-12): with a grant a fresh fix replaces it within a minute of launch anyway, and a revoked grant plus a flight east gave a dark map at 3 pm local for the whole trip; past that it falls back to the clock. Separately, **`AppTheme.navDayNight`** switches by daylight ONLY while navigating
   and keeps the chosen mode everywhere else - the reporter's actual ask ("my default is dark, but
   driving in daylight I want the light map"); it is hidden under AUTO, where it would claim to do
   something already happening. `AppTheme.navigating` is mirrored from the nav state by MapViewModel.
@@ -1193,7 +1193,7 @@ Defaults that make the safe path the easy one:
   handover is an era/lighting flip in the DATA - the fade blends the seam like Google does
   (user noticed the pop, 2026-08-08). The bottom credit follows whose pixels are on screen
   (review 2026-09-12): `satDeep == -1` past the fade reads "Google" with no Esri capture year,
-  the blend zone credits both; zoom is derived from the scale bar's metres-per-pixel. (4) **Road-name halos are
+  the blend zone credits both; zoom is derived from the scale bar's metres-per-pixel. The probe runs 20 -> 21 -> 22 and stops at the first MISSING level (same review): where Esri tops out at 19, most of the world, one request settles the Google fallback where 22-first spent three sequential round trips on the blur; `ensureActive` between requests so a probe cancelled by the next pan stops, and the deep layer's minZoom is the fade's first stop (18.6) so it no longer loads tiles while invisible. (4) **Road-name halos are
   WIDER than the blanket** (2026-07-09): applyDark/applyLight give the three `highway-name-*`
   symbol layers `textHaloWidth 1.9` vs the 1.1 every other label gets - route lines and the
   dotted walking line run right under street names and made them unreadable; the fatter halo
@@ -2983,7 +2983,7 @@ architecture note.
   Google's honest alternates; and the snap's ETA-margin gate compared Google's live ETA against
   the RAW free-flow, so a jam-avoiding snap lost to the fiction every time. The gate now uses the
   calibrated free-flow, and the `directions` diag logs `cal=`. Multi-stop trips still take the
-  ratio-only `applyTrafficRatio` path (open, #227 for stops). **Per-alternate re-rank (2026-07-01):** each Google route in `root[0][1]` carries its
+  ratio-only `applyTrafficRatio` path (open, #227 for stops). **Multi-stop trips are calibrated too (same review):** Google's keyless answer is the DIRECT trip, so `speedCal` compares average SPEEDS (the distance difference cancels) and the via route goes through `applyTraffic` with `withSpans = false`; `applyTrafficRatio` is gone, and the recheck's `etaScale` no longer jumps when the last stop is passed. A same-course primary also carries Google's `typicalLow/High` range (distance-scaled), so the depart-time chooser shows "usually X-Y" for it, not only for provisional alternates. **Per-alternate re-rank (2026-07-01):** each Google route in `root[0][1]` carries its
   OWN `duration_in_traffic` (`parseRoute` reads `summary[10][0][0]` per route), so the returned list is now
   **sorted by live in-traffic ETA - fastest leads, Google-style.** (Earlier note that this was "impossible"
   was wrong: it's only true for the OSRM-only alts, which share `gTop`'s ratio; Google's alts carry real
@@ -3446,7 +3446,7 @@ architecture note.
   one announcement per camera per route; never for a camera behind you; silent below 2 m/s so
   sitting beside one is not narrated. A new route key EMPTIES `routeCamMeters` before the fetch
   (review 2026-09-12): a reroute resets traveledM to 0, so the old route's distances against it
-  announced a camera kilometres behind you until the corridor fetch landed. Unit-tested (`CameraAlertsTest`, `RouteProjectionTest`).
+  announced a camera kilometres behind you until the corridor fetch landed. Flipping "Warn me out loud" on MID-DRIVE fetches the current route's cameras at once (a `snapshotFlow` on the two toggles in the VM); it used to wait for the next reroute. Unit-tested (`CameraAlertsTest`, `RouteProjectionTest`).
   **The spoken half is its own nested opt-in** (`SpeedCamWarn`, "Warn me out loud", shown only
   while the layer is on): being spoken to is a different ask from seeing a marker, and warning
   about cameras while driving is legally restricted in some countries. Respects the global
@@ -3590,7 +3590,7 @@ architecture note.
   issue #297 is already about landscape being crowded (the PiP gate was missing until the
   2026-09-12 review; the strip sat outside the `!pipUi` block). A merged cluster keeps the member
   that says the MOST (`Mark.priority`: camera > crossing > hump > stop > light), because ALPR
-  cameras hang on signal masts and first-by-distance hid every one behind the light's dot.
+  cameras hang on signal masts and first-by-distance hid every one behind the light's dot. The bar's total is the POLYLINE's own length (`totalM`, cached beside the marks): traveledM and the marks are measured along it while `Route.distanceMeters` is the router's figure. The projection cache keys on the mark lists' IDENTITY (a replaced set with the same count kept stale marks), and `RouteProjection.alongMeters` takes one cosine per point, not per segment.
   ⚠️ **INIT-ORDER TRAP (cost a launch crash, device-caught):** `refreshRouteBar()` was first called
   from the main `init` block, but `settingsPrefs` is declared ~3400 lines further down the class,
   and Kotlin runs property initializers + init blocks in DECLARATION order - so it read a null
@@ -3699,7 +3699,7 @@ architecture note.
   Bushwick and Brisbane were the same trap. The whole LEG is passed in, not just `[14]`, because
   the generic vehicle icon sits outside the badge node. Subway is now tested before rail.
   Pinned by `TransitSubwayTest` using the real captured nodes; re-verified by replaying the new
-  rules over the whole live payload (6 trips -> lines 2/3/5 SUBWAY, M101 BUS, walks still WALK).
+  rules over the whole live payload (6 trips -> lines 2/3/5 SUBWAY, M101 BUS, walks still WALK). The trip SUMMARY (`parseLines` with `leg == null`) keeps EVERY bullet line beside the pills (review 2026-09-12): a two-subway trip showed one line on the card and a bus-plus-subway trip showed the bus alone. A per-leg node still takes one line, pill first.
 - **Live stop departure board (`WebStopDeparturesFetcher` + `core/.../StopDeparturesParser`,
   2026-07-12, keyless + device-verified).** Tapping a transit STATION shows Google's "See departure
   board" in the place sheet. The board is embedded in the station's OWN place page's

--- a/app/src/main/java/app/vela/car/ManeuverMapper.kt
+++ b/app/src/main/java/app/vela/car/ManeuverMapper.kt
@@ -20,9 +20,12 @@ import app.vela.core.model.Maneuver as VelaManeuver
  */
 object ManeuverMapper {
 
-    /** Right-hand traffic (US, Israel, most of the world) → counter-clockwise roundabouts; the
-     *  car API needs a concrete CW/CCW type. A future locale hook can flip this for the UK etc. */
-    private const val ROUNDABOUT_CCW = true
+    /** The car API needs a concrete CW/CCW roundabout type. The direction of travel comes from the
+     *  MEASURED geometry when the router gave one (`RoundaboutGeometry.clockwise`, derived from the
+     *  sign of the entry turn on OSRM routes, issue #259); with none, counter-clockwise, which is
+     *  right-hand traffic (US, Israel, most of the world). A UK driver on a head unit used to get
+     *  a counter-clockwise glyph for every roundabout (review 2026-09-12). */
+    private const val ROUNDABOUT_CCW_DEFAULT = true
 
     fun carManeuver(m: VelaManeuver): Maneuver {
         val type = when (m.type) {
@@ -43,15 +46,20 @@ object ManeuverMapper {
             ManeuverType.RAMP_RIGHT -> Maneuver.TYPE_ON_RAMP_NORMAL_RIGHT
             ManeuverType.KEEP_LEFT -> Maneuver.TYPE_KEEP_LEFT
             ManeuverType.KEEP_RIGHT -> Maneuver.TYPE_KEEP_RIGHT
-            ManeuverType.ROUNDABOUT, ManeuverType.EXIT_ROUNDABOUT ->
-                if (ROUNDABOUT_CCW) Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW
+            ManeuverType.ROUNDABOUT, ManeuverType.EXIT_ROUNDABOUT -> {
+                val ccw = m.roundabout?.let { !it.clockwise } ?: ROUNDABOUT_CCW_DEFAULT
+                if (ccw) Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW
                 else Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CW
+            }
         }
         val b = Maneuver.Builder(type)
         if (type == Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW ||
             type == Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CW
         ) {
-            b.setRoundaboutExitNumber(1) // exit count unknown from OSRM here; 1 keeps the builder valid
+            // The exit NUMBER the router phrased ("take the 2nd exit"), threaded on the maneuver by
+            // all three routers; the builder throws without one, so 1 is the floor, not a guess
+            // the card shows when the router actually said otherwise.
+            b.setRoundaboutExitNumber(m.roundaboutExit?.takeIf { it > 0 } ?: 1)
         }
         return b.build()
     }

--- a/app/src/main/java/app/vela/ui/map/MapScreen.kt
+++ b/app/src/main/java/app/vela/ui/map/MapScreen.kt
@@ -155,6 +155,10 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -1448,7 +1452,7 @@ fun MapScreen(
                 // exactly what you need to see while driving.
                 modifier = Modifier
                     .align(if (landscapeChrome) Alignment.TopStart else Alignment.TopCenter)
-                    .then(if (landscapeChrome) Modifier.widthIn(max = sidePanelWidthDp) else Modifier)
+                    .landscapeColumn(landscapeChrome, sidePanelWidthDp)
                     .statusBarsPadding()
                     .padding(12.dp)
                     // Report the banner's bottom edge so the compass can drop just below it (any height).
@@ -1914,7 +1918,7 @@ fun MapScreen(
             state.navigating && state.results.isEmpty() -> Column(
                 Modifier
                     .align(if (landscapeChrome) Alignment.BottomStart else Alignment.BottomCenter)
-                    .then(if (landscapeChrome) Modifier.widthIn(max = sidePanelWidthDp) else Modifier)
+                    .landscapeColumn(landscapeChrome, sidePanelWidthDp)
                     .navigationBarsPadding()
                     .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -1984,7 +1988,7 @@ fun MapScreen(
                 // gone, which is a poor way to ask someone to choose between routes drawn on it.
                 modifier = Modifier
                     .align(if (landscapeChrome) Alignment.BottomStart else Alignment.BottomCenter)
-                    .then(if (landscapeChrome) Modifier.widthIn(max = sidePanelWidthDp) else Modifier),
+                    .landscapeColumn(landscapeChrome, sidePanelWidthDp),
             )
 
             // The place sheet yields while Street View is up - the pano takes the top half and the
@@ -2036,7 +2040,7 @@ fun MapScreen(
                 // landscape layout, user 2026-07-20).
                 modifier = Modifier
                     .align(if (landscapeChrome) Alignment.BottomStart else Alignment.BottomCenter)
-                    .then(if (landscapeChrome) Modifier.widthIn(max = sidePanelWidthDp) else Modifier)
+                    .landscapeColumn(landscapeChrome, sidePanelWidthDp)
                     // Live top edge for the layers button's overlap gate (see placeSheetTopPx).
                     .onGloballyPositioned { placeSheetTopPx = it.positionInRoot().y.roundToInt() },
             )
@@ -2068,7 +2072,7 @@ fun MapScreen(
                 // Landscape: left side panel like the place sheet (see its modifier note).
                 modifier = Modifier
                     .align(if (landscapeChrome) Alignment.BottomStart else Alignment.BottomCenter)
-                    .then(if (landscapeChrome) Modifier.widthIn(max = sidePanelWidthDp) else Modifier),
+                    .landscapeColumn(landscapeChrome, sidePanelWidthDp),
               )
             // Imported Google list preview: offer to save (nothing persisted until tapped).
             // A pill under the search bar, clear of the results sheet at the bottom.
@@ -4854,3 +4858,14 @@ private fun ScaleBarReader(
 ) {
     ScaleBar(metersPerPixel = state.value, dark = dark, modifier = modifier)
 }
+
+/**
+ * Route and nav chrome in landscape is a LEFT column (issue #297): width-capped to the side panel
+ * and kept clear of a display cutout on that edge. In landscape the notch sits on the left, outside
+ * the status-bar insets these cards already pad, so without this the turn card's 12 dp margin ran
+ * under it (review 2026-09-12). Portrait is untouched. The caller keeps its own `.align`.
+ */
+@Composable
+private fun Modifier.landscapeColumn(landscape: Boolean, widthDp: androidx.compose.ui.unit.Dp): Modifier =
+    if (!landscape) this
+    else this.widthIn(max = widthDp).windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Start))

--- a/app/src/main/java/app/vela/ui/map/MapViewModel.kt
+++ b/app/src/main/java/app/vela/ui/map/MapViewModel.kt
@@ -5644,6 +5644,7 @@ class MapViewModel @Inject constructor(
     // never re-walks the polyline. Null route key = nothing cached.
     private var routeBarKey: String? = null
     private var routeBarMarks: List<Pair<app.vela.core.nav.RouteBar.Mark, Double>> = emptyList()
+    private var routeBarTotalM: Double? = null // the polyline's own length, the axis the marks are measured on
 
     /** Recompute the route bar for this nav tick (see the call site for why the work is split). */
     private fun updateRouteBar(ns: app.vela.core.nav.NavSession.State) {
@@ -5656,10 +5657,10 @@ class MapViewModel @Inject constructor(
             }
             return
         }
-        // Identity = the same key shape the corridor fetch uses, so a steps/traffic heal on the
-        // same course does not throw the projection away.
+        // Keyed on the route's endpoints + length and on the IDENTITY of the two mark lists (a
+        // replaced set with the same count used to keep stale marks; review 2026-09-12).
         val key = "${route.polyline.first()}|${route.polyline.last()}|${route.distanceMeters.toInt()}|" +
-            "${_state.value.trafficControls.size}|${_state.value.flockCameras.size}"
+            "${System.identityHashCode(_state.value.trafficControls)}|${System.identityHashCode(_state.value.flockCameras)}"
         if (key != routeBarKey) {
             routeBarKey = key
             val poly = route.polyline
@@ -5688,13 +5689,14 @@ class MapViewModel @Inject constructor(
                     // Guard against a route swap landing while this was computing.
                     if (routeBarKey == key) {
                         routeBarMarks = marks
-                        _state.update { it.copy(routeBar = app.vela.core.nav.RouteBar.build(route, ns.nav.traveledM, marks)) }
+                        routeBarTotalM = cum.last()
+                        _state.update { it.copy(routeBar = app.vela.core.nav.RouteBar.build(route, ns.nav.traveledM, marks, totalM = routeBarTotalM)) }
                     }
                 }
             }
             return
         }
-        _state.update { it.copy(routeBar = app.vela.core.nav.RouteBar.build(route, ns.nav.traveledM, routeBarMarks)) }
+        _state.update { it.copy(routeBar = app.vela.core.nav.RouteBar.build(route, ns.nav.traveledM, routeBarMarks, totalM = routeBarTotalM)) }
     }
 
     /** Show or hide the route bar (pref `route_bar`). */
@@ -5713,6 +5715,20 @@ class MapViewModel @Inject constructor(
 
     /** One corridor fetch of speed cameras per driven route, projected onto it for the spoken
      *  approach warning (issue #229). No-op unless the layer AND the spoken warning are on. */
+    // Flipping "Warn me out loud" on MID-DRIVE fetches the current route's cameras right away;
+    // before, the fetch only ran on a route change, so the toggle did nothing until the next
+    // reroute (review 2026-09-12). Flipping it off clears the list through the same function.
+    init {
+        viewModelScope.launch {
+            androidx.compose.runtime.snapshotFlow { app.vela.ui.SpeedCamWarn.on.value && app.vela.ui.SpeedCams.on.value }
+                .collect { on ->
+                    val r = navSession.state.value.route ?: return@collect
+                    if (on) routeCamKey = null // force the fetch even for the same route
+                    refreshRouteSpeedCams(r)
+                }
+        }
+    }
+
     private fun refreshRouteSpeedCams(route: app.vela.core.model.Route) {
         if (!app.vela.ui.SpeedCams.on.value || !app.vela.ui.SpeedCamWarn.on.value) {
             routeCamKey = null; routeCamMeters = emptyList(); spokenCams = emptySet()
@@ -5916,7 +5932,18 @@ class MapViewModel @Inject constructor(
             kotlinx.coroutines.delay(350)
             val level = withContext(Dispatchers.IO) {
                 runCatching {
-                    intArrayOf(22, 21, 20).firstOrNull { lvl -> esriTileExists(cLat, cLng, lvl) } ?: -1
+                    // Bottom-up: 20 first, because everywhere Esri stops at 19 (most of the
+                    // world outside metros) one request settles the Google fallback, where
+                    // 22-then-21-then-20 spent three sequential round trips on the blur. Only
+                    // areas that DO have z20 pay for the z21/z22 checks. ensureActive between
+                    // requests, or a probe cancelled by the next pan keeps burning the chain.
+                    var found = -1
+                    for (lvl in intArrayOf(20, 21, 22)) {
+                        kotlin.coroutines.coroutineContext.ensureActive()
+                        if (!esriTileExists(cLat, cLng, lvl)) break
+                        found = lvl
+                    }
+                    found
                 }.getOrNull()
             } ?: return@launch // network failure: don't cache the box, retry on the next idle
             val padLat = (north - south) * 0.5; val padLng = (east - west) * 0.5

--- a/app/src/main/java/app/vela/ui/map/VelaMapView.kt
+++ b/app/src/main/java/app/vela/ui/map/VelaMapView.kt
@@ -4466,7 +4466,7 @@ private const val SAT_DEEP_SRC = "vela-sat-deep-src" // suffixed with the provid
 // rather than 404s, so the fallback never paints holes; true 404s (open ocean) fall back to the
 // overzoomed parent tile like any failed raster fetch.
 private const val SAT_G_TILES = "https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}"
-private const val SAT_DEEP_MIN_ZOOM = 18.4f // engage just before the base z19 tiles start visibly stretching
+private const val SAT_DEEP_MIN_ZOOM = 18.6f // = the cross-fade's first stop; below it the layer was invisible yet loading tiles
 
 /** The deep-imagery layer for the current area: Esri at its probed native max level, or the Google
  *  fallback to z21. The source id carries provider+level, so moving between areas with different

--- a/app/src/main/java/app/vela/ui/nav/RoundaboutGlyph.kt
+++ b/app/src/main/java/app/vela/ui/nav/RoundaboutGlyph.kt
@@ -106,16 +106,15 @@ internal fun roundaboutGlyph(geom: RoundaboutGeometry?): ImageVector {
         return b.build()
     }
 
-    // The travelled arc. isPositiveArc is the SVG sweep flag: true draws clockwise on screen, which
-    // is left-hand-traffic circulation.
-    if (sweep > 1.0) {
-        b.path(
-            stroke = ink, strokeLineWidth = TRAVELLED_W,
-            strokeLineCap = StrokeCap.Round, strokeLineJoin = StrokeJoin.Round,
-        ) {
-            moveTo(entryX, entryY)
-            arcTo(R, R, 0f, sweep > 180.0, geom.clockwise, exitX, exitY)
-        }
+    // The travelled arc (sweep is > 1 here, the guard above took the degenerate cases).
+    // isPositiveArc is the SVG sweep flag: true draws clockwise on screen, which is
+    // left-hand-traffic circulation.
+    b.path(
+        stroke = ink, strokeLineWidth = TRAVELLED_W,
+        strokeLineCap = StrokeCap.Round, strokeLineJoin = StrokeJoin.Round,
+    ) {
+        moveTo(entryX, entryY)
+        arcTo(R, R, 0f, sweep > 180.0, geom.clockwise, exitX, exitY)
     }
     // ...and the rest of the ring, thinner, so the roundabout still reads as a full circle.
     val rest = 360.0 - sweep
@@ -144,7 +143,7 @@ private fun exitStub(b: ImageVector.Builder, ink: SolidColor, exitDeg: Double) {
         lineTo(outX, outY)
     }
     val tip = ring(exitDeg, R + STUB + 1.4f)
-    val base = ring(exitDeg, R + STUB * 0.55f)
+    val base = outX to outY
     val perp = Math.toRadians(exitDeg + 90.0)
     val hx = (2.0 * sin(perp)).toFloat()
     val hy = (-2.0 * cos(perp)).toFloat()

--- a/app/src/main/java/app/vela/ui/theme/AppTheme.kt
+++ b/app/src/main/java/app/vela/ui/theme/AppTheme.kt
@@ -41,8 +41,17 @@ object AppTheme {
 
     private var lat: Double? = null
     private var lng: Double? = null
+    private var at: Long = 0L // when the point was recorded (epoch ms); 0 = a pre-timestamp store
+    private var appContext: Context? = null
+
+    /** A stored point older than this is not trusted for the sun: with permission granted a fresh
+     *  fix replaces it within a minute of launch anyway, and without permission (revoked since)
+     *  the old point can be a continent away (review 2026-09-12: a revoked grant plus a flight
+     *  east gave a dark map at 3 pm for the whole trip). */
+    private const val POINT_MAX_AGE_MS = 24L * 60 * 60 * 1000
 
     fun init(context: Context) {
+        appContext = context.applicationContext
         mode.value = runCatching { ThemeMode.valueOf(prefs(context).getString(KEY, null) ?: "SYSTEM") }
             .getOrDefault(ThemeMode.SYSTEM)
         navDayNight.value = prefs(context).getBoolean(KEY_NAV_DAY_NIGHT, false)
@@ -50,6 +59,7 @@ object AppTheme {
         if (p.contains(KEY_LAT)) {
             lat = p.getFloat(KEY_LAT, 0f).toDouble()
             lng = p.getFloat(KEY_LNG, 0f).toDouble()
+            at = p.getLong(KEY_AT, 0L)
         }
         refreshNight()
     }
@@ -76,7 +86,8 @@ object AppTheme {
         if (rLat == lat && rLng == lng) return
         lat = rLat
         lng = rLng
-        prefs(context).edit().putFloat(KEY_LAT, rLat.toFloat()).putFloat(KEY_LNG, rLng.toFloat()).apply()
+        at = System.currentTimeMillis()
+        prefs(context).edit().putFloat(KEY_LAT, rLat.toFloat()).putFloat(KEY_LNG, rLng.toFloat()).putLong(KEY_AT, at).apply()
         refreshNight()
     }
 
@@ -85,12 +96,21 @@ object AppTheme {
     fun refreshNight() {
         val la = lat
         val ln = lng
-        night.value = if (la != null && ln != null) {
-            SunTimes.isNight(la, ln, System.currentTimeMillis())
+        val now = System.currentTimeMillis()
+        val usable = la != null && ln != null && now - at < POINT_MAX_AGE_MS && locationAllowed()
+        night.value = if (usable) {
+            SunTimes.isNight(la!!, ln!!, now)
         } else {
-            // No fix yet (cold launch, or location denied outright): fall back to the clock.
+            // No fix yet (cold launch), location denied or revoked, or the stored point is a day
+            // old: fall back to the clock rather than the sun somewhere the phone no longer is.
             SunTimes.isNightByClock(java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY))
         }
+    }
+
+    private fun locationAllowed(): Boolean {
+        val c = appContext ?: return true
+        return androidx.core.content.ContextCompat.checkSelfPermission(c, android.Manifest.permission.ACCESS_COARSE_LOCATION) ==
+            android.content.pm.PackageManager.PERMISSION_GRANTED
     }
 
     private fun prefs(c: Context) = c.getSharedPreferences("vela_settings", Context.MODE_PRIVATE)
@@ -98,6 +118,7 @@ object AppTheme {
     private const val KEY_NAV_DAY_NIGHT = "theme_nav_day_night"
     private const val KEY_LAT = "theme_sun_lat"
     private const val KEY_LNG = "theme_sun_lng"
+    private const val KEY_AT = "theme_sun_at"
 }
 
 /** The single source of truth for "is the app dark right now" - honours the user's

--- a/app/src/main/java/app/vela/ui/theme/Theme.kt
+++ b/app/src/main/java/app/vela/ui/theme/Theme.kt
@@ -98,5 +98,7 @@ fun VelaTheme(
         darkTheme -> DarkColors
         else -> LightColors
     }
-    MaterialTheme(colorScheme = colorScheme, typography = velaTypography(app.vela.ui.AppFont.family.value), content = content)
+    val family = app.vela.ui.AppFont.family.value
+    val typography = androidx.compose.runtime.remember(family) { velaTypography(family) }
+    MaterialTheme(colorScheme = colorScheme, typography = typography, content = content)
 }

--- a/core/src/main/java/app/vela/core/data/GraphHopperRouteEngine.kt
+++ b/core/src/main/java/app/vela/core/data/GraphHopperRouteEngine.kt
@@ -237,6 +237,7 @@ class GraphHopperRouteEngine(private val graphsRoot: File) : RouteEngine {
             Maneuver(
                 type = type,
                 instruction = ghPhrase(type, road, rbExit, dest, exitNo),
+                roundaboutExit = rbExit,
                 location = at,
                 distanceMeters = ins.distance,
                 durationSeconds = ins.time / 1000.0,

--- a/core/src/main/java/app/vela/core/data/ObfRouteEngine.kt
+++ b/core/src/main/java/app/vela/core/data/ObfRouteEngine.kt
@@ -212,6 +212,7 @@ class ObfRouteEngine(private val obfRoot: File) : RouteEngine {
                     Maneuver(
                         type = type,
                         instruction = GraphHopperRouteEngine.ghPhrase(type, road, rbExit, dest, null),
+                        roundaboutExit = rbExit,
                         location = at,
                         distanceMeters = 0.0,
                         durationSeconds = 0.0,

--- a/core/src/main/java/app/vela/core/data/RouteGeometry.kt
+++ b/core/src/main/java/app/vela/core/data/RouteGeometry.kt
@@ -586,6 +586,7 @@ object RouteGeometry {
         return Maneuver(
             type = osrmType(effType, mod),
             instruction = osrmPhrase(effType, mod, road, dest, exits, man["exit"]?.jsonPrimitive?.intOrNull),
+            roundaboutExit = man["exit"]?.jsonPrimitive?.intOrNull?.takeIf { it > 0 },
             side = if (type == "arrive" && mod != null) {
                 when {
                     mod.contains("left") -> "left"

--- a/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
+++ b/core/src/main/java/app/vela/core/data/google/GoogleMapsDataSource.kt
@@ -476,7 +476,14 @@ class GoogleMapsDataSource @Inject constructor(
                 val onDevice = if (via == null && routeEngine.isReady(mode))
                     chainOnDevice(listOf(origin) + waypoints + destination, mode, avoidTolls, avoidHighways) else null
                 var result = when {
-                    via != null -> listOf(applyTrafficRatio(via, gD.await().firstOrNull()))
+                    // Calibrated like a single-destination trip (review 2026-09-12): the ratio-only
+                    // overlay this used to take reproduced issue #227 verbatim the moment one stop was
+                    // added, and the nav recheck's etaScale jumped by up to 2.5x when the last stop
+                    // was passed and the recheck switched to the calibrated path. Google's keyless
+                    // answer is the DIRECT trip, so the bias is measured as a speed ratio (the
+                    // distance difference cancels) and Google's congestion spans stay off a route
+                    // that takes other roads.
+                    via != null -> gD.await().firstOrNull().let { g -> listOf(applyTraffic(via, g, freeFlowCal = speedCal(via, g), withSpans = false)) }
                     onDevice != null -> listOf(onDevice)
                     else -> gD.await().take(1).map { it.copy(abbreviatedSteps = true) }
                 }
@@ -730,6 +737,11 @@ class GoogleMapsDataSource @Inject constructor(
         )
         return calibrated.copy(
             durationInTrafficSeconds = calibrated.durationSeconds * factor,
+            // Google's "usually X-Y" typical range belongs to its course; on a same-course route the
+            // primary's durationSeconds IS Google's typical now, so the range applies to it too and
+            // the depart-time chooser can show it (before, only provisional alternates had one).
+            typicalLowSeconds = if (sameCourse) g.typicalLowSeconds?.times(scale) else route.typicalLowSeconds,
+            typicalHighSeconds = if (sameCourse) g.typicalHighSeconds?.times(scale) else route.typicalHighSeconds,
             // Google's congestion spans belong to Google's course: mapped by fraction onto a route
             // that takes different roads they painted red segments on roads Google never reported
             // on (review 2026-09-06).
@@ -781,11 +793,15 @@ class GoogleMapsDataSource @Inject constructor(
     /** Lighter traffic overlay for a multi-stop route: scale the ETA by Google's in-traffic ratio for a
      *  traffic-aware time, but DON'T map the congestion spans — Google's direct origin→dest path differs
      *  from the through-the-stops path, so its span offsets wouldn't line up. ETA only. */
-    private fun applyTrafficRatio(route: Route, g: Route?): Route {
-        val typical = g?.durationSeconds?.takeIf { it > 0 } ?: return route
-        val inTraffic = g.durationInTrafficSeconds ?: return route
-        val factor = (inTraffic / typical).coerceIn(0.5, 4.0)
-        return route.copy(durationInTrafficSeconds = route.durationSeconds * factor)
+    /** Free-flow calibration for a route that does NOT follow Google's course (a stops trip is
+     *  routed through its stops while Google's keyless answer is the direct trip): compare average
+     *  SPEEDS instead of times, so the distance difference cancels and what is left is the speed
+     *  model's bias for that network. Null when either side lacks a duration or a distance. */
+    private fun speedCal(route: Route, g: Route?): Double? {
+        if (g == null || g.durationSeconds <= 0 || g.distanceMeters <= 0 || route.durationSeconds <= 0 || route.distanceMeters <= 0) return null
+        val gSpeed = g.distanceMeters / g.durationSeconds
+        val rSpeed = route.distanceMeters / route.durationSeconds
+        return (rSpeed / gSpeed).coerceIn(0.5, 3.0)
     }
 
     /** Name a provisional alternate the moment the user picks it to drive: snap its (Google) polyline

--- a/core/src/main/java/app/vela/core/data/google/parse/TransitParser.kt
+++ b/core/src/main/java/app/vela/core/data/google/parse/TransitParser.kt
@@ -280,10 +280,35 @@ object TransitParser {
         // whole identity is an agency-scoped icon. New York's subway is the case that exposed this
         // (issue #284): every subway leg parsed to no line, which made it fall through to WALK and
         // render as an empty walking step, while buses (which do get a text pill) were fine.
-        if (out.isEmpty()) iconLineName(root)?.let { name ->
+        // A per-LEG node carries one line, so the first bullet is the line. The trip SUMMARY
+        // (leg == null) carries every ridden line, and a subway trip's bullets are all it has:
+        // keeping only the first showed a two-line trip as one line on the card people pick from,
+        // and a bus-plus-subway trip as the bus alone (review 2026-09-12). Pills already seen win.
+        if (leg == null) {
+            iconLineNames(root).forEach { name -> if (seen.add(name)) out.add(TransitLine(name = name, mode = mode)) }
+        } else if (out.isEmpty()) iconLineName(root)?.let { name ->
             out.add(TransitLine(name = name, mode = mode))
         }
         return out
+    }
+
+    /** Every agency-scoped line bullet in [root], in document order, distinct; see [iconLineName]. */
+    private fun iconLineNames(root: JsonElement): List<String> {
+        val out = LinkedHashSet<String>()
+        fun walk(n: JsonElement) {
+            when (n) {
+                is JsonArray -> n.forEach(::walk)
+                else -> {
+                    val v = n.str()
+                    if (v != null && v.endsWith(".png") && !v.startsWith("//") && "/" in v) {
+                        val name = v.substringAfterLast('/').removeSuffix(".png").trim()
+                        if (name.isNotEmpty() && name.length <= 12) out.add(name)
+                    }
+                }
+            }
+        }
+        walk(root)
+        return out.toList()
     }
 
     /**
@@ -315,10 +340,10 @@ object TransitParser {
         return best
     }
 
-    /** Infer the vehicle class from any icon filename ("bus2.png", "tram.png",
-     *  "rail.png", …) or mode label in the badge subtree. Vehicle classes are
-     *  tested before WALK: line nodes only exist for ridden segments, so a trip
-     *  whose badges mention both "walk" and "bus" is a bus trip with a walk leg. */
+    /** Infer the vehicle class from the icon FILENAMES in the subtree ("bus2.png", "tram.png",
+     *  "rail.png", "subway2.png", "ferry.png"). Vehicle classes are tested before WALK: line nodes
+     *  only exist for ridden segments, so a trip whose badges mention both "walk" and "bus" is a
+     *  bus trip with a walk leg. */
     private fun guessMode(node: JsonElement): TransitMode {
         // ICON FILENAMES ONLY, never arbitrary strings (issue #284). The old version scanned every
         // short string in the subtree, so a stop or headsign containing a mode word decided the
@@ -343,10 +368,10 @@ object TransitParser {
         val s = hay.toString().lowercase()
         return when {
             "bus" in s -> TransitMode.BUS
-            "subway" in s || "metro" in s -> TransitMode.SUBWAY
-            "tram" in s || "light rail" in s || "streetcar" in s || "lightrail" in s -> TransitMode.TRAM
-            "train" in s || "rail" in s -> TransitMode.TRAIN
-            "ferry" in s || "boat" in s -> TransitMode.FERRY
+            "subway" in s -> TransitMode.SUBWAY
+            "tram" in s -> TransitMode.TRAM
+            "rail" in s || "train" in s -> TransitMode.TRAIN
+            "ferry" in s -> TransitMode.FERRY
             "walk" in s -> TransitMode.WALK
             else -> TransitMode.GENERIC
         }

--- a/core/src/main/java/app/vela/core/model/Route.kt
+++ b/core/src/main/java/app/vela/core/model/Route.kt
@@ -25,6 +25,7 @@ data class Maneuver(
                                   // (OSRM's arrive modifier); null = unknown/straight ahead
     val lanes: List<Lane> = emptyList(), // per-lane turn guidance (from OSRM) for the Google-style diagram
     val roundabout: RoundaboutGeometry? = null, // ROUNDABOUT/EXIT_ROUNDABOUT only: how to draw the glyph
+    val roundaboutExit: Int? = null, // ROUNDABOUT only: which exit to take (1 = first); every router phrases it, the car needs it as a number
 )
 
 /**

--- a/core/src/main/java/app/vela/core/nav/RouteBar.kt
+++ b/core/src/main/java/app/vela/core/nav/RouteBar.kt
@@ -2,7 +2,6 @@ package app.vela.core.nav
 
 import app.vela.core.model.LatLng
 import app.vela.core.model.Route
-import app.vela.core.model.distanceTo
 
 /**
  * The model behind the route bar (issue #228) - a strip showing the road AHEAD of you at a glance:
@@ -86,8 +85,12 @@ object RouteBar {
         traveledM: Double,
         markMeters: List<Pair<Mark, Double>> = emptyList(),
         windowM: Double = WINDOW_M,
+        totalM: Double? = null,
     ): Model {
-        val total = route.distanceMeters
+        // The polyline's own length when the caller has it: traveledM and the marks are both
+        // measured along the polyline, while Route.distanceMeters is the router's figure, and a
+        // few percent between them shifted bands against pins and stood the bar down early.
+        val total = totalM?.takeIf { it > 0.0 } ?: route.distanceMeters
         val done = traveledM.coerceIn(0.0, total)
         val remaining = total - done
         if (remaining < MIN_REMAINING_M) return Model(emptyList(), emptyList(), remaining, true)

--- a/core/src/main/java/app/vela/core/nav/RouteProjection.kt
+++ b/core/src/main/java/app/vela/core/nav/RouteProjection.kt
@@ -35,14 +35,16 @@ object RouteProjection {
         if (poly.size < 2) return null
         var bestD = Double.MAX_VALUE
         var bestAlong = 0.0
+        // One cosine per POINT, not per segment: the route bar projects thousands of corridor
+        // marks over thousands of vertices, and cos(lat) changes by 0.02% over a degree of
+        // latitude, far below the 40 m question this answers (review 2026-09-12).
+        val latScale = Math.cos(Math.toRadians(p.lat))
         for (i in 0 until poly.size - 1) {
             val a = poly[i]
             val b = poly[i + 1]
             val segLen = cum[i + 1] - cum[i]
             if (segLen <= 0.0) continue
-            // Local flat frame per segment: exact enough over one segment, and avoids trigonometry
-            // per vertex on a polyline with thousands of points.
-            val latScale = Math.cos(Math.toRadians(a.lat))
+            // Local flat frame per segment: exact enough over one segment.
             val bx = (b.lng - a.lng) * latScale
             val by = b.lat - a.lat
             val px = (p.lng - a.lng) * latScale

--- a/core/src/test/java/app/vela/core/data/google/parse/TransitSubwayTest.kt
+++ b/core/src/test/java/app/vela/core/data/google/parse/TransitSubwayTest.kt
@@ -49,6 +49,16 @@ class TransitSubwayTest {
         assertEquals("the line name comes from the agency icon, not the localized label", "2", lines[0].name)
     }
 
+    // The trip SUMMARY carries every ridden line. Two subway bullets used to collapse to the first,
+    // and a bus pill beside a subway bullet dropped the subway (the card people pick from).
+    @Test fun `the trip summary keeps every bullet line beside the pills`() {
+        val summary = node(
+            """[[5,["M101",1,"#1d59b3","#ffffff"]],[5,null,[3,"us-ny-mta/2.png",null,"2 Line"]],[5,null,[3,"us-ny-mta/5.png",null,"5 Line"]]]"""
+        )
+        val names = TransitParser.parseLinesForTest(summary, null).map { it.name }
+        assertEquals(listOf("M101", "2", "5"), names)
+    }
+
     @Test fun `a bus keeps its text pill and its colours`() {
         val lines = TransitParser.parseLinesForTest(busBadges, null)
         assertEquals("M101", lines[0].name)


### PR DESCRIPTION
The remaining findings from the read-through of the recent feature PRs, after #376 took the six sharpest ones:

- **ETA calibration for trips with stops (#242):** a waypointed trip took the old ratio-only overlay, so adding one stop reproduced the too-fast ETA from #227, and the nav ETA scale jumped by up to 2.5x when the last stop was passed. Google's keyless answer is the direct trip, so the bias is measured as a speed ratio and applied the same way as for a direct trip. A route that follows Google's course also carries the usual X to Y range now.
- **Android Auto roundabouts (#266):** the car maneuver used a hard-coded counter-clockwise type and exit 1. It reads the measured direction from the roundabout geometry and the exit number the router phrased, which all three routers now put on the maneuver.
- **Sun-following theme (#267):** the stored point is timestamped, trusted for 24 hours, and only while location permission is still granted; otherwise the clock decides.
- **Satellite deep zoom (#247):** the availability probe checks z20 first and stops at the first missing level, so the common fallback settles in one request instead of three; a cancelled probe stops between requests; the deep layer's minimum zoom matches the fade's first stop so it no longer loads invisible tiles.
- **Route bar (#298):** the total is the polyline's own length, the projection cache keys on the mark lists themselves rather than their sizes, and the projection takes one cosine per point instead of one per segment. Turning the spoken camera warning on mid-drive (#300) fetches the current route's cameras at once instead of waiting for the next reroute.
- **Transit summary cards (#303):** the card keeps every bullet-style line beside the pills, so a two-line subway trip or a bus-plus-subway trip reads correctly.
- **Landscape nav chrome (#310):** the left column pads the display cutout on its edge; six copies of the column modifier became one helper.
- Dead branches removed in the roundabout glyph and the transit mode guess; the typography is remembered per font family.

Not done, on purpose: glyph geometry for GraphHopper and obf roundabouts (both expose a turn angle whose sign convention is not documented in the vendored jars; a guessed arrow is the original bug), and per-route calibration of alternates (a design trade the current code documents).

Core tests pass with two new cases (summary bullet lines, route-bar merge priority). Smoke-tested on a Pixel 4a: search, place sheet, directions with mode chips, no crashes.